### PR TITLE
Tracing for gRPC Server

### DIFF
--- a/core/dnsserver/server-grpc.go
+++ b/core/dnsserver/server-grpc.go
@@ -35,9 +35,6 @@ func NewServergRPC(addr string, group []*Config) (*servergRPC, error) {
 	return gs, nil
 }
 
-// Address together with Stop() implement caddy.GracefulServer.
-func (s *servergRPC) Address() string { return s.Addr }
-
 // Serve implements caddy.TCPServer interface.
 func (s *servergRPC) Serve(l net.Listener) error {
 	s.m.Lock()

--- a/core/dnsserver/server-grpc.go
+++ b/core/dnsserver/server-grpc.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
+	opentracing "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
@@ -30,18 +32,29 @@ func NewServergRPC(addr string, group []*Config) (*servergRPC, error) {
 		return nil, err
 	}
 	gs := &servergRPC{Server: s}
-	gs.grpcServer = grpc.NewServer()
-	// trace foo... TODO(miek)
-	pb.RegisterDnsServiceServer(gs.grpcServer, gs)
-
 	return gs, nil
 }
+
+// Address together with Stop() implement caddy.GracefulServer.
+func (s *servergRPC) Address() string { return s.Addr }
 
 // Serve implements caddy.TCPServer interface.
 func (s *servergRPC) Serve(l net.Listener) error {
 	s.m.Lock()
 	s.listenAddr = l.Addr()
 	s.m.Unlock()
+
+	if s.Tracer() != nil {
+		onlyIfParent := func(parentSpanCtx opentracing.SpanContext, method string, req, resp interface{}) bool {
+			return parentSpanCtx != nil
+		}
+		intercept := otgrpc.OpenTracingServerInterceptor(s.Tracer(), otgrpc.IncludingSpans(onlyIfParent))
+		s.grpcServer = grpc.NewServer(grpc.UnaryInterceptor(intercept))
+	} else {
+		s.grpcServer = grpc.NewServer()
+	}
+
+	pb.RegisterDnsServiceServer(s.grpcServer, s)
 
 	return s.grpcServer.Serve(l)
 }

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -13,9 +13,11 @@ import (
 	"github.com/coredns/coredns/middleware/metrics/vars"
 	"github.com/coredns/coredns/middleware/pkg/edns"
 	"github.com/coredns/coredns/middleware/pkg/rcode"
+	"github.com/coredns/coredns/middleware/pkg/trace"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+	ot "github.com/opentracing/opentracing-go"
 	"golang.org/x/net/context"
 )
 
@@ -33,6 +35,7 @@ type Server struct {
 	zones       map[string]*Config // zones keyed by their address
 	dnsWg       sync.WaitGroup     // used to wait on outstanding connections
 	connTimeout time.Duration      // the maximum duration of a graceful shutdown
+	trace       trace.Trace        // the trace middleware for the server
 }
 
 // NewServer returns a new CoreDNS server and compiles all middleware in to it.
@@ -59,6 +62,15 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		var stack middleware.Handler
 		for i := len(site.Middleware) - 1; i >= 0; i-- {
 			stack = site.Middleware[i](stack)
+			if s.trace == nil && stack.Name() == "trace" {
+				// we have to stash away the middleware, not the
+				// Tracer object, because the Tracer won't be initialized yet
+				if t, ok := stack.(trace.Trace); ok {
+					s.trace = t
+				} else {
+					log.Println("[WARNING] Invalid type found for trace middleware. This is a bug.")
+				}
+			}
 		}
 		site.middlewareChain = stack
 	}
