### PR TITLE
Add insecure A records for pods

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -43,21 +43,36 @@ This is the default kubernetes setup, with everything specified in full:
         # Kubernetes data API resync period
         # Example values: 60s, 5m, 1h
         resyncperiod 5m
+		
         # Use url for k8s API endpoint
         endpoint https://k8sendpoint:8080
+		
         # The tls cert, key and the CA cert filenames
         tls cert key cacert
+		
         # Assemble k8s record names with the template
         template {service}.{namespace}.{type}.{zone}
+		
         # Only expose the k8s namespace "demo"
         namespaces demo
+		
         # Only expose the records for kubernetes objects
         # that match this label selector. The label
         # selector syntax is described in the kubernetes
         # API documentation: http://kubernetes.io/docs/user-guide/labels/
         # Example selector below only exposes objects tagged as
         # "application=nginx" in the staging or qa environments.
-        labels environment in (staging, qa),application=nginx
+        #labels environment in (staging, qa),application=nginx
+		
+		# The mode of responding to pod A record requests. 
+		# e.g 1-2-3-4.ns.pod.zone.  This option is provided to allow use of
+		# SSL certs when connecting directly to pods.
+		# Valid values: disabled, verified, insecure
+		#  disabled: default. ignore pod requests, always returning NXDOMAIN
+		#  insecure: Always return an A record with IP from request (without 
+		#            checking k8s).  This option is is vulnerable to abuse if
+		# 	         used maliciously in conjuction with wildcard SSL certs.
+		pods disabled
     }
     # Perform DNS response caching for the coredns.local zone
     # Cache timeout is specified by an integer in seconds
@@ -72,6 +87,7 @@ Defaults:
 * The `labels` keyword is only used when filtering results based on kubernetes label selector syntax
   is required. The label selector syntax is described in the kubernetes API documentation at:
   http://kubernetes.io/docs/user-guide/labels/
+* If the `pods` keyword is omitted, all pod type requests will result in NXDOMAIN
 
 ### Template Syntax
 Record name templates can be constructed using the symbolic elements:

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -54,6 +54,7 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 	k8s := &Kubernetes{ResyncPeriod: defaultResyncPeriod}
 	k8s.NameTemplate = new(nametemplate.Template)
 	k8s.NameTemplate.SetTemplate(defaultNameTemplate)
+	k8s.PodMode = PodModeDisabled
 
 	for c.Next() {
 		if c.Val() == "kubernetes" {
@@ -86,6 +87,19 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 
 			for c.NextBlock() {
 				switch c.Val() {
+				case "pods":
+					args := c.RemainingArgs()
+					if len(args) == 1 {
+						switch args[0] {
+						case PodModeDisabled, PodModeInsecure:
+							k8s.PodMode = args[0]
+						default:
+							return nil, errors.New("pods must be one of: disabled, insecure")
+						}
+						continue
+					}
+					return nil, c.ArgErr()
+
 				case "template":
 					args := c.RemainingArgs()
 					if len(args) > 0 {
@@ -152,4 +166,5 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 const (
 	defaultNameTemplate = "{service}.{namespace}.{type}.{zone}"
 	defaultResyncPeriod = 5 * time.Minute
+	defaultPodMode      = PodModeDisabled
 )

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -195,6 +195,18 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{},
 	},
 	{
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-20-0-101.test-1.pod.cluster.local. 0 IN A    10.20.0.101"),
+		},
+	},
+	{
+		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
 		Qname: "123.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{},
@@ -238,6 +250,7 @@ func TestKubernetesIntegration(t *testing.T) {
 		#tls admin.pem admin-key.pem ca.pem
 		#tls k8s_auth/client2.crt k8s_auth/client2.key k8s_auth/ca2.crt
 		namespaces test-1
+		pods insecure
     }
 `
 	server, udp := createTestServer(t, corefile)


### PR DESCRIPTION
Add option for insecure A record responses for pods.
When a request comes in the following format: `1-2-3-4.namespace.pod.myzone.local.` an A record is returned for 1.2.3.4.  The IP is pulled directly from the request name, and is not verified/validated with k8s to be a valid ip.  This option will create an a record for any IP/namespace passed, even if the IP is not actually in the namespace. This is vulnerable to abuse: for example, it can allow a user to use a wild card certificate to establish a secure connection to a pod that is not actually in the namespace that the certificate is for. Hence the optioned is named "insecure"