### PR TITLE
Use *dns.Server

### DIFF
--- a/core/sigtrap_posix.go
+++ b/core/sigtrap_posix.go
@@ -53,7 +53,7 @@ func trapSignalsPosix() {
 				caddyfileMu.Lock()
 				if caddyfile == nil {
 					// Hmm, did spawing process forget to close stdin? Anyhow, this is unusual.
-					log.Println("[ERROR] SIGUSR1: no Caddyfile to reload (was stdin left open?)")
+					log.Println("[ERROR] SIGUSR1: no Corefile to reload (was stdin left open?)")
 					caddyfileMu.Unlock()
 					continue
 				}


### PR DESCRIPTION
This does not fix the reload issue, but will give us flexibility
to access the packetConn and listener to make this all work.
