### PR TITLE
Add A lookup for headless services

### DIFF
--- a/.travis/kubernetes/dns-test.yaml
+++ b/.travis/kubernetes/dns-test.yaml
@@ -91,6 +91,26 @@ spec:
           name: c-port
           protocol: UDP
 ---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: de-d1
+  namespace: test-1
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: app-d
+    spec:
+      containers:
+      - name: app-d-c
+        image: gcr.io/google_containers/pause-amd64:3.0
+        ports:
+        - containerPort: 1234
+          name: c-port
+          protocol: UDP
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -145,6 +165,20 @@ spec:
   selector:
     app: app-c
   clusterIP: 10.0.0.120
+  ports:
+  - name: c-port
+    port: 1234
+    protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+  namespace: test-1
+spec:
+  selector:
+    app: app-d
+  clusterIP: None
   ports:
   - name: c-port
     port: 1234

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -59,6 +59,8 @@ var dnsTestCases = []test.Case{
 			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
 			test.A("svc-1-b.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
 			test.A("svc-c.test-1.svc.cluster.local.        303    IN      A       10.0.0.115"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.5"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.6"),
 		},
 	},
 	{
@@ -68,6 +70,8 @@ var dnsTestCases = []test.Case{
 			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
 			test.A("svc-1-b.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
 			test.A("svc-c.test-1.svc.cluster.local.        303    IN      A       10.0.0.115"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.5"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.6"),
 		},
 	},
 	{
@@ -87,6 +91,16 @@ var dnsTestCases = []test.Case{
 			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
 			test.A("svc-1-b.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
 			test.A("svc-c.test-1.svc.cluster.local.        303    IN      A       10.0.0.115"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.5"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.6"),
+		},
+	},
+	{
+		Qname: "headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.5"),
+			test.A("headless-svc.test-1.svc.cluster.local.      303    IN      A       172.17.0.6"),
 		},
 	},
 	//TODO: Fix below to all use test.SRV not test.A!
@@ -137,6 +151,8 @@ var dnsTestCases = []test.Case{
 			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{
@@ -147,6 +163,8 @@ var dnsTestCases = []test.Case{
 			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{
@@ -167,6 +185,8 @@ var dnsTestCases = []test.Case{
 			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{
@@ -223,6 +243,7 @@ func TestKubernetesIntegration(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	for _, tc := range dnsTestCases {
+
 		dnsClient := new(dns.Client)
 		dnsMessage := new(dns.Msg)
 


### PR DESCRIPTION
- Adds caching for endpoints
- When a service is headless (e.g. Cluster IP = None), look up the endpoints (pods) that serve the service
- Adds headless service A record config and tests to k8s integration testing
