### PR TITLE
correct k8s name parsing response codes

### DIFF
--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -181,17 +181,17 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeServerFailure,
+		Rcode:  dns.RcodeNameError,
 		Answer: []dns.RR{},
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeServerFailure,
+		Rcode:  dns.RcodeNameError,
 		Answer: []dns.RR{},
 	},
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeServerFailure,
+		Rcode:  dns.RcodeNameError,
 		Answer: []dns.RR{},
 	},
 	{


### PR DESCRIPTION
Fixes #491.

When a query string is invalid for kubernetes, return NXDOMAIN, so that clients will continue to try other domains in the search list.