### PR TITLE
Golint middleware/proxy

### DIFF
--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -63,6 +63,7 @@ func (p Proxy) Lookup(state request.Request, name string, tpe uint16) (*dns.Msg,
 	return p.lookup(state, req)
 }
 
+// Forward will forward the request to upstream
 func (p Proxy) Forward(state request.Request) (*dns.Msg, error) {
 	return p.lookup(state, state.Req)
 }

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -21,6 +21,7 @@ type Proxy struct {
 	Upstreams []Upstream
 }
 
+// Client represents client information that the proxy uses.
 type Client struct {
 	UDP *dns.Client
 	TCP *dns.Client
@@ -104,6 +105,7 @@ func (p Proxy) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	return p.Next.ServeDNS(ctx, w, r)
 }
 
+// Clients returns the new client for proxy requests.
 func Clients() Client {
 	udp := newClient("udp", defaultTimeout)
 	tcp := newClient("tcp", defaultTimeout)

--- a/middleware/proxy/reverseproxy.go
+++ b/middleware/proxy/reverseproxy.go
@@ -7,12 +7,14 @@ import (
 	"github.com/miekg/dns"
 )
 
+// ReverseProxy is a basic reverse proxy
 type ReverseProxy struct {
 	Host    string
 	Client  Client
 	Options Options
 }
 
+// ServeDNS implements the middleware.Handler interface.
 func (p ReverseProxy) ServeDNS(w dns.ResponseWriter, r *dns.Msg, extra []dns.RR) error {
 	var (
 		reply *dns.Msg

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -39,6 +39,7 @@ type staticUpstream struct {
 	options           Options
 }
 
+// Options ...
 type Options struct {
 	Ecs []*net.IPNet // EDNS0 CLIENT SUBNET address (v4/v6) to add in CIDR notaton.
 }


### PR DESCRIPTION
While looking into the proxy middleware it appears that there are several golint messages. Think it makes sense to clean it up:

```
ubuntu@ubuntu:~/coredns$ golint middleware/proxy/
middleware/proxy/lookup.go:66:1: exported method Proxy.Forward should have comment or be unexported
middleware/proxy/proxy.go:24:6: exported type Client should have comment or be unexported
middleware/proxy/proxy.go:107:1: exported function Clients should have comment or be unexported
middleware/proxy/reverseproxy.go:10:6: exported type ReverseProxy should have comment or be unexported
middleware/proxy/reverseproxy.go:16:1: exported method ReverseProxy.ServeDNS should have comment or be unexported
middleware/proxy/upstream.go:42:6: exported type Options should have comment or be unexported
```

This fix addressed the above messages with necessary comments for exported functions.
