### PR TITLE
Add type to default template

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -48,7 +48,7 @@ This is the default kubernetes setup, with everything specified in full:
         # The tls cert, key and the CA cert filenames
         tls cert key cacert
         # Assemble k8s record names with the template
-        template {service}.{namespace}.{zone}
+        template {service}.{namespace}.{type}.{zone}
         # Only expose the k8s namespace "demo"
         namespaces demo
         # Only expose the records for kubernetes objects
@@ -67,7 +67,7 @@ This is the default kubernetes setup, with everything specified in full:
 
 Defaults:
 * If the `namespaces` keyword is omitted, all kubernetes namespaces are exposed.
-* If the `template` keyword is omitted, the default template of "{service}.{namespace}.{zone}" is used.
+* If the `template` keyword is omitted, the default template of "{service}.{namespace}.{type}.{zone}" is used.
 * If the `resyncperiod` keyword is omitted, the default resync period is 5 minutes.
 * The `labels` keyword is only used when filtering results based on kubernetes label selector syntax
   is required. The label selector syntax is described in the kubernetes API documentation at:
@@ -130,7 +130,7 @@ Build CoreDNS and launch using this configuration file:
     kubernetes coredns.local {
         resyncperiod 5m
         endpoint http://localhost:8080
-        template {service}.{namespace}.{zone}
+        template {service}.{namespace}.{type}.{zone}
         namespaces demo
         # Only expose the records for kubernetes objects
         # that matches this label selector. 

--- a/middleware/kubernetes/nametemplate/nametemplate_test.go
+++ b/middleware/kubernetes/nametemplate/nametemplate_test.go
@@ -14,8 +14,8 @@ const (
 // Map of format string :: expected locations of name symbols in the format.
 // -1 value indicates that symbol does not exist in format.
 var exampleTemplates = map[string][]int{
-	"{service}.{namespace}.{zone}": []int{2, 1, 0}, // service symbol expected @ position 0, namespace @ 1, zone @ 2
-	"{namespace}.{zone}":           []int{1, 0, -1},
+	"{service}.{namespace}.{type}.{zone}": []int{3, 1, 0}, // service symbol expected @ position 0, namespace @ 1, zone @ 3
+	"{namespace}.{type}.{zone}":           []int{2, 0, -1},
 	"":                             []int{-1, -1, -1},
 }
 
@@ -46,10 +46,10 @@ func TestServiceFromSegmentArray(t *testing.T) {
 
 	// Case where template contains {service}
 	n = new(Template)
-	formatString = "{service}.{namespace}.{zone}"
+	formatString = "{service}.{namespace}.{type}.{zone}"
 	n.SetTemplate(formatString)
 
-	queryString = "myservice.mynamespace.coredns"
+	queryString = "myservice.mynamespace.svc.coredns"
 	splitQuery = strings.Split(queryString, ".")
 	expectedService = "myservice"
 	actualService = n.ServiceFromSegmentArray(splitQuery)
@@ -60,10 +60,10 @@ func TestServiceFromSegmentArray(t *testing.T) {
 
 	// Case where template does not contain {service}
 	n = new(Template)
-	formatString = "{namespace}.{zone}"
+	formatString = "{namespace}.{type}.{zone}"
 	n.SetTemplate(formatString)
 
-	queryString = "mynamespace.coredns"
+	queryString = "mynamespace.svc.coredns"
 	splitQuery = strings.Split(queryString, ".")
 	expectedService = ""
 	actualService = n.ServiceFromSegmentArray(splitQuery)
@@ -85,10 +85,10 @@ func TestZoneFromSegmentArray(t *testing.T) {
 
 	// Case where template contains {zone}
 	n = new(Template)
-	formatString = "{service}.{namespace}.{zone}"
+	formatString = "{service}.{namespace}.{type}.{zone}"
 	n.SetTemplate(formatString)
 
-	queryString = "myservice.mynamespace.coredns"
+	queryString = "myservice.mynamespace.svc.coredns"
 	splitQuery = strings.Split(queryString, ".")
 	expectedZone = "coredns"
 	actualZone = n.ZoneFromSegmentArray(splitQuery)
@@ -99,10 +99,10 @@ func TestZoneFromSegmentArray(t *testing.T) {
 
 	// Case where template does not contain {zone}
 	n = new(Template)
-	formatString = "{service}.{namespace}"
+	formatString = "{service}.{namespace}.{type}"
 	n.SetTemplate(formatString)
 
-	queryString = "mynamespace.coredns"
+	queryString = "mynamespace.coredns.svc"
 	splitQuery = strings.Split(queryString, ".")
 	expectedZone = ""
 	actualZone = n.ZoneFromSegmentArray(splitQuery)
@@ -113,10 +113,10 @@ func TestZoneFromSegmentArray(t *testing.T) {
 
 	// Case where zone is multiple segments
 	n = new(Template)
-	formatString = "{service}.{namespace}.{zone}"
+	formatString = "{service}.{namespace}.{type}.{zone}"
 	n.SetTemplate(formatString)
 
-	queryString = "myservice.mynamespace.coredns.cluster.local"
+	queryString = "myservice.mynamespace.svc.coredns.cluster.local"
 	splitQuery = strings.Split(queryString, ".")
 	expectedZone = "coredns.cluster.local"
 	actualZone = n.ZoneFromSegmentArray(splitQuery)

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -137,6 +137,6 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 }
 
 const (
-	defaultNameTemplate = "{service}.{namespace}.{zone}"
+	defaultNameTemplate = "{service}.{namespace}.{type}.{zone}"
 	defaultResyncPeriod = 5 * time.Minute
 )

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -19,22 +19,22 @@ var testdataLookupA = []struct {
 	ARecordCount     int
 }{
 	// Matching queries
-	{"mynginx.demo.coredns.local.", 1, 1}, // One A record, should exist
+	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One A record, should exist
 
 	// Failure queries
-	{"mynginx.test.coredns.local.", 0, 0},                     // One A record, is not exposed
-	{"someservicethatdoesnotexist.demo.coredns.local.", 0, 0}, // Record does not exist
+	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One A record, is not exposed
+	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
 
 	// Namespace wildcards
-	{"mynginx.*.coredns.local.", 1, 1},                       // One A record, via wildcard namespace
-	{"mynginx.any.coredns.local.", 1, 1},                     // One A record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.coredns.local.", 2, 2},                          // Two A records, via wildcard
-	{"any.demo.coredns.local.", 2, 2},                        // Two A records, via wildcard
-	{"*.test.coredns.local.", 0, 0},                          // Two A record, via wildcard that is not exposed
-	{"any.test.coredns.local.", 0, 0},                        // Two A record, via wildcard that is not exposed
-	{"*.*.coredns.local.", 2, 2},                             // Two A records, via namespace and service wildcard
+	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One A record, via wildcard namespace
+	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One A record, via wildcard namespace
+	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
+	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
+	{"*.demo.svc.coredns.local.", 2, 2},                          // Two A records, via wildcard
+	{"any.demo.svc.coredns.local.", 2, 2},                        // Two A records, via wildcard
+	{"*.test.svc.coredns.local.", 0, 0},                          // Two A record, via wildcard that is not exposed
+	{"any.test.svc.coredns.local.", 0, 0},                        // Two A record, via wildcard that is not exposed
+	{"*.*.svc.coredns.local.", 2, 2},                             // Two A records, via namespace and service wildcard
 }
 
 // Test data for SRV records
@@ -45,22 +45,22 @@ var testdataLookupSRV = []struct {
 	SRVRecordCount int
 }{
 	// Matching queries
-	{"mynginx.demo.coredns.local.", 1, 1}, // One SRV record, should exist
+	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One SRV record, should exist
 
 	// Failure queries
-	{"mynginx.test.coredns.local.", 0, 0},                     // One SRV record, is not exposed
-	{"someservicethatdoesnotexist.demo.coredns.local.", 0, 0}, // Record does not exist
+	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One SRV record, is not exposed
+	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
 
 	// Namespace wildcards
-	{"mynginx.*.coredns.local.", 1, 1},                       // One SRV record, via wildcard namespace
-	{"mynginx.any.coredns.local.", 1, 1},                     // One SRV record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.coredns.local.", 2, 2},                          // Two (mynginx, webserver) SRV record, via wildcard
-	{"any.demo.coredns.local.", 2, 2},                        // Two (mynginx, webserver) SRV record, via wildcard
-	{"*.test.coredns.local.", 0, 0},                          // One SRV record, via wildcard that is not exposed
-	{"any.test.coredns.local.", 0, 0},                        // One SRV record, via wildcard that is not exposed
-	{"*.*.coredns.local.", 2, 2},                             // Two SRV record, via namespace and service wildcard
+	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One SRV record, via wildcard namespace
+	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One SRV record, via wildcard namespace
+	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
+	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
+	{"*.demo.svc.coredns.local.", 2, 2},                          // Two (mynginx, webserver) SRV record, via wildcard
+	{"any.demo.svc.coredns.local.", 2, 2},                        // Two (mynginx, webserver) SRV record, via wildcard
+	{"*.test.svc.coredns.local.", 0, 0},                          // One SRV record, via wildcard that is not exposed
+	{"any.test.svc.coredns.local.", 0, 0},                        // One SRV record, via wildcard that is not exposed
+	{"*.*.svc.coredns.local.", 2, 2},                             // Two SRV record, via namespace and service wildcard
 }
 
 func TestKubernetesIntegration(t *testing.T) {


### PR DESCRIPTION
Adds type to the default value for template:  {service}.{namespace}.{type}.{zone}
Updates tests to include type in the test queries.
