### PR TITLE
Fix proxy upstream parser issue and add test cases

### DIFF
--- a/middleware/proxy/setup.go
+++ b/middleware/proxy/setup.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func setup(c *caddy.Controller) error {
-	upstreams, err := NewStaticUpstreams(c.Dispenser)
+	upstreams, err := NewStaticUpstreams(&c.Dispenser)
 	if err != nil {
 		return middleware.Error("proxy", err)
 	}

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -44,7 +44,7 @@ type Options struct {
 
 // NewStaticUpstreams parses the configuration input and sets up
 // static upstreams for the proxy middleware.
-func NewStaticUpstreams(c caddyfile.Dispenser) ([]Upstream, error) {
+func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 	var upstreams []Upstream
 	for c.Next() {
 		upstream := &staticUpstream{
@@ -126,7 +126,7 @@ func (u *staticUpstream) Options() Options {
 	return u.options
 }
 
-func parseBlock(c caddyfile.Dispenser, u *staticUpstream) error {
+func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 	switch c.Val() {
 	case "policy":
 		if !c.NextArg() {


### PR DESCRIPTION
This fix tries to fix #261 where proxy upstream parser is not able to parse upstream correctly. (The patch was actually provided in #261)

Several test cases have also been added to cover the changes and prevent regression in the future.

This fix fixes #261.
