### PR TITLE
Fix `go fmt`, `go lint`, and `go vet` issues

### DIFF
--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -27,8 +27,8 @@ func TestSymbolContainsWildcard(t *testing.T) {
 
 func expectString(t *testing.T, function, qtype, query string, r *recordRequest, field, expected string) {
 	ref := reflect.ValueOf(r)
-	ref_f := reflect.Indirect(ref).FieldByName(field)
-	got := ref_f.String()
+	refField := reflect.Indirect(ref).FieldByName(field)
+	got := refField.String()
 	if got != expected {
 		t.Errorf("Expected %v(%v, \"%v\") to get %v == \"%v\". Instead got \"%v\".", function, query, qtype, field, expected, got)
 	}

--- a/middleware/pkg/tls/tls_test.go
+++ b/middleware/pkg/tls/tls_test.go
@@ -1,8 +1,8 @@
 package tls
 
 import (
-        "testing"
-        "path/filepath"
+	"path/filepath"
+	"testing"
 
 	"github.com/miekg/coredns/middleware/test"
 )
@@ -57,7 +57,7 @@ func TestNewTLSConfigFromArgs(t *testing.T) {
 		t.Error("RootCAs should not be nil when one arg passed")
 	}
 
-	c, err = NewTLSConfigFromArgs(cert,key)
+	c, err = NewTLSConfigFromArgs(cert, key)
 	if err != nil {
 		t.Errorf("Failed to create TLSConfig: %s", err)
 	}
@@ -67,7 +67,7 @@ func TestNewTLSConfigFromArgs(t *testing.T) {
 	if len(c.Certificates) != 1 {
 		t.Error("Certificates should have a single entry when two args passed")
 	}
-	args := []string{cert,key,ca}
+	args := []string{cert, key, ca}
 	c, err = NewTLSConfigFromArgs(args...)
 	if err != nil {
 		t.Errorf("Failed to create TLSConfig: %s", err)

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/miekg/coredns/request"
 
 	"github.com/miekg/dns"
-        ot "github.com/opentracing/opentracing-go"
+	ot "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 

--- a/middleware/trace/setup.go
+++ b/middleware/trace/setup.go
@@ -38,7 +38,7 @@ func setup(c *caddy.Controller) error {
 
 func traceParse(c *caddy.Controller) (*Trace, error) {
 	var (
-		tr = &Trace{Endpoint: defEP, EndpointType: defEpType}
+		tr  = &Trace{Endpoint: defEP, EndpointType: defEpType}
 		err error
 	)
 
@@ -82,6 +82,6 @@ func normalizeEndpoint(epType, ep string) (string, error) {
 var traceOnce sync.Once
 
 const (
-	defEP = "localhost:9411"
+	defEP     = "localhost:9411"
 	defEpType = "zipkin"
 )

--- a/middleware/trace/setup_test.go
+++ b/middleware/trace/setup_test.go
@@ -10,7 +10,7 @@ func TestTraceParse(t *testing.T) {
 	tests := []struct {
 		input     string
 		shouldErr bool
-		endpoint      string
+		endpoint  string
 	}{
 		// oks
 		{`trace`, false, "http://localhost:9411/api/v1/spans"},

--- a/middleware/trace/trace.go
+++ b/middleware/trace/trace.go
@@ -5,22 +5,22 @@ import (
 	"fmt"
 	"sync"
 
-        "golang.org/x/net/context"
+	"golang.org/x/net/context"
 
 	"github.com/miekg/coredns/middleware"
-        "github.com/miekg/dns"
-        ot "github.com/opentracing/opentracing-go"
-        zipkin "github.com/openzipkin/zipkin-go-opentracing"
+	"github.com/miekg/dns"
+	ot "github.com/opentracing/opentracing-go"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 )
 
 // Trace holds the tracer and endpoint info
 type Trace struct {
-	Next middleware.Handler
+	Next            middleware.Handler
 	ServiceEndpoint string
-	Endpoint string
-	EndpointType string
-	Tracer ot.Tracer
-	Once sync.Once
+	Endpoint        string
+	EndpointType    string
+	Tracer          ot.Tracer
+	Once            sync.Once
 }
 
 // OnStartup sets up the tracer
@@ -52,10 +52,12 @@ func (t *Trace) setupZipkin() error {
 	return nil
 }
 
-func (t *Trace) Name() (string) {
+// Name implements the Handler interface.
+func (t *Trace) Name() string {
 	return "trace"
 }
 
+// ServeDNS implements the middleware.Handle interface.
 func (t *Trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	span := t.Tracer.StartSpan("servedns")
 	defer span.Finish()

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -70,7 +70,7 @@ func TestEtcdStubAndProxyLookup(t *testing.T) {
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 	resp, err := p.Lookup(state, "example.com.", dns.TypeA)
 	if err != nil {
-		t.Fatalf("Expected to receive reply, but didn't", err)
+		t.Fatalf("Expected to receive reply, but didn't: %v", err)
 	}
 	if len(resp.Answer) == 0 {
 		t.Fatalf("Expected to at least one RR in the answer section, got none")
@@ -79,7 +79,7 @@ func TestEtcdStubAndProxyLookup(t *testing.T) {
 		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
 	}
 	if resp.Answer[0].(*dns.A).A.String() != "93.184.216.34" {
-		t.Errorf("Expected 93.184.216.34, got: %d", resp.Answer[0].(*dns.A).A.String())
+		t.Errorf("Expected 93.184.216.34, got: %s", resp.Answer[0].(*dns.A).A.String())
 	}
 }
 


### PR DESCRIPTION
This fix fixes several `go fmt`, `go lint`, and `go vet` issues, to make goreportcard happy:

https://goreportcard.com/report/github.com/miekg/coredns

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>