### PR TITLE
middleware/proxy: implement Exchanger

### DIFF
--- a/middleware/auto/setup.go
+++ b/middleware/auto/setup.go
@@ -153,7 +153,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 					if err != nil {
 						return a, err
 					}
-					a.loader.proxy = proxy.New(ups)
+					a.loader.proxy = proxy.NewLookup(ups)
 
 				default:
 					t, _, e := file.TransferParse(c, false)

--- a/middleware/etcd/proxy_lookup_test.go
+++ b/middleware/etcd/proxy_lookup_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestProxyLookupFailDebug(t *testing.T) {
 	etc := newEtcdMiddleware()
-	etc.Proxy = proxy.New([]string{"127.0.0.1:154"})
+	etc.Proxy = proxy.NewLookup([]string{"127.0.0.1:154"})
 	etc.Debugging = true
 
 	for _, serv := range servicesProxy {

--- a/middleware/etcd/setup.go
+++ b/middleware/etcd/setup.go
@@ -49,7 +49,7 @@ func setup(c *caddy.Controller) error {
 func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 	stub := make(map[string]proxy.Proxy)
 	etc := Etcd{
-		Proxy:      proxy.New([]string{"8.8.8.8:53", "8.8.4.4:53"}),
+		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53", "8.8.4.4:53"}),
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
 		Inflight:   &singleflight.Group{},
@@ -57,7 +57,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 	}
 	var (
 		tlsConfig *tls.Config
-		err	  error
+		err       error
 		endpoints = []string{defaultEndpoint}
 		stubzones = false
 	)
@@ -96,7 +96,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 					if err != nil {
 						return &Etcd{}, false, err
 					}
-					etc.Proxy = proxy.New(ups)
+					etc.Proxy = proxy.NewLookup(ups)
 				case "tls": // cert key cacertfile
 					args := c.RemainingArgs()
 					tlsConfig, err = mwtls.NewTLSConfigFromArgs(args...)
@@ -134,7 +134,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 						if err != nil {
 							return &Etcd{}, false, c.ArgErr()
 						}
-						etc.Proxy = proxy.New(ups)
+						etc.Proxy = proxy.NewLookup(ups)
 					case "tls": // cert key cacertfile
 						args := c.RemainingArgs()
 						tlsConfig, err = mwtls.NewTLSConfigFromArgs(args...)

--- a/middleware/etcd/setup_test.go
+++ b/middleware/etcd/setup_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/miekg/coredns/middleware/etcd/msg"
 	"github.com/miekg/coredns/middleware/pkg/dnsrecorder"
 	"github.com/miekg/coredns/middleware/pkg/singleflight"
+	"github.com/miekg/coredns/middleware/pkg/tls"
 	"github.com/miekg/coredns/middleware/proxy"
 	"github.com/miekg/coredns/middleware/test"
-	"github.com/miekg/coredns/middleware/pkg/tls"
 
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/mholt/caddy"
@@ -33,7 +33,7 @@ func newEtcdMiddleware() *Etcd {
 	client, _ := newEtcdClient(endpoints, tlsc)
 
 	return &Etcd{
-		Proxy:      proxy.New([]string{"8.8.8.8:53"}),
+		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53"}),
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
 		Inflight:   &singleflight.Group{},

--- a/middleware/etcd/stub.go
+++ b/middleware/etcd/stub.go
@@ -67,7 +67,7 @@ Services:
 	}
 
 	for domain, nss := range nameservers {
-		stubmap[domain] = proxy.New(nss)
+		stubmap[domain] = proxy.NewLookup(nss)
 	}
 	// atomic swap (at least that's what we hope it is)
 	if len(stubmap) > 0 {

--- a/middleware/file/cname_test.go
+++ b/middleware/file/cname_test.go
@@ -93,7 +93,7 @@ func TestLookupCNAMEExternal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected no error when reading zone, got %q", err)
 	}
-	zone.Proxy = proxy.New([]string{"8.8.8.8:53"}) // TODO(miek): point to local instance
+	zone.Proxy = proxy.NewLookup([]string{"8.8.8.8:53"}) // TODO(miek): point to local instance
 
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{name: zone}, Names: []string{name}}}
 	ctx := context.TODO()

--- a/middleware/file/setup.go
+++ b/middleware/file/setup.go
@@ -110,7 +110,7 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 					if err != nil {
 						return Zones{}, err
 					}
-					prxy = proxy.New(ups)
+					prxy = proxy.NewLookup(ups)
 				}
 
 				for _, origin := range origins {

--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -26,6 +26,7 @@ proxy FROM TO... {
     health_check PATH:PORT [DURATION]
     except IGNORED_NAMES...
     spray
+    protocol [dns|https_google]
 }
 ~~~
 
@@ -37,6 +38,8 @@ proxy FROM TO... {
 * `health_check` will check path (on port) on each backend. If a backend returns a status code of 200-399, then that backend is healthy. If it doesn't, the backend is marked as unhealthy for duration and no requests are routed to it. If this option is not provided then health checks are disabled. The default duration is 10 seconds ("10s").
 * `ignored_names...` is a space-separated list of paths to exclude from proxying. Requests that match any of these paths will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is a failsafe.)
+* `protocol` specifies what protocol to use to speak to an upstream, `dns` (the default) is plain old DNS, and
+  `https_google` uses `https://dns.google.com` and speaks a JSON DNS dialect.
 
 ## Policies
 
@@ -48,14 +51,20 @@ There are three load-balancing policies available:
 All polices implement randomly spraying packets to backend hosts when *no healthy* hosts are
 available. This is to preeempt the case where the healthchecking (as a mechanism) fails.
 
+## Upstream Protocols
+
+Currently supported are `dns` (i.e., standard DNS over UDP) and `https_google`. Note that with
+`https_google` the entire transport is encrypted. Only *you* and *Google* can see your DNS activity.
+
 ## Metrics
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
 
-* coredns_proxy_request_count_total{zone, proto, family}
+* coredns_proxy_request_count_total{protocol, zone, family}
 
 This has some overlap with `coredns_dns_request_count_total{zone, proto, family}`, but allows for
 specifics on upstream query resolving. See the *prometheus* documentation for more details.
+`protocol` is the protocol used to query the upstream.
 
 ## Examples
 

--- a/middleware/proxy/exchanger.go
+++ b/middleware/proxy/exchanger.go
@@ -1,0 +1,18 @@
+package proxy
+
+import (
+	"github.com/miekg/coredns/request"
+	"github.com/miekg/dns"
+)
+
+// Exchanger is an interface that specifies a type implementing a DNS resolver that
+// can use whatever transport it likes.
+type Exchanger interface {
+	Exchange(request.Request) (*dns.Msg, error)
+	SetUpstream(Upstream) error // (Re)set the upstream
+	OnStartup() error
+	OnShutdown() error
+	Protocol() protocol
+}
+
+type protocol string

--- a/middleware/proxy/metrics.go
+++ b/middleware/proxy/metrics.go
@@ -12,14 +12,14 @@ import (
 var (
 	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: middleware.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "proxy",
 		Name:      "request_duration_milliseconds",
 		Buckets:   append(prometheus.DefBuckets, []float64{50, 100, 200, 500, 1000, 2000, 3000, 4000, 5000, 10000}...),
 		Help:      "Histogram of the time (in milliseconds) each request took.",
-	}, []string{"zone"})
+	}, []string{"protocol", "zone"})
 )
 
