### PR TITLE
Allow more than 1 address for transfer

### DIFF
--- a/core/setup/secondary.go
+++ b/core/setup/secondary.go
@@ -57,11 +57,11 @@ func secondaryParse(c *Controller) (file.Zones, error) {
 					return file.Zones{}, e
 				}
 				for _, origin := range origins {
-					if t != "" {
-						z[origin].TransferTo = append(z[origin].TransferTo, t)
+					if t != nil {
+						z[origin].TransferTo = append(z[origin].TransferTo, t...)
 					}
-					if f != "" {
-						z[origin].TransferFrom = append(z[origin].TransferFrom, f)
+					if f != nil {
+						z[origin].TransferFrom = append(z[origin].TransferFrom, f...)
 					}
 				}
 			}

--- a/middleware/file/README.md
+++ b/middleware/file/README.md
@@ -18,18 +18,19 @@ file dbfile [zones...]
 If you want to round robin A and AAAA responses look at the `loadbalance` middleware.
 
 TSIG key configuration is TODO; directive format for transfer will probably be extended with
-TSIG key information, something like `transfer out [address] key [name] [base64]`
+TSIG key information, something like `transfer out [address...] key [name] [base64]`
 
 ~~~
 file dbfile [zones... ] {
-    transfer out [address...]
-    transfer to [address]
+    transfer from [address...]
+    transfer to [address...]
+
 }
 ~~~
 
 * `transfer` enables zone transfers. It may be specified multiples times. *To* or *from* signals
-    the direction. Address must be denoted in CIDR notation (127.0.0.1/32 etc.). The special
-    wildcard "*" means: the entire internet.
+    the direction. Addresses must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as plain
+    address. The special wildcard "*" means: the entire internet (only valid for 'transfer to').
 
 ## Examples
 

--- a/server/server.go
+++ b/server/server.go
@@ -163,17 +163,20 @@ func (s *Server) Serve(ln ListenerFile) error {
 // ListenAndServe starts the server with a new listener. It blocks until the server stops.
 func (s *Server) ListenAndServe() error {
 	err := s.setup()
-	defer close(s.startChan)
+	// defer close(s.startChan) // Don't understand why defer wouldn't actually work in this method.
 	if err != nil {
+		close(s.startChan)
 		return err
 	}
 
 	l, err := net.Listen("tcp", s.Addr)
 	if err != nil {
+		close(s.startChan)
 		return err
 	}
 	pc, err := net.ListenPacket("udp", s.Addr)
 	if err != nil {
+		close(s.startChan)
 		return err
 	}
 
@@ -187,6 +190,7 @@ func (s *Server) ListenAndServe() error {
 	go func() {
 		s.server[0].ActivateAndServe()
 	}()
+	close(s.startChan)
 	return s.server[1].ActivateAndServe()
 }
 


### PR DESCRIPTION
No reason why not to allow more then one address:
`transfer to 127.0.0.1 10.240.20.1`.

Fix startup as well, as it turned out to be broken...
