### PR TITLE
Makefile.release: bogus all target

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -23,7 +23,7 @@
 # * Get an access token: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
 # * export GITHUB_ACCESS_TOKEN=<token>
 # * Up the version in coremain/version.go
-# * Run: make -f Makefile.release
+# * Run: make -f Makefile.release release
 #   * will commit your change with 'Release $VERSION'
 #   * push to github
 #   * build the release and do all that fluff.
@@ -41,9 +41,12 @@ GITHUB:=coredns
 DOCKER:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 
-all:	commit push build tar release
+all:
+	@echo Use the 'release' target to start a release
 
-docker: docker-build docker-release
+release:	commit push build tar upload
+
+docker: docker-build docker-upload
 
 .PHONY: push
 push:
@@ -81,8 +84,8 @@ tar:
 	tar -zcf release/$(NAME)_$(VERSION)_linux_armv6l.tgz -C build/Linux/Arm $(NAME)
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(ARCH).tgz -C build/Darwin $(NAME)
 
-.PHONY: release
-release:
+.PHONY: upload
+upload:
 	@echo Releasing: $(VERSION)
 	gh-release create $(GITHUB)/$(NAME) $(VERSION)
 
@@ -92,8 +95,8 @@ docker:
 	docker build -t $(DOCKER_IMAGE_NAME) .
 	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(VERSION)
 
-.PHONY: docker-release
-docker-release:
+.PHONY: docker-upload
+docker-upload:
 	@echo Pushing: $(VERSION)
 	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(VERSION)
 	docker push $(DOCKER_IMAGE_NAME):latest


### PR DESCRIPTION
Make the default target do nothing and put the actual release under a
'release' target. Prevent accidentally committing unwanted commits to
the repo.

Tested with `make -f Makefile.release -n`.