### PR TITLE
middleware/chaos: fix version

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -50,15 +50,15 @@ func init() {
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
+
+	caddy.AppName = coreName
+	caddy.AppVersion = coreVersion
 }
 
 // Run is CoreDNS's main() function.
 func Run() {
 
 	flag.Parse()
-
-	caddy.AppName = coreName
-	caddy.AppVersion = coreVersion
 
 	// Set up process log before anything bad happens
 	switch logfile {

--- a/middleware/chaos/setup.go
+++ b/middleware/chaos/setup.go
@@ -12,6 +12,7 @@ func init() {
 		ServerType: "dns",
 		Action:     setup,
 	})
+
 }
 
 func setup(c *caddy.Controller) error {
@@ -28,13 +29,16 @@ func setup(c *caddy.Controller) error {
 }
 
 func chaosParse(c *caddy.Controller) (string, map[string]bool, error) {
+	// Set here so we pick up AppName and AppVersion that get set in coremain's init().
+	chaosVersion = caddy.AppName + "-" + caddy.AppVersion
+
 	version := ""
 	authors := make(map[string]bool)
 
 	for c.Next() {
 		args := c.RemainingArgs()
 		if len(args) == 0 {
-			return defaultVersion, nil, nil
+			return chaosVersion, nil, nil
 		}
 		if len(args) == 1 {
 			return args[0], nil, nil
@@ -48,4 +52,4 @@ func chaosParse(c *caddy.Controller) (string, map[string]bool, error) {
 	return version, authors, nil
 }
 
-var defaultVersion = caddy.AppName + "-" + caddy.AppVersion
+var chaosVersion string

--- a/middleware/chaos/setup_test.go
+++ b/middleware/chaos/setup_test.go
@@ -1,7 +1,6 @@
 package chaos
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -18,18 +17,10 @@ func TestSetupChaos(t *testing.T) {
 	}{
 		// positive
 		{
-			`chaos`, false, defaultVersion, "", "",
-		},
-		{
 			`chaos v2`, false, "v2", "", "",
 		},
 		{
 			`chaos v3 "Miek Gieben"`, false, "v3", "Miek Gieben", "",
-		},
-		{
-			fmt.Sprintf(`chaos {
-				%s
-			}`, defaultVersion), false, defaultVersion, "", "",
 		},
 	}
 

--- a/test/chaos_test.go
+++ b/test/chaos_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	// Plug in CoreDNS, needed for AppVersion and AppName in this test.
+	_ "github.com/coredns/coredns/coremain"
+
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+)
+
+func TestChaos(t *testing.T) {
+	corefile := `.:0 {
+		chaos
+}
+`
+
+	i, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	// Stop the server.
+	defer i.Stop()
+
+	udp, _ := CoreDNSServerPorts(i, 0)
+	if udp == "" {
+		t.Fatalf("Could not get UDP listening port")
+	}
+
+	log.SetOutput(ioutil.Discard)
+
+	m := new(dns.Msg)
+	m.SetQuestion("version.bind.", dns.TypeTXT)
+	m.Question[0].Qclass = dns.ClassCHAOS
+
+	resp, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %v", err)
+	}
+	chTxt := resp.Answer[0].(*dns.TXT).Txt[0]
+	version := caddy.AppName + "-" + caddy.AppVersion
+	if chTxt != version {
+		t.Fatalf("Expected version to bo %s, got %s", version, chTxt)
+	}
+}


### PR DESCRIPTION
Move the version setting into a init function so it is done early. Then
tweak the setup code for chaos a bit to correctly pick this version up.
Add an integration test to pick this up in the toplevel test/ directory.

Fixes #667