### PR TITLE
Add `go lint` check and fix several lint issues

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -155,10 +155,10 @@ func (s *Server) Address() string { return s.Addr }
 // defined in the request so that the correct zone
 // (configuration and middleware stack) will handle the request.
 func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-	s.ServeDNSWithContext(context.Background(), w, r)
+	s.serveDNSWithContext(context.Background(), w, r)
 }
 
-func (s *Server) ServeDNSWithContext(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) {
+func (s *Server) serveDNSWithContext(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) {
 	defer func() {
 		// In case the user doesn't enable error middleware, we still
 		// need to make sure that we stay alive up here

--- a/middleware/trace/trace_test.go
+++ b/middleware/trace/trace_test.go
@@ -6,15 +6,15 @@ import (
 	"github.com/mholt/caddy"
 )
 
-// CreateTestTrace creates a trace middleware to be used in tests
-func CreateTestTrace(config string) (*caddy.Controller, *trace, error) {
+// createTestTrace creates a trace middleware to be used in tests
+func createTestTrace(config string) (*caddy.Controller, *trace, error) {
 	c := caddy.NewTestController("dns", config)
 	m, err := traceParse(c)
 	return c, m, err
 }
 
 func TestTrace(t *testing.T) {
-	_, m, err := CreateTestTrace(`trace`)
+	_, m, err := createTestTrace(`trace`)
 	if err != nil {
 		t.Errorf("Error parsing test input: %s", err)
 		return


### PR DESCRIPTION
This fix updates the Makefile to add the `go lint` check for the build. This fix also fixes several go lint issues.

NOTE: This fix does not enforce `go lint` (suggestion only). This fix also ignores the `go lint` error:
```
middleware/middleware.go:72:1: context.Context should be the first parameter of a function
```
as it requires too many changes in API.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>