### PR TITLE
middleware/file: add test for SRV additional

### DIFF
--- a/test/example_test.go
+++ b/test/example_test.go
@@ -9,4 +9,6 @@ example.org.		IN	A	127.0.0.2
 *.w.example.org.        IN      TXT     "Wildcard"
 a.b.c.w.example.org.    IN      TXT     "Not a wildcard"
 cname.example.org.      IN      CNAME   www.example.net.
+
+service.example.org.    IN      SRV     8080 10 10 example.org.
 `

--- a/test/file_srv_additional_test.go
+++ b/test/file_srv_additional_test.go
@@ -1,0 +1,53 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/middleware/proxy"
+	"github.com/coredns/coredns/middleware/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestZoneSRVAdditional(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "service.example.org.", dns.TypeSRV)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// There should be 2 A records in the additional section.
+	if len(resp.Extra) != 2 {
+		t.Fatalf("Expected 2 RR in additional section got %d", len(resp.Extra))
+	}
+}


### PR DESCRIPTION
Add test for checking the additional section after a SRV query. Though
this wasn't fixed, but it is.

Fixes #609