### PR TITLE
coredns: default Corefile

### DIFF
--- a/core/coredns.go
+++ b/core/coredns.go
@@ -23,6 +23,3 @@ import (
 	_ "github.com/miekg/coredns/middleware/secondary"
 	_ "github.com/miekg/coredns/middleware/whoami"
 )
-
-// Quiet mode will not show any informative output on initialization.
-var Quiet bool

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -1,6 +1,7 @@
 package dnsserver
 
 import (
+	"fmt"
 	"log"
 	"net"
 	"runtime"
@@ -211,6 +212,18 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	remoteHost := w.RemoteAddr().String()
 	DefaultErrorFunc(w, r, dns.RcodeRefused)
 	log.Printf("[INFO] \"%s %s %s\" - No such zone at %s (Remote: %s)", dns.Type(r.Question[0].Qtype), dns.Class(r.Question[0].Qclass), q, s.Addr, remoteHost)
+}
+
+// OnStartupComplete lists the sites served by this server
+// and any relevant information, assuming Quiet == false.
+func (s *Server) OnStartupComplete() {
+	if Quiet {
+		return
+	}
+
+	for zone, config := range s.zones {
+		fmt.Println(zone + ":" + config.Port)
+	}
 }
 
 // DefaultErrorFunc responds to an DNS request with an error.


### PR DESCRIPTION
When no Corefile is given default to loading the whoami middleware on
the default port (2053).
Also add back the -port flag that allows you to override the default
port.
