### PR TITLE
middleware/metrics: export actual size

### DIFF
--- a/middleware/metrics/handler.go
+++ b/middleware/metrics/handler.go
@@ -25,7 +25,7 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	rw := dnsrecorder.New(w)
 	status, err := m.Next.ServeDNS(ctx, rw, r)
 
-	vars.Report(state, zone, rcode.ToString(rw.Rcode), rw.Size, rw.Start)
+	vars.Report(state, zone, rcode.ToString(rw.Rcode), rw.Len, rw.Start)
 
 	return status, err
 }

--- a/middleware/metrics/vars/report.go
+++ b/middleware/metrics/vars/report.go
@@ -10,7 +10,7 @@ import (
 
 // Report reports the metrics data associcated with request.
 func Report(req request.Request, zone, rcode string, size int, start time.Time) {
-	// Proto and Family
+	// Proto and Family.
 	net := req.Proto()
 	fam := "1"
 	if req.Family() == 2 {
@@ -33,7 +33,7 @@ func Report(req request.Request, zone, rcode string, size int, start time.Time) 
 	}
 
 	ResponseSize.WithLabelValues(zone, net).Observe(float64(size))
-	RequestSize.WithLabelValues(zone, net).Observe(float64(req.Size()))
+	RequestSize.WithLabelValues(zone, net).Observe(float64(req.Len()))
 
 	ResponseRcode.WithLabelValues(zone, rcode).Inc()
 }

--- a/middleware/pkg/dnsrecorder/recorder.go
+++ b/middleware/pkg/dnsrecorder/recorder.go
@@ -16,7 +16,7 @@ import (
 type Recorder struct {
 	dns.ResponseWriter
 	Rcode int
-	Size  int
+	Len   int
 	Msg   *dns.Msg
 	Start time.Time
 }
@@ -39,16 +39,16 @@ func (r *Recorder) WriteMsg(res *dns.Msg) error {
 	r.Rcode = res.Rcode
 	// We may get called multiple times (axfr for instance).
 	// Save the last message, but add the sizes.
-	r.Size += res.Len()
+	r.Len += res.Len()
 	r.Msg = res
 	return r.ResponseWriter.WriteMsg(res)
 }
 
-// Write is a wrapper that records the size of the message that gets written.
+// Write is a wrapper that records the length of the message that gets written.
 func (r *Recorder) Write(buf []byte) (int, error) {
 	n, err := r.ResponseWriter.Write(buf)
 	if err == nil {
-		r.Size += n
+		r.Len += n
 	}
 	return n, err
 }

--- a/middleware/pkg/replacer/replacer.go
+++ b/middleware/pkg/replacer/replacer.go
@@ -53,7 +53,7 @@ func New(r *dns.Msg, rr *dnsrecorder.Recorder, emptyValue string) Replacer {
 			rcode = strconv.Itoa(rr.Rcode)
 		}
 		rep.replacements["{rcode}"] = rcode
-		rep.replacements["{size}"] = strconv.Itoa(rr.Size)
+		rep.replacements["{size}"] = strconv.Itoa(rr.Len)
 		rep.replacements["{duration}"] = time.Since(rr.Start).String()
 	}
 

--- a/request/request.go
+++ b/request/request.go
@@ -106,7 +106,10 @@ func (r *Request) Do() bool {
 	return false
 }
 
-// Size returns if UDP buffer size advertised in the requests OPT record.
+// Len returns the length in bytes in the request.
+func (r *Request) Len() int { return r.Req.Len() }
+
+// Size returns if buffer size *advertised* in the requests OPT record.
 // Or when the request was over TCP, we return the maximum allowed size of 64K.
 func (r *Request) Size() int {
 	if r.size != 0 {


### PR DESCRIPTION
The `*_size*` metrics now export the actual packet length, not the
advertised one (although that might be nice as well).