### PR TITLE
handle A/PTR/SRV for headless services/endpoints

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 const (
 	coreName    = "CoreDNS"
-	coreVersion = "003"
+	coreVersion = "004"
 
 	serverType = "dns"
 )

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -64,18 +63,11 @@ var errInvalidRequest = errors.New("invalid query name")
 
 // Services implements the ServiceBackend interface.
 func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) ([]msg.Service, []msg.Service, error) {
-
-	if state.Type() == "SRV" && !validSrvPrefix(state.QName()) {
+	if state.Type() == "SRV" && !ValidSRV(state.Name()) {
 		return nil, nil, errInvalidRequest
 	}
-
 	s, e := k.Records(state.Name(), exact)
 	return s, nil, e // Haven't implemented debug queries yet.
-}
-
-func validSrvPrefix(name string) bool {
-	matched, _ := regexp.MatchString("^_[^\\.]+\\._(tcp|udp|\\*|any)\\.", strings.ToLower(name))
-	return matched
 }
 
 // PrimaryZone will return the first non-reverse zone being handled by this middleware
@@ -195,10 +187,13 @@ func (k *Kubernetes) getZoneForName(name string) (string, []string) {
 	return zone, serviceSegments
 }
 
-func stripSrvPrefix(name []string) (port string, protocol string, nameOut []string) {
-	if strings.HasPrefix(name[0], "_") && strings.HasPrefix(name[1], "_") {
-		return strings.ToLower(name[0][1:]), strings.ToLower(name[1][1:]), name[2:]
+// stripSrvPrefix separates out the port and protocol segments, if present
+// If not present, assume all ports/protocols (e.g. wildcard)
+func stripSrvPrefix(name []string) (string, string, []string) {
+	if name[0][:1] == "_" && name[1][:1] == "_" {
+		return name[0][1:], name[1][1:], name[2:]
 	}
+	// no srv prefix present
 	return "*", "*", name
 }
 
@@ -430,4 +425,58 @@ func (k *Kubernetes) getServiceRecordForIP(ip, name string) []msg.Service {
 // symbolContainsWildcard checks whether symbol contains a wildcard value
 func symbolContainsWildcard(symbol string) bool {
 	return (strings.Contains(symbol, "*") || (symbol == "any"))
+}
+
+// ValidSRV parses a server record validating _port._proto. prefix labels.
+// The valid schema is:
+//   * Fist two segments must start with an "_",
+//   * Second segment must be one of _tcp|_udp|_*|_any
+func ValidSRV(name string) bool {
+
+	// Does it start with a "_" ?
+	if len(name) > 0 && name[0] != '_' {
+		return false
+	}
+
+	// First label
+	first, end := dns.NextLabel(name, 0)
+	if end {
+		return false
+	}
+	// Second label
+	off, end := dns.NextLabel(name, first)
+	if end {
+		return false
+	}
+
+	// first:off has captured _tcp. or _udp. (if present)
+	second := name[first:off]
+	if len(second) > 0 && second[0] != '_' {
+		return false
+	}
+
+	// A bit convoluted to avoid strings.ToLower
+	if len(second) == 5 {
+		// matches _tcp
+		if (second[1] == 't' || second[1] == 'T') && (second[2] == 'c' || second[2] == 'C') &&
+			(second[3] == 'p' || second[3] == 'P') {
+			return true
+		}
+		// matches _udp
+		if (second[1] == 'u' || second[1] == 'U') && (second[2] == 'd' || second[2] == 'D') &&
+			(second[3] == 'p' || second[3] == 'P') {
+			return true
+		}
+		// matches _any
+		if (second[1] == 'a' || second[1] == 'A') && (second[2] == 'n' || second[2] == 'N') &&
+			(second[3] == 'y' || second[3] == 'Y') {
+			return true
+		}
+	}
+	// matches _*
+	if len(second) == 3 && second[1] == '*' {
+		return true
+	}
+
+	return false
 }

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -190,7 +190,7 @@ func (k *Kubernetes) getZoneForName(name string) (string, []string) {
 // stripSrvPrefix separates out the port and protocol segments, if present
 // If not present, assume all ports/protocols (e.g. wildcard)
 func stripSrvPrefix(name []string) (string, string, []string) {
-	if name[0][:1] == "_" && name[1][:1] == "_" {
+	if name[0][0] == '_' && name[1][0] == '_' {
 		return name[0][1:], name[1][1:], name[2:]
 	}
 	// no srv prefix present

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -187,9 +187,9 @@ func (k *Kubernetes) getZoneForName(name string) (string, []string) {
 	return zone, serviceSegments
 }
 
-// stripSrvPrefix separates out the port and protocol segments, if present
+// stripSRVPrefix separates out the port and protocol segments, if present
 // If not present, assume all ports/protocols (e.g. wildcard)
-func stripSrvPrefix(name []string) (string, string, []string) {
+func stripSRVPrefix(name []string) (string, string, []string) {
 	if name[0][0] == '_' && name[1][0] == '_' {
 		return name[0][1:], name[1][1:], name[2:]
 	}
@@ -215,7 +215,7 @@ func (k *Kubernetes) Records(name string, exact bool) ([]msg.Service, error) {
 	)
 
 	zone, serviceSegments := k.getZoneForName(name)
-	port, protocol, serviceSegments := stripSrvPrefix(serviceSegments)
+	port, protocol, serviceSegments := stripSRVPrefix(serviceSegments)
 	endpointname, serviceSegments := stripEndpointName(serviceSegments)
 	if len(serviceSegments) < 3 {
 		return nil, errNoItems
@@ -303,7 +303,7 @@ func (k *Kubernetes) getRecordsForServiceItems(serviceItems []service, zone stri
 }
 
 // Get performs the call to the Kubernetes http API.
-func (k *Kubernetes) Get(namespace string, servicename string, endpointname string, port string, protocol string, typeName string) (services []service, err error) {
+func (k *Kubernetes) Get(namespace, servicename, endpointname, port, protocol, typeName string) (services []service, err error) {
 	switch {
 	case typeName == "pod":
 		return nil, fmt.Errorf("%v not implemented", typeName)
@@ -312,7 +312,7 @@ func (k *Kubernetes) Get(namespace string, servicename string, endpointname stri
 	}
 }
 
-func (k *Kubernetes) getServices(namespace string, servicename string, endpointname string, port string, protocol string) ([]service, error) {
+func (k *Kubernetes) getServices(namespace, servicename, endpointname, port, protocol string) ([]service, error) {
 	serviceList := k.APIConn.ServiceList()
 
 	var resultItems []service
@@ -371,7 +371,7 @@ func (k *Kubernetes) getServices(namespace string, servicename string, endpointn
 	return resultItems, nil
 }
 
-func symbolMatches(queryString string, candidateString string, wildcard bool) bool {
+func symbolMatches(queryString, candidateString string, wildcard bool) bool {
 	result := false
 	switch {
 	case !wildcard:

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -74,7 +74,7 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.
 }
 
 func validSrvPrefix(name string) bool {
-	matched, _ := regexp.MatchString("^_.*\\._.*\\..*", name)
+	matched, _ := regexp.MatchString("^_[^\\.]+\\._(tcp|udp|\\*|any)\\.", strings.ToLower(name))
 	return matched
 }
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -105,89 +105,99 @@ var dnsTestCases = []test.Case{
 	},
 	//TODO: Fix below to all use test.SRV not test.A!
 	{
+		Qname: "_*._*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*._*.bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "_*._*.svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*._*.svc-1-a.any.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*._*.bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "_*._*.bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "_*._*.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*._*.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*._*.any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "_*._*.*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "_*._*.*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
+			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
+		},
+	},
+	{
+		Qname: "_*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-		},
-	},
-	{
-		Qname: "bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode:  dns.RcodeNameError,
 		Answer: []dns.RR{},
-	},
-	{
-		Qname: "svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-		},
-	},
-	{
-		Qname: "svc-1-a.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-		},
-	},
-	{
-		Qname: "bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-	},
-	{
-		Qname: "bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-	},
-	{
-		Qname: "*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-		},
-	},
-	{
-		Qname: "any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-		},
-	},
-	{
-		Qname: "any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-	},
-	{
-		Qname: "*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-	},
-	{
-		Qname: "*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 headless-svc.test-1.svc.cluster.local."),
-		},
 	},
 	{
 		Qname: "123.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
@@ -196,14 +206,14 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "100.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
-		Rcode:  dns.RcodeSuccess,
+		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.PTR("100.0.0.10.in-addr.arpa.      303    IN      PTR       svc-1-a.test-1.svc.cluster.local."),
 		},
 	},
 	{
 		Qname: "115.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
-		Rcode:  dns.RcodeSuccess,
+		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.PTR("115.0.0.10.in-addr.arpa.      303    IN      PTR       svc-c.test-1.svc.cluster.local."),
 		},

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -195,6 +195,11 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{},
 	},
 	{
+		Qname: "_*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode:  dns.RcodeNameError,
 		Answer: []dns.RR{},

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -144,27 +144,21 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{},
 	},
 	{
-		Qname: "_*._*.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Qname: "_c-port._*.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
 			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{
-		Qname: "_*._*.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Qname: "_*._tcp.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{
@@ -178,15 +172,11 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{},
 	},
 	{
-		Qname: "_*._*.*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Qname: "_http._tcp.*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_http._tcp.svc-1-b.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-b.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.svc-c.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 svc-c.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-5.headless-svc.test-1.svc.cluster.local."),
-			test.SRV("_c-port._udp.headless-svc.test-1.svc.cluster.local.      303    IN    SRV 10 100 1234 172-17-0-6.headless-svc.test-1.svc.cluster.local."),
 		},
 	},
 	{


### PR DESCRIPTION
This is a complete refactor of the prior PR (which i recently cancelled), to minimize as much as possible the amount of code change.  I have only refactored existing code where absolutely necessary.

This adds...
* 'A' lookups for headless service targets (e.g. hostname.svc-name.namespace.cluster.local.)
* 'SRV' lookups for headless service
* 'SRV' lookups for normal services (prior implementation was wrong)
* 'PTR' lookups for headless service targets

There is some necessary refactoring to the way that we pass services around internally in k8s middleware.
Prior design assumed that all answers could be gleaned from api.Service objects.  However headless service endoints are stored in api.Endpoints objects.  Also, per port/protocol filtering requires finer resolution than a list of api.Service.  So new structs are added ...  `type service struct` and `type endpoint struct` 

