### PR TITLE
Cleanup Makefile and .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ go:
 
 go_import_path: github.com/miekg/coredns
 
+env:
+  - ETCD_VERSION=2.3.1 K8S_VERSION=1.3.7
+
 # In the Travis VM-based build environment, IPv6 networking is not
 # enabled by default. The sysctl operations below enable IPv6.
 # IPv6 is needed by some of the CoreDNS test cases. The VM environment
@@ -26,22 +29,12 @@ before_install:
   - env
 
 before_script:
-  # Download etcd, unpack and launch
-  - curl -L  https://github.com/coreos/etcd/releases/download/v2.3.1/etcd-v2.3.1-linux-amd64.tar.gz -o etcd-v2.3.1-linux-amd64.tar.gz
-  - tar xzvf etcd-v2.3.1-linux-amd64.tar.gz
-  - ./etcd-v2.3.1-linux-amd64/etcd &
-  # If docker is available, pull the kubernetes hyperkube image down and launch kubernetes.
-  - if which docker &>/dev/null ; then docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4 ; docker ps -a ; fi
-  - if which docker &>/dev/null ; then ./contrib/kubernetes/testscripts/start_k8s_with_services.sh ; docker ps -a ; fi
-  # Get golang dependencies, and build coredns binary
-  - go get -v -d ./...
-  - go get github.com/coreos/go-etcd/etcd
-    #- go build -v -ldflags="-s -w"
+  - docker run -d --net=host --name=etcd quay.io/coreos/etcd:v$ETCD_VERSION
+  - ./contrib/kubernetes/testscripts/start_k8s_with_services.sh
 
 script:
-  - go test -tags etcd -race -bench=. ./...
-  # Run kubernetes integration tests only if kubectl is available. i.e. If kubernetes was launched
-  - ./contrib/kubernetes/testscripts/kubectl version && go test -v -tags k8s -race -bench=. -run 'TestK8sIntegration' ./test
+  - docker ps -a
+  - ./contrib/kubernetes/testscripts/kubectl version
   - make coverage
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-#BUILD_VERBOSE :=
 BUILD_VERBOSE := -v
 
-#TEST_VERBOSE :=
 TEST_VERBOSE := -v
 
 DOCKER_IMAGE_NAME := $$USER/coredns
@@ -29,24 +27,17 @@ test: deps
 
 .PHONY: testk8s
 testk8s: deps
-	# With -args --v=100 the k8s API response data will be printed in the log:
-	#go test $(TEST_VERBOSE) -tags=k8s -run 'TestK8sIntegration' ./test -args --v=100
-	# Without the k8s API response data:
-	go test $(TEST_VERBOSE) -tags=k8s -run 'TestK8sIntegration' ./test
-
-.PHONY: testk8s-setup
-testk8s-setup: deps
-	go test -v ./middleware/kubernetes/... -run TestKubernetes
+	go test $(TEST_VERBOSE) -tags=k8s -run 'TestKubernetes' ./test ./middleware/kubernetes/...
 
 .PHONY: coverage
 coverage: deps
 	set -e -x
 	echo "" > coverage.txt
 	for d in `go list ./... | grep -v vendor`; do \
-		go test -race -coverprofile=profile.out -covermode=atomic $$d; \
-		if [ -f profile.out ]; then \
-			cat profile.out >> coverage.txt; \
-			rm profile.out; \
+		go test $(TEST_VERBOSE)  -tags 'etcd k8s' -race -coverprofile=cover.out -covermode=atomic -bench=. $$d || exit 1; \
+		if [ -f cover.out ]; then \
+			cat cover.out >> coverage.txt; \
+			rm cover.out; \
 		fi; \
 	done
 

--- a/contrib/kubernetes/testscripts/00_run_k8s.sh
+++ b/contrib/kubernetes/testscripts/00_run_k8s.sh
@@ -5,7 +5,7 @@ set -e
 # Based on instructions at: http://kubernetes.io/docs/getting-started-guides/docker/
 
 #K8S_VERSION=$(curl -sS https://storage.googleapis.com/kubernetes-release/release/latest.txt)
-K8S_VERSION="v1.3.7"
+K8S_VERSION=${K8S_VERSION:-"1.3.7"}
 
 ARCH="amd64"
 
@@ -32,7 +32,7 @@ docker run -d \
     --net=host \
     --pid=host \
     --privileged \
-    gcr.io/google_containers/hyperkube-${ARCH}:${K8S_VERSION} \
+    gcr.io/google_containers/hyperkube-${ARCH}:v${K8S_VERSION} \
     /hyperkube kubelet \
     --containerized \
     --hostname-override=127.0.0.1 \

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -63,7 +63,7 @@ var testdataLookupSRV = []struct {
 	{"*.*.coredns.local.", 1, 1},                             // One SRV record, via namespace and service wildcard
 }
 
-func TestK8sIntegration(t *testing.T) {
+func TestKubernetesIntegration(t *testing.T) {
 
 	// t.Skip("Skip Kubernetes Integration tests")
 	// subtests here (Go 1.7 feature).


### PR DESCRIPTION
This fix updates .travis.yml and Makefile for several places:
- Remove unneeded/unrelated `docker pull gcr.io/google_containers/hyperkube-amd64:v1.2.4` (only v1.3.7 was used)
- Use docker to deploy etcd (insteadof downloading etcd binary).
- Merge `make testk8s` and `make testk8s-setup` (no need to have multiple targets for several test cases only)
- Set version of etcd and kubernetes in .travis.yml (so that it is easy to update new version in the future): Currently `ETCD_VERSION=2.3.1 K8S_VERSION=1.3.7`
