### PR TITLE
Add a setup test for middleware/file

### DIFF
--- a/middleware/file/setup_test.go
+++ b/middleware/file/setup_test.go
@@ -1,0 +1,75 @@
+package file
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestFileParse(t *testing.T) {
+	zonePath, err := ioutil.TempDir("", "TestFilePath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(zonePath)
+
+	zoneFile1, err := ioutil.TempFile(zonePath, "zone1-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zoneFileName1 := zoneFile1.Name()
+	zoneFile1.Write([]byte(dbMiekNL))
+	zoneFile1.Close()
+
+	zoneFile2, err := ioutil.TempFile(zonePath, "zone2-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zoneFileName2 := zoneFile2.Name()
+	zoneFile2.Write([]byte(dbDnssexNLSigned))
+	zoneFile2.Close()
+
+	tests := []struct {
+		inputFileRules string
+		shouldErr      bool
+		expectedZones  Zones
+	}{
+		{
+			`file`,
+			true,
+			Zones{},
+		},
+		{
+			`file ` + zoneFileName1 + ` miek.nl.`,
+			false,
+			Zones{Names: []string{"miek.nl."}},
+		},
+		{
+			`file ` + zoneFileName2 + ` dnssex.nl.`,
+			false,
+			Zones{Names: []string{"dnssex.nl."}},
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("file", test.inputFileRules)
+		actualZones, err := fileParse(c)
+
+		if err == nil && test.shouldErr {
+			t.Fatalf("Test %d expected errors, but got no error", i)
+		} else if err != nil && !test.shouldErr {
+			t.Fatalf("Test %d expected no errors, but got '%v'", i, err)
+		} else {
+			if len(actualZones.Names) != len(test.expectedZones.Names) {
+				t.Fatalf("Test %d expected %v, got %v", i, test.expectedZones.Names, actualZones.Names)
+			}
+			for j, name := range test.expectedZones.Names {
+				if actualZones.Names[j] != name {
+					t.Fatalf("Test %d expected %v for %d th zone, got %v", i, name, j, actualZones.Names[j])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This fix adds a setup test for middleware/file so that there is a basic coverage for the Corefile processing of middleware/file.
