### PR TITLE
Rename port to dns.port

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -14,8 +14,10 @@ import (
 
 const serverType = "dns"
 
+// Any flags defined here, need to be namespaced to the serverType other
+// wise they potentially clash with other server types.
 func init() {
-	flag.StringVar(&Port, "port", DefaultPort, "Default port")
+	flag.StringVar(&Port, serverType+".port", DefaultPort, "Default port")
 
 	caddy.RegisterServerType(serverType, caddy.ServerType{
 		Directives: func() []string { return directives },


### PR DESCRIPTION
Avoid clashing with other server types.
