### PR TITLE
Add `cache_capacity` option to dnssec middleware for the capacity of LRU cache

### DIFF
--- a/middleware/dnssec/README.md
+++ b/middleware/dnssec/README.md
@@ -26,11 +26,17 @@ TODO(miek): think about key rollovers, and how to do them automatically.
 ~~~
 dnssec [ZONES... ] {
     key file KEY...
+    cache_capacity CAPACITY
 }
 ~~~
 
 * `key file` indicates that key file(s) should be read from disk. When multiple keys are specified, RRsets
   will be signed with all keys. Generating a key can be done with `dnssec-keygen`: `dnssec-keygen -a
   ECDSAP256SHA256 <zonename>`. A key created for zone *A* can be safely used for zone *B*.
+
+
+* `cache_capacity` indicates the capacity of the LRU cache. The dnssec middleware uses LRU cache to manage
+  objects and the default capacity is 10000.
+
 
 ## Examples


### PR DESCRIPTION
This fix adds a `cache_capacity` option to dnssec middleware, so that
it is possible to specify the capacity of the LRU cache used by dnssec
middleware.

Note: The reason to have `cache_capacity` instead of `cache` is because
`cache` has been used in other middleware with different meanings.

This fix fixes #335.
