### PR TITLE
middleware/cache: don't cache expired RRSIGs

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -63,7 +63,7 @@ type ResponseWriter struct {
 // WriteMsg implements the dns.ResponseWriter interface.
 func (c *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	do := false
-	mt, opt := response.Typify(res)
+	mt, opt := response.Typify(res, time.Now().UTC())
 	if opt != nil {
 		do = opt.Do()
 	}

--- a/middleware/dnssec/dnssec.go
+++ b/middleware/dnssec/dnssec.go
@@ -41,7 +41,7 @@ func New(zones []string, keys []*DNSKEY, next middleware.Handler, cache *lru.Cac
 func (d Dnssec) Sign(state request.Request, zone string, now time.Time) *dns.Msg {
 	req := state.Req
 
-	mt, _ := response.Typify(req) // TODO(miek): need opt record here?
+	mt, _ := response.Typify(req, time.Now().UTC()) // TODO(miek): need opt record here?
 	if mt == response.Delegation {
 		return req
 	}

--- a/middleware/log/log.go
+++ b/middleware/log/log.go
@@ -52,7 +52,8 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 			rc = 0
 		}
 
-		class, _ := response.Classify(rrw.Msg)
+		tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
+		class := response.Classify(tpe)
 		if rule.Class == response.All || rule.Class == class {
 			rep := replacer.New(r, rrw, CommonLogEmptyValue)
 			rule.Log.Println(rep.Replace(rule.Format))

--- a/middleware/pkg/response/classify.go
+++ b/middleware/pkg/response/classify.go
@@ -1,10 +1,6 @@
 package response
 
-import (
-	"fmt"
-
-	"github.com/miekg/dns"
-)
+import "fmt"
 
 // Class holds sets of Types
 type Class int
@@ -50,14 +46,8 @@ func ClassFromString(s string) (Class, error) {
 	return All, fmt.Errorf("invalid Class: %s", s)
 }
 
-// Classify classifies a dns message: it returns its Class.
-func Classify(m *dns.Msg) (Class, *dns.OPT) {
-	t, o := Typify(m)
-	return classify(t), o
-}
-
-// Does need to be exported?
-func classify(t Type) Class {
+// Classify classifies the Type t, it returns its Class.
+func Classify(t Type) Class {
 	switch t {
 	case NoError, Delegation:
 		return Success

--- a/middleware/pkg/response/typify_test.go
+++ b/middleware/pkg/response/typify_test.go
@@ -2,6 +2,7 @@ package response
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
@@ -11,17 +12,39 @@ import (
 func TestTypifyNilMsg(t *testing.T) {
 	var m *dns.Msg
 
-	ty, _ := Typify(m)
+	ty, _ := Typify(m, time.Now().UTC())
 	if ty != OtherError {
-		t.Errorf("message wrongly typified, expected OtherError, got %d", ty)
+		t.Errorf("message wrongly typified, expected OtherError, got %s", ty)
 	}
 }
 
-func TestClassifyDelegation(t *testing.T) {
+func TestTypifyDelegation(t *testing.T) {
 	m := delegationMsg()
-	mt, _ := Typify(m)
+	mt, _ := Typify(m, time.Now().UTC())
 	if mt != Delegation {
-		t.Errorf("message is wrongly classified, expected delegation, got %d", mt)
+		t.Errorf("message is wrongly typified, expected Delegation, got %s", mt)
+	}
+}
+
+func TestTypifyRRSIG(t *testing.T) {
+	now, _ := time.Parse(time.UnixDate, "Fri Apr 21 10:51:21 BST 2017")
+	utc := now.UTC()
+
+	m := delegationMsgRRSIGOK()
+	if mt, _ := Typify(m, utc); mt != Delegation {
+		t.Errorf("message is wrongly typified, expected Delegation, got %s", mt)
+	}
+
+	// Still a Delegation because EDNS0 OPT DO bool is not set, so we won't check the sigs.
+	m = delegationMsgRRSIGFail()
+	if mt, _ := Typify(m, utc); mt != Delegation {
+		t.Errorf("message is wrongly typified, expected Delegation, got %s", mt)
+	}
+
+	m = delegationMsgRRSIGFail()
+	m = addOpt(m)
+	if mt, _ := Typify(m, utc); mt != OtherError {
+		t.Errorf("message is wrongly typified, expected OtherError, got %s", mt)
 	}
 }
 
@@ -37,4 +60,25 @@ func delegationMsg() *dns.Msg {
 			test.AAAA("omval.tednet.nl.	3600	IN	AAAA	2a04:b900:0:100::42"),
 		},
 	}
+}
+
+func delegationMsgRRSIGOK() *dns.Msg {
+	del := delegationMsg()
+	del.Ns = append(del.Ns,
+		test.RRSIG("miek.nl.		1800	IN	RRSIG	NS 8 2 1800 20170521031301 20170421031301 12051 miek.nl. PIUu3TKX/sB/N1n1E1yWxHHIcPnc2q6Wq9InShk+5ptRqChqKdZNMLDm gCq+1bQAZ7jGvn2PbwTwE65JzES7T+hEiqR5PU23DsidvZyClbZ9l0xG JtKwgzGXLtUHxp4xv/Plq+rq/7pOG61bNCxRyS7WS7i7QcCCWT1BCcv+ wZ0="),
+	)
+	return del
+}
+
+func delegationMsgRRSIGFail() *dns.Msg {
+	del := delegationMsg()
+	del.Ns = append(del.Ns,
+		test.RRSIG("miek.nl.		1800	IN	RRSIG	NS 8 2 1800 20160521031301 20160421031301 12051 miek.nl. PIUu3TKX/sB/N1n1E1yWxHHIcPnc2q6Wq9InShk+5ptRqChqKdZNMLDm gCq+1bQAZ7jGvn2PbwTwE65JzES7T+hEiqR5PU23DsidvZyClbZ9l0xG JtKwgzGXLtUHxp4xv/Plq+rq/7pOG61bNCxRyS7WS7i7QcCCWT1BCcv+ wZ0="),
+	)
+	return del
+}
+
+func addOpt(m *dns.Msg) *dns.Msg {
+	m.Extra = append(m.Extra, test.OPT(4096, true))
+	return m
 }


### PR DESCRIPTION
Check message for expired sig and don't cache those.

Aside: This hack of caching entire messages is probably something we
should stop doing at some point in the future and do this on a per RRset
basis.

Fixes #367 #635