### PR TITLE
Run tests in parallel

### DIFF
--- a/middleware/loadbalance/loadbalance_test.go
+++ b/middleware/loadbalance/loadbalance_test.go
@@ -27,14 +27,14 @@ func TestLoadBalance(t *testing.T) {
 	}{
 		{
 			answer: []dns.RR{
-				newCNAME("cname1.region2.skydns.test.	300	IN	CNAME		cname2.region2.skydns.test."),
-				newCNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
-				newCNAME("cname5.region2.skydns.test.	300	IN	CNAME		cname6.region2.skydns.test."),
-				newCNAME("cname6.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
-				newMX("mx.region2.skydns.test.			300	IN	MX		2	mx2.region2.skydns.test."),
-				newMX("mx.region2.skydns.test.			300	IN	MX		3	mx3.region2.skydns.test."),
+				test.CNAME("cname1.region2.skydns.test.	300	IN	CNAME		cname2.region2.skydns.test."),
+				test.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				test.CNAME("cname5.region2.skydns.test.	300	IN	CNAME		cname6.region2.skydns.test."),
+				test.CNAME("cname6.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		2	mx2.region2.skydns.test."),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		3	mx3.region2.skydns.test."),
 			},
 			cnameAnswer:   4,
 			addressAnswer: 1,
@@ -42,9 +42,9 @@ func TestLoadBalance(t *testing.T) {
 		},
 		{
 			answer: []dns.RR{
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
-				newCNAME("cname.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				test.CNAME("cname.region2.skydns.test.	300	IN	CNAME		endpoint.region2.skydns.test."),
 			},
 			cnameAnswer:   1,
 			addressAnswer: 1,
@@ -52,23 +52,23 @@ func TestLoadBalance(t *testing.T) {
 		},
 		{
 			answer: []dns.RR{
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.2"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
-				newCNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.2"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
+				test.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
 			},
 			extra: []dns.RR{
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
-				newAAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::1"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
-				newCNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
-				newA("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
-				newAAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::2"),
-				newMX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.1"),
+				test.AAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::1"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx1.region2.skydns.test."),
+				test.CNAME("cname2.region2.skydns.test.	300	IN	CNAME		cname3.region2.skydns.test."),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx2.region2.skydns.test."),
+				test.A("endpoint.region2.skydns.test.		300	IN	A			10.240.0.3"),
+				test.AAAA("endpoint.region2.skydns.test.	300	IN	AAAA		::2"),
+				test.MX("mx.region2.skydns.test.			300	IN	MX		1	mx3.region2.skydns.test."),
 			},
 			cnameAnswer:   1,
 			cnameExtra:    1,
@@ -166,8 +166,3 @@ func handler() middleware.Handler {
 		return dns.RcodeSuccess, nil
 	})
 }
-
-func newA(rr string) *dns.A         { r, _ := dns.NewRR(rr); return r.(*dns.A) }
-func newAAAA(rr string) *dns.AAAA   { r, _ := dns.NewRR(rr); return r.(*dns.AAAA) }
-func newCNAME(rr string) *dns.CNAME { r, _ := dns.NewRR(rr); return r.(*dns.CNAME) }
-func newMX(rr string) *dns.MX       { r, _ := dns.NewRR(rr); return r.(*dns.MX) }

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestAuto(t *testing.T) {
+	t.Parallel()
 	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
@@ -81,6 +82,7 @@ func TestAuto(t *testing.T) {
 }
 
 func TestAutoNonExistentZone(t *testing.T) {
+	t.Parallel()
 	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
 	if err != nil {
 		t.Fatal(err)
@@ -119,6 +121,7 @@ func TestAutoNonExistentZone(t *testing.T) {
 }
 
 func TestAutoAXFR(t *testing.T) {
+	t.Parallel()
 	log.SetOutput(ioutil.Discard)
 
 	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestLookupCache(t *testing.T) {
+	t.Parallel()
 	// Start auth. CoreDNS holding the auth zone.
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -32,6 +32,7 @@ var dsTestCases = []mtest.Case{
 }
 
 func TestLookupDS(t *testing.T) {
+	t.Parallel()
 	name, rm, err := TempFile(".", miekNL)
 	if err != nil {
 		t.Fatalf("failed to created zone: %s", err)

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -31,7 +31,7 @@ func etcdMiddleware() *etcd.Etcd {
 
 // This test starts two coredns servers (and needs etcd). Configure a stubzones in both (that will loop) and
 // will then test if we detect this loop.
-func TestEtcdStubForwarding(t *testing.T) {
+func TestEtcdStubLoop(t *testing.T) {
 	// TODO(miek)
 }
 

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestZoneReload(t *testing.T) {
+	t.Parallel()
 	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", exampleOrg)

--- a/test/file_test.go
+++ b/test/file_test.go
@@ -3,6 +3,7 @@ package test
 import "testing"
 
 func TestTempFile(t *testing.T) {
+	t.Parallel()
 	_, f, e := TempFile(".", "test")
 	if e != nil {
 		t.Fatalf("failed to create temp file: %s", e)

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -230,6 +230,7 @@ func createTestServer(t *testing.T, corefile string) (*caddy.Instance, string) {
 }
 
 func TestKubernetesIntegration(t *testing.T) {
+	t.Parallel()
 	corefile :=
 		`.:0 {
     kubernetes cluster.local 0.0.10.in-addr.arpa {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/miekg/dns"
 )
 
+// fail when done in parallel
+
 // Start test server that has metrics enabled. Then tear it down again.
 func TestMetricsServer(t *testing.T) {
 	corefile := `example.org:0 {

--- a/test/middleware_dnssec_test.go
+++ b/test/middleware_dnssec_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
+	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
 		t.Fatalf("failed to created zone: %s", err)

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestLookupProxy(t *testing.T) {
+	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
 		t.Fatalf("failed to created zone: %s", err)

--- a/test/server.go
+++ b/test/server.go
@@ -3,6 +3,7 @@ package test
 import (
 	"io/ioutil"
 	"log"
+	"sync"
 
 	"github.com/miekg/coredns/core/dnsserver"
 
@@ -12,8 +13,12 @@ import (
 	"github.com/mholt/caddy"
 )
 
+var mu sync.Mutex
+
 // CoreDNSServer returns a CoreDNS test server. It just takes a normal Corefile as input.
 func CoreDNSServer(corefile string) (*caddy.Instance, error) {
+	mu.Lock()
+	defer mu.Unlock()
 	caddy.Quiet = true
 	dnsserver.Quiet = true
 	log.SetOutput(ioutil.Discard)

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -8,6 +8,7 @@ import (
 
 // Start 2 tests server, server A will proxy to B, server B is an CH server.
 func TestProxyToChaosServer(t *testing.T) {
+	t.Parallel()
 	corefile := `.:0 {
 	chaos CoreDNS-001 miek@miek.nl
 }

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestLookupWildcard(t *testing.T) {
+	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
 		t.Fatalf("failed to created zone: %s", err)


### PR DESCRIPTION
Create a small speedup running the tests:

PASS
ok  	github.com/miekg/coredns/test	10.329s

PASS
ok  	github.com/miekg/coredns/test	6.079s

Skip the etcd ones. Doing the middleware/*/*_test ones doesn't yield
any speedup as these are still done on a per directory basis.