### PR TITLE
Return NXDOMAIN when no items match query

### DIFF
--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -71,7 +71,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	}
 
 	if len(records) == 0 {
-		return middleware.BackendError(&k, zone, dns.RcodeSuccess, state, nil /*debug*/, nil, middleware.Options{})
+		return middleware.BackendError(&k, zone, dns.RcodeNameError, state, nil /*debug*/, nil, middleware.Options{})
 	}
 
 	m.Answer = append(m.Answer, records...)

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -71,7 +71,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	}
 
 	if len(records) == 0 {
-		return middleware.BackendError(&k, zone, dns.RcodeNameError, state, nil /*debug*/, nil, middleware.Options{})
+		return middleware.BackendError(&k, zone, dns.RcodeSuccess, state, nil /*debug*/, nil, middleware.Options{})
 	}
 
 	m.Answer = append(m.Answer, records...)

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -44,8 +44,8 @@ type Kubernetes struct {
 	Selector      *labels.Selector
 }
 
-var noItemsErr     = errors.New("No items found")
-var nsUnexposedErr = errors.New("Namespace is not exposed")
+var noItemsErr     = errors.New("no items found")
+var nsUnexposedErr = errors.New("namespace is not exposed")
 
 // Services implements the ServiceBackend interface.
 func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) ([]msg.Service, []msg.Service, error) {

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -44,6 +44,8 @@ type Kubernetes struct {
 	Selector      *labels.Selector
 }
 
+var noItemsErr = errors.New("No items found")
+
 // Services implements the ServiceBackend interface.
 func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) ([]msg.Service, []msg.Service, error) {
 	s, e := k.Records(state.Name(), exact)
@@ -69,7 +71,7 @@ func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dn
 // IsNameError implements the ServiceBackend interface.
 // TODO(infoblox): implement!
 func (k *Kubernetes) IsNameError(err error) bool {
-	return false
+	return err == noItemsErr
 }
 
 // Debug implements the ServiceBackend interface.
@@ -209,7 +211,7 @@ func (k *Kubernetes) Records(name string, exact bool) ([]msg.Service, error) {
 	}
 	if k8sItems == nil {
 		// Did not find item in k8s
-		return nil, nil
+		return nil, noItemsErr
 	}
 
 	records := k.getRecordsForServiceItems(k8sItems, zone)

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
 	"github.com/miekg/coredns/middleware/test"
+
+	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
 )
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -3,72 +3,159 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
 	"github.com/mholt/caddy"
+	"github.com/miekg/coredns/middleware/test"
 	"github.com/miekg/dns"
 )
 
