### PR TITLE
Add a test for health middleware

### DIFF
--- a/middleware/health/health_test.go
+++ b/middleware/health/health_test.go
@@ -1,0 +1,37 @@
+package health
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+)
+
+func TestHealth(t *testing.T) {
+	// We use a random port instead of a fixed port like 8080 that may have been
+	// occupied by some other process.
+	health := Health{Addr: ":0"}
+	if err := health.Startup(); err != nil {
+		t.Fatalf("Unable to startup the health server: %v", err)
+	}
+	defer health.Shutdown()
+
+	// Reconstruct the http address based on the port allocated by operating system.
+	address := fmt.Sprintf("http://%s%s", health.ln.Addr().String(), path)
+
+	response, err := http.Get(address)
+	if err != nil {
+		t.Fatalf("Unable to query %s: %v", address, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		t.Errorf("Invalid status code: expecting '200', got '%d'", response.StatusCode)
+	}
+	content, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("Unable to get response body from %s: %v", address, err)
+	}
+	if string(content) != "OK" {
+		t.Errorf("Invalid response body: expecting 'OK', got '%s'", string(content))
+	}
+}


### PR DESCRIPTION
This commit adds a simple test of `TestHealth` for the middleware
of `health` so that there is coverage for this middleware.
