### PR TITLE
Fix Travis IPv6 and add k8s integration testing to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_install:
   - sudo ifup eth0
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
+  - env
 
 before_script:
   - curl -L  https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz -o etcd-v2.3.1-linux-amd64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ go:
 # In the Travis VM-based build environment, IPv6 networking is not
 # enabled by default. The sysctl operations below enable IPv6.
 # IPv6 is needed by some of the CoreDNS test cases. The VM environment
-# is needed to have sudo in the test environment. Sudo is needed to have
-# docker in the test environment. Docker is needed to launch a kubernetes
-# instance in the test environment.
+# is needed to have access to sudo in the test environment. Sudo is 
+# needed to have docker in the test environment. Docker is needed to
+# launch a kubernetes instance in the test environment.
 # (Dependencies are fun! :) )
 before_install:
   - cat /proc/net/if_inet6
@@ -36,4 +36,4 @@ before_script:
 
 script:
   - go test -tags etcd -race -bench=. ./...
-  - ./middleware/kubernetes/test/kubectl version && go test -tags k8sIntegration -race -bench=. -run 'TestK8sIntegration' ./test
+  - ./middleware/kubernetes/test/kubectl version && go test -tags k8s -race -bench=. -run 'TestK8sIntegration' ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,29 @@
+sudo: required
+# Trusty distribution is much faster when sudo is required
+dist: trusty
+
 language: go
 go:
   - 1.5
   - 1.6
