### PR TITLE
Don't error log NXDOMAIN

### DIFF
--- a/middleware/etcd/handler.go
+++ b/middleware/etcd/handler.go
@@ -89,7 +89,8 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if e.IsNameError(err) {
-		return middleware.BackendError(e, zone, dns.RcodeNameError, state, debug, err, opt)
+		// Make err nil when returning here, so we don't log spam for NXDOMAIN.
+		return middleware.BackendError(e, zone, dns.RcodeNameError, state, debug, nil /* err */, opt)
 	}
 	if err != nil {
 		return middleware.BackendError(e, zone, dns.RcodeServerFailure, state, debug, err, opt)

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -71,7 +71,8 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		_, _, err = middleware.A(&k, zone, state, nil, middleware.Options{})
 	}
 	if k.IsNameError(err) {
-		return middleware.BackendError(&k, zone, dns.RcodeNameError, state, nil /*debug*/, err, middleware.Options{})
+		// Make err nil when returning here, so we don't log spam for NXDOMAIN.
+		return middleware.BackendError(&k, zone, dns.RcodeNameError, state, nil /*debug*/, nil /* err */, middleware.Options{})
 	}
 	if err != nil {
 		return dns.RcodeServerFailure, err


### PR DESCRIPTION
In both etcd and k8s don't error log NXDOMAIN as this log spams the logs
for no good reason.

Fixes #568

Better long term solution is log rate limiting for both *log* and
*error*.