### PR TITLE
Allow cidr based reverse zone config

### DIFF
--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -29,7 +29,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		// If this is a PTR request, and a the request is in a defined
 		// pod/service cidr range, process the request in this middleware,
 		// otherwise pass to next middleware.
-		if state.Type() != "PTR" || !k.IsIpInReverseRange(k.ExtractAddressFromReverse(state)) {
+		if state.Type() != "PTR" || !k.IsRequestInReverseRange(state) {
 			return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
 		}
 	}

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -26,7 +26,12 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	// otherwise delegate to the next in the pipeline.
 	zone := middleware.Zones(k.Zones).Matches(state.Name())
 	if zone == "" {
-		return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+		// If this is a PTR request, and a the request is in a defined
+		// pod/service cidr range, process the request in this middleware,
+		// otherwise pass to next middleware.
+		if state.Type() != "PTR" || !k.IsIpInReverseRange(k.ExtractAddressFromReverse(state)) {
+			return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+		}
 	}
 
 	var (

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -28,22 +28,21 @@ import (
 
 // Kubernetes implements a middleware that connects to a Kubernetes cluster.
 type Kubernetes struct {
-	Next                      middleware.Handler
-	Zones                     []string
-	primaryZone               int
-	Proxy                     proxy.Proxy // Proxy for looking up names during the resolution process
-	APIEndpoint               string
-	APICertAuth               string
-	APIClientCert             string
-	APIClientKey              string
-	APIConn                   *dnsController
-	ResyncPeriod              time.Duration
-	Namespaces                []string
-	LabelSelector             *unversionedapi.LabelSelector
-	Selector                  *labels.Selector
-	PodMode                   string
-	ReverseCidrs              []net.IPNet
-	extractAddressFromReverse string
+	Next          middleware.Handler
+	Zones         []string
+	primaryZone   int
+	Proxy         proxy.Proxy // Proxy for looking up names during the resolution process
+	APIEndpoint   string
+	APICertAuth   string
+	APIClientCert string
+	APIClientKey  string
+	APIConn       *dnsController
+	ResyncPeriod  time.Duration
+	Namespaces    []string
+	LabelSelector *unversionedapi.LabelSelector
+	Selector      *labels.Selector
+	PodMode       string
+	ReverseCidrs  []net.IPNet
 }
 
 const (
@@ -122,7 +121,7 @@ func (k *Kubernetes) PrimaryZone() string {
 
 // Reverse implements the ServiceBackend interface.
 func (k *Kubernetes) Reverse(state request.Request, exact bool, opt middleware.Options) ([]msg.Service, []msg.Service, error) {
-	ip := k.ExtractAddressFromReverse(state)
+	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
 		return nil, nil, nil
 	}
@@ -131,17 +130,8 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt middleware.O
 	return records, nil, nil
 }
 
-func (k *Kubernetes) ExtractAddressFromReverse(state request.Request) string {
-	if state.Type() != "PTR" {
-		return ""
-	}
-	if k.extractAddressFromReverse == "" {
-		k.extractAddressFromReverse = dnsutil.ExtractAddressFromReverse(state.Name())
-	}
-	return k.extractAddressFromReverse
-}
-
-func (k *Kubernetes) IsIpInReverseRange(ip string) bool {
+func (k *Kubernetes) IsRequestInReverseRange(state request.Request) bool {
+	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	for _, c := range k.ReverseCidrs {
 		if c.Contains(net.ParseIP(ip)) {
 			return true

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -84,6 +85,20 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 
 			for c.NextBlock() {
 				switch c.Val() {
+				case "cidrs":
+					args := c.RemainingArgs()
+					if len(args) > 0 {
+						for _, cidrStr := range args {
+							_, cidr, err := net.ParseCIDR(cidrStr)
+							if err != nil {
+								return nil, errors.New(c.Val() + " contains an invalid cidr: " + cidrStr)
+							}
+							k8s.ReverseCidrs = append(k8s.ReverseCidrs, *cidr)
+
+						}
+						continue
+					}
+					return nil, c.ArgErr()
 				case "pods":
 					args := c.RemainingArgs()
 					if len(args) == 1 {


### PR DESCRIPTION
Instead of requiring declaration of in-addr.arpa style reverse zones for PTR lookups, allow simpler config in kubnenetes section.  This approach draws some, from the proposed PR middleware/reverse.

` kubernetes cluster.local 0.0.10.in-addr.arpa 0.17.172.in-addr.arpa {`
`                ...`
`}`

becomes...

`   kubernetes cluster.local {`
`                cidrs 172.17.0.0/24 10.0.0.0/24`
`                ...`
`}`

This allows for easier configuration of reverse ranges for cidrs that dont fall on an octet (e.g. /24 /16).
Existing style zone configs are still accepted.  Zone configurations take precedence (e.g. if both zones and cidrs are defined, the matching zone is always served in entirety, regardless of cidr configs).

@miekg, let me know if you are OK with this approach, and I'll add documentation and unit tests.