### PR TITLE
Use dns.port argument as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ listening on port 2053, it should show the following:
 
 ~~~ txt
 .:2053
-2016/09/18 09:20:50 [INFO] CoreDNS-001 starting
-CoreDNS-001 starting
+2016/09/18 09:20:50 [INFO] CoreDNS-001
+CoreDNS-001
 ~~~
 
 Any query send to port 2053 should return some information; your sending address, port and protocol

--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -39,7 +39,7 @@ func normalizeZone(str string) (zoneAddr, error) {
 	}
 
 	if port == "" {
-		port = "53"
+		port = Port
 	}
 
 	return zoneAddr{Zone: strings.ToLower(dns.Fqdn(host)), Port: port}, err

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -128,13 +128,13 @@ func groupConfigsByListenAddr(configs []*Config) (map[string][]*Config, error) {
 
 const (
 	// DefaultPort is the default port.
-	DefaultPort = "2053"
+	DefaultPort = "53"
 )
 
 // These "soft defaults" are configurable by
 // command line flags, etc.
 var (
-	// Port is the site port
+	// Port is the port we listen on by default.
 	Port = DefaultPort
 
 	// GracefulTimeout is the maximum duration of a graceful shutdown.


### PR DESCRIPTION
Make DefaultPort just be 53. And use the value of Port to make the zone
stanzas complete (instead of defaulting to 53 always). This allows you
to override the port with dns.port.