-// Test data for A records
-var testdataLookupA = []struct {
-	Query            string
-	TotalAnswerCount int
-	ARecordCount     int
-}{
-	// Matching queries
-	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One A record, should exist
+// Test data
+// TODO: Fix the actual RR values
 
-	// Failure queries
-	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One A record, is not exposed
-	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
-
-	// Namespace wildcards
-	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One A record, via wildcard namespace
-	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One A record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.svc.coredns.local.", 2, 2},                          // Two A records, via wildcard
-	{"any.demo.svc.coredns.local.", 2, 2},                        // Two A records, via wildcard
-	{"*.test.svc.coredns.local.", 0, 0},                          // Two A record, via wildcard that is not exposed
-	{"any.test.svc.coredns.local.", 0, 0},                        // Two A record, via wildcard that is not exposed
-	{"*.*.svc.coredns.local.", 2, 2},                             // Two A records, via namespace and service wildcard
-}
-
-// Test data for SRV records
-var testdataLookupSRV = []struct {
-	Query            string
-	TotalAnswerCount int
-	//	ARecordCount     int
-	SRVRecordCount int
-}{
-	// Matching queries
-	{"mynginx.demo.svc.coredns.local.", 1, 1}, // One SRV record, should exist
-
-	// Failure queries
-	{"mynginx.test.svc.coredns.local.", 0, 0},                     // One SRV record, is not exposed
-	{"someservicethatdoesnotexist.demo.svc.coredns.local.", 0, 0}, // Record does not exist
-
-	// Namespace wildcards
-	{"mynginx.*.svc.coredns.local.", 1, 1},                       // One SRV record, via wildcard namespace
-	{"mynginx.any.svc.coredns.local.", 1, 1},                     // One SRV record, via wildcard namespace
-	{"someservicethatdoesnotexist.*.svc.coredns.local.", 0, 0},   // Record does not exist with wildcard for namespace
-	{"someservicethatdoesnotexist.any.svc.coredns.local.", 0, 0}, // Record does not exist with wildcard for namespace
-	{"*.demo.svc.coredns.local.", 2, 2},                          // Two (mynginx, webserver) SRV record, via wildcard
-	{"any.demo.svc.coredns.local.", 2, 2},                        // Two (mynginx, webserver) SRV record, via wildcard
-	{"*.test.svc.coredns.local.", 0, 0},                          // One SRV record, via wildcard that is not exposed
-	{"any.test.svc.coredns.local.", 0, 0},                        // One SRV record, via wildcard that is not exposed
-	{"*.*.svc.coredns.local.", 2, 2},                             // Two SRV record, via namespace and service wildcard
-}
-
-func TestKubernetesIntegration(t *testing.T) {
-
-	// t.Skip("Skip Kubernetes Integration tests")
-	// subtests here (Go 1.7 feature).
-	testLookupA(t)
-	testLookupSRV(t)
+var dnsTestCases = []test.Case{
+	{
+		Qname: "mynginx.demo.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "bogusservice.demo.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "mynginx.*.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "mynginx.any.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "bogusservice.*.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "bogusservice.any.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.demo.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
+	{
+		Qname: "any.demo.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
+	{
+		Qname: "any.test.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.test.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.*.svc.coredns.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
+	//TODO: Fix below to all use test.SRV not test.A!
+	{
+		Qname: "mynginx.demo.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "bogusservice.demo.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "mynginx.*.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "mynginx.any.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+		},
+	},
+	{
+		Qname: "bogusservice.*.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "bogusservice.any.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.demo.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
+	{
+		Qname: "any.demo.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
+	{
+		Qname: "any.test.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.test.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "*.*.svc.coredns.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("mynginx.demo.svc.coredns.local.      1800    IN      A       10.3.0.10"),
+			test.A("webserver.demo.svc.coredns.local.      1800    IN      A       10.3.0.20"),
+		},
+	},
 }
 
 func createTestServer(t *testing.T, corefile string) (*caddy.Instance, string) {
@@ -85,96 +172,44 @@ func createTestServer(t *testing.T, corefile string) (*caddy.Instance, string) {
 	return server, udp
 }
 
-func testLookupA(t *testing.T) {
+func TestKubernetesIntegration(t *testing.T) {
 	corefile :=
 		`.:0 {
     kubernetes coredns.local {
                 endpoint http://localhost:8080
+		#endpoint https://kubernetes/ admin.pem admin-key.pem ca.pem
+		#endpoint https://kubernetes/ 
+		#tls k8s_auth/client2.crt k8s_auth/client2.key k8s_auth/ca2.crt
 		namespaces demo
     }
-
 `
 	server, udp := createTestServer(t, corefile)
 	defer server.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	// Work-around for timing condition that results in no-data being returned in
 	// test environment.
 	time.Sleep(5 * time.Second)
 
-	for _, testData := range testdataLookupA {
+	for _, tc := range dnsTestCases {
 		dnsClient := new(dns.Client)
 		dnsMessage := new(dns.Msg)
 
-		dnsMessage.SetQuestion(testData.Query, dns.TypeA)
-		dnsMessage.SetEdns0(4096, true)
+		dnsMessage.SetQuestion(tc.Qname, tc.Qtype)
 
 		res, _, err := dnsClient.Exchange(dnsMessage, udp)
 		if err != nil {
 			t.Fatalf("Could not send query: %s", err)
 		}
-		// Count A records in the answer section
-		ARecordCount := 0
-		for _, a := range res.Answer {
-			if a.Header().Rrtype == dns.TypeA {
-				ARecordCount++
-			}
+
+		// check the answer
+		if res.Rcode != tc.Rcode {
+			t.Errorf("Expected rcode %d but got %d for query %s, %d", tc.Rcode, res.Rcode, tc.Qname, tc.Qtype)
 		}
 
-		if ARecordCount != testData.ARecordCount {
-			t.Errorf("Expected '%v' A records in response. Instead got '%v' A records. Test query string: '%v'", testData.ARecordCount, ARecordCount, testData.Query)
-		}
-		if len(res.Answer) != testData.TotalAnswerCount {
-			t.Errorf("Expected '%v' records in answer section. Instead got '%v' records in answer section. Test query string: '%v'", testData.TotalAnswerCount, len(res.Answer), testData.Query)
-		}
-	}
-}
-
-func testLookupSRV(t *testing.T) {
-	corefile :=
-		`.:0 {
-    kubernetes coredns.local {
-                endpoint http://localhost:8080
-		namespaces demo
-    }
-`
-
-	server, udp := createTestServer(t, corefile)
-	defer server.Stop()
-
-	log.SetOutput(ioutil.Discard)
-
-	// Work-around for timing condition that results in no-data being returned in
-	// test environment.
-	time.Sleep(5 * time.Second)
-
-	// TODO: Add checks for A records in additional section
-
-	for _, testData := range testdataLookupSRV {
-		dnsClient := new(dns.Client)
-		dnsMessage := new(dns.Msg)
-
-		dnsMessage.SetQuestion(testData.Query, dns.TypeSRV)
-		dnsMessage.SetEdns0(4096, true)
-
-		res, _, err := dnsClient.Exchange(dnsMessage, udp)
-		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
-		}
-		// Count SRV records in the answer section
-		srvRecordCount := 0
-		for _, a := range res.Answer {
-			if a.Header().Rrtype == dns.TypeSRV {
-				srvRecordCount++
-			}
+		if len(res.Answer) != len(tc.Answer) {
+			t.Errorf("Expected %d answers but got %d for query %s, %d", len(tc.Answer), len(res.Answer), tc.Qname, tc.Qtype)
 		}
 
-		if srvRecordCount != testData.SRVRecordCount {
-			t.Errorf("Expected '%v' SRV records in response. Instead got '%v' SRV records. Test query string: '%v', res: %v", testData.SRVRecordCount, srvRecordCount, testData.Query, res)
-		}
-		if len(res.Answer) != testData.TotalAnswerCount {
-			t.Errorf("Expected '%v' records in answer section. Instead got '%v' records in answer section. Test query string: '%v', res: %v", testData.TotalAnswerCount, len(res.Answer), testData.Query, res)
-		}
+		//TODO: Check the actual RR values
 	}
 }


### PR DESCRIPTION
Return NXDOMAIN when...

- No records matching the query.
- Namespace in query is unexposed.

I pulled the proposed changes to test/kubernetes_test.go from PR #421 by @johnbelamaric, updated it to check for NXDOMAIN in the proper tests.  