### PR TITLE
middleware/metrics: export ListenAddr

### DIFF
--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -61,6 +61,7 @@ func (m *Metrics) OnStartup() error {
 		}
 
 		m.ln = ln
+		ListenAddr = m.ln.Addr().String()
 
 		m.mux = http.NewServeMux()
 
@@ -97,3 +98,7 @@ func keys(m map[string]bool) []string {
 	}
 	return sx
 }
+
+// ListenAddr is assigned the address of the prometheus listener. Its use is mainly in tests where
+// we listen on "localhost:0" and need to retrieve the actual address.
+var ListenAddr string

--- a/middleware/metrics/metrics_test.go
+++ b/middleware/metrics/metrics_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	met := &Metrics{Addr: Addr, zoneMap: make(map[string]bool)}
+	met := &Metrics{Addr: "localhost:0", zoneMap: make(map[string]bool)}
 	if err := met.OnStartup(); err != nil {
 		t.Fatalf("Failed to start metrics handler: %s", err)
 	}
@@ -71,7 +71,7 @@ func TestMetrics(t *testing.T) {
 			t.Fatalf("Test %d: Expected no error, but got %s", i, err)
 		}
 
-		result := mtest.Scrape(t, "http://"+Addr+"/metrics")
+		result := mtest.Scrape(t, "http://"+ListenAddr+"/metrics")
 
 		if tc.expectedValue != "" {
 			got, _ := mtest.MetricValue(tc.metric, result)

--- a/middleware/metrics/setup.go
+++ b/middleware/metrics/setup.go
@@ -38,7 +38,7 @@ func setup(c *caddy.Controller) error {
 
 func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	var (
-		met = &Metrics{Addr: Addr, zoneMap: make(map[string]bool)}
+		met = &Metrics{Addr: addr, zoneMap: make(map[string]bool)}
 		err error
 	)
 
@@ -88,4 +88,4 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 var metricsOnce sync.Once
 
 // Addr is the address the where the metrics are exported by default.
-const Addr = "localhost:9153"
+const addr = "localhost:9153"


### PR DESCRIPTION
ListenAddr is the address where the prometheus metric are exported.
This can be used in tests to listen on "localhost:0" and then later
retrieve the metrics from there. It makes the tests indepent on each
other.
