### PR TITLE
middleware/metrics: survive restart

### DIFF
--- a/middleware/metrics/README.md
+++ b/middleware/metrics/README.md
@@ -27,6 +27,7 @@ Extra labels used are:
 If monitoring is enabled, queries that do not enter the middleware chain are exported under the fake
 name "dropped" (without a closing dot - this is never a valid domain name).
 
+
 ## Syntax
 
 ~~~
@@ -45,3 +46,8 @@ Use an alternative address:
 ~~~
 prometheus localhost:9253
 ~~~
+
+# Bugs
+
+When reloading, we keep the handler running, meaning that any changes to the handler aren't picked
+up. You'll need to restart CoreDNS for that to happen.

--- a/middleware/metrics/setup.go
+++ b/middleware/metrics/setup.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/miekg/coredns/core/dnsserver"
 	"github.com/miekg/coredns/middleware"
-	"github.com/miekg/coredns/middleware/pkg/resync"
 
 	"github.com/mholt/caddy"
 )
@@ -16,8 +15,6 @@ func init() {
 		ServerType: "dns",
 		Action:     setup,
 	})
-
-	metricsOnce = new(resync.Once)
 }
 
 func setup(c *caddy.Controller) error {


### PR DESCRIPTION
Keep the handler running during restart. Stopping and starting the
handler results in "address in use" - sometimes, meaning the reload
will be flaky. In turn this behavior means any changes to the monitor
stanza are not picked up.