### PR TITLE
Don't register quiet flag in register.go

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -16,7 +16,6 @@ const serverType = "dns"
 
 func init() {
 	flag.StringVar(&Port, "port", DefaultPort, "Default port")
-	flag.BoolVar(&Quiet, "quiet", false, "Quiet mode (no initialization output)")
 
 	caddy.RegisterServerType(serverType, caddy.ServerType{
 		Directives: func() []string { return directives },
@@ -138,7 +137,4 @@ var (
 
 	// GracefulTimeout is the maximum duration of a graceful shutdown.
 	GracefulTimeout time.Duration
-
-	// Quiet mode will not show any informative output on initialization.
-	Quiet bool
 )

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -218,7 +218,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 }
 
 // OnStartupComplete lists the sites served by this server
-// and any relevant information, assuming Quiet == false.
+// and any relevant information, assuming Quiet is false.
 func (s *Server) OnStartupComplete() {
 	if Quiet {
 		return
@@ -258,4 +258,9 @@ func rcodeNoClientWrite(rcode int) bool {
 const (
 	tcp = 0
 	udp = 1
+)
+
+var (
+	// Quiet mode will not show any informative output on initialization.
+	Quiet bool
 )

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mholt/caddy"
 
 	"github.com/miekg/coredns/core/dnsserver"
+
 	// Plug in CoreDNS
 	_ "github.com/miekg/coredns/core"
 )
@@ -31,6 +32,7 @@ func init() {
 	flag.StringVar(&logfile, "log", "", "Process log file")
 	flag.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
 	flag.BoolVar(&version, "version", false, "Show version")
+	flag.BoolVar(&dnsserver.Quiet, "quiet", false, "Quiet mode (no initialization output)")
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
@@ -81,7 +83,9 @@ func Run() {
 	}
 
 	logVersion()
-	showVersion()
+	if !dnsserver.Quiet {
+		showVersion()
+	}
 
 	// Twiddle your thumbs
 	instance.Wait()
@@ -142,9 +146,6 @@ func logVersion() { log.Print("[INFO] " + versionString()) }
 
 // showVersion prints the version that is starting.
 func showVersion() {
-	if dnsserver.Quiet {
-		return
-	}
 	fmt.Print(versionString())
 	if devBuild && gitShortStat != "" {
 		fmt.Printf("%s\n%s\n", gitShortStat, gitFilesModified)
@@ -153,7 +154,7 @@ func showVersion() {
 
 // versionString returns the CoreDNS version as a string.
 func versionString() string {
-	return fmt.Sprintf("%s-%s starting\n", caddy.AppName, caddy.AppVersion)
+	return fmt.Sprintf("%s-%s\n", caddy.AppName, caddy.AppVersion)
 }
 
 // setVersion figures out the version information


### PR DESCRIPTION
This clashes to Caddy, which also has its own quiet flag. Move stuff
around a bit, also to prevent cyclic imports.
