### PR TITLE
Add host-local-values

### DIFF
--- a/middleware/etcd/README.md
+++ b/middleware/etcd/README.md
@@ -60,3 +60,10 @@ This is the default SkyDNS setup, with everying specified in full:
     proxy . 8.8.8.8:53 8.8.4.4:53
 }
 ~~~
+
+~~~
+skydns.local:53 {
+    etcd {
+        local mylocalname.instance.skyns.local
+    }
+}

--- a/middleware/etcd/README.md
+++ b/middleware/etcd/README.md
@@ -27,6 +27,7 @@ etcd [zones...] {
     endpoint endpoint...
     upstream address...
     tls cert key cacert
+    local name
 }
 ~~~
 
@@ -38,6 +39,8 @@ etcd [zones...] {
   pointing to external names. If you want CoreDNS to act as a proxy for clients you'll need to add
   the proxy middleware.
 * `tls` followed the cert, key and the CA's cert filenames.
+* `local` use name for the host-local-value. This name will be substituted when looking up
+  `local.dns.<zone>`.
 
 ## Examples
 

--- a/middleware/etcd/etcd.go
+++ b/middleware/etcd/etcd.go
@@ -18,8 +18,9 @@ import (
 type Etcd struct {
 	Next       middleware.Handler
 	Zones      []string
+	Local      string // Path for host-local-value queries.
 	PathPrefix string
-	Proxy      proxy.Proxy // Proxy for looking up names during the resolution process
+	Proxy      proxy.Proxy // Proxy for looking up names during the resolution process.
 	Client     etcdc.KeysAPI
 	Ctx        context.Context
 	Inflight   *singleflight.Group

--- a/middleware/etcd/handler.go
+++ b/middleware/etcd/handler.go
@@ -40,6 +40,12 @@ func (e Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	m.SetReply(r)
 	m.Authoritative, m.RecursionAvailable, m.Compress = true, true, true
 
+	// If the qname is local.dns.<zone> and e.Local != "" substitute that name.
+	if e.Local != "" && state.Name() == localDomain+zone {
+		state.Req.Question[0].Name = e.Local
+		state.Clear() // oh my
+	}
+
 	var (
 		records, extra []dns.RR
 		err            error
@@ -107,3 +113,5 @@ func dedup(m *dns.Msg) *dns.Msg {
 	m.Extra = dns.Dedup(m.Extra, nil)
 	return m
 }
+
+const localDomain = "local.dns."

--- a/middleware/etcd/lookup_test.go
+++ b/middleware/etcd/lookup_test.go
@@ -29,6 +29,8 @@ var services = []*msg.Service{
 	// Nameservers.
 	{Host: "10.0.0.2", Key: "a.ns.dns.skydns.test."},
 	{Host: "10.0.0.3", Key: "b.ns.dns.skydns.test."},
+	// Local data test, when looking up local.dns.<zone> we look up this key
+	{Host: "10.1.1.1", Key: "localdata.for.skydns.skydns.test."},
 }
 
 var dnsTestCases = []test.Case{
@@ -197,5 +199,10 @@ var dnsTestCases = []test.Case{
 	{
 		Qname: "skydns_extra.test.", Qtype: dns.TypeSOA,
 		Answer: []dns.RR{test.SOA("skydns_extra.test. 300 IN SOA ns.dns.skydns_extra.test. hostmaster.skydns_extra.test. 1460498836 14400 3600 604800 60")},
+	},
+	// Local data query
+	{
+		Qname: "local.dns.skydns.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A("local.dns.skydns.test. 300 A 10.1.1.1")},
 	},
 }

--- a/middleware/etcd/lookup_test.go
+++ b/middleware/etcd/lookup_test.go
@@ -205,4 +205,9 @@ var dnsTestCases = []test.Case{
 		Qname: "local.dns.skydns.test.", Qtype: dns.TypeA,
 		Answer: []dns.RR{test.A("local.dns.skydns.test. 300 A 10.1.1.1")},
 	},
+	// Local data query
+	{
+		Qname: "notlocal.dns.skydns.test.", Qtype: dns.TypeA, Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{test.SOA("skydns.test.	300	IN	SOA	ns.dns.skydns.test. hostmaster.skydns.test. 1460498836 14400 3600 604800 60")},
+	},
 }

--- a/middleware/etcd/setup_test.go
+++ b/middleware/etcd/setup_test.go
@@ -35,6 +35,7 @@ func init() {
 	etc = Etcd{
 		Proxy:      proxy.New([]string{"8.8.8.8:53"}),
 		PathPrefix: "skydns",
+		Local:      "localdata.for.skydns.skydns.test.",
 		Ctx:        context.Background(),
 		Inflight:   &singleflight.Group{},
 		Zones:      []string{"skydns.test.", "skydns_extra.test."},


### PR DESCRIPTION
Port the host-local-value feature from SkyDNS. Querying for
local.dns.<zone> returns data that is specific for this CoreDNS
instance.
