### PR TITLE
Propagate both message and error in proxy exchange.

### DIFF
--- a/middleware/proxy/client.go
+++ b/middleware/proxy/client.go
@@ -65,13 +65,9 @@ func (c *client) Exchange(m *dns.Msg, co net.Conn) (*dns.Msg, time.Duration, err
 		return ret, e
 	})
 
-	rtt := time.Since(start)
-	if err != nil {
-		return &dns.Msg{}, rtt, err
-	}
-
 	r1 := r.(dns.Msg)
-	return &r1, rtt, nil
+	rtt := time.Since(start)
+	return &r1, rtt, err
 }
 
 // exchange does *not* return a pointer to dns.Msg because that leads to buffer reuse when


### PR DESCRIPTION
When the proxy backend returns an error, coredns currently forcibly clears the response message. In the case of truncated messages, this breaks the proxy, as instead of returning a truncate message, the server returns a servfail. Following the pattern in miekg/dns/client, always return the proxied message, even if there's an error.