### PR TITLE
Use qname/qtype for lookups

### DIFF
--- a/middleware/file/closest_test.go
+++ b/middleware/file/closest_test.go
@@ -25,11 +25,8 @@ func TestClosestEncloser(t *testing.T) {
 		{"blaat.a.miek.nl.", "a.miek.nl."},
 	}
 
-	mk, _ := dns.TypeToRR[dns.TypeA]
-	rr := mk()
 	for _, tc := range tests {
-		rr.Header().Name = tc.in
-		ce := z.ClosestEncloser(rr)
+		ce := z.ClosestEncloser(tc.in, dns.TypeA)
 		if ce != tc.out {
 			t.Errorf("expected ce to be %s for %s, got %s", tc.out, tc.in, ce)
 		}

--- a/middleware/file/tree/elem.go
+++ b/middleware/file/tree/elem.go
@@ -91,9 +91,8 @@ func (e *Elem) Delete(rr dns.RR) (empty bool) {
 	return
 }
 
-func Less(a *Elem, rr dns.RR) int {
-	return middleware.Less(rr.Header().Name, a.Name())
-}
+// Less is a tree helper function that calles middleware.Less.
+func Less(a *Elem, name string) int { return middleware.Less(name, a.Name()) }
 
 // Assuming the same type and name this will check if the rdata is equal as well.
 func equalRdata(a, b dns.RR) bool {


### PR DESCRIPTION
Drop the use of dns.RR when in fact the only thing we use is the name
and type of the RR. Cleans up a bunch of stuff and also stops the weird
making of dns.RRs just for a lookup. Should safe some memory as well.

Fixes: #66
