### PR TITLE
Add MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,7 @@
+Chris O'Haver
+Cricket Liu
+John Belamaric
+Manuel Alejandro de Brito Fontes
+Michael Richmond
+Miek Gieben
+Yong Tang

--- a/Makefile.release
+++ b/Makefile.release
@@ -16,6 +16,9 @@
 # git log --pretty=format:'%an' v001..master | sort -u
 # (where v001 is the previous release, obviously you'll need to adjust this)
 #
+# Side note: check if MAINTAINERS need an update with `git shortlog -s -n` and see if
+# someone has more than 5 (arbitrary number).
+#
 # Steps:
 # * Get an access token: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
 # * export GITHUB_ACCESS_TOKEN=<token>


### PR DESCRIPTION
Add a MAINTAINERS file. It's not generated and not as elaborate (i.e. no
focus areas) as the one prometheus uses. But it's a start.

Generated with `git shortlog -s -n`, everyone with more than 5 commits.

Docs are put in `Makefile.release`.

Fixes #566