### PR TITLE
middleware/cache: rename categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ listening on port 2053, it should show the following:
 
 ~~~ txt
 .:2053
-2016/09/18 09:20:50 [INFO] CoreDNS-001 starting
-CoreDNS-001 starting
+2016/09/18 09:20:50 [INFO] CoreDNS-001
+CoreDNS-001
 ~~~
 
 Any query send to port 2053 should return some information; your sending address, port and protocol

--- a/middleware/cache/README.md
+++ b/middleware/cache/README.md
@@ -9,7 +9,7 @@ cache [ttl] [zones...]
 ~~~
 
 * `ttl` max TTL in seconds. If not specified, the maximum TTL will be used which is 1 hour for
-    positive responses and half an hour for negative ones.
+    noerror responses and half an hour for denial of existence ones.
 * `zones` zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with `ttl` as the max).
@@ -20,16 +20,18 @@ Or if you want more control:
 
 ~~~ txt
 cache [ttl] [zones...] {
-    postive capacity [ttl]
-    negative capacity [ttl]
+    noerror capacity [ttl]
+    denial capacity [ttl]
 }
 ~~~
 
 * `ttl`  and `zones` as above.
-* `positive`, override the settings for caching positive responses, capacity indicates the maximum
+* `success`, override the settings for caching noerror responses, capacity indicates the maximum
   number of packets we cache before we start evicting (LRU). Ttl overrides the cache maximum TTL.
-* `negative`, override the settings for caching negative responses, capacity indicates the maximum
+* `denial`, override the settings for caching denial of existence responses, capacity indicates the maximum
   number of packets we cache before we start evicting (LRU). Ttl overrides the cache maximum TTL.
+
+There is a third category (`error`) but those responses are never cached.
 
 The minimum TTL allowed on resource records is 5 seconds.
 

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Cache is middleware that looks up responses in a cache and caches replies.
-// It has a positive and a negative cache.
+// It has a success and a denial of existence cache.
 type Cache struct {
 	Next  middleware.Handler
 	Zones []string

--- a/middleware/cache/setup.go
+++ b/middleware/cache/setup.go
@@ -58,7 +58,7 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 		for c.NextBlock() {
 			switch c.Val() {
 			// first number is cap, second is an new ttl
-			case "positive":
+			case "success":
 				args := c.RemainingArgs()
 				if len(args) == 0 {
 					return nil, c.ArgErr()
@@ -75,7 +75,7 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 					}
 					ca.pttl = time.Duration(pttl) * time.Second
 				}
-			case "negative":
+			case "denial":
 				args := c.RemainingArgs()
 				if len(args) == 0 {
 					return nil, c.ArgErr()

--- a/middleware/cache/setup_test.go
+++ b/middleware/cache/setup_test.go
@@ -19,22 +19,26 @@ func TestSetup(t *testing.T) {
 		{`cache`, false, defaultCap, defaultCap, maxNTTL, maxTTL},
 		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, maxTTL},
 		{`cache example.nl {
-			positive 10
+			success 10
 		}`, false, defaultCap, 10, maxNTTL, maxTTL},
 		{`cache example.nl {
-			positive 10
-			negative 10 15
+			success 10
+			denial 10 15
 		}`, false, 10, 10, 15 * time.Second, maxTTL},
 		{`cache 25 example.nl {
-			positive 10
-			negative 10 15
+			success 10
+			denial 10 15
 		}`, false, 10, 10, 15 * time.Second, 25 * time.Second},
 		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, maxTTL},
 
 		// fails
 		{`cache example.nl {
-			positive
-			negative 10 15
+			success
+			denial 10 15
+		}`, true, defaultCap, defaultCap, maxTTL, maxTTL},
+		{`cache example.nl {
+			success 15
+			denial aaa
 		}`, true, defaultCap, defaultCap, maxTTL, maxTTL},
 		{`cache example.nl {
 			positive 15

--- a/middleware/file/README.md
+++ b/middleware/file/README.md
@@ -24,7 +24,6 @@ TSIG key information, something like `transfer out [address...] key [name] [base
 
 ~~~
 file dbfile [zones... ] {
-    transfer from [address...]
     transfer to [address...]
     no_reload
 }


### PR DESCRIPTION
Rename: positive -> noerror
negative -> denial

There is a third (unused category) which is error. Start using these
new in the caching middleware and later in the logging middleware.
