### PR TITLE
Fix BUILD VERBOSE and add ldflags to reduce size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ TEST_VERBOSE :=
 TEST_VERBOSE := -v
 
 all:
-	go build $(BUILD_VERBOSE)
+	go build ${BUILD_VERBOSE} -ldflags="-s -w"
 
 .PHONY: docker
 docker:
-	GOOS=linux go build -a -tags netgo -installsuffix netgo
+	GOOS=linux go build -a -tags netgo -installsuffix netgo -ldflags="-s -w"
 	docker build -t $$USER/coredns .
 
 .PHONY: deps


### PR DESCRIPTION
- fix BUILD_VERBOSE
- add ldflags to reduce the binary size (22M -> 16M)

https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/
