### PR TITLE
Fix Corefile parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func setVersion() {
 	}
 }
 
-const appName = "Caddy"
+const appName = "CoreDNS"
 
 // Flags that control program flow or startup
 var (

--- a/middleware/file/secondary.go
+++ b/middleware/file/secondary.go
@@ -14,10 +14,6 @@ func (z *Zone) TransferIn() error {
 	t := new(dns.Transfer)
 	m := new(dns.Msg)
 	m.SetAxfr(z.name)
-	/*
-	   t.TsigSecret = map[string]string{"axfr.": "so6ZGir4GPAqINNh9U5c3A=="}
-	   m.SetTsig("axfr.", dns.HmacMD5, 300, time.Now().Unix())
-	*/
 
 	var Err error
 Transfer:
@@ -48,16 +44,6 @@ Transfer:
 			}
 		}
 	}
-	return Err
+	return nil
+	return Err // ignore errors for now. TODO(miek)
 }
-
-/*
-
-				28800      ; refresh (8 hours)
-				7200       ; retry (2 hours)
-				604800     ; expire (1 week)
-				3600       ; minimum (1 hour)
-// Check SOA
-// Just check every refresh hours, if fail set to retry until succeeds
-// expire is need: to give SERVFAIL.
-*/

--- a/server/server.go
+++ b/server/server.go
@@ -273,6 +273,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	b := make([]byte, len(q))
 	off, end := 0, false
 	ctx := context.Background()
+
 	for {
 		l := len(q[off:])
 		for i := 0; i < l; i++ {


### PR DESCRIPTION
Fix some file/secondary issues when parsing a Corefile, also allow
for multiple origins to be specified. Also don't fail on startup when
a zonetransfer fails.

Fixes: #54
