### PR TITLE
middleware/cache: Add metrics

### DIFF
--- a/middleware/cache/handler.go
+++ b/middleware/cache/handler.go
@@ -4,6 +4,7 @@ import (
 	"github.com/miekg/coredns/middleware"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 )
 
@@ -24,8 +25,12 @@ func (c Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		resp := i.toMsg(r)
 		state.SizeAndDo(resp)
 		w.WriteMsg(resp)
+
+		cacheHitCount.WithLabelValues(zone).Inc()
 		return dns.RcodeSuccess, nil
 	}
+	cacheMissCount.WithLabelValues(zone).Inc()
+
 	crr := NewCachingResponseWriter(w, c.cache, c.cap)
 	return c.Next.ServeDNS(ctx, crr, r)
 }
@@ -41,4 +46,27 @@ func (c Cache) Get(qname string, qtype uint16, do bool) (*item, bool) {
 		return i.(*item), true
 	}
 	return nil, false
+}
+
+var (
+	cacheHitCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: middleware.Namespace,
+		Subsystem: subsystem,
+		Name:      "hit_count_total",
+		Help:      "Counter of DNS requests that were found in the cache.",
+	}, []string{"zone"})
+
+	cacheMissCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: middleware.Namespace,
+		Subsystem: subsystem,
+		Name:      "miss_count_total",
+		Help:      "Counter of DNS requests that were not found in the cache.",
+	}, []string{"zone"})
+)
+
+const subsystem = "cache"
+
+func init() {
+	prometheus.MustRegister(cacheHitCount)
+	prometheus.MustRegister(cacheMissCount)
 }

--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -6,10 +6,9 @@ import (
 	"sync"
 
 	"github.com/miekg/coredns/middleware"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
-
-const namespace = "coredns"
 
 var (
 	requestCount    *prometheus.CounterVec
@@ -48,18 +47,15 @@ func (m *Metrics) Start() error {
 }
 
 func define(subsystem string) {
-	if subsystem == "" {
-		subsystem = "dns"
-	}
 	requestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
+		Namespace: middleware.Namespace,
 		Subsystem: subsystem,
 		Name:      "request_count_total",
 		Help:      "Counter of DNS requests made per zone and protocol.",
 	}, []string{"zone", "proto"})
 
 	requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
+		Namespace: middleware.Namespace,
 		Subsystem: subsystem,
 		Name:      "request_duration_seconds",
 		Buckets:   append([]float64{.0001, .0005, .001, .0025}, prometheus.DefBuckets...),
@@ -67,7 +63,7 @@ func define(subsystem string) {
 	}, []string{"zone"})
 
 	responseSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: namespace,
+		Namespace: middleware.Namespace,
 		Subsystem: subsystem,
 		Name:      "response_size_bytes",
 		Help:      "Size of the returns response in bytes.",
@@ -75,12 +71,16 @@ func define(subsystem string) {
 	}, []string{"zone"})
 
 	responseRcode = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: namespace,
+		Namespace: middleware.Namespace,
 		Subsystem: subsystem,
 		Name:      "response_rcode_count_total",
 		Help:      "Counter of response status codes.",
 	}, []string{"zone", "rcode"})
 }
 
-// Dropped indicates we dropped the query before any handling. It has no closing dot, so it can not be a valid zone.
-const Dropped = "dropped"
+const (
+	// Dropped indicates we dropped the query before any handling. It has no closing dot, so it can not be a valid zone.
+	Dropped = "dropped"
+
+	subsystem = "dns"
+)

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -54,6 +54,8 @@ func (f HandlerFunc) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	return f(ctx, w, r)
 }
 
+const Namespace = "coredns"
+
 // IndexFile looks for a file in /root/fpath/indexFile for each string
 // in indexFiles. If an index file is found, it returns the root-relative
 // path to the file and true. If no index file is found, empty string


### PR DESCRIPTION
Add prometheus metrics to the cache handler. This just uses prometheus,
if the metrics middleware does not set up the handler, there is nobody
reading these metrics, but they are still reported. Seems the simplest
solution while keeping the whole middleware separation in tact.
