### PR TITLE
Fix issue 187: exit test

### DIFF
--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -44,6 +44,7 @@ func TestLookupProxy(t *testing.T) {
 	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {
 		t.Error("Expected to receive reply, but didn't")
+		return
 	}
 	// expect answer section with A record in it
 	if len(resp.Answer) == 0 {


### PR DESCRIPTION
When not receiving a reply, exit the test and don't check the contents
of the unreceived packet.

Fixes #187
