### PR TITLE
Changes needed to support external gRPC server middleware

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -21,6 +21,9 @@ type Config struct {
 	// First consumer is the file middleware to looks for zone files in this place.
 	Root string
 
+	// Server is the server that handles this config
+	Server  *Server
+
 	// Middleware stack.
 	Middleware []middleware.Middleware
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -67,6 +67,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 			stack = site.Middleware[i](stack)
 		}
 		site.middlewareChain = stack
+		site.Server = s
 	}
 
 	return s, nil


### PR DESCRIPTION
The gRPC server middleware[1] needs access to the Server object
in order to push the unpacked Msg through the normal middleware
pipeline. These are the changes to core needed to make that
possible.

[1] https://github.com/infobloxopen/coredns-grpc