### PR TITLE
Adding label selector support to Corefile

### DIFF
--- a/conf/k8sCorefile
+++ b/conf/k8sCorefile
@@ -12,7 +12,11 @@
         # Only expose the k8s namespace "demo"
         namespaces demo
         # Only expose the records for kubernetes objects
-        # that matches this label selector
+        # that matches this label selector. The label
+        # selector syntax is described in the kubernetes
+        # API documentation: http://kubernetes.io/docs/user-guide/labels/
+        # Example selector below only exposes objects tagged as
+        # "application=nginx" in the staging or qa environments.
         #labels environment in (staging, qa),application=nginx
     }
     # Perform DNS response caching for the coredns.local zone

--- a/conf/k8sCorefile
+++ b/conf/k8sCorefile
@@ -12,7 +12,7 @@
         # Only expose the k8s namespace "demo"
         namespaces demo
         # Only expose the records for kubernetes objects
-        # these labels
+        # that matches this label selector
         #labels environment in (staging, qa),application=nginx
     }
     # Perform DNS response caching for the coredns.local zone

--- a/conf/k8sCorefile
+++ b/conf/k8sCorefile
@@ -11,6 +11,9 @@
         template {service}.{namespace}.{zone}
         # Only expose the k8s namespace "demo"
         namespaces demo
+        # Only expose the records for kubernetes objects
+        # these labels
+        #labels environment in (staging, qa),application=nginx
     }
     # Perform DNS response caching for the coredns.local zone
     # Cache timeout is provided by the integer in seconds

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -44,6 +44,9 @@ This is the default kubernetes setup, with everything specified in full:
         template {service}.{namespace}.{zone}
         # Only expose the k8s namespace "demo"
         namespaces demo
+        # Only expose the records for kubernetes objects
+        # these labels
+        #labels environment in (staging, qa),application=nginx
     }
     # Perform DNS response caching for the coredns.local zone
     # Cache timeout is provided by the integer in seconds
@@ -51,10 +54,12 @@ This is the default kubernetes setup, with everything specified in full:
 }
 ~~~
 
-Notes:
+Defaults:
 * If the `namespaces` keyword is omitted, all kubernetes namespaces are exposed.
 * If the `template` keyword is omitted, the default template of "{service}.{namespace}.{zone}" is used.
 * If the `resyncperiod` keyword is omitted, the default resync period is 5 minutes.
+* The `labels` keyword is only used when filtering of results based on kubernetes label selector syntax
+  is required.
 
 ### Basic Setup
 
@@ -191,7 +196,7 @@ mynginx.demo.coredns.local. 0   IN  A   10.0.0.10
 
 ## Implementation Notes/Ideas
 
-### Basic Zone Mapping (implemented)
+### Basic Zone Mapping
 The middleware is configured with a "zone" string. For 
 example: "zone = coredns.local".
 
@@ -200,8 +205,8 @@ to: "myservice.mynamespace.coredns.local".
 
 The middleware should publish an A record for that service and a service record.
 
-Initial implementation just performs the above simple mapping. Subsequent 
-revisions should allow different namespaces to be published under different zones.
+If multiple zone names are specified, the records for kubernetes objects are
+exposed in all listed zones.
 
 For example:
 
@@ -262,11 +267,6 @@ return the IP addresses for all services with "nginx" in the service name.
 
 TBD:
 * How does this relate the the k8s load-balancer configuration?
-* Do wildcards search across namespaces? (Yes)
-* Initial implementation assumes that a namespace maps to the first DNS label
-  below the zone managed by the kubernetes middleware. This assumption may
-  need to be revised. (Template scheme for record names removes this assumption.)
-
 
 ## TODO
 * SkyDNS compatibility/equivalency:

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -45,7 +45,11 @@ This is the default kubernetes setup, with everything specified in full:
         # Only expose the k8s namespace "demo"
         namespaces demo
         # Only expose the records for kubernetes objects
-        # these labels
+        # that matches this label selector. The label
+        # selector syntax is described in the kubernetes
+        # API documentation: http://kubernetes.io/docs/user-guide/labels/
+        # Example selector below only exposes objects tagged as
+        # "application=nginx" in the staging or qa environments.
         #labels environment in (staging, qa),application=nginx
     }
     # Perform DNS response caching for the coredns.local zone
@@ -59,7 +63,8 @@ Defaults:
 * If the `template` keyword is omitted, the default template of "{service}.{namespace}.{zone}" is used.
 * If the `resyncperiod` keyword is omitted, the default resync period is 5 minutes.
 * The `labels` keyword is only used when filtering of results based on kubernetes label selector syntax
