### PR TITLE
Fix file reload failure within a single root zone.

### DIFF
--- a/middleware/file/setup.go
+++ b/middleware/file/setup.go
@@ -27,12 +27,13 @@ func setup(c *caddy.Controller) error {
 
 	// Add startup functions to notify the master(s).
 	for _, n := range zones.Names {
+		z := zones.Z[n]
 		c.OnStartup(func() error {
-			zones.Z[n].StartupOnce.Do(func() {
-				if len(zones.Z[n].TransferTo) > 0 {
-					zones.Z[n].Notify()
+			z.StartupOnce.Do(func() {
+				if len(z.TransferTo) > 0 {
+					z.Notify()
 				}
-				zones.Z[n].Reload(nil)
+				z.Reload(nil)
 			})
 			return nil
 		})


### PR DESCRIPTION
In the file middleware, if there are multiple zone files under a single root zone, watchers are only invoked on the last element of `zones.Names`. This is caused by loop override on the variable `n`.

This issue can be fixed by passing zone object, which calls reload watcher directly.
