### PR TITLE
Fix stubzone retention

### DIFF
--- a/conf/chaosCorefile
+++ b/conf/chaosCorefile
@@ -1,0 +1,4 @@
+.:1053 authors.bind:1053 {
+    chaos CoreDNS-001 "Miek Gieben" miek@miek.nl
+    proxy . 8.8.8.8:53
+}

--- a/conf/etcdCorefile
+++ b/conf/etcdCorefile
@@ -1,0 +1,10 @@
+.:1053 {
+    etcd skydns.local {
+        stubzones
+        path /skydns
+        endpoint http://localhost:2379
+        upstream 8.8.8.8:53 8.8.4.4:53
+        debug
+    }
+    proxy . 8.8.8.8:53
+}

--- a/core/setup/etcd.go
+++ b/core/setup/etcd.go
@@ -38,7 +38,7 @@ func Etcd(c *Controller) (middleware.Middleware, error) {
 	}, nil
 }
 
-func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
+func etcdParse(c *Controller) (*etcd.Etcd, bool, error) {
 	stub := make(map[string]proxy.Proxy)
 	etc := etcd.Etcd{
 		Proxy:      proxy.New([]string{"8.8.8.8:53", "8.8.4.4:53"}),
@@ -72,19 +72,19 @@ func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
 					etc.Debug = true
 				case "path":
 					if !c.NextArg() {
-						return etcd.Etcd{}, false, c.ArgErr()
+						return &etcd.Etcd{}, false, c.ArgErr()
 					}
 					etc.PathPrefix = c.Val()
 				case "endpoint":
 					args := c.RemainingArgs()
 					if len(args) == 0 {
-						return etcd.Etcd{}, false, c.ArgErr()
+						return &etcd.Etcd{}, false, c.ArgErr()
 					}
 					endpoints = args
 				case "upstream":
 					args := c.RemainingArgs()
 					if len(args) == 0 {
-						return etcd.Etcd{}, false, c.ArgErr()
+						return &etcd.Etcd{}, false, c.ArgErr()
 					}
 					for i := 0; i < len(args); i++ {
 						h, p, e := net.SplitHostPort(args[i])
@@ -97,7 +97,7 @@ func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
 				case "tls": // cert key cacertfile
 					args := c.RemainingArgs()
 					if len(args) != 3 {
-						return etcd.Etcd{}, false, c.ArgErr()
+						return &etcd.Etcd{}, false, c.ArgErr()
 					}
 					tlsCertFile, tlsKeyFile, tlsCAcertFile = args[0], args[1], args[2]
 				}
@@ -109,19 +109,19 @@ func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
 						etc.Debug = true
 					case "path":
 						if !c.NextArg() {
-							return etcd.Etcd{}, false, c.ArgErr()
+							return &etcd.Etcd{}, false, c.ArgErr()
 						}
 						etc.PathPrefix = c.Val()
 					case "endpoint":
 						args := c.RemainingArgs()
 						if len(args) == 0 {
-							return etcd.Etcd{}, false, c.ArgErr()
+							return &etcd.Etcd{}, false, c.ArgErr()
 						}
 						endpoints = args
 					case "upstream":
 						args := c.RemainingArgs()
 						if len(args) == 0 {
-							return etcd.Etcd{}, false, c.ArgErr()
+							return &etcd.Etcd{}, false, c.ArgErr()
 						}
 						for i := 0; i < len(args); i++ {
 							h, p, e := net.SplitHostPort(args[i])
@@ -133,7 +133,7 @@ func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
 					case "tls": // cert key cacertfile
 						args := c.RemainingArgs()
 						if len(args) != 3 {
-							return etcd.Etcd{}, false, c.ArgErr()
+							return &etcd.Etcd{}, false, c.ArgErr()
 						}
 						tlsCertFile, tlsKeyFile, tlsCAcertFile = args[0], args[1], args[2]
 					}
@@ -141,13 +141,13 @@ func etcdParse(c *Controller) (etcd.Etcd, bool, error) {
 			}
 			client, err := newEtcdClient(endpoints, tlsCertFile, tlsKeyFile, tlsCAcertFile)
 			if err != nil {
-				return etcd.Etcd{}, false, err
+				return &etcd.Etcd{}, false, err
 			}
 			etc.Client = client
-			return etc, stubzones, nil
+			return &etc, stubzones, nil
 		}
 	}
