### PR TITLE
Add `force-tcp` to proxy over DNS

### DIFF
--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -71,7 +71,8 @@ Currently `protocol` supports `dns` (i.e., standard DNS over UDP/TCP) and `https
 payload over HTTPS). Note that with `https_google` the entire transport is encrypted. Only *you* and
 *Google* can see your DNS activity.
 
-* `dns`: no options can be given at the moment.
+* `dns`: uses the standard DNS exchange. You can pass `force-tcp` to make sure that the proxied connection is performed
+  over TCP, regardless of the inbound request's protocol.
 * `https_google`: bootstrap **ADDRESS...** is used to (re-)resolve `dns.google.com` to an address to
   connect to. This happens every 300s. If not specified the default is used: 8.8.8.8:53/8.8.4.4:53.
   Note that **TO** is *ignored* when `https_google` is used, as its upstream is defined as

--- a/middleware/proxy/dns.go
+++ b/middleware/proxy/dns.go
@@ -12,12 +12,17 @@ import (
 )
 
 type dnsEx struct {
-	Timeout time.Duration
-	group   *singleflight.Group
+	forcedProto string
+	Timeout     time.Duration
+	group       *singleflight.Group
 }
 
 func newDNSEx() *dnsEx {
-	return &dnsEx{group: new(singleflight.Group), Timeout: defaultTimeout * time.Second}
+	return newDNSExWithForcedProto("")
+}
+
+func newDNSExWithForcedProto(forcedProto string) *dnsEx {
+	return &dnsEx{group: new(singleflight.Group), Timeout: defaultTimeout * time.Second, forcedProto: forcedProto}
 }
 
 func (d *dnsEx) Protocol() string          { return "dns" }
@@ -26,7 +31,11 @@ func (d *dnsEx) OnStartup(p *Proxy) error  { return nil }
 
 // Exchange implements the Exchanger interface.
 func (d *dnsEx) Exchange(ctx context.Context, addr string, state request.Request) (*dns.Msg, error) {
-	co, err := net.DialTimeout(state.Proto(), addr, d.Timeout)
+	proto := state.Proto()
+	if d.forcedProto != "" {
+		proto = d.forcedProto
+	}
+	co, err := net.DialTimeout(proto, addr, d.Timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/middleware/proxy/dns.go
+++ b/middleware/proxy/dns.go
@@ -52,10 +52,8 @@ func (d *dnsEx) Exchange(ctx context.Context, addr string, state request.Request
 	if err != nil {
 		return nil, err
 	}
-	if reply.Len() > allowedReplySize(state) {
-		// Maybe clear the RR fields so the truncated definitely gets there?
-		reply.Truncated = true
-	}
+	// Make sure it fits in the DNS response.
+	reply, _ = state.Scrub(reply)
 	reply.Compress = true
 	reply.Id = state.Req.Id
 
@@ -82,17 +80,6 @@ func (d *dnsEx) ExchangeConn(m *dns.Msg, co net.Conn) (*dns.Msg, time.Duration, 
 	r1 := r.(dns.Msg)
 	rtt := time.Since(start)
 	return &r1, rtt, err
-}
-
-func allowedReplySize(state request.Request) int {
-	if state.Proto() == "tcp" {
-		return dns.MaxMsgSize
-	}
-	opt := state.Req.IsEdns0()
-	if opt == nil {
-		return dns.MinMsgSize
-	}
-	return int(opt.UDPSize())
 }
 
 // exchange does *not* return a pointer to dns.Msg because that leads to buffer reuse when

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -14,6 +14,11 @@ import (
 
 // NewLookup create a new proxy with the hosts in host and a Random policy.
 func NewLookup(hosts []string) Proxy {
+	return NewLookupWithForcedProto(hosts, "")
+}
+
+// NewLookupWithForcedProto process creates a simple round robin forward with potentially forced proto for upstream.
+func NewLookupWithForcedProto (hosts []string, forcedProto string) Proxy {
 	p := Proxy{Next: nil}
 
 	upstream := &staticUpstream{
@@ -23,7 +28,7 @@ func NewLookup(hosts []string) Proxy {
 		Spray:       nil,
 		FailTimeout: 10 * time.Second,
 		MaxFails:    3, // TODO(miek): disable error checking for simple lookups?
-		ex:          newDNSEx(),
+		ex:          newDNSExWithForcedProto(forcedProto),
 	}
 
 	for i, host := range hosts {
@@ -53,6 +58,7 @@ func NewLookup(hosts []string) Proxy {
 	p.Upstreams = &[]Upstream{upstream}
 	return p
 }
+
 
 // Lookup will use name and type to forge a new message and will send that upstream. It will
 // set any EDNS0 options correctly so that downstream will be able to process the reply.

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -190,7 +190,15 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		}
 		switch encArgs[0] {
 		case "dns":
-			u.ex = newDNSEx()
+			if len(encArgs) > 1 {
+				if encArgs[1] == "force-tcp" {
+					u.ex = newDNSExWithForcedProto("tcp")
+				} else {
+					return fmt.Errorf("only force-tcp allowed as parameter to dns")
+				}
+			} else {
+				u.ex = newDNSEx()
+			}
 		case "https_google":
 			boot := []string{"8.8.8.8:53", "8.8.4.4:53"}
 			if len(encArgs) > 2 && encArgs[1] == "bootstrap" {

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -56,6 +56,50 @@ func TestLookupProxy(t *testing.T) {
 	}
 }
 
+func TestLookupDnsWithForcedTcp(t *testing.T) {
+	t.Parallel()
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	_, tcp := CoreDNSServerPorts(i, 0)
+	if tcp == "" {
+		t.Fatalf("Could not get TCP listening port")
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookupWithForcedProto([]string{tcp}, "tcp")
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatalf("Expected to at least one RR in the answer section, got none: %s", resp)
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}
+
 func BenchmarkLookupProxy(b *testing.B) {
 	t := new(testing.T)
 	name, rm, err := test.TempFile(".", exampleOrg)


### PR DESCRIPTION
This change adds a parameter to `proxy` middleware's `protocol dns` option of `force-tcp`.

This allows the proxying mode to be done over `tcp` instead of respecting the inbound request's protocol. This makes it significantly more reliable in case you're querying DNS over weird VPNs that have weird MTUs and blackhole packets.