### PR TITLE
Fix make gen

### DIFF
--- a/directives_generate.go
+++ b/directives_generate.go
@@ -56,7 +56,7 @@ func genImports(file, pack string, mi map[string]string) {
 	}
 
 	for _, v := range mi {
-		outs += `_ "` + v + `\` + "\n"
+		outs += `_ "` + v + `"` + "\n"
 	}
 	outs += ")\n"
 


### PR DESCRIPTION
When using an external middleware, the generated file was failing to compile.
The issue is a typo in directives_generate.go that left imports with an
unterminated string.