### PR TITLE
middleware/metrics: allow multiple listeners

### DIFF
--- a/middleware/metrics/README.md
+++ b/middleware/metrics/README.md
@@ -49,5 +49,5 @@ prometheus localhost:9253
 
 # Bugs
 
-When reloading, we keep the handler running, meaning that any changes to the handler aren't picked
-up. You'll need to restart CoreDNS for that to happen.
+When reloading, we keep the handler running, meaning that any changes to the handler's address
+aren't picked up. You'll need to restart CoreDNS for that to happen.


### PR DESCRIPTION
There was no inherent reason *not* to allow multiple listeners for the
monitoring data. Actually enforcing only one listener lead to more code
then just allowing multiple. It's probably not what you want; but
CoreDNS is happy to oblige.