### PR TITLE
Fix no PTR records response for cidr ranges 

### DIFF
--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -33,8 +33,8 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 			if !k.IsRequestInReverseRange(state) {
 				return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
 			}
-			// Set the zone. We can assume ipv4 for now.
-			zone = "ip-addr.arpa."
+			// Set the zone to this specific request.
+			zone = state.Name()
 		}
 	}
 

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -26,11 +26,15 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	// otherwise delegate to the next in the pipeline.
 	zone := middleware.Zones(k.Zones).Matches(state.Name())
 	if zone == "" {
-		// If this is a PTR request, and a the request is in a defined
-		// pod/service cidr range, process the request in this middleware,
-		// otherwise pass to next middleware.
-		if state.Type() != "PTR" || !k.IsRequestInReverseRange(state) {
-			return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+		if state.Type() == "PTR" {
+			// If this is a PTR request, and a the request is in a defined
+			// pod/service cidr range, process the request in this middleware,
+			// otherwise pass to next middleware.
+			if !k.IsRequestInReverseRange(state) {
+				return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
+			}
+			// Set the zone. We can assume ipv4 for now.
+			zone = "ip-addr.arpa."
 		}
 	}
 


### PR DESCRIPTION
Partly addresses #503, the PTR malformed packet response.

The issue was specific to cidr based PTR responses, when there is no PTR record.
In this configuration, the authoritative range of IPs is defined in a cidr, not as a zone in the corefile config.
When a request comes in that is in range, but we don't have a record, we need to reply with what zone it does not exist.  In the case that the range is defined by a cidr, we'll claim authority for just the requested IP.