### PR TITLE
only a * by itself is wild

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -529,5 +529,5 @@ func (k *Kubernetes) getServiceRecordForIP(ip, name string) []msg.Service {
 
 // symbolContainsWildcard checks whether symbol contains a wildcard value
 func symbolContainsWildcard(symbol string) bool {
-	return (strings.Contains(symbol, "*") || (symbol == "any"))
+	return (symbol == "*" || symbol == "any")
 }

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -11,9 +11,9 @@ var testdataSymbolContainsWildcard = []struct {
 	{"mynamespace", false},
 	{"*", true},
 	{"any", true},
-	{"my*space", true},
-	{"*space", true},
-	{"myname*", true},
+	{"my*space", false},
+	{"*space", false},
+	{"myname*", false},
 }
 
 func TestSymbolContainsWildcard(t *testing.T) {


### PR DESCRIPTION
Addressing issue #470:  Only a `*` by itself in a label is a wildcard.  
