### PR TITLE
middleware/proxy: add read/writeDeadline

### DIFF
--- a/middleware/proxy/client.go
+++ b/middleware/proxy/client.go
@@ -83,8 +83,14 @@ func (c *client) exchange(m *dns.Msg, co net.Conn) (dns.Msg, error) {
 
 	dnsco := &dns.Conn{Conn: co, UDPSize: udpsize}
 
+	writeDeadline := time.Now().Add(defaultTimeout)
+	dnsco.SetWriteDeadline(writeDeadline)
 	dnsco.WriteMsg(m)
+
+	readDeadline := time.Now().Add(defaultTimeout)
+	co.SetReadDeadline(readDeadline)
 	r, err := dnsco.ReadMsg()
+
 	dnsco.Close()
 	if r == nil {
 		return dns.Msg{}, err

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -1,3 +1,0 @@
-package proxy
-
-/* TODO */

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/miekg/coredns/middleware/proxy"
+	"github.com/miekg/coredns/middleware/test"
+	"github.com/miekg/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestProxyErratic(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+
+	corefile := `example.org:0 {
+		erratic {
+			drop 2
+		}
+	}
+`
+
+	backend, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(backend, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer backend.Stop()
+
+	p := proxy.New([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	// We do one lookup that should not time out.
+	// After this the backend is marked unhealthy anyway. So basically this
+	// tests that it times out.
+	p.Lookup(state, "example.org.", dns.TypeA)
+}


### PR DESCRIPTION
Add deadline to break the connection. We use the default of 5 seconds.
After this the backend is marked unhealthy and not used for some time.

Fixes #467