### PR TITLE
Failed startup was not flagged

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -163,8 +163,8 @@ func (s *Server) Serve(ln ListenerFile) error {
 // ListenAndServe starts the server with a new listener. It blocks until the server stops.
 func (s *Server) ListenAndServe() error {
 	err := s.setup()
+	defer close(s.startChan)
 	if err != nil {
-		close(s.startChan)
 		return err
 	}
 
@@ -187,8 +187,6 @@ func (s *Server) ListenAndServe() error {
 	go func() {
 		s.server[0].ActivateAndServe()
 	}()
-
-	close(s.startChan) // unblock anyone waiting for this to start listening
 	return s.server[1].ActivateAndServe()
 }
 

--- a/test/fail_start_test.go
+++ b/test/fail_start_test.go
@@ -1,0 +1,21 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/coredns/core"
+)
+
+// Bind to low port should fail.
+func TestFailStartServer(t *testing.T) {
+	corefile := `.:53 {
+	chaos CoreDNS-001 miek@miek.nl
+}
+`
+	srv, _ := core.TestServer(t, corefile)
+	err := srv.ListenAndServe()
+	if err == nil {
+		srv.Stop()
+		t.Fatalf("Low port startup should fail")
+	}
+}

--- a/test/tests.go
+++ b/test/tests.go
@@ -34,7 +34,7 @@ func Server(t *testing.T, corefile string) (*server.Server, string, string, erro
 	}
 	go srv.ListenAndServe()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(1 * time.Second) // yeah... I regret nothing
 	tcp, udp := srv.LocalAddr()
 	return srv, tcp.String(), udp.String(), nil
 }


### PR DESCRIPTION
The error propagation from srv.ListenAndServe did not work as intended,
simplified it a bit and added a test for it.
