### PR TITLE
Fix resolving CNAME with no proxy

### DIFF
--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -138,6 +138,10 @@ func (p Proxy) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 }
 
 func (p Proxy) match(state request.Request) (u Upstream) {
+	if p.Upstreams == nil {
+		return nil
+	}
+
 	longestMatch := 0
 	for _, upstream := range *p.Upstreams {
 		from := upstream.From()

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -18,7 +18,7 @@ func TestLookupCache(t *testing.T) {
 	// Start auth. CoreDNS holding the auth zone.
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -35,7 +35,7 @@ func TestLookupDS(t *testing.T) {
 	t.Parallel()
 	name, rm, err := TempFile(".", miekNL)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -8,4 +8,5 @@ example.org.		IN	A	127.0.0.1
 example.org.		IN	A	127.0.0.2
 *.w.example.org.        IN      TXT     "Wildcard"
 a.b.c.w.example.org.    IN      TXT     "Not a wildcard"
+cname.example.org.      IN      CNAME   www.example.net.
 `

--- a/test/middleware_dnssec_test.go
+++ b/test/middleware_dnssec_test.go
@@ -15,7 +15,7 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 	rm1 := createKeyFile(t)

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -14,7 +14,7 @@ func benchmarkLookupBalanceRewriteCache(b *testing.B) {
 	t := new(testing.T)
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -16,7 +16,7 @@ func TestLookupProxy(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/reverse_test.go
+++ b/test/reverse_test.go
@@ -16,7 +16,7 @@ func TestReverseFallthrough(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -16,7 +16,7 @@ func TestLookupWildcard(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("failed to create zone: %s", err)
 	}
 	defer rm()
 


### PR DESCRIPTION
This fixes a crash when we resolve (or try to) an external CNAME
when no proxy is set.

Add test as well.