### PR TITLE
Spray to backend hosts when all are unhealthy

### DIFF
--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -45,6 +45,9 @@ There are three load balancing policies available:
 * *least_conn* - Select backend with the fewest active connections
 * *round_robin* - Select backend in round-robin fashion
 
+All polices implement randomly spraying packets to backend hosts when *no healthy* hosts are
+available. This is to preeempt the case where the healthchecking (as a mechanism) fails.
+
 ## Examples
 
 Proxy all requests within example.org. to a backend system:


### PR DESCRIPTION
When all backend hosts are unhealthy, randomly select one and use
that as a target.

This is to preempt the health checking itself failing.
 Fixes #170.
