### PR TITLE
middleware/file|auto: Notifies and AXFR

### DIFF
--- a/middleware/auto/setup.go
+++ b/middleware/auto/setup.go
@@ -127,7 +127,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 						a.loader.template = rewriteToExpand(c.Val())
 					}
 
-					// template
+					// duration
 					if c.NextArg() {
 						i, err := strconv.Atoi(c.Val())
 						if err != nil {
@@ -147,7 +147,9 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 					if e != nil {
 						return a, e
 					}
-					a.loader.transferTo = t
+					if t != nil {
+						a.loader.transferTo = append(a.loader.transferTo, t...)
+					}
 				}
 			}
 

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -97,28 +97,28 @@ func serviceListFunc(c *kubernetes.Clientset, ns string, s *labels.Selector) fun
 	}
 }
 
-func v1ToApiFilter(in watch.Event) (out watch.Event, keep bool) {
+func v1ToAPIFilter(in watch.Event) (out watch.Event, keep bool) {
 	if in.Type == watch.Error {
 		return in, true
 	}
 
 	switch v1Obj := in.Object.(type) {
-		case *v1.Service:
-			var apiObj api.Service
-			err := v1.Convert_v1_Service_To_api_Service(v1Obj, &apiObj, nil)
-			if err != nil {
-				log.Printf("[ERROR] Could not convert v1.Service: %s", err)
-				return in, true
-			}
-			return watch.Event{Type: in.Type, Object: &apiObj}, true
-		case *v1.Namespace:
-			var apiObj api.Namespace
-			err := v1.Convert_v1_Namespace_To_api_Namespace(v1Obj, &apiObj, nil)
-			if err != nil {
-				log.Printf("[ERROR] Could not convert v1.Namespace: %s", err)
-				return in, true
-			}
-			return watch.Event{Type: in.Type, Object: &apiObj}, true
+	case *v1.Service:
+		var apiObj api.Service
+		err := v1.Convert_v1_Service_To_api_Service(v1Obj, &apiObj, nil)
+		if err != nil {
+			log.Printf("[ERROR] Could not convert v1.Service: %s", err)
+			return in, true
+		}
+		return watch.Event{Type: in.Type, Object: &apiObj}, true
+	case *v1.Namespace:
+		var apiObj api.Namespace
+		err := v1.Convert_v1_Namespace_To_api_Namespace(v1Obj, &apiObj, nil)
+		if err != nil {
+			log.Printf("[ERROR] Could not convert v1.Namespace: %s", err)
+			return in, true
+		}
+		return watch.Event{Type: in.Type, Object: &apiObj}, true
 	}
 
 	log.Printf("[WARN] Unhandled v1 type in event: %v", in)
@@ -134,7 +134,7 @@ func serviceWatchFunc(c *kubernetes.Clientset, ns string, s *labels.Selector) fu
 		if err != nil {
 			return nil, err
 		}
-		return watch.Filter(w, v1ToApiFilter), nil
+		return watch.Filter(w, v1ToAPIFilter), nil
 	}
 }
 
@@ -165,7 +165,7 @@ func namespaceWatchFunc(c *kubernetes.Clientset, s *labels.Selector) func(option
 		if err != nil {
 			return nil, err
 		}
-		return watch.Filter(w, v1ToApiFilter), nil
+		return watch.Filter(w, v1ToAPIFilter), nil
 	}
 }
 


### PR DESCRIPTION
Be more explicit in the logs when a notify fails.
New notify error message looks like:

2016/11/07 18:21:42 [ERROR] Notify for zone "example.org." was not accepted by "8.8.8.8:53": rcode was "SERVFAIL"

Correctly pick up secondaries

When multiple secondary are specified make sure they are picked up.

Fixes #393 #398