### PR TITLE
middlewware/startup|shutdown

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -34,4 +34,6 @@ var directives = []string{
 	"proxy",
 	"whoami",
 	"erratic",
+	"startup",
+	"shutdown",
 }

--- a/core/zmiddleware.go
+++ b/core/zmiddleware.go
@@ -27,4 +27,5 @@ import (
 	_ "github.com/coredns/coredns/middleware/tls"
 	_ "github.com/coredns/coredns/middleware/trace"
 	_ "github.com/coredns/coredns/middleware/whoami"
+	_ "github.com/mholt/caddy/startupshutdown"
 )

--- a/middleware.cfg
+++ b/middleware.cfg
@@ -42,3 +42,5 @@
 200:proxy:proxy
 210:whoami:whoami
 220:erratic:erratic
+500:startup:github.com/mholt/caddy/startupshutdown
+510:shutdown:github.com/mholt/caddy/startupshutdown


### PR DESCRIPTION
Add middleware by directly linking it from caddy, i.e. without any code
changes. To be fair: this does not added a ServeHTTP, but does give
some nice features in the Corefile.