### PR TITLE
Fix error reporting

### DIFF
--- a/core/directives.go
+++ b/core/directives.go
@@ -53,7 +53,9 @@ var directiveOrder = []directive{
 
 	// Directives that inject handlers (middleware)
 	{"prometheus", setup.Prometheus},
+	{"errors", setup.Errors},
 	{"log", setup.Log},
+
 	{"chaos", setup.Chaos},
 	{"rewrite", setup.Rewrite},
 	{"loadbalance", setup.Loadbalance},
@@ -62,7 +64,6 @@ var directiveOrder = []directive{
 	{"secondary", setup.Secondary},
 	{"etcd", setup.Etcd},
 	{"proxy", setup.Proxy},
-	{"errors", setup.Errors},
 }
 
 // RegisterDirective adds the given directive to caddy's list of directives.
@@ -90,5 +91,5 @@ type directive struct {
 
 // SetupFunc takes a controller and may optionally return a middleware.
 // If the resulting middleware is not nil, it will be chained into
-// the HTTP handlers in the order specified in this package.
+// the DNS handlers in the order specified in this package.
 type SetupFunc func(c *setup.Controller) (middleware.Middleware, error)

--- a/middleware/etcd/handler.go
+++ b/middleware/etcd/handler.go
@@ -73,7 +73,6 @@ func (e Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return e.Err(zone, dns.RcodeNameError, state)
 	}
 	if err != nil {
-		println("returning error", err.Error())
 		return dns.RcodeServerFailure, err
 	}
 


### PR DESCRIPTION
Put error back in the correct place in the directives.go. Also don't
make it a pointer. If it _is_ a pointer the buildstack function does
not correctly set the Next Handler. Don't understand _why_ this is
different from Caddy. Anyway this fixes it, with the caveat that
the error log file is now openend earlier in the startup.

Fixes #127
