### PR TITLE
core: add reload tests

### DIFF
--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -1,0 +1,50 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestReload(t *testing.T) {
+	corefile := `.:0 {
+	whoami
+}
+`
+	coreInput := NewInput(corefile)
+
+	c, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(c, 0)
+
+	send(t, udp)
+
+	c1, err := c.Restart(coreInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	udp, _ = CoreDNSServerPorts(c1, 0)
+
+	send(t, udp)
+
+	c1.Stop()
+}
+
+func send(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("whoami.example.org.", dns.TypeSRV)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+	if r.Rcode != dns.RcodeSuccess {
+		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
+	}
+	if len(r.Extra) != 2 {
+		t.Fatalf("Expected 2 RRs in additional, got %s", len(r.Extra))
+	}
+}


### PR DESCRIPTION
This adds a simple reload test for the UDP socket.
See discussion in #620 