### PR TITLE
Set correct versioning for CoreDNS

### DIFF
--- a/coredns.go
+++ b/coredns.go
@@ -10,15 +10,22 @@ import (
 //go:generate go run plugin_generate.go
 
 func main() {
-	// Default values for flags for CoreDNS.
-	flag.Set("type", "dns")
-
-	// Values specific for CoreDNS.
-	caddy.DefaultConfigFile = "Corefile"
-	caddy.AppName = "coredns"
-	caddy.AppVersion = version
+	setFlag()
+	setName()
 
 	caddymain.Run()
+}
+
+// setFlag sets flags to predefined values for CoreDNS.
+func setFlag() {
+	flag.Set("type", "dns")
+}
+
+// setName sets application name and versioning information for CoreDNS.
+func setName() {
+	caddy.DefaultConfigFile = "Corefile"
+	caddy.AppName = "CoreDNS"
+	caddy.AppVersion = version
 }
 
 const version = "001"


### PR DESCRIPTION
This needs a patch in caddy to work properly, but we want something like
it anyway.

See https://github.com/mholt/caddy/pull/1058 and #224