-	return etcd.Etcd{}, false, nil
+	return &etcd.Etcd{}, false, nil
 }
 
 func newEtcdClient(endpoints []string, tlsCert, tlsKey, tlsCACert string) (etcdc.KeysAPI, error) {

--- a/middleware/chaos/README.md
+++ b/middleware/chaos/README.md
@@ -1,7 +1,7 @@
 # chaos
 
 The `chaos` middleware allows CoreDNS to response to TXT queries in CH class.
-Useful for retrieving version or author information from the server.
+Useful for retrieving version or author information from the server. If 
 
 ## Syntax
 
@@ -12,9 +12,9 @@ chaos [version] [authors...]
 * `version` the version to return, defaults to CoreDNS.
 * `authors` what authors to return. No default.
 
-Note this middleware can only be specified for a zone once. This is because it hijacks
-the zones `version.bind`, `version.server`, `authors.bind`, `hostname.bind` and
-`id.server`, which means it can only be routed to one middleware.
+Note that you have to make sure that this middleware will get actual queries for the
+following zones: `version.bind`, `version.server`, `authors.bind`, `hostname.bind` and
+`id.server`.
 
 ## Examples
 

--- a/middleware/etcd/debug.go
+++ b/middleware/etcd/debug.go
@@ -12,11 +12,12 @@ const debugName = "o-o.debug."
 
 // isDebug checks if name is a debugging name, i.e. starts with o-o.debug.
 // it return the empty string if it is not a debug message, otherwise it will return the
-// name with o-o.debug. stripped off.
+// name with o-o.debug. stripped off. Must be called with name lowercased.
 func isDebug(name string) string {
 	if len(name) == len(debugName) {
 		return ""
 	}
+	name = strings.ToLower(name)
 	debug := strings.HasPrefix(name, debugName)
 	if !debug {
 		return ""

--- a/middleware/etcd/debug_test.go
+++ b/middleware/etcd/debug_test.go
@@ -4,6 +4,7 @@ package etcd
 
 import (
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/miekg/coredns/middleware"
@@ -13,17 +14,17 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestisDebug(t *testing.T) {
+func TestIsDebug(t *testing.T) {
 	if ok := isDebug("o-o.debug.miek.nl."); ok != "miek.nl." {
 		t.Errorf("expected o-o.debug.miek.nl. to be debug")
 	}
-	if ok := isDebug("o-o.Debug.miek.nl."); ok != "miek.nl." {
+	if ok := isDebug(strings.ToLower("o-o.Debug.miek.nl.")); ok != "miek.nl." {
 		t.Errorf("expected o-o.Debug.miek.nl. to be debug")
 	}
-	if ok := isDebug("i-o.Debug.miek.nl."); ok != "" {
+	if ok := isDebug("i-o.debug.miek.nl."); ok != "" {
 		t.Errorf("expected i-o.Debug.miek.nl. to be non-debug")
 	}
-	if ok := isDebug("i-o.Debug."); ok != "" {
+	if ok := isDebug(strings.ToLower("i-o.Debug.")); ok != "" {
 		t.Errorf("expected o-o.Debug. to be non-debug")
 	}
 }
@@ -35,6 +36,7 @@ func TestDebugLookup(t *testing.T) {
 	}
 	etc.Debug = true
 	defer func() { etc.Debug = false }()
+
 	for _, tc := range dnsTestCasesDebug {
 		m := tc.Msg()
 

--- a/middleware/etcd/lookup.go
+++ b/middleware/etcd/lookup.go
@@ -12,20 +12,24 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (e Etcd) records(state middleware.State, exact bool) (services, debug []msg.Service, err error) {
+type Options struct {
+	Debug string
+}
+
+func (e Etcd) records(state middleware.State, exact bool, opt Options) (services, debug []msg.Service, err error) {
 	services, err = e.Records(state.Name(), exact)
 	if err != nil {
 		return
 	}
-	if e.debug != "" {
+	if opt.Debug != "" {
 		debug = services
 	}
 	services = msg.Group(services)
 	return
 }
 
-func (e Etcd) A(zone string, state middleware.State, previousRecords []dns.RR) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, false)
+func (e Etcd) A(zone string, state middleware.State, previousRecords []dns.RR, opt Options) (records []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, debug, err
 	}
@@ -50,7 +54,7 @@ func (e Etcd) A(zone string, state middleware.State, previousRecords []dns.RR) (
 			}
 
 			state1 := copyState(state, serv.Host, state.QType())
-			nextRecords, nextDebug, err := e.A(zone, state1, append(previousRecords, newRecord))
+			nextRecords, nextDebug, err := e.A(zone, state1, append(previousRecords, newRecord), opt)
 
 			if err == nil {
 				// Not only have we found something we should add the CNAME and the IP addresses.
@@ -84,8 +88,8 @@ func (e Etcd) A(zone string, state middleware.State, previousRecords []dns.RR) (
 	return records, debug, nil
 }
 
-func (e Etcd) AAAA(zone string, state middleware.State, previousRecords []dns.RR) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, false)
+func (e Etcd) AAAA(zone string, state middleware.State, previousRecords []dns.RR, opt Options) (records []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, debug, err
 	}
@@ -110,7 +114,7 @@ func (e Etcd) AAAA(zone string, state middleware.State, previousRecords []dns.RR
 			}
 
 			state1 := copyState(state, serv.Host, state.QType())
-			nextRecords, nextDebug, err := e.AAAA(zone, state1, append(previousRecords, newRecord))
+			nextRecords, nextDebug, err := e.AAAA(zone, state1, append(previousRecords, newRecord), opt)
 
 			if err == nil {
 				// Not only have we found something we should add the CNAME and the IP addresses.
@@ -147,8 +151,8 @@ func (e Etcd) AAAA(zone string, state middleware.State, previousRecords []dns.RR
 
 // SRV returns SRV records from etcd.
 // If the Target is not a name but an IP address, a name is created on the fly.
-func (e Etcd) SRV(zone string, state middleware.State) (records, extra []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, false)
+func (e Etcd) SRV(zone string, state middleware.State, opt Options) (records, extra []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -206,7 +210,7 @@ func (e Etcd) SRV(zone string, state middleware.State) (records, extra []dns.RR,
 			// Internal name, we should have some info on them, either v4 or v6
 			// Clients expect a complete answer, because we are a recursor in their view.
 			state1 := copyState(state, srv.Target, dns.TypeA)
-			addr, debugAddr, e1 := e.A(zone, state1, nil)
+			addr, debugAddr, e1 := e.A(zone, state1, nil, opt)
 			if e1 == nil {
 				extra = append(extra, addr...)
 				debug = append(debug, debugAddr...)
@@ -231,8 +235,8 @@ func (e Etcd) SRV(zone string, state middleware.State) (records, extra []dns.RR,
 
 // MX returns MX records from etcd.
 // If the Target is not a name but an IP address, a name is created on the fly.
-func (e Etcd) MX(zone string, state middleware.State) (records, extra []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, false)
+func (e Etcd) MX(zone string, state middleware.State, opt Options) (records, extra []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, nil, debug, err
 	}
@@ -271,7 +275,7 @@ func (e Etcd) MX(zone string, state middleware.State) (records, extra []dns.RR, 
 			}
 			// Internal name
 			state1 := copyState(state, mx.Mx, dns.TypeA)
-			addr, debugAddr, e1 := e.A(zone, state1, nil)
+			addr, debugAddr, e1 := e.A(zone, state1, nil, opt)
 			if e1 == nil {
 				extra = append(extra, addr...)
 				debug = append(debug, debugAddr...)
@@ -290,8 +294,8 @@ func (e Etcd) MX(zone string, state middleware.State) (records, extra []dns.RR, 
 	return records, extra, debug, nil
 }
 
-func (e Etcd) CNAME(zone string, state middleware.State) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, true)
+func (e Etcd) CNAME(zone string, state middleware.State, opt Options) (records []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, true, opt)
 	if err != nil {
 		return nil, debug, err
 	}
@@ -306,8 +310,8 @@ func (e Etcd) CNAME(zone string, state middleware.State) (records []dns.RR, debu
 }
 
 // PTR returns the PTR records, only services that have a domain name as host are included.
-func (e Etcd) PTR(zone string, state middleware.State) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, true)
+func (e Etcd) PTR(zone string, state middleware.State, opt Options) (records []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, true, opt)
 	if err != nil {
 		return nil, debug, err
 	}
@@ -320,8 +324,8 @@ func (e Etcd) PTR(zone string, state middleware.State) (records []dns.RR, debug 
 	return records, debug, nil
 }
 
-func (e Etcd) TXT(zone string, state middleware.State) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := e.records(state, false)
+func (e Etcd) TXT(zone string, state middleware.State, opt Options) (records []dns.RR, debug []msg.Service, err error) {
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, debug, err
 	}
@@ -335,14 +339,14 @@ func (e Etcd) TXT(zone string, state middleware.State) (records []dns.RR, debug 
 	return records, debug, nil
 }
 
-func (e Etcd) NS(zone string, state middleware.State) (records, extra []dns.RR, debug []msg.Service, err error) {
+func (e Etcd) NS(zone string, state middleware.State, opt Options) (records, extra []dns.RR, debug []msg.Service, err error) {
 	// NS record for this zone live in a special place, ns.dns.<zone>. Fake our lookup.
 	// only a tad bit fishy...
 	old := state.QName()
 
 	state.Clear()
 	state.Req.Question[0].Name = "ns.dns." + zone
-	services, debug, err := e.records(state, false)
+	services, debug, err := e.records(state, false, opt)
 	if err != nil {
 		return nil, nil, debug, err
 	}
@@ -368,7 +372,7 @@ func (e Etcd) NS(zone string, state middleware.State) (records, extra []dns.RR, 
 }
 
 // SOA Record returns a SOA record.
-func (e Etcd) SOA(zone string, state middleware.State) ([]dns.RR, []msg.Service, error) {
+func (e Etcd) SOA(zone string, state middleware.State, opt Options) ([]dns.RR, []msg.Service, error) {
 	header := dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Ttl: 300, Class: dns.ClassINET}
 
 	soa := &dns.SOA{Hdr: header,

--- a/middleware/etcd/multi_test.go
+++ b/middleware/etcd/multi_test.go
@@ -14,13 +14,13 @@ import (
 )
 
 func TestMultiLookup(t *testing.T) {
-	etcMulti := etc
+	etcMulti := *etc
 	etcMulti.Zones = []string{"skydns.test.", "miek.nl."}
 	etcMulti.Next = test.ErrorHandler()
 
 	for _, serv := range servicesMulti {
-		set(t, etcMulti, serv.Key, 0, serv)
-		defer delete(t, etcMulti, serv.Key)
+		set(t, &etcMulti, serv.Key, 0, serv)
+		defer delete(t, &etcMulti, serv.Key)
 	}
 	for _, tc := range dnsTestCasesMulti {
 		m := tc.Msg()

--- a/middleware/etcd/setup_test.go
+++ b/middleware/etcd/setup_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	etc    Etcd
+	etc    *Etcd
 	client etcdc.KeysAPI
 	ctxt   context.Context
 )
@@ -32,7 +32,7 @@ func init() {
 		Endpoints: []string{"http://localhost:2379"},
 	}
 	cli, _ := etcdc.New(etcdCfg)
-	etc = Etcd{
+	etc = &Etcd{
 		Proxy:      proxy.New([]string{"8.8.8.8:53"}),
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
@@ -42,7 +42,7 @@ func init() {
 	}
 }
 
-func set(t *testing.T, e Etcd, k string, ttl time.Duration, m *msg.Service) {
+func set(t *testing.T, e *Etcd, k string, ttl time.Duration, m *msg.Service) {
 	b, err := json.Marshal(m)
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func set(t *testing.T, e Etcd, k string, ttl time.Duration, m *msg.Service) {
 	e.Client.Set(ctxt, path, string(b), &etcdc.SetOptions{TTL: ttl})
 }
 
-func delete(t *testing.T, e Etcd, k string) {
+func delete(t *testing.T, e *Etcd, k string) {
 	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
 	e.Client.Delete(ctxt, path, &etcdc.DeleteOptions{Recursive: false})
 }

--- a/middleware/etcd/stub.go
+++ b/middleware/etcd/stub.go
@@ -13,7 +13,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (e Etcd) UpdateStubZones() {
+func (e *Etcd) UpdateStubZones() {
 	go func() {
 		for {
 			e.updateStubZones()

--- a/middleware/etcd/stub_cycle_test.go
+++ b/middleware/etcd/stub_cycle_test.go
@@ -17,6 +17,7 @@ func TestStubCycle(t *testing.T) {
 		defer delete(t, etc, serv.Key)
 	}
 	etc.updateStubZones()
+	defer func() { etc.Stubmap = nil }()
 
 	for _, tc := range dnsTestCasesCycleStub {
 		m := tc.Msg()

--- a/middleware/etcd/stub_handler.go
+++ b/middleware/etcd/stub_handler.go
@@ -12,7 +12,7 @@ import (
 
 // Stub wraps an Etcd. We have this type so that it can have a ServeDNS method.
 type Stub struct {
-	Etcd
+	*Etcd
 	Zone string // for what zone (and thus what nameservers are we called)
 }
 

--- a/middleware/etcd/stub_test.go
+++ b/middleware/etcd/stub_test.go
@@ -19,6 +19,7 @@ func TestStubLookup(t *testing.T) {
 		defer delete(t, etc, serv.Key)
 	}
 	etc.updateStubZones()
+	defer func() { etc.Stubmap = nil }()
 
 	for _, tc := range dnsTestCasesStub {
 		m := tc.Msg()

--- a/middleware/test/helpers.go
+++ b/middleware/test/helpers.go
@@ -21,6 +21,7 @@ func (p RRSet) Len() int           { return len(p) }
 func (p RRSet) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func (p RRSet) Less(i, j int) bool { return p[i].String() < p[j].String() }
 
+// If the TTL of a record is 303 we don't care what the TTL is.
 type Case struct {
 	Qname  string
 	Qtype  uint16

--- a/server/server.go
+++ b/server/server.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/miekg/coredns/middleware"
-	"github.com/miekg/coredns/middleware/chaos"
 	"github.com/miekg/coredns/middleware/metrics"
 
 	"github.com/miekg/dns"
@@ -111,19 +110,6 @@ func New(addr string, configs []Config, gracefulTimeout time.Duration) (*Server,
 		}
 
 		s.zones[conf.Host] = z
-
-		// A bit of a hack. Loop through the middlewares of this zone and check if
-		// they have enabled the chaos middleware. If so add the special chaos zones.
-	Middleware:
-		for _, mid := range z.config.Middleware {
-			fn := mid(nil)
-			if _, ok := fn.(chaos.Chaos); ok {
-				for _, ch := range []string{"authors.bind.", "version.bind.", "version.server.", "hostname.bind.", "id.server."} {
-					s.zones[ch] = z
-				}
-				break Middleware
-			}
-		}
 	}
 
 	return s, nil

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -2,10 +2,103 @@
 
 package test
 
-import "testing"
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/miekg/coredns/middleware"
+	"github.com/miekg/coredns/middleware/etcd"
+	"github.com/miekg/coredns/middleware/etcd/msg"
+	"github.com/miekg/coredns/middleware/proxy"
+	"github.com/miekg/coredns/middleware/test"
+
+	etcdc "github.com/coreos/etcd/client"
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+func etcdMiddleware() *etcd.Etcd {
+	etcdCfg := etcdc.Config{
+		Endpoints: []string{"http://localhost:2379"},
+	}
+	cli, _ := etcdc.New(etcdCfg)
+	client := etcdc.NewKeysAPI(cli)
+	return &etcd.Etcd{Client: client}
+}
 
 // This test starts two coredns servers (and needs etcd). Configure a stubzones in both (that will loop) and
 // will then test if we detect this loop.
 func TestEtcdStubForwarding(t *testing.T) {
 	// TODO(miek)
+}
+
+func TestEtcdStubAndProxyLookup(t *testing.T) {
+	corefile := `.:0 {
+    etcd skydns.local {
+        stubzones
+        path /skydns
+        endpoint http://localhost:2379
+        upstream 8.8.8.8:53 8.8.4.4:53
+    }
+    proxy . 8.8.8.8:53
+}`
+
+	etc := etcdMiddleware()
+	ex, _, udp, err := Server(t, corefile)
+	if err != nil {
+		t.Fatalf("Could get server: %s", err)
+	}
+	defer ex.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	var ctx = context.TODO()
+	for _, serv := range servicesStub { // adds example.{net,org} as stubs
+		set(ctx, t, etc, serv.Key, 0, serv)
+		defer delete(ctx, t, etc, serv.Key)
+	}
+
+	p := proxy.New([]string{udp}) // use udp port from the server
+	state := middleware.State{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.com.", dns.TypeA)
+	if err != nil {
+		t.Error("Expected to receive reply, but didn't")
+		return
+	}
+	if len(resp.Answer) == 0 {
+		t.Error("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Error("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "93.184.216.34" {
+		t.Error("Expected 93.184.216.34, got: %d", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
+var servicesStub = []*msg.Service{
+	// Two tests, ask a question that should return servfail because remote it no accessible
+	// and one with edns0 option added, that should return refused.
+	{Host: "127.0.0.1", Port: 666, Key: "b.example.org.stub.dns.skydns.test."},
+	// Actual test that goes out to the internet.
+	{Host: "199.43.132.53", Key: "a.example.net.stub.dns.skydns.test."},
+}
+
+// Copied from middleware/etcd/setup_test.go
+func set(ctx context.Context, t *testing.T, e *etcd.Etcd, k string, ttl time.Duration, m *msg.Service) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Set(ctx, path, string(b), &etcdc.SetOptions{TTL: ttl})
+}
+
+// Copied from middleware/etcd/setup_test.go
+func delete(ctx context.Context, t *testing.T, e *etcd.Etcd, k string) {
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Delete(ctx, path, &etcdc.DeleteOptions{Recursive: false})
 }


### PR DESCRIPTION
Make the receiver a pointer so that the uptdateStubZones map update will
retain the stubzones found, unlike the current case where the update
will be applied and then promptly forgotten, because it is working on a
copy.
