### PR TITLE
Fix docker-build target in Makefile.release

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -90,7 +90,7 @@ upload:
 	gh-release create $(GITHUB)/$(NAME) $(VERSION)
 
 .PHONY: docker-build
-docker:
+docker-build:
 	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
 	docker build -t $(DOCKER_IMAGE_NAME) .
 	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(VERSION)


### PR DESCRIPTION
The typo prevented the `docker-upload` target from executing when doing `make docker`.