### PR TITLE
middleware/file: transfer from does not make sense

### DIFF
--- a/middleware/file/setup_test.go
+++ b/middleware/file/setup_test.go
@@ -27,6 +27,13 @@ func TestFileParse(t *testing.T) {
 		expectedZones  Zones
 	}{
 		{
+			`file ` + zoneFileName1 + ` miek.nl {
+				transfer from 127.0.0.1
+			}`,
+			true,
+			Zones{},
+		},
+		{
 			`file`,
 			true,
 			Zones{},

--- a/middleware/secondary/setup.go
+++ b/middleware/secondary/setup.go
@@ -63,7 +63,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 			}
 
 			for c.NextBlock() {
-				t, f, e := file.TransferParse(c)
+				t, f, e := file.TransferParse(c, true)
 				if e != nil {
 					return file.Zones{}, e
 				}


### PR DESCRIPTION
Make it return an error when you use `transfer from` when you're
not a secondary.

Add tests as well.

Fixes #310
