### PR TITLE
Return no items if less than 3 items in service segments

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -182,6 +182,9 @@ func (k *Kubernetes) Records(name string, exact bool) ([]msg.Service, error) {
 	)
 
 	zone, serviceSegments := k.getZoneForName(name)
+	if len(serviceSegments) < 3 {
+		return nil, errNoItems
+	}
 
 	// TODO: Implementation above globbed together segments for the serviceName if
 	//       multiple segments remained. Determine how to do similar globbing using


### PR DESCRIPTION
Making a request against the domain that is served by kubernetes middlewear panics if there are less than three elements.
