### PR TITLE
Tidy up most errors and warnings from lint tools.

### DIFF
--- a/middleware/etcd/cname_test.go
+++ b/middleware/etcd/cname_test.go
@@ -24,7 +24,7 @@ func TestCnameLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			return

--- a/middleware/etcd/debug_test.go
+++ b/middleware/etcd/debug_test.go
@@ -39,7 +39,7 @@ func TestDebugLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			continue
@@ -75,7 +75,7 @@ func TestDebugLookupFalse(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			continue

--- a/middleware/etcd/etcd.go
+++ b/middleware/etcd/etcd.go
@@ -114,7 +114,7 @@ Nodes:
 		bx[b] = true
 
 		serv.Key = n.Key
-		serv.Ttl = g.Ttl(n, serv)
+		serv.Ttl = g.TTL(n, serv)
 		if serv.Priority == 0 {
 			serv.Priority = priority
 		}
@@ -123,22 +123,22 @@ Nodes:
 	return sx, nil
 }
 
-// Ttl returns the smaller of the etcd TTL and the service's
+// TTL returns the smaller of the etcd TTL and the service's
 // TTL. If neither of these are set (have a zero value), a default is used.
-func (g Etcd) Ttl(node *etcdc.Node, serv *msg.Service) uint32 {
-	etcdTtl := uint32(node.TTL)
+func (g Etcd) TTL(node *etcdc.Node, serv *msg.Service) uint32 {
+	etcdTTL := uint32(node.TTL)
 
-	if etcdTtl == 0 && serv.Ttl == 0 {
+	if etcdTTL == 0 && serv.Ttl == 0 {
 		return ttl
 	}
-	if etcdTtl == 0 {
+	if etcdTTL == 0 {
 		return serv.Ttl
 	}
 	if serv.Ttl == 0 {
-		return etcdTtl
+		return etcdTTL
 	}
-	if etcdTtl < serv.Ttl {
-		return etcdTtl
+	if etcdTTL < serv.Ttl {
+		return etcdTTL
 	}
 	return serv.Ttl
 }
@@ -154,7 +154,7 @@ func isEtcdNameError(err error) bool {
 const (
 	priority    = 10  // default priority when nothing is set
 	ttl         = 300 // default ttl when nothing is set
-	minTtl      = 60
+	minTTL      = 60
 	hostmaster  = "hostmaster"
 	etcdTimeout = 5 * time.Second
 )

--- a/middleware/etcd/group_test.go
+++ b/middleware/etcd/group_test.go
@@ -22,7 +22,7 @@ func TestGroupLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			continue

--- a/middleware/etcd/handler.go
+++ b/middleware/etcd/handler.go
@@ -28,7 +28,7 @@ func (e Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	// are not auth. for *but* do have a stubzone forward for. If we do the stubzone
 	// handler will handle the request.
 	if e.Stubmap != nil && len(*e.Stubmap) > 0 {
-		for zone, _ := range *e.Stubmap {
+		for zone := range *e.Stubmap {
 			if middleware.Name(zone).Matches(name) {
 				stub := Stub{Etcd: e, Zone: zone}
 				return stub.ServeDNS(ctx, w, r)

--- a/middleware/etcd/lookup.go
+++ b/middleware/etcd/lookup.go
@@ -398,6 +398,6 @@ func isDuplicateCNAME(r *dns.CNAME, records []dns.RR) bool {
 // TODO(miek): Move to middleware?
 func copyState(state middleware.State, target string, typ uint16) middleware.State {
 	state1 := middleware.State{W: state.W, Req: state.Req.Copy()}
-	state1.Req.Question[0] = dns.Question{dns.Fqdn(target), dns.ClassINET, typ}
+	state1.Req.Question[0] = dns.Question{Name: dns.Fqdn(target), Qclass: dns.ClassINET, Qtype: typ}
 	return state1
 }

--- a/middleware/etcd/multi_test.go
+++ b/middleware/etcd/multi_test.go
@@ -26,7 +26,7 @@ func TestMultiLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etcMulti.ServeDNS(ctx, rec, m)
+		_, err := etcMulti.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			return

--- a/middleware/etcd/other_test.go
+++ b/middleware/etcd/other_test.go
@@ -24,7 +24,7 @@ func TestOtherLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got %v\n", err)
 			continue

--- a/middleware/etcd/setup_test.go
+++ b/middleware/etcd/setup_test.go
@@ -22,11 +22,11 @@ import (
 var (
 	etc    Etcd
 	client etcdc.KeysAPI
-	ctx    context.Context
+	ctxt   context.Context
 )
 
 func init() {
-	ctx, _ = context.WithTimeout(context.Background(), etcdTimeout)
+	ctxt, _ = context.WithTimeout(context.Background(), etcdTimeout)
 
 	etcdCfg := etcdc.Config{
 		Endpoints: []string{"http://localhost:2379"},
@@ -48,12 +48,12 @@ func set(t *testing.T, e Etcd, k string, ttl time.Duration, m *msg.Service) {
 		t.Fatal(err)
 	}
 	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
-	e.Client.Set(ctx, path, string(b), &etcdc.SetOptions{TTL: ttl})
+	e.Client.Set(ctxt, path, string(b), &etcdc.SetOptions{TTL: ttl})
 }
 
 func delete(t *testing.T, e Etcd, k string) {
 	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
-	e.Client.Delete(ctx, path, &etcdc.DeleteOptions{Recursive: false})
+	e.Client.Delete(ctxt, path, &etcdc.DeleteOptions{Recursive: false})
 }
 
 func TestLookup(t *testing.T) {
@@ -65,7 +65,7 @@ func TestLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			t.Errorf("expected no error, got: %v for %s %s\n", err, m.Question[0].Name, dns.Type(m.Question[0].Qtype))
 			return

--- a/middleware/etcd/stub_cycle_test.go
+++ b/middleware/etcd/stub_cycle_test.go
@@ -26,7 +26,7 @@ func TestStubCycle(t *testing.T) {
 		}
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err == nil {
 			t.Errorf("expected error, got none")
 			continue

--- a/middleware/etcd/stub_handler.go
+++ b/middleware/etcd/stub_handler.go
@@ -58,7 +58,7 @@ func addStubEdns0(m *dns.Msg) *dns.Msg {
 	option := m.IsEdns0()
 	// Add a custom EDNS0 option to the packet, so we can detect loops when 2 stubs are forwarding to each other.
 	if option != nil {
-		option.Option = append(option.Option, &dns.EDNS0_LOCAL{ednsStubCode, []byte{1}})
+		option.Option = append(option.Option, &dns.EDNS0_LOCAL{Code: ednsStubCode, Data: []byte{1}})
 		return m
 	}
 

--- a/middleware/etcd/stub_test.go
+++ b/middleware/etcd/stub_test.go
@@ -23,7 +23,7 @@ func TestStubLookup(t *testing.T) {
 		m := tc.Msg()
 
 		rec := middleware.NewResponseRecorder(&test.ResponseWriter{})
-		_, err := etc.ServeDNS(ctx, rec, m)
+		_, err := etc.ServeDNS(ctxt, rec, m)
 		if err != nil {
 			if tc.Rcode != dns.RcodeServerFailure {
 				t.Errorf("expected no error, got %v\n", err)


### PR DESCRIPTION
Fix some shadowing by test code (ctx -> ctxt), struct initializations and case change for TTLs.

I only did this for the etcd middleware. I didn't touch the missing comments from etcd.go:type Etcd and the the record methods since I don't know if you intended to expose them.
