### PR TITLE
middleware/metrics: fix crash on startup

### DIFF
--- a/middleware/metrics/handler.go
+++ b/middleware/metrics/handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ServeDNS implements the Handler interface.
-func (m Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 
 	qname := state.QName()

--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -32,7 +32,7 @@ type Metrics struct {
 	Addr      string
 	ln        net.Listener
 	mux       *http.ServeMux
-	Once      *sync.Once
+	Once      sync.Once
 	ZoneNames []string
 }
 

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -1,0 +1,17 @@
+package test
+
+import "testing"
+
+// Start test server that has metrics enabled. Then tear it down again.
+func TestMetricsServer(t *testing.T) {
+	corefile := `.:0 {
+	chaos CoreDNS-001 miek@miek.nl
+	prometheus localhost:0
+}
+`
+	srv, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer srv.Stop()
+}


### PR DESCRIPTION
Make the methods that handle Metrics all use pointer receivers to fix
sync.Once not being initialized.

Finish the setup_test to test for failures. And make the check for the
address more strict and return an error when it does not have a port
number.

Add a toplevel test that starts a CoreDNS server with metrics enabled
so we catch these errors in the future.
