### PR TITLE
Kubernetes Integration Test Cleanup

### DIFF
--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -3,7 +3,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"log"
 	"testing"
 	"time"
@@ -12,63 +11,158 @@ import (
 	"github.com/miekg/dns"
 )
 
-// Test data for A records
-var testdataLookupA = []struct {
-	Query            string
-	TotalAnswerCount int
-	ARecordCount     int
-}{
-	// Matching queries
-	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One A record, should exist
-
-	// Failure queries
-	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One A record, is not exposed
-	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
-
-	// Namespace wildcards
-	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One A record, via wildcard namespace
-	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One A record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.svc.coredns.local.", 2, 2},                          // Two A records, via wildcard
-	{"any.demo.svc.coredns.local.", 2, 2},                        // Two A records, via wildcard
-	{"*.test.svc.coredns.local.", 0, 0},                          // Two A record, via wildcard that is not exposed
-	{"any.test.svc.coredns.local.", 0, 0},                        // Two A record, via wildcard that is not exposed
-	{"*.*.svc.coredns.local.", 2, 2},                             // Two A records, via namespace and service wildcard
+func makeRR(s string) dns.RR {
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		log.Printf("Bad test RR (%s): %s", s, err)
+	}
+	return rr
 }
 
-// Test data for SRV records
-var testdataLookupSRV = []struct {
-	Query            string
-	TotalAnswerCount int
-	//	ARecordCount     int
-	SRVRecordCount int
-}{
-	// Matching queries
-	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One SRV record, should exist
-
-	// Failure queries
-	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One SRV record, is not exposed
-	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
-
-	// Namespace wildcards
-	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One SRV record, via wildcard namespace
-	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One SRV record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.svc.coredns.local.", 2, 2},                          // Two (mynginx, webserver) SRV record, via wildcard
-	{"any.demo.svc.coredns.local.", 2, 2},                        // Two (mynginx, webserver) SRV record, via wildcard
-	{"*.test.svc.coredns.local.", 0, 0},                          // One SRV record, via wildcard that is not exposed
-	{"any.test.svc.coredns.local.", 0, 0},                        // One SRV record, via wildcard that is not exposed
-	{"*.*.svc.coredns.local.", 2, 2},                             // Two SRV record, via namespace and service wildcard
+type testquery struct {
+	fqdn  string
+	qtype uint16
 }
 
-func TestKubernetesIntegration(t *testing.T) {
+type testanswer struct {
+	rcode int
+	rrs   []dns.RR
+}
 
-	// t.Skip("Skip Kubernetes Integration tests")
-	// subtests here (Go 1.7 feature).
-	testLookupA(t)
-	testLookupSRV(t)
+type testdefn struct {
+	query  testquery
+	answer testanswer
+}
+
+// Test data
+// TODO: Fix the actual RR values
+var testdata = []testdefn{
+	{testquery{"mynginx.demo.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"bogusservice.demo.svc.coredns.local.", dns.TypeA},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"mynginx.*.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"mynginx.any.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"bogusservice.*.svc.coredns.local.", dns.TypeA},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"bogusservice.any.svc.coredns.local.", dns.TypeA},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.demo.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"any.demo.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"any.test.svc.coredns.local.", dns.TypeA},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.test.svc.coredns.local.", dns.TypeA},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.*.svc.coredns.local.", dns.TypeA},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"mynginx.demo.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"bogusservice.demo.svc.coredns.local.", dns.TypeSRV},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"mynginx.*.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"mynginx.any.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"bogusservice.*.svc.coredns.local.", dns.TypeSRV},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"bogusservice.any.svc.coredns.local.", dns.TypeSRV},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.demo.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"any.demo.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
+	{testquery{"any.test.svc.coredns.local.", dns.TypeSRV},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.test.svc.coredns.local.", dns.TypeSRV},
+		// TODO: fix NameError bug so this can be used instead of success: testanswer{dns.RcodeNameError,
+		testanswer{dns.RcodeSuccess,
+			nil,
+		},
+	},
+	{testquery{"*.*.svc.coredns.local.", dns.TypeSRV},
+		testanswer{dns.RcodeSuccess,
+			[]dns.RR{makeRR("mynginx.demo.svc.coredns.local. A 10.3.0.10"),
+				makeRR("webserver.demo.svc.coredns.local. A 10.3.0.10")},
+		},
+	},
 }
 
 func createTestServer(t *testing.T, corefile string) (*caddy.Instance, string) {
@@ -85,7 +179,7 @@ func createTestServer(t *testing.T, corefile string) (*caddy.Instance, string) {
 	return server, udp
 }
 
-func testLookupA(t *testing.T) {
+func TestKubernetesIntegration(t *testing.T) {
 	corefile :=
 		`.:0 {
     kubernetes coredns.local {
@@ -97,84 +191,31 @@ func testLookupA(t *testing.T) {
 	server, udp := createTestServer(t, corefile)
 	defer server.Stop()
 
-	log.SetOutput(ioutil.Discard)
-
 	// Work-around for timing condition that results in no-data being returned in
 	// test environment.
 	time.Sleep(5 * time.Second)
 
-	for _, testData := range testdataLookupA {
+	for _, td := range testdata {
 		dnsClient := new(dns.Client)
 		dnsMessage := new(dns.Msg)
 
-		dnsMessage.SetQuestion(testData.Query, dns.TypeA)
-		dnsMessage.SetEdns0(4096, true)
+		dnsMessage.SetQuestion(td.query.fqdn, td.query.qtype)
+		//		dnsMessage.SetEdns0(4096, true)
 
 		res, _, err := dnsClient.Exchange(dnsMessage, udp)
 		if err != nil {
 			t.Fatalf("Could not send query: %s", err)
 		}
-		// Count A records in the answer section
-		ARecordCount := 0
-		for _, a := range res.Answer {
-			if a.Header().Rrtype == dns.TypeA {
-				ARecordCount++
-			}
+
+		// check the answer
+		if res.Rcode != td.answer.rcode {
+			t.Errorf("Expected rcode %d but got %d for query %v", td.answer.rcode, res.Rcode, td.query)
 		}
 
-		if ARecordCount != testData.ARecordCount {
-			t.Errorf("Expected '%v' A records in response. Instead got '%v' A records. Test query string: '%v'", testData.ARecordCount, ARecordCount, testData.Query)
-		}
-		if len(res.Answer) != testData.TotalAnswerCount {
-			t.Errorf("Expected '%v' records in answer section. Instead got '%v' records in answer section. Test query string: '%v'", testData.TotalAnswerCount, len(res.Answer), testData.Query)
-		}
-	}
-}
-
-func testLookupSRV(t *testing.T) {
-	corefile :=
-		`.:0 {
-    kubernetes coredns.local {
-                endpoint http://localhost:8080
-		namespaces demo
-    }
-`
-
-	server, udp := createTestServer(t, corefile)
-	defer server.Stop()
-
-	log.SetOutput(ioutil.Discard)
-
-	// Work-around for timing condition that results in no-data being returned in
-	// test environment.
-	time.Sleep(5 * time.Second)
-
-	// TODO: Add checks for A records in additional section
-
-	for _, testData := range testdataLookupSRV {
-		dnsClient := new(dns.Client)
-		dnsMessage := new(dns.Msg)
-
-		dnsMessage.SetQuestion(testData.Query, dns.TypeSRV)
-		dnsMessage.SetEdns0(4096, true)
-
-		res, _, err := dnsClient.Exchange(dnsMessage, udp)
-		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
-		}
-		// Count SRV records in the answer section
-		srvRecordCount := 0
-		for _, a := range res.Answer {
-			if a.Header().Rrtype == dns.TypeSRV {
-				srvRecordCount++
-			}
+		if len(res.Answer) != len(td.answer.rrs) {
+			t.Errorf("Expected %d answers but got %d for query %v", len(td.answer.rrs), len(res.Answer), td.query)
 		}
 
-		if srvRecordCount != testData.SRVRecordCount {
-			t.Errorf("Expected '%v' SRV records in response. Instead got '%v' SRV records. Test query string: '%v', res: %v", testData.SRVRecordCount, srvRecordCount, testData.Query, res)
-		}
-		if len(res.Answer) != testData.TotalAnswerCount {
-			t.Errorf("Expected '%v' records in answer section. Instead got '%v' records in answer section. Test query string: '%v', res: %v", testData.TotalAnswerCount, len(res.Answer), testData.Query, res)
-		}
+		//TODO: Check the actual RR values
 	}
 }


### PR DESCRIPTION
Improved the testdata struct to include Rcode and actual RRs.
Now checks Rcode not just counts. Also checks counts. Checking
actual RR values still TODO.