@@ -240,6 +252,14 @@ func (s *Server) OnStartupComplete() {
 	for zone, config := range s.zones {
 		fmt.Println(zone + ":" + config.Port)
 	}
+}
+
+func (s *Server) Tracer() ot.Tracer {
+	if s.trace == nil {
+		return nil
+	}
+
+	return s.trace.Tracer()
 }
 
 // DefaultErrorFunc responds to an DNS request with an error.

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -67,8 +67,6 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 				// Tracer object, because the Tracer won't be initialized yet
 				if t, ok := stack.(trace.Trace); ok {
 					s.trace = t
-				} else {
-					log.Println("[WARNING] Invalid type found for trace middleware. This is a bug.")
 				}
 			}
 		}

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -1,0 +1,26 @@
+package dnsserver
+
+import (
+	"testing"
+)
+
+func makeConfig(transport string) *Config {
+	return &Config{Zone: "example.com", Transport: transport, ListenHost: "127.0.0.1", Port: "53"}
+}
+
+func TestNewServer(t *testing.T) {
+	_, err := NewServer("127.0.0.1:53", []*Config{makeConfig("dns")})
+	if err != nil {
+		t.Errorf("Expected no error for NewServer, got %s.", err)
+	}
+
+	_, err = NewServergRPC("127.0.0.1:53", []*Config{makeConfig("grpc")})
+	if err != nil {
+		t.Errorf("Expected no error for NewServergRPC, got %s.", err)
+	}
+
+	_, err = NewServerTLS("127.0.0.1:53", []*Config{makeConfig("tls")})
+	if err != nil {
+		t.Errorf("Expected no error for NewServerTLS, got %s.", err)
+	}
+}

--- a/middleware/pkg/trace/trace.go
+++ b/middleware/pkg/trace/trace.go
@@ -1,0 +1,12 @@
+package trace
+
+import (
+	"github.com/coredns/coredns/middleware"
+	ot "github.com/opentracing/opentracing-go"
+)
+
+// Trace holds the tracer and endpoint info
+type Trace interface {
+	middleware.Handler
+	Tracer() ot.Tracer
+}

--- a/middleware/proxy/grpc.go
+++ b/middleware/proxy/grpc.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"log"
 
-	"github.com/coredns/coredns/middleware/trace"
+	"github.com/coredns/coredns/middleware/pkg/trace"
 	"github.com/coredns/coredns/pb"
 	"github.com/coredns/coredns/request"
 

--- a/middleware/trace/setup.go
+++ b/middleware/trace/setup.go
@@ -36,13 +36,14 @@ func setup(c *caddy.Controller) error {
 
 func traceParse(c *caddy.Controller) (*trace, error) {
 	var (
-		tr    = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
-		err   error
+		tr  = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
+		err error
 	)
 
 	cfg := dnsserver.GetConfig(c)
 	tr.ServiceEndpoint = cfg.ListenHost + ":" + cfg.Port
 	for c.Next() { // trace
+		var err error
 		args := c.RemainingArgs()
 		switch len(args) {
 		case 0:

--- a/middleware/trace/setup.go
+++ b/middleware/trace/setup.go
@@ -38,16 +38,11 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	var (
 		tr    = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
 		err   error
-		found bool
 	)
 
 	cfg := dnsserver.GetConfig(c)
 	tr.ServiceEndpoint = cfg.ListenHost + ":" + cfg.Port
 	for c.Next() { // trace
-		if found {
-			return tr, c.Err("can only have one trace directive per server")
-		}
-		found = true
 		args := c.RemainingArgs()
 		switch len(args) {
 		case 0:

--- a/middleware/trace/setup.go
+++ b/middleware/trace/setup.go
@@ -36,14 +36,18 @@ func setup(c *caddy.Controller) error {
 
 func traceParse(c *caddy.Controller) (*trace, error) {
 	var (
-		tr  = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
-		err error
+		tr    = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
+		err   error
+		found bool
 	)
 
 	cfg := dnsserver.GetConfig(c)
 	tr.ServiceEndpoint = cfg.ListenHost + ":" + cfg.Port
 	for c.Next() { // trace
-		var err error
+		if found {
+			return tr, c.Err("can only have one trace directive per server")
+		}
+		found = true
 		args := c.RemainingArgs()
 		switch len(args) {
 		case 0:

--- a/middleware/trace/trace.go
+++ b/middleware/trace/trace.go
@@ -7,18 +7,13 @@ import (
 	"sync/atomic"
 
 	"github.com/coredns/coredns/middleware"
+	_ "github.com/coredns/coredns/middleware/pkg/trace"
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 
 	"golang.org/x/net/context"
 )
-
-// Trace holds the tracer and endpoint info
-type Trace interface {
-	middleware.Handler
-	Tracer() ot.Tracer
-}
 
 type trace struct {
 	Next            middleware.Handler


### PR DESCRIPTION
This implements the tracing for the gRPC server. It does not implement it for other servers, which will require more extensive changes to pass context through the proxy.