### PR TITLE
middleware/file: correctly parse the stanza

### DIFF
--- a/middleware/secondary/setup.go
+++ b/middleware/secondary/setup.go
@@ -70,7 +70,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 
 				switch c.Val() {
 				case "transfer":
-					t, _, e = file.TransferParse(c, false)
+					t, _, e = file.TransferParse(c, true)
 					if e != nil {
 						return file.Zones{}, e
 					}

--- a/middleware/secondary/setup.go
+++ b/middleware/secondary/setup.go
@@ -48,6 +48,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 	names := []string{}
 	origins := []string{}
 	for c.Next() {
+
 		if c.Val() == "secondary" {
 			// secondary [origin]
 			origins = make([]string, len(c.ServerBlockKeys))
@@ -63,10 +64,18 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 			}
 
 			for c.NextBlock() {
-				t, f, e := file.TransferParse(c, true)
-				if e != nil {
-					return file.Zones{}, e
+
+				t, f := []string{}, []string{}
+				var e error
+
+				switch c.Val() {
+				case "transfer":
+					t, _, e = file.TransferParse(c, false)
+					if e != nil {
+						return file.Zones{}, e
+					}
 				}
+
 				for _, origin := range origins {
 					if t != nil {
 						z[origin].TransferTo = append(z[origin].TransferTo, t...)

--- a/test/file_cname_proxy_test.go
+++ b/test/file_cname_proxy_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestZoneExternalCNAMELookup(t *testing.T) {
+func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
 	t.Parallel()
 	log.SetOutput(ioutil.Discard)
 
@@ -48,5 +48,47 @@ func TestZoneExternalCNAMELookup(t *testing.T) {
 	// There should only be a CNAME in the answer section.
 	if len(resp.Answer) != 1 {
 		t.Fatalf("Expected 1 RR in answer section got %d", len(resp.Answer))
+	}
+}
+
+func TestZoneExternalCNAMELookupWithProxy(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + ` {
+	       upstream 8.8.8.8
+	}
+}
+`
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+	defer i.Stop()
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "cname.example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+	// There should be a CNAME *and* an IP address in the answer section.
+	// For now, just check that we have 2 RRs
+	if len(resp.Answer) != 2 {
+		t.Fatalf("Expected 2 RRs in answer section got %d", len(resp.Answer))
 	}
 }


### PR DESCRIPTION
Parsing the file stanza would give precedence to 'transfer' and ignore
other bits if it wasn't specified.

This change fixes the parsing. The actually external CNAME retrieval is
working fine (once the upstream is correctly parsed).

This wasn't caught in tests, because we lack a parsing test for this.

Fixes #657