### PR TITLE
middleware/file: add nsec for wildcard expansion

### DIFF
--- a/middleware/file/closest.go
+++ b/middleware/file/closest.go
@@ -6,7 +6,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// ClosestEncloser returns the closest encloser for rr.
+// ClosestEncloser returns the closest encloser for qname.
 func (z *Zone) ClosestEncloser(qname string) (*tree.Elem, bool) {
 
 	offset, end := dns.NextLabel(qname, 0)

--- a/middleware/file/dnssec_test.go
+++ b/middleware/file/dnssec_test.go
@@ -30,6 +30,17 @@ var dnssecTestCases = []test.Case{
 		Extra: []dns.RR{test.OPT(4096, true)},
 	},
 	{
+		Qname: "miek.nl.", Qtype: dns.TypeNS, Do: true,
+		Answer: []dns.RR{
+			test.NS("miek.nl.	1800	IN	NS	ext.ns.whyscream.net."),
+			test.NS("miek.nl.	1800	IN	NS	linode.atoom.net."),
+			test.NS("miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
+			test.NS("miek.nl.	1800	IN	NS	omval.tednet.nl."),
+			test.RRSIG("miek.nl.	1800	IN	RRSIG	NS 8 2 1800 20160426031301 20160327031301 12051 miek.nl. ZLtsQhwaz+lHfNpztFoR1Vxs="),
+		},
+		Extra: []dns.RR{test.OPT(4096, true)},
+	},
+	{
 		Qname: "miek.nl.", Qtype: dns.TypeMX, Do: true,
 		Answer: []dns.RR{
 			test.MX("miek.nl.	1800	IN	MX	1 aspmx.l.google.com."),

--- a/middleware/file/wildcard_test.go
+++ b/middleware/file/wildcard_test.go
@@ -31,6 +31,10 @@ var wildcardTestCases = []test.Case{
 			test.RRSIG("wild.dnssex.nl.	1800	IN	RRSIG	TXT 8 2 1800 20160428190224 20160329190224 14460 dnssex.nl. FUZSTyvZfeuuOpCm"),
 			test.TXT(`wild.dnssex.nl.	1800	IN	TXT	"Doing It Safe Is Better"`),
 		},
+		Ns: []dns.RR{
+			test.NSEC("a.dnssex.nl.	14400	IN	NSEC	www.dnssex.nl. A AAAA RRSIG NSEC"),
+			test.RRSIG("a.dnssex.nl.	14400	IN	RRSIG	NSEC 8 3 14400 20160428190224 20160329190224 14460 dnssex.nl. S+UMs2ySgRaaRY"),
+		},
 		Extra: []dns.RR{test.OPT(4096, true)},
 	},
 	{
@@ -38,6 +42,10 @@ var wildcardTestCases = []test.Case{
 		Answer: []dns.RR{
 			test.RRSIG("a.wild.dnssex.nl.	1800	IN	RRSIG	TXT 8 2 1800 20160428190224 20160329190224 14460 dnssex.nl. FUZSTyvZfeuuOpCm"),
 			test.TXT(`a.wild.dnssex.nl.	1800	IN	TXT	"Doing It Safe Is Better"`),
+		},
+		Ns: []dns.RR{
+			test.NSEC("a.dnssex.nl.	14400	IN	NSEC	www.dnssex.nl. A AAAA RRSIG NSEC"),
+			test.RRSIG("a.dnssex.nl.	14400	IN	RRSIG	NSEC 8 3 14400 20160428190224 20160329190224 14460 dnssex.nl. S+UMs2ySgRaaRY"),
 		},
 		Extra: []dns.RR{test.OPT(4096, true)},
 	},


### PR DESCRIPTION
A NSEC record is need to deny any other name that might exist.
Also don't blindly perform the interface conversion when getting
glue for NS records as they now may include RRSIG - also add tests
for that.