-// OnStartup sets up the metrics on startup.
+// OnStartup sets up the metrics on startup. This is done for all proxy protocols.
 func OnStartup() error {
 	metricsOnce.Do(func() {
 		prometheus.MustRegister(RequestDuration)
@@ -28,5 +28,3 @@ func OnStartup() error {
 }
 
 var metricsOnce sync.Once
-
-const subsystem = "proxy"

--- a/middleware/proxy/setup.go
+++ b/middleware/proxy/setup.go
@@ -20,7 +20,7 @@ func setup(c *caddy.Controller) error {
 		return middleware.Error("proxy", err)
 	}
 	dnsserver.GetConfig(c).AddMiddleware(func(next middleware.Handler) middleware.Handler {
-		return Proxy{Next: next, Client: newClient(), Upstreams: upstreams}
+		return Proxy{Next: next, Upstreams: upstreams}
 	})
 
 	c.OnStartup(OnStartup)

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -165,6 +165,20 @@ proxy . 8.8.8.8:53 {
 proxy . some_bogus_filename`,
 			true,
 		},
+		{
+			`
+proxy . 8.8.8.8:53 {
+	protocol dns
+}`,
+			false,
+		},
+		{
+			`
+proxy . 8.8.8.8:53 {
+	protocol foobar
+}`,
+			true,
+		},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputUpstreams)

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -42,7 +42,7 @@ func TestAuto(t *testing.T) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	resp, err := p.Lookup(state, "www.example.org.", dns.TypeA)
@@ -108,7 +108,7 @@ func TestAutoNonExistentZone(t *testing.T) {
 	}
 	defer i.Stop()
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
@@ -155,7 +155,7 @@ func TestAutoAXFR(t *testing.T) {
 
 	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	m := new(dns.Msg)
 	m.SetAxfr("example.org.")
 	state := request.Request{W: &test.ResponseWriter{}, Req: m}

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -56,7 +56,7 @@ func TestLookupCache(t *testing.T) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
@@ -65,7 +65,7 @@ func TestLookupCache(t *testing.T) {
 	}
 	// expect answer section with A record in it
 	if len(resp.Answer) == 0 {
-		t.Error("Expected to at least one RR in the answer section, got none")
+		t.Fatal("Expected to at least one RR in the answer section, got none")
 	}
 
 	ttl := resp.Answer[0].Header().Ttl

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -57,7 +57,7 @@ func TestLookupDS(t *testing.T) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &mtest.ResponseWriter{}, Req: new(dns.Msg)}
 
 	for _, tc := range dsTestCases {

--- a/test/etcd_cache_debug_test.go
+++ b/test/etcd_cache_debug_test.go
@@ -47,7 +47,7 @@ func TestEtcdCacheAndDebug(t *testing.T) {
 		defer delete(ctx, t, etc, serv.Key)
 	}
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	resp, err := p.Lookup(state, "b.example.skydns.test.", dns.TypeA)

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -66,15 +66,14 @@ func TestEtcdStubAndProxyLookup(t *testing.T) {
 		defer delete(ctx, t, etc, serv.Key)
 	}
 
-	p := proxy.New([]string{udp}) // use udp port from the server
+	p := proxy.NewLookup([]string{udp}) // use udp port from the server
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 	resp, err := p.Lookup(state, "example.com.", dns.TypeA)
 	if err != nil {
-		t.Error("Expected to receive reply, but didn't")
-		return
+		t.Fatalf("Expected to receive reply, but didn't", err)
 	}
 	if len(resp.Answer) == 0 {
-		t.Error("Expected to at least one RR in the answer section, got none")
+		t.Fatalf("Expected to at least one RR in the answer section, got none")
 	}
 	if resp.Answer[0].Header().Rrtype != dns.TypeA {
 		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -42,7 +42,7 @@ example.net:0 {
 	}
 	defer i.Stop()
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	resp, err := p.Lookup(state, "example.org.", dns.TypeA)

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -33,7 +33,7 @@ func TestProxyErratic(t *testing.T) {
 	}
 	defer backend.Stop()
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	// We do one lookup that should not time out.

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -38,7 +38,7 @@ func TestLookupProxy(t *testing.T) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {
@@ -82,7 +82,7 @@ func BenchmarkLookupProxy(b *testing.B) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	b.ResetTimer()

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -38,7 +38,7 @@ func TestLookupWildcard(t *testing.T) {
 
 	log.SetOutput(ioutil.Discard)
 
-	p := proxy.New([]string{udp})
+	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 
 	for _, lookup := range []string{"a.w.example.org.", "a.a.w.example.org."} {


### PR DESCRIPTION
By defining and using an proxy.Exchanger interface we make the proxy
more generic and we can then fold back httproxy into proxy.

This overrides #463 and #473 and should make futures extensions rather
trivial