### PR TITLE
No `f` in  in line 73 in coredns/middleware/secondary/setup.go

### DIFF
--- a/middleware/secondary/setup.go
+++ b/middleware/secondary/setup.go
@@ -70,7 +70,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 
 				switch c.Val() {
 				case "transfer":
-					t, _, e = file.TransferParse(c, true)
+					t, f, e = file.TransferParse(c, true)
 					if e != nil {
 						return file.Zones{}, e
 					}


### PR DESCRIPTION
Cant' transfer zone from masters without populating `f`.
This error prevents secondary zones recognized as "true" secondary, so secondary setting never worked.