### PR TITLE
Nil SOA causes panic if we compare it to incoming SOA during transfer

### DIFF
--- a/middleware/file/secondary.go
+++ b/middleware/file/secondary.go
@@ -88,6 +88,9 @@ Transfer:
 	if serial == -1 {
 		return false, Err
 	}
+	if z.Apex.SOA == nil {
+		return true, Err
+	}
 	return less(z.Apex.SOA.Serial, uint32(serial)), Err
 }
 

--- a/middleware/file/secondary_test.go
+++ b/middleware/file/secondary_test.go
@@ -84,9 +84,17 @@ func TestShouldTransfer(t *testing.T) {
 	z.origin = testZone
 	z.TransferFrom = []string{addrstr}
 
+	// when we have a nil SOA (initial state)
+	should, err := z.shouldTransfer()
+	if err != nil {
+		t.Fatalf("unable to run shouldTransfer: %v", err)
+	}
+	if !should {
+		t.Fatalf("shouldTransfer should return true for serial: %d", soa.serial)
+	}
 	// Serial smaller
 	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, soa.serial-1))
-	should, err := z.shouldTransfer()
+	should, err = z.shouldTransfer()
 	if err != nil {
 		t.Fatalf("unable to run shouldTransfer: %v", err)
 	}


### PR DESCRIPTION
I'm working on setting up a dumb secondary server, one that doesn't have zone information already.

Scenario:
I first start up my secondary server.  Since my primary server isn't started up  yet, the initial transfer won't succeed.
After I start up my primary server it'll transfer the zone to the secondary.

Before this fix the secondary server would panic when the primary server did a transfer when comparing SOA records since the secondary didn't have a SOA record to begin with.

Secondary CoreDNS configuration: no zone file present.

```
foo.com:53 {
    errors stdout
    log stdout

        secondary foo.com {
                transfer from x.x.x.x
        }
}
```

Primary CoreDNS file

```
foo.com:53 {
    errors stdout
    log stdout

        file foo.com.zone {
            transfer to *
        }
}
```
