### PR TITLE
Enable monitoring for non middleware

### DIFF
--- a/middleware/prometheus/handler.go
+++ b/middleware/prometheus/handler.go
@@ -22,14 +22,21 @@ func (m Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	rw := middleware.NewResponseRecorder(w)
 	status, err := m.Next.ServeDNS(ctx, rw, r)
 
-	m.Report(zone, qtype, rw)
+	Report(zone, qtype, rw.Rcode(), rw.Size(), rw.Start())
 
 	return status, err
 }
 
-func (m Metrics) Report(zone, qtype string, rw *middleware.ResponseRecorder) {
+// Report is a plain reporting function that the server can use for REFUSED and other
+// queries that are turned down because they don't match any middleware.
+func Report(zone, qtype, rcode string, size int, start time.Time) {
+	if requestCount == nil {
+		// no metrics are enabled
+		return
+	}
+
 	requestCount.WithLabelValues(zone, qtype).Inc()
-	requestDuration.WithLabelValues(zone, qtype).Observe(float64(time.Since(rw.Start()) / time.Second))
-	responseSize.WithLabelValues(zone, qtype).Observe(float64(rw.Size()))
-	responseRcode.WithLabelValues(zone, rw.Rcode(), qtype).Inc()
+	requestDuration.WithLabelValues(zone, qtype).Observe(float64(time.Since(start) / time.Second))
+	responseSize.WithLabelValues(zone, qtype).Observe(float64(size))
+	responseRcode.WithLabelValues(zone, rcode, qtype).Inc()
 }


### PR DESCRIPTION
If monitoring is enabled for one zone, also enable it for when the
server reports REFUSED. Normally the metrics are only enabled if
you enter the middleware, with this you'll see REFUSED queries.
Each of these are reported agains the root zone otherwise
