### PR TITLE
BackendService: add Reverse method

### DIFF
--- a/middleware/backend.go
+++ b/middleware/backend.go
@@ -9,9 +9,13 @@ import (
 
 // ServiceBackend defines a (dynamic) backend that returns a slice of service definitions.
 type ServiceBackend interface {
-	// Services communitates with the backend to retrieve the service defintion. Exact indicates
+	// Services communicates with the backend to retrieve the service defintion. Exact indicates
 	// on exact much are that we are allowed to recurs.
 	Services(state request.Request, exact bool, opt Options) ([]msg.Service, []msg.Service, error)
+
+	// Reverse communicates with the backend to retrieve service definition based on a IP address
+	// instead of a name. I.e. a reverse DNS lookup.
+	Reverse(state request.Request, exact bool, opt Options) ([]msg.Service, []msg.Service, error)
 
 	// Lookup is used to find records else where.
 	Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error)

--- a/middleware/backend_lookup.go
+++ b/middleware/backend_lookup.go
@@ -330,9 +330,8 @@ func TXT(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 }
 
 // PTR returns the PTR records from the backend, only services that have a domain name as host are included.
-// TODO(miek|infoblox): move k8s to this as well.
 func PTR(b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, debug []msg.Service, err error) {
-	services, debug, err := b.Services(state, true, opt)
+	services, debug, err := b.Reverse(state, true, opt)
 	if err != nil {
 		return nil, debug, err
 	}

--- a/middleware/etcd/etcd.go
+++ b/middleware/etcd/etcd.go
@@ -46,6 +46,11 @@ func (e *Etcd) Services(state request.Request, exact bool, opt middleware.Option
 	return
 }
 
+// Reverse implements the ServiceBackend interface.
+func (e *Etcd) Reverse(state request.Request, exact bool, opt middleware.Options) (services, debug []msg.Service, err error) {
+	return e.Services(state, exact, opt)
+}
+
 // Lookup implements the ServiceBackend interface.
 func (e *Etcd) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
 	return e.Proxy.Lookup(state, name, typ)

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -5,13 +5,13 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/pkg/api"
 	"k8s.io/client-go/1.5/pkg/api/v1"
-	"k8s.io/client-go/1.5/tools/cache"
-	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/pkg/labels"
 	"k8s.io/client-go/1.5/pkg/runtime"
 	"k8s.io/client-go/1.5/pkg/watch"
+	"k8s.io/client-go/1.5/tools/cache"
 )
 
 var (
@@ -36,11 +36,11 @@ type dnsController struct {
 
 	selector *labels.Selector
 
-	svcController  *cache.Controller
-	nsController   *cache.Controller
+	svcController *cache.Controller
+	nsController  *cache.Controller
 
-	svcLister  cache.StoreToServiceLister
-	nsLister   storeToNamespaceLister
+	svcLister cache.StoreToServiceLister
+	nsLister  storeToNamespaceLister
 
 	// stopLock is used to enforce only a single call to Stop is active.
 	// Needed because we allow stopping through an http endpoint and


### PR DESCRIPTION
Add a Reverse method to BackendService because different backends want
to to do diff. things. This allows etc/k8s to share even more code and
we can unify the PTR handling.