### PR TITLE
Middleware should survive a restart

### DIFF
--- a/core/restart.go
+++ b/core/restart.go
@@ -117,6 +117,9 @@ func Restart(newCorefile Input) error {
 	}
 	wpipe.Close()
 
+	// Run all shutdown functions for the middleware, if child start fails, restart them all...
+	executeShutdownCallbacks("SIGUSR1")
+
 	// Determine whether child startup succeeded
 	answer, readErr := ioutil.ReadAll(sigrpipe)
 	if answer == nil || len(answer) == 0 {
@@ -125,6 +128,9 @@ func Restart(newCorefile Input) error {
 		if readErr != nil {
 			log.Printf("[ERROR] Restart: additionally, error communicating with child process: %v", readErr)
 		}
+		// re-call all startup functions.
+		// TODO(miek): this needs to be tested, somehow.
+		executeStartupCallbacks("SIGUSR1")
 		return errIncompleteRestart
 	}
 

--- a/core/setup/health.go
+++ b/core/setup/health.go
@@ -11,8 +11,9 @@ func Health(c *Controller) (middleware.Middleware, error) {
 		return nil, err
 	}
 
-	h := health.Health{Addr: addr}
-	c.Startup = append(c.Startup, h.ListenAndServe)
+	h := &health.Health{Addr: addr}
+	c.Startup = append(c.Startup, h.Start)
+	c.Shutdown = append(c.Shutdown, h.Shutdown)
 	return nil, nil
 }
 

--- a/core/setup/metrics.go
+++ b/core/setup/metrics.go
@@ -12,18 +12,19 @@ const addr = "localhost:9153"
 var metricsOnce sync.Once
 
 func Prometheus(c *Controller) (middleware.Middleware, error) {
-	met, err := parsePrometheus(c)
+	m, err := parsePrometheus(c)
 	if err != nil {
 		return nil, err
 	}
 
 	metricsOnce.Do(func() {
-		c.Startup = append(c.Startup, met.Start)
+		c.Startup = append(c.Startup, m.Start)
+		c.Shutdown = append(c.Shutdown, m.Shutdown)
 	})
 
 	return func(next middleware.Handler) middleware.Handler {
-		met.Next = next
-		return met
+		m.Next = next
+		return m
 	}, nil
 }
 

--- a/core/setup/pprof.go
+++ b/core/setup/pprof.go
@@ -27,6 +27,7 @@ func PProf(c *Controller) (middleware.Middleware, error) {
 	handler := &pprof.Handler{}
 	pprofOnce.Do(func() {
 		c.Startup = append(c.Startup, handler.Start)
+		c.Shutdown = append(c.Shutdown, handler.Shutdown)
 	})
 
 	return func(next middleware.Handler) middleware.Handler {

--- a/middleware/health/health.go
+++ b/middleware/health/health.go
@@ -3,6 +3,7 @@ package health
 import (
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 )
@@ -11,28 +12,45 @@ var once sync.Once
 
 type Health struct {
 	Addr string
+	ln   net.Listener
+	mux  *http.ServeMux
 }
 
 func health(w http.ResponseWriter, r *http.Request) {
 	io.WriteString(w, ok)
 }
 
-func (h Health) ListenAndServe() error {
+func (h *Health) Start() error {
 	if h.Addr == "" {
 		h.Addr = defAddr
 	}
+
 	once.Do(func() {
-		http.HandleFunc("/health", health)
+		if ln, err := net.Listen("tcp", h.Addr); err != nil {
+			log.Printf("[ERROR] Failed to start health handler: %s", err)
+			return
+		} else {
+			h.ln = ln
+		}
+		h.mux = http.NewServeMux()
+
+		h.mux.HandleFunc(path, health)
 		go func() {
-			if err := http.ListenAndServe(h.Addr, nil); err != nil {
-				log.Printf("[ERROR] Failed to start health handler: %s", err)
-			}
+			http.Serve(h.ln, h.mux)
 		}()
 	})
+	return nil
+}
+
+func (h *Health) Shutdown() error {
+	if h.ln != nil {
+		return h.ln.Close()
+	}
 	return nil
 }
 
 const (
 	ok      = "OK"
 	defAddr = ":8080"
+	path    = "/health"
 )

--- a/middleware/pprof/README.md
+++ b/middleware/pprof/README.md
@@ -1,7 +1,7 @@
 # pprof
 
 pprof publishes runtime profiling data at endpoints under /debug/pprof. You can visit /debug/pprof
-on your site for an index of the available endpoints. By default it will listen on localhost:8053.
+on your site for an index of the available endpoints. By default it will listen on localhost:6053.
 
 > This is a debugging tool. Certain requests (such as collecting execution traces) can be slow. If
 > you use pprof on a live site, consider restricting access or enabling it only temporarily.

--- a/middleware/pprof/pprof.go
+++ b/middleware/pprof/pprof.go
@@ -2,8 +2,9 @@ package pprof
 
 import (
 	"log"
+	"net"
 	"net/http"
-	_ "net/http/pprof"
+	pp "net/http/pprof"
 
 	"github.com/miekg/coredns/middleware"
 
@@ -11,10 +12,10 @@ import (
 	"golang.org/x/net/context"
 )
 
-const addr = "localhost:8053"
-
 type Handler struct {
 	Next middleware.Handler
+	ln   net.Listener
+	mux  *http.ServeMux
 }
 
 // ServeDNS passes all other requests up the chain.
@@ -23,10 +24,34 @@ func (h *Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 }
 
 func (h *Handler) Start() error {
+	if ln, err := net.Listen("tcp", addr); err != nil {
+		log.Printf("[ERROR] Failed to start pprof handler: %s", err)
+		return err
+	} else {
+		h.ln = ln
+	}
+
+	h.mux = http.NewServeMux()
+	h.mux.HandleFunc(path+"/", pp.Index)
+	h.mux.HandleFunc(path+"/cmdline", pp.Cmdline)
+	h.mux.HandleFunc(path+"/profile", pp.Profile)
+	h.mux.HandleFunc(path+"/symbol", pp.Symbol)
+	h.mux.HandleFunc(path+"/trace", pp.Trace)
+
 	go func() {
-		if err := http.ListenAndServe(addr, nil); err != nil {
-			log.Printf("[ERROR] Failed to start pprof handler: %s", err)
-		}
+		http.Serve(h.ln, h.mux)
 	}()
 	return nil
 }
+
+func (h *Handler) Shutdown() error {
+	if h.ln != nil {
+		return h.ln.Close()
+	}
+	return nil
+}
+
+const (
+	addr = "localhost:6053"
+	path = "/debug/pprof"
+)


### PR DESCRIPTION
Make middleware that sets up a (http) handler survive a graceful restart:
- middleware/health: OK
