### PR TITLE
Suppress proxy error for truncated responses

### DIFF
--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -24,6 +24,10 @@ func (p ReverseProxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg, extra []dns.RR)
 		reply, err = middleware.Exchange(p.Client.TCP, r, p.Host)
 	default:
 		reply, err = middleware.Exchange(p.Client.UDP, r, p.Host)
+		if reply != nil && reply.Truncated {
+			// Suppress proxy error for truncated responses
+			err = nil
+		}
 	}
 
 	if err != nil {

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -24,15 +24,17 @@ func (p ReverseProxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg, extra []dns.RR)
 		reply, err = middleware.Exchange(p.Client.TCP, r, p.Host)
 	default:
 		reply, err = middleware.Exchange(p.Client.UDP, r, p.Host)
-		if reply != nil && reply.Truncated {
-			// Suppress proxy error for truncated responses
-			err = nil
-		}
+	}
+
+	if reply != nil && reply.Truncated {
+		// Suppress proxy error for truncated responses
+		err = nil
 	}
 
 	if err != nil {
 		return err
 	}
+
 	reply.Compress = true
 	reply.Id = r.Id
 	w.WriteMsg(reply)


### PR DESCRIPTION
Reverse proxy fails on truncated upstream responses. 
This fix makes proxy respond truncated messages to client.