+
+# Note: with sudo enabled IPv6 networking is not configured on eth0
+#       this difference breaks the coredns tests.
+before_install:
+  - cat /proc/net/if_inet6
+  - cat /etc/network/interfaces
+  - ls -la /etc/network/interfaces.d/
+  - cat /etc/network/interfaces.d/*.cfg
+  - sudo modprobe ipv6
+  - sudo sh -c 'echo "auto eth0" >> /etc/network/interfaces.d/eth0.cfg'
+  - sudo sh -c 'echo "iface eth0 inet6 auto" >> /etc/network/interfaces.d/eth0.cfg'
+  - cat /etc/network/interfaces.d/*.cfg
+  - sudo ifdown eth0
+  - sudo ifup eth0
+  - cat /proc/net/if_inet6
+  - cat /etc/network/interfaces
+  - uname -a
+
 before_script:
   - curl -L  https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz -o etcd-v2.3.1-linux-amd64.tar.gz
   - tar xzvf etcd-v2.3.1-linux-amd64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,7 @@ before_install:
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - uname -a
-  - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
-  - sudo sysctl net.ipv6.conf.default.disable_ipv6=0
-  - sudo sysctl net.ipv6.conf.lo.disable_ipv6=0
-  - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
-  - #sudo ifdown eth0
-  - #sudo ifup eth0
+  - if [ `cat /proc/net/if_inet6 | wc -l` = "0" ]; then $(sudo sysctl net.ipv6.conf.all.disable_ipv6=0) ; $(sudo sysctl net.ipv6.conf.default.disable_ipv6=0) ; $(sudo sysctl net.ipv6.conf.lo.disable_ipv6=0) ; fi
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,23 +12,13 @@ go:
 before_install:
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
-  - ls -la /etc/network/interfaces.d/
-  - cat /etc/network/interfaces.d/*.cfg
-  - sudo modprobe ipv6
-  - sudo sh -c 'echo "auto eth0" >> /etc/network/interfaces.d/eth0.cfg'
-  - sudo sh -c 'echo "iface eth0 inet6 auto" >> /etc/network/interfaces.d/eth0.cfg'
-  - cat /etc/network/interfaces.d/*.cfg
-  - sudo ifdown eth0
-  - sudo ifup eth0
-  - cat /proc/net/if_inet6
-  - cat /etc/network/interfaces
   - uname -a
   - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
   - sudo sysctl net.ipv6.conf.default.disable_ipv6=0
   - sudo sysctl net.ipv6.conf.lo.disable_ipv6=0
   - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
-  - sudo ifdown eth0
-  - sudo ifup eth0
+  - #sudo ifdown eth0
+  - #sudo ifup eth0
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,10 @@ before_script:
   - ./etcd-v2.3.1-linux-amd64/etcd &
   - go get
   - go get github.com/coreos/go-etcd/etcd
-  - docker ps -a
   - if which docker &>/dev/null ; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
   - pwd
   - if which docker &>/dev/null ; then ./middleware/kubernetes/test/00_run_k8s.sh && ./middleware/kubernetes/test/10_setup_kubectl.sh && ./middleware/kubernetes/test/20_setup_k8s_services.sh ; docker ps -a ; fi
 
 script:
   - go test -tags etcd -race -bench=. ./...
-  - if ./middleware/kubernetes/test/kubctl version ; then make testk8s ; fi
+  - if ./middleware/kubernetes/test/kubectl version ; then make testk8s ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - ./etcd-v2.3.1-linux-amd64/etcd &
   - go get
   - go get github.com/coreos/go-etcd/etcd
-  - if [ `which docker` -eq 0 ]; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
+  - if ! which docker &>/dev/null ; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
   - pwd
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_script:
 
 script:
   - go test -tags etcd -race -bench=. ./...
-  - ./middleware/kubernetes/test/kubectl version && make testk8s
+  - ./middleware/kubernetes/test/kubectl version && go test -tags k8sIntegration -race -bench=. -run 'TestK8sIntegration' ./test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,26 @@ sudo: required
 # Trusty distribution is much faster when sudo is required
 dist: trusty
 
+services:
+  - docker
+
 language: go
 go:
   - 1.5
   - 1.6
 
-# Note: with sudo enabled IPv6 networking is not configured on eth0
-#       this difference breaks the coredns tests.
+# In the Travis VM-based build environment, IPv6 networking is not
+# enabled by default. The sysctl operations below enable IPv6.
+# IPv6 is needed by some of the CoreDNS test cases. The VM environment
+# is needed to have sudo in the test environment. Sudo is needed to have
+# docker in the test environment. Docker is needed to launch a kubernetes
+# instance in the test environment.
+# (Dependencies are fun! :) )
 before_install:
   - cat /proc/net/if_inet6
-  - cat /etc/network/interfaces
   - uname -a
   - sudo bash -c 'if [ `cat /proc/net/if_inet6 | wc -l` = "0" ]; then echo "Enabling IPv6" ; sysctl net.ipv6.conf.all.disable_ipv6=0 ; sysctl net.ipv6.conf.default.disable_ipv6=0 ; sysctl net.ipv6.conf.lo.disable_ipv6=0 ; fi'
   - cat /proc/net/if_inet6
-  - cat /etc/network/interfaces
   - env
 
 before_script:
@@ -24,5 +30,7 @@ before_script:
   - ./etcd-v2.3.1-linux-amd64/etcd &
   - go get
   - go get github.com/coreos/go-etcd/etcd
+  - if [ `which docker` -eq 0 ]; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
+
 script:
   - go test -tags etcd -race -bench=. ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ before_script:
   - go get
   - go get github.com/coreos/go-etcd/etcd
   - if [ `which docker` -eq 0 ]; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
+  - pwd
 
 script:
   - go test -tags etcd -race -bench=. ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - uname -a
-  - if [ `cat /proc/net/if_inet6 | wc -l` = "0" ]; then $(sudo sysctl net.ipv6.conf.all.disable_ipv6=0) ; $(sudo sysctl net.ipv6.conf.default.disable_ipv6=0) ; $(sudo sysctl net.ipv6.conf.lo.disable_ipv6=0) ; fi
+  - sudo bash -c 'if [ `cat /proc/net/if_inet6 | wc -l` = "0" ]; then echo "Enabling IPv6" ; sysctl net.ipv6.conf.all.disable_ipv6=0 ; sysctl net.ipv6.conf.default.disable_ipv6=0 ; sysctl net.ipv6.conf.lo.disable_ipv6=0 ; fi'
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - env

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,11 @@ before_script:
   - ./etcd-v2.3.1-linux-amd64/etcd &
   - go get
   - go get github.com/coreos/go-etcd/etcd
-  - if ! which docker &>/dev/null ; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
+  - docker ps -a
+  - if which docker &>/dev/null ; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
   - pwd
+  - if which docker &>/dev/null ; then ./middleware/kubernetes/test/00_run_k8s.sh && ./middleware/kubernetes/test/10_setup_kubectl.sh && ./middleware/kubernetes/test/20_setup_k8s_services.sh ; docker ps -a ; fi
 
 script:
   - go test -tags etcd -race -bench=. ./...
+  - if ./middleware/kubernetes/test/kubctl version ; then make testk8s ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_script:
 
 script:
   - go test -tags etcd -race -bench=. ./...
-  - if ./middleware/kubernetes/test/kubectl version ; then make testk8s ; fi
+  - ./middleware/kubernetes/test/kubectl version && make testk8s

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,14 @@ before_install:
   - cat /proc/net/if_inet6
   - cat /etc/network/interfaces
   - uname -a
+  - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+  - sudo sysctl net.ipv6.conf.default.disable_ipv6=0
+  - sudo sysctl net.ipv6.conf.lo.disable_ipv6=0
+  - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+  - sudo ifdown eth0
+  - sudo ifup eth0
+  - cat /proc/net/if_inet6
+  - cat /etc/network/interfaces
 
 before_script:
   - curl -L  https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz -o etcd-v2.3.1-linux-amd64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ test:
 
 .PHONY: testk8s
 testk8s:
-#	go test $(TEST_VERBOSE) -tags=k8sIntegration ./...
-	go test $(TEST_VERBOSE) -tags=k8sIntegration -run 'TestK8sIntegration' ./test
+	go test $(TEST_VERBOSE) -tags=k8s -run 'TestK8sIntegration' ./test
 
 .PHONY: clean
 clean:

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -102,7 +102,7 @@ kubectl to communicate with kubernetes running on the localhost:
 ~~~
 #!/bin/bash
 
-BASEDIR=`realpath $(dirname ${0})`
+BASEDIR=`readlink -e $(dirname ${0})`
 
 ${BASEDIR}/kubectl config set-cluster test-doc --server=http://localhost:8080
 ${BASEDIR}/kubectl config set-context test-doc --cluster=test-doc

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -343,12 +343,14 @@ TBD:
 	* Do we need to generate synthetic zone records for namespaces?
 	* Do we need to generate synthetic zone records for the skydns synthetic zones?
 * Test cases
-	* ~~Implement test cases for http data parsing using dependency injection
-	  for http get operations.~~
 	* Test with CoreDNS caching. CoreDNS caching for DNS response is working
 	  using the `cache` directive. Tested working using 20s cache timeout
 	  and A-record queries. Automate testing with cache in place.
 	* Automate CoreDNS performance tests. Initially for zone files, and for
 	  pre-loaded k8s API cache.
-    * Automate integration testing with kubernetes. (k8s launch and service start-up
-      automation is in middleware/kubernetes/tests)
+    * Try to get rid of kubernetes launch scripts by moving operations into
+      .travis.yml file.
+	* ~~Implement test cases for http data parsing using dependency injection
+	  for http get operations.~~
+    * ~~Automate integration testing with kubernetes. (k8s launch and service start-up
+      automation is in middleware/kubernetes/tests)~~

--- a/middleware/kubernetes/test/00_run_k8s.sh
+++ b/middleware/kubernetes/test/00_run_k8s.sh
@@ -7,7 +7,6 @@ K8S_VERSION="v1.2.4"
 
 ARCH="amd64"
 
-
 export K8S_VERSION
 export ARCH
 

--- a/middleware/kubernetes/test/10_setup_kubectl.sh
+++ b/middleware/kubernetes/test/10_setup_kubectl.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 PWD=`pwd`
-BASEDIR=`realpath $(dirname ${0})`
+BASEDIR=`readlink -e $(dirname ${0})`
+
+echo ${BASEDIR}
+exit
 
 cd ${BASEDIR}
 if [ ! -e kubectl ]; then

--- a/middleware/kubernetes/test/10_setup_kubectl.sh
+++ b/middleware/kubernetes/test/10_setup_kubectl.sh
@@ -3,9 +3,6 @@
 PWD=`pwd`
 BASEDIR=`readlink -e $(dirname ${0})`
 
-echo ${BASEDIR}
-exit
-
 cd ${BASEDIR}
 if [ ! -e kubectl ]; then
 	curl -O http://storage.googleapis.com/kubernetes-release/release/v1.2.4/bin/linux/amd64/kubectl

--- a/middleware/kubernetes/test/15_run_skydns.sh
+++ b/middleware/kubernetes/test/15_run_skydns.sh
@@ -2,6 +2,11 @@
 
 # Running skydns based on instructions at: https://testdatamanagement.wordpress.com/2015/09/01/running-kubernetes-in-docker-with-dns-on-a-single-node/
 
+PWD=`pwd`
+BASEDIR=`readlink -e $(dirname ${0})`
+
+cd ${BASEDIR}
+
 KUBECTL='./kubectl'
 
 #RUN_SKYDNS="yes"
@@ -15,7 +20,7 @@ wait_until_k8s_ready() {
 		if [ "${?}" = "0" ]; then
 			break
 		else
-			echo "sleeping for 5 seconds"
+			echo "sleeping for 5 seconds (waiting for kubernetes to start)"
 			sleep 5
 		fi
 	done
@@ -37,3 +42,5 @@ if [ "${RUN_SKYDNS}" = "yes" ]; then
 else
 	true
 fi
+
+cd ${PWD}

--- a/middleware/kubernetes/test/20_setup_k8s_services.sh
+++ b/middleware/kubernetes/test/20_setup_k8s_services.sh
@@ -11,7 +11,6 @@ wait_until_k8s_ready() {
 	# Wait until kubernetes is up and fully responsive
 	while :
 	do
-   	    ${KUBECTL} get nodes | grep -q '127.0.0.1'
    	    ${KUBECTL} get nodes 2>/dev/null | grep -q '127.0.0.1'
 		if [ "${?}" = "0" ]; then
 			break

--- a/middleware/kubernetes/test/20_setup_k8s_services.sh
+++ b/middleware/kubernetes/test/20_setup_k8s_services.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 
+PWD=`pwd`
+BASEDIR=`readlink -e $(dirname ${0})`
+
+cd ${BASEDIR}
+
 KUBECTL='./kubectl'
 
 wait_until_k8s_ready() {
 	# Wait until kubernetes is up and fully responsive
 	while :
 	do
-   	 ${KUBECTL} get nodes 2>/dev/null | grep -q '127.0.0.1'
+   	    ${KUBECTL} get nodes | grep -q '127.0.0.1'
+   	    ${KUBECTL} get nodes 2>/dev/null | grep -q '127.0.0.1'
 		if [ "${?}" = "0" ]; then
 			break
 		else
-			echo "sleeping for 5 seconds"
+			echo "sleeping for 5 seconds (waiting for kubernetes to start)"
 			sleep 5
 		fi
 	done
@@ -78,3 +84,5 @@ run_and_expose_service webserver test nginx 80
 echo ""
 echo "Services exposed:"
 ${KUBECTL} get services --all-namespaces
+
+cd ${PWD}

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -1,4 +1,4 @@
-// +build k8sIntegration
+// +build k8s
 
 package test
 


### PR DESCRIPTION
Updating travis yaml file to:
- Force IPv6 to work in their VM environment
- Enable docker (requires VM environment and sudo)
- Run kubernetes integration tests in Travis

@miekg Please review, this impacts everyone using the CoreDNS codebase with Travis.
