### PR TITLE
middleware/metrics: fix crash

### DIFF
--- a/middleware/metrics/setup.go
+++ b/middleware/metrics/setup.go
@@ -79,6 +79,6 @@ func prometheusParse(c *caddy.Controller) (Metrics, error) {
 	return met, err
 }
 
-var metricsOnce *sync.Once
+var metricsOnce sync.Once
 
 const addr = "localhost:9153"

--- a/middleware/metrics/setup_test.go
+++ b/middleware/metrics/setup_test.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestPrometheus(t *testing.T) {
+	tests := []struct {
+		input     string
+		shouldErr bool
+	}{
+		{`prometheus`, false},
+		{`prometheus {}`, false},   // TODO(miek): should be true
+		{`prometheus /foo`, false}, // TODO(miek): should be true
+		{`prometheus localhost:53`, false},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		err := setup(c)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %v: Expected error but found nil", i)
+		} else if !test.shouldErr && err != nil {
+			t.Errorf("Test %v: Expected no error but found error: %v", i, err)
+		}
+	}
+}


### PR DESCRIPTION
Fix the crash and add `setup_test.go` to catch this in the future.

Fixes #292