-  is required.
+  is required. The label selector syntax is described in the kubernetes API documentation at: 
+  http://kubernetes.io/docs/user-guide/labels/
 
 ### Basic Setup
 
@@ -318,7 +323,7 @@ TBD:
 * Additional features:
 	* Reverse IN-ADDR entries for services. (Is there any value in supporting 
 	  reverse lookup records?) (need tests, functionality should work based on @aledbf's code.)
-	* How to support label specification in Corefile to allow use of labels to 
+	* (done) ~~How to support label specification in Corefile to allow use of labels to 
 	  indicate zone? (Is this even useful?) For example, the following
 	  configuration exposes all services labeled for the "staging" environment
 	  and tenant "customerB" in the zone "customerB.stage.local":
@@ -326,11 +331,11 @@ TBD:
 			kubernetes customerB.stage.local {
 				# Use url for k8s API endpoint
 				endpoint http://localhost:8080
-				label "environment" : "staging", "tenant" : "customerB"
+				labels environment in (staging),tenant=customerB
 			}
 
 	  Note: label specification/selection is a killer feature for segmenting
-	  test vs staging vs prod environments.
+	  test vs staging vs prod environments.~~ Need label testing.
 	* Implement IP selection and ordering (internal/external). Related to
 	  wildcards and SkyDNS use of CNAMES.
 	* Flatten service and namespace names to valid DNS characters. (service names

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -324,7 +324,7 @@ TBD:
 	* Reverse IN-ADDR entries for services. (Is there any value in supporting 
 	  reverse lookup records?) (need tests, functionality should work based on @aledbf's code.)
 	* (done) ~~How to support label specification in Corefile to allow use of labels to 
-	  indicate zone? (Is this even useful?) For example, the following
+	  indicate zone? For example, the following
 	  configuration exposes all services labeled for the "staging" environment
 	  and tenant "customerB" in the zone "customerB.stage.local":
 

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -149,7 +149,6 @@ func (dns *dnsController) GetNamespaceList() *api.NamespaceList {
 }
 
 func (dns *dnsController) GetServiceList() *api.ServiceList {
-	log.Printf("[debug] here in GetServiceList")
 	svcList, err := dns.svcLister.List()
 	if err != nil {
 		return &api.ServiceList{}

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/cache"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/controller/framework"
+    "k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/watch"
 )
@@ -22,6 +23,8 @@ var (
 
 type dnsController struct {
 	client *client.Client
+
+    selector *labels.Selector
 
 	endpController *framework.Controller
 	svcController  *framework.Controller
@@ -40,68 +43,87 @@ type dnsController struct {
 }
 
 // newDNSController creates a controller for coredns
-func newdnsController(kubeClient *client.Client, resyncPeriod time.Duration) *dnsController {
+func newdnsController(kubeClient *client.Client, resyncPeriod time.Duration, lselector *labels.Selector) *dnsController {
 	dns := dnsController{
 		client: kubeClient,
+        selector: lselector,
 		stopCh: make(chan struct{}),
 	}
 
 	dns.endpLister.Store, dns.endpController = framework.NewInformer(
 		&cache.ListWatch{
-			ListFunc:  endpointsListFunc(dns.client, namespace),
-			WatchFunc: endpointsWatchFunc(dns.client, namespace),
+			ListFunc:  endpointsListFunc(dns.client, namespace, dns.selector),
+			WatchFunc: endpointsWatchFunc(dns.client, namespace, dns.selector),
 		},
 		&api.Endpoints{}, resyncPeriod, framework.ResourceEventHandlerFuncs{})
 
 	dns.svcLister.Store, dns.svcController = framework.NewInformer(
 		&cache.ListWatch{
-			ListFunc:  serviceListFunc(dns.client, namespace),
-			WatchFunc: serviceWatchFunc(dns.client, namespace),
+			ListFunc:  serviceListFunc(dns.client, namespace, dns.selector),
+			WatchFunc: serviceWatchFunc(dns.client, namespace, dns.selector),
 		},
 		&api.Service{}, resyncPeriod, framework.ResourceEventHandlerFuncs{})
 
 	dns.nsLister.Store, dns.nsController = framework.NewInformer(
 		&cache.ListWatch{
-			ListFunc:  namespaceListFunc(dns.client),
-			WatchFunc: namespaceWatchFunc(dns.client),
+			ListFunc:  namespaceListFunc(dns.client, dns.selector),
+			WatchFunc: namespaceWatchFunc(dns.client, dns.selector),
 		},
 		&api.Namespace{}, resyncPeriod, framework.ResourceEventHandlerFuncs{})
 
 	return &dns
 }
 
-func serviceListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
+func serviceListFunc(c *client.Client, ns string, s *labels.Selector) func(api.ListOptions) (runtime.Object, error) {
 	return func(opts api.ListOptions) (runtime.Object, error) {
+        if s != nil {
+            opts.LabelSelector = *s
+        }
 		return c.Services(ns).List(opts)
 	}
 }
 
-func serviceWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+func serviceWatchFunc(c *client.Client, ns string, s *labels.Selector) func(options api.ListOptions) (watch.Interface, error) {
 	return func(options api.ListOptions) (watch.Interface, error) {
+        if s != nil {
+            options.LabelSelector = *s
+        }
 		return c.Services(ns).Watch(options)
 	}
 }
 
-func endpointsListFunc(c *client.Client, ns string) func(api.ListOptions) (runtime.Object, error) {
+func endpointsListFunc(c *client.Client, ns string, s *labels.Selector) func(api.ListOptions) (runtime.Object, error) {
 	return func(opts api.ListOptions) (runtime.Object, error) {
+        if s != nil {
+            opts.LabelSelector = *s
+        }
 		return c.Endpoints(ns).List(opts)
 	}
 }
 
-func endpointsWatchFunc(c *client.Client, ns string) func(options api.ListOptions) (watch.Interface, error) {
+func endpointsWatchFunc(c *client.Client, ns string, s *labels.Selector) func(options api.ListOptions) (watch.Interface, error) {
 	return func(options api.ListOptions) (watch.Interface, error) {
+        if s != nil {
+            options.LabelSelector = *s
+        }
 		return c.Endpoints(ns).Watch(options)
 	}
 }
 
-func namespaceListFunc(c *client.Client) func(api.ListOptions) (runtime.Object, error) {
+func namespaceListFunc(c *client.Client, s *labels.Selector) func(api.ListOptions) (runtime.Object, error) {
 	return func(opts api.ListOptions) (runtime.Object, error) {
+        if s != nil {
+            opts.LabelSelector = *s
+        }
 		return c.Namespaces().List(opts)
 	}
 }
 
-func namespaceWatchFunc(c *client.Client) func(options api.ListOptions) (watch.Interface, error) {
+func namespaceWatchFunc(c *client.Client, s *labels.Selector) func(options api.ListOptions) (watch.Interface, error) {
 	return func(options api.ListOptions) (watch.Interface, error) {
+        if s != nil {
+            options.LabelSelector = *s
+        }
 		return c.Namespaces().Watch(options)
 	}
 }

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -15,20 +15,22 @@ import (
 
 	"github.com/miekg/dns"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	unversionedapi "k8s.io/kubernetes/pkg/api/unversioned"
+	unversionedclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
 
 type Kubernetes struct {
-	Next         middleware.Handler
-	Zones        []string
-	Proxy        proxy.Proxy // Proxy for looking up names during the resolution process
-	APIEndpoint  string
-	APIConn      *dnsController
-	ResyncPeriod time.Duration
-	NameTemplate *nametemplate.NameTemplate
-	Namespaces   []string
+	Next          middleware.Handler
+	Zones         []string
+	Proxy         proxy.Proxy // Proxy for looking up names during the resolution process
+	APIEndpoint   string
+	APIConn       *dnsController
+	ResyncPeriod  time.Duration
+	NameTemplate  *nametemplate.NameTemplate
+	Namespaces    []string
+	LabelSelector *unversionedapi.LabelSelector
 }
 
 func (g *Kubernetes) StartKubeCache() error {
@@ -45,7 +47,7 @@ func (g *Kubernetes) StartKubeCache() error {
 		log.Printf("[debug] error connecting to the client: %v", err)
 		return err
 	}
-	kubeClient, err := unversioned.New(config)
+	kubeClient, err := unversionedclient.New(config)
 
 	if err != nil {
 		log.Printf("[ERROR] Failed to create kubernetes notification controller: %v", err)


### PR DESCRIPTION
This PR implements k8s label selection to allow filtering of exposed services using the k8s label selector syntax. Syntax is described at: http://kubernetes.io/docs/user-guide/labels/

@aledbf Please review for any concerns. This updates how the k8s dns controller operates.

Basic manual testing works. Automated integration test cases to follow.
