### PR TITLE
middleware/kubernetes: Implement current federation beta

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -115,6 +115,12 @@ kubernetes coredns.local {
 	# a path to a file structured like resolv.conf.
 	upstream 12.34.56.78:53
 	
+	# federation <federation-name> <federation-domain>
+	#
+	# Defines federation membership.  One line for each federation membership.
+	# Each line consists of the name of the federation, and the domain.
+	federation myfed foo.example.com
+	
 	# fallthrough
 	#
 	# If a query for a record in the cluster zone results in NXDOMAIN,

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -206,15 +206,6 @@ func v1ToAPIFilter(in watch.Event) (out watch.Event, keep bool) {
 			return in, true
 		}
 		return watch.Event{Type: in.Type, Object: &apiObj}, true
-	case *v1.Node:
-		var apiObj api.Node
-		err := v1.Convert_v1_Node_To_api_Node(v1Obj, &apiObj, nil)
-		if err != nil {
-			log.Printf("[ERROR] Could not convert v1.Node: %s", err)
-			return in, true
-		}
-		return watch.Event{Type: in.Type, Object: &apiObj}, true
-
 	}
 
 	log.Printf("[WARN] Unhandled v1 type in event: %v", in)

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -389,6 +389,9 @@ func (dns *dnsControl) Run() {
 	if dns.podController != nil {
 		go dns.podController.Run(dns.stopCh)
 	}
+	if dns.nodeController != nil {
+		go dns.nodeController.Run(dns.stopCh)
+	}
 	<-dns.stopCh
 }
 

--- a/middleware/kubernetes/controller.go
+++ b/middleware/kubernetes/controller.go
@@ -422,3 +422,8 @@ func (dns *dnsControl) EndpointsList() api.EndpointsList {
 
 	return epl
 }
+
+func (dns *dnsControl) NodeList() api.NodeList {
+	nodeList, _ := dns.nodeLister.List()
+	return nodeList
+}

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -12,7 +12,15 @@ type Federation struct {
 }
 
 const (
-	// TODO: Do not hard code these, pull them out of the API
+	// TODO: Do not hardcode these labels. Pull them out of the API instead.
+	//
+	// We can get them via ....
+	//   import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//     metav1.LabelZoneFailureDomain
+	//     metav1.LabelZoneRegion
+	//
+	// But importing above breaks coredns with flag collision of 'log_dir'
+
 	LabelAvailabilityZone = "failure-domain.beta.kubernetes.io/zone"
 	LabelRegion           = "failure-domain.beta.kubernetes.io/region"
 )

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -12,6 +12,7 @@ type Federation struct {
 }
 
 const (
+	// TODO: Do not hard code these, pull them out of the API
 	LabelAvailabilityZone = "failure-domain.beta.kubernetes.io/zone"
 	LabelRegion           = "failure-domain.beta.kubernetes.io/region"
 )

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"net"
 	"strings"
 
 	"github.com/coredns/coredns/middleware/etcd/msg"
@@ -10,6 +11,10 @@ type Federation struct {
 	name string
 	zone string
 }
+
+var localNodeName string
+var federationZone string
+var federationRegion string
 
 const (
 	// TODO: Do not hardcode these labels. Pull them out of the API instead.
@@ -47,32 +52,51 @@ func (k *Kubernetes) stripFederation(segs []string) (string, []string) {
 // with the target host in the federated CNAME format which the external DNS provider
 // should be able to resolve
 func (k *Kubernetes) federationCNAMERecord(r recordRequest) msg.Service {
-	for _, node := range k.APIConn.NodeList().Items {
-		// Mimic kube-dns implementation, and arbitrarily pick the first node with
-		// non-empty availability-zone and region
-		if node.Labels[LabelRegion] == "" || node.Labels[LabelAvailabilityZone] == "" {
+
+	myNodeName := k.localNodeName()
+	node, err := k.APIConn.GetNodeByName(myNodeName)
+	if err != nil {
+		return msg.Service{}
+	}
+
+	for _, f := range k.Federations {
+		if f.name != r.federation {
 			continue
 		}
-		for _, f := range k.Federations {
-			if f.name != r.federation {
-				continue
+		if r.endpoint == "" {
+			return msg.Service{
+				Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service}, "/"),
+				Host: strings.Join([]string{r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
 			}
-			if r.endpoint == "" {
-				return msg.Service{
-					Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service}, "/"),
-					Host: strings.Join([]string{r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
+		}
+		return msg.Service{
+			Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service, r.endpoint}, "/"),
+			Host: strings.Join([]string{r.endpoint, r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
+		}
+	}
+
+	return msg.Service{}
+}
+
+func (k *Kubernetes) localNodeName() string {
+	if localNodeName != "" {
+		return localNodeName
+	}
+	localIP := k.localPodIP()
+	if localIP == nil {
+		return ""
+	}
+	// Find endpoint matching localIP
+	endpointsList := k.APIConn.EndpointsList()
+	for _, ep := range endpointsList.Items {
+		for _, eps := range ep.Subsets {
+			for _, addr := range eps.Addresses {
+				if localIP.Equal(net.ParseIP(addr.IP)) {
+					localNodeName = *addr.NodeName
+					return localNodeName
 				}
 			}
-			return msg.Service{
-				Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service, r.endpoint}, "/"),
-				Host: strings.Join([]string{r.endpoint, r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
-			}
-
 		}
-		// Federation name in request didnt match a configured federation. Break and
-		// return empty
-		break
-
 	}
-	return msg.Service{}
+	return ""
 }

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -43,7 +43,7 @@ func (k *Kubernetes) stripFederation(segs []string) (string, []string) {
 	return "", segs
 }
 
-// federation CNAMRecord returns a service record for the requested federated service
+// federationCNAMERecord returns a service record for the requested federated service
 // with the target host in the federated CNAME format which the external DNS provider
 // should be able to resolve
 func (k *Kubernetes) federationCNAMERecord(r recordRequest) msg.Service {
@@ -69,6 +69,8 @@ func (k *Kubernetes) federationCNAMERecord(r recordRequest) msg.Service {
 			}
 
 		}
+		// Federation name in request didnt match a configured federation. Break and
+		// return empty
 		break
 
 	}

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -1,0 +1,60 @@
+package kubernetes
+
+import (
+	"strings"
+
+	"github.com/coredns/coredns/middleware/etcd/msg"
+)
+
+type Federation struct {
+	name string
+	zone string
+}
+
+const (
+	LabelAvailabilityZone = "failure-domain.beta.kubernetes.io/zone"
+	LabelRegion           = "failure-domain.beta.kubernetes.io/region"
+)
+
+// stripFederation removes the federation segment from the segment list, if it
+// matches a configured federation name.
+func (k *Kubernetes) stripFederation(segs []string) (string, []string) {
+
+	if len(segs) < 3 {
+		return "", segs
+	}
+	for _, f := range k.Federations {
+		if f.name == segs[len(segs)-2] {
+			fed := segs[len(segs)-2]
+			segs[len(segs)-2] = segs[len(segs)-1]
+			segs = segs[:len(segs)-1]
+			return fed, segs
+		}
+	}
+	return "", segs
+}
+
+func (k *Kubernetes) federationCNAMERecord(r recordRequest) msg.Service {
+	for _, node := range k.APIConn.NodeList().Items {
+		if node.Labels[LabelRegion] != "" && node.Labels[LabelAvailabilityZone] != "" {
+			for _, f := range k.Federations {
+				if f.name == r.federation {
+					if r.endpoint == "" {
+						return msg.Service{
+							Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service}, "/"),
+							Host: strings.Join([]string{r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
+						}
+					} else {
+						return msg.Service{
+							Key:  strings.Join([]string{msg.Path(r.zone, "coredns"), r.typeName, r.federation, r.namespace, r.service, r.endpoint}, "/"),
+							Host: strings.Join([]string{r.endpoint, r.service, r.namespace, r.federation, r.typeName, node.Labels[LabelAvailabilityZone], node.Labels[LabelRegion], f.zone}, "."),
+						}
+					}
+				}
+				return msg.Service{}
+			}
+
+		}
+	}
+	return msg.Service{}
+}

--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -32,26 +32,11 @@ func TestStripFederation(t *testing.T) {
 
 type apiConnFedTest struct{}
 
-func (apiConnFedTest) Run() {
-	return
-}
-
-func (apiConnFedTest) Stop() error {
-	return nil
-}
-
-func (apiConnFedTest) ServiceList() []*api.Service {
-	return []*api.Service{}
-
-}
-
-func (apiConnFedTest) PodIndex(string) []interface{} {
-	return nil
-}
-
-func (apiConnFedTest) EndpointsList() api.EndpointsList {
-	return api.EndpointsList{}
-}
+func (apiConnFedTest) Run()                             { return }
+func (apiConnFedTest) Stop() error                      { return nil }
+func (apiConnFedTest) ServiceList() []*api.Service      { return []*api.Service{} }
+func (apiConnFedTest) PodIndex(string) []interface{}    { return nil }
+func (apiConnFedTest) EndpointsList() api.EndpointsList { return api.EndpointsList{} }
 
 func (apiConnFedTest) NodeList() api.NodeList {
 	return api.NodeList{

--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -56,21 +56,21 @@ func (apiConnFedTest) EndpointsList() api.EndpointsList {
 func (apiConnFedTest) NodeList() api.NodeList {
 	return api.NodeList{
 		Items: []api.Node{
-			api.Node{
+			{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
 						LabelAvailabilityZone: "fd-az",
 					},
 				},
 			},
-			api.Node{
+			{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
 						LabelRegion: "fd-r",
 					},
 				},
 			},
-			api.Node{
+			{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
 						LabelRegion:           "fd-r",

--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -1,0 +1,105 @@
+package kubernetes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/middleware/etcd/msg"
+	"github.com/miekg/dns"
+	"k8s.io/client-go/1.5/pkg/api"
+)
+
+func testStripFederation(t *testing.T, k Kubernetes, input []string, expectedFed string, expectedSegs string) {
+	fed, segs := k.stripFederation(input)
+
+	if expectedSegs != strings.Join(segs, ".") {
+		t.Errorf("For '%v', expected segs result '%v'. Instead got result '%v'.", strings.Join(input, "."), expectedSegs, strings.Join(segs, "."))
+	}
+	if expectedFed != fed {
+		t.Errorf("For '%v', expected fed result '%v'. Instead got result '%v'.", strings.Join(input, "."), expectedFed, fed)
+	}
+}
+
+func TestStripFederation(t *testing.T) {
+	k := Kubernetes{Zones: []string{"inter.webs.test"}}
+	k.Federations = []Federation{{name: "fed", zone: "era.tion.com"}}
+
+	testStripFederation(t, k, []string{"service", "ns", "fed", "svc"}, "fed", "service.ns.svc")
+	testStripFederation(t, k, []string{"service", "ns", "foo", "svc"}, "", "service.ns.foo.svc")
+	testStripFederation(t, k, []string{"foo", "bar"}, "", "foo.bar")
+
+}
+
+type apiConnFedTest struct{}
+
+func (apiConnFedTest) Run() {
+	return
+}
+
+func (apiConnFedTest) Stop() error {
+	return nil
+}
+
+func (apiConnFedTest) ServiceList() []*api.Service {
+	return []*api.Service{}
+
+}
+
+func (apiConnFedTest) PodIndex(string) []interface{} {
+	return nil
+}
+
+func (apiConnFedTest) EndpointsList() api.EndpointsList {
+	return api.EndpointsList{}
+}
+
+func (apiConnFedTest) NodeList() api.NodeList {
+	return api.NodeList{
+		Items: []api.Node{
+			api.Node{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						LabelAvailabilityZone: "fd-az",
+					},
+				},
+			},
+			api.Node{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						LabelRegion: "fd-r",
+					},
+				},
+			},
+			api.Node{
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						LabelRegion:           "fd-r",
+						LabelAvailabilityZone: "fd-az",
+					},
+				},
+			},
+		},
+	}
+}
+
+func testFederationCNAMERecord(t *testing.T, k Kubernetes, input recordRequest, expected msg.Service) {
+	svc := k.federationCNAMERecord(input)
+
+	if expected.Host != svc.Host {
+		t.Errorf("For '%v', expected Host result '%v'. Instead got result '%v'.", input, expected.Host, svc.Host)
+	}
+	if expected.Key != svc.Key {
+		t.Errorf("For '%v', expected Key result '%v'. Instead got result '%v'.", input, expected.Key, svc.Key)
+	}
+}
+
+func TestFederationCNAMERecord(t *testing.T) {
+	k := Kubernetes{Zones: []string{"inter.webs"}}
+	k.Federations = []Federation{{name: "fed", zone: "era.tion.com"}}
+	k.APIConn = apiConnFedTest{}
+
+	var r recordRequest
+	r, _ = k.parseRequest("s1.ns.fed.svc.inter.webs", dns.TypeA)
+	testFederationCNAMERecord(t, k, r, msg.Service{Key: "/coredns/webs/inter/svc/fed/ns/s1", Host: "s1.ns.fed.svc.fd-az.fd-r.era.tion.com"})
+
+}

--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -102,4 +102,9 @@ func TestFederationCNAMERecord(t *testing.T) {
 	r, _ = k.parseRequest("s1.ns.fed.svc.inter.webs", dns.TypeA)
 	testFederationCNAMERecord(t, k, r, msg.Service{Key: "/coredns/webs/inter/svc/fed/ns/s1", Host: "s1.ns.fed.svc.fd-az.fd-r.era.tion.com"})
 
+	r, _ = k.parseRequest("ep1.s1.ns.fed.svc.inter.webs", dns.TypeA)
+	testFederationCNAMERecord(t, k, r, msg.Service{Key: "/coredns/webs/inter/svc/fed/ns/s1/ep1", Host: "ep1.s1.ns.fed.svc.fd-az.fd-r.era.tion.com"})
+
+	r, _ = k.parseRequest("ep1.s1.ns.foo.svc.inter.webs", dns.TypeA)
+	testFederationCNAMERecord(t, k, r, msg.Service{Key: "", Host: ""})
 }

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -244,8 +244,11 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 		log.Printf("[INFO] Kubernetes middleware configured with the label selector '%s'. Only kubernetes objects matching this label selector will be exposed.", unversionedapi.FormatLabelSelector(k.LabelSelector))
 	}
 
-	// TODO: pass correct federation bool
-	k.APIConn = newdnsController(kubeClient, k.ResyncPeriod, k.Selector, k.PodMode == PodModeVerified, true)
+	opts := dnsControlOpts{
+		initPodCache:  k.PodMode == PodModeVerified,
+		initNodeCache: len(k.Federations) > 0,
+	}
+	k.APIConn = newdnsController(kubeClient, k.ResyncPeriod, k.Selector, opts)
 
 	return err
 }

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -411,6 +411,10 @@ func (APIConnServiceTest) EndpointsList() api.EndpointsList {
 	}
 }
 
+func (APIConnServiceTest) NodeList() api.NodeList {
+	return api.NodeList{}
+}
+
 func TestServices(t *testing.T) {
 
 	k := Kubernetes{Zones: []string{"interwebs.test"}}

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -414,7 +414,7 @@ func (APIConnServiceTest) EndpointsList() api.EndpointsList {
 func (APIConnServiceTest) NodeList() api.NodeList {
 	return api.NodeList{
 		Items: []api.Node{
-			api.Node{
+			{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
 						LabelRegion:           "fd-r",

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -417,8 +417,8 @@ func (APIConnServiceTest) NodeList() api.NodeList {
 			api.Node{
 				ObjectMeta: api.ObjectMeta{
 					Labels: map[string]string{
-						"failure-domain.beta.kubernetes.io/region": "fd-r",
-						"failure-domain.beta.kubernetes.io/zone":   "fd-az",
+						LabelRegion:           "fd-r",
+						LabelAvailabilityZone: "fd-az",
 					},
 				},
 			},

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -339,6 +339,8 @@ func (APIConnServiceTest) PodIndex(string) []interface{} {
 }
 
 func (APIConnServiceTest) EndpointsList() api.EndpointsList {
+	n := "test.node.foo.bar"
+
 	return api.EndpointsList{
 		Items: []api.Endpoints{
 			{
@@ -407,18 +409,15 @@ func (APIConnServiceTest) EndpointsList() api.EndpointsList {
 					Namespace: "testns",
 				},
 			},
-		},
-	}
-}
-
-func (APIConnServiceTest) NodeList() api.NodeList {
-	return api.NodeList{
-		Items: []api.Node{
 			{
-				ObjectMeta: api.ObjectMeta{
-					Labels: map[string]string{
-						LabelRegion:           "fd-r",
-						LabelAvailabilityZone: "fd-az",
+				Subsets: []api.EndpointSubset{
+					{
+						Addresses: []api.EndpointAddress{
+							{
+								IP:       "10.9.8.7",
+								NodeName: &n,
+							},
+						},
 					},
 				},
 			},
@@ -426,6 +425,17 @@ func (APIConnServiceTest) NodeList() api.NodeList {
 	}
 }
 
+func (APIConnServiceTest) GetNodeByName(name string) (api.Node, error) {
+	return api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name: "test.node.foo.bar",
+			Labels: map[string]string{
+				LabelRegion:           "fd-r",
+				LabelAvailabilityZone: "fd-az",
+			},
+		},
+	}, nil
+}
 func TestServices(t *testing.T) {
 
 	k := Kubernetes{Zones: []string{"interwebs.test"}}

--- a/middleware/kubernetes/ns_test.go
+++ b/middleware/kubernetes/ns_test.go
@@ -104,9 +104,7 @@ func (APIConnTest) EndpointsList() api.EndpointsList {
 	}
 }
 
-func (APIConnTest) NodeList() api.NodeList {
-	return api.NodeList{}
-}
+func (APIConnTest) GetNodeByName(name string) (api.Node, error) { return api.Node{}, nil }
 
 type interfaceAddrsTest struct{}
 

--- a/middleware/kubernetes/ns_test.go
+++ b/middleware/kubernetes/ns_test.go
@@ -104,6 +104,10 @@ func (APIConnTest) EndpointsList() api.EndpointsList {
 	}
 }
 
+func (APIConnTest) NodeList() api.NodeList {
+	return api.NodeList{}
+}
+
 type interfaceAddrsTest struct{}
 
 func (i interfaceAddrsTest) interfaceAddrs() ([]net.Addr, error) {

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -177,6 +177,19 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 						return nil, err
 					}
 					k8s.Proxy = proxy.NewLookup(ups)
+				case "federation": // name zone
+					args := c.RemainingArgs()
+					if len(args) == 2 {
+						k8s.Federations = append(k8s.Federations, Federation{
+							name: args[0],
+							zone: args[1],
+						})
+						continue
+					} else {
+						return nil, fmt.Errorf("Incorrect number of arguments for federation. Got %v, expect 2.", len(args))
+					}
+					return nil, c.ArgErr()
+
 				}
 			}
 			return k8s, nil

--- a/middleware/kubernetes/setup_test.go
+++ b/middleware/kubernetes/setup_test.go
@@ -29,6 +29,7 @@ func TestKubernetesParse(t *testing.T) {
 		expectedCidrs         []net.IPNet
 		expectedFallthrough   bool
 		expectedUpstreams     []string
+		expectedFederations   []Federation
 	}{
 		// positive
 		{
@@ -44,6 +45,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"kubernetes keyword with multiple zones",
@@ -58,6 +60,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"kubernetes keyword with zone and empty braces",
@@ -73,6 +76,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"endpoint keyword with url",
@@ -89,6 +93,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"namespaces keyword with one namespace",
@@ -104,6 +109,7 @@ func TestKubernetesParse(t *testing.T) {
 			defaultPodMode,
 			nil,
 			false,
+			nil,
 			nil,
 		},
 		{
@@ -121,6 +127,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"resync period in seconds",
@@ -137,6 +144,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"resync period in minutes",
@@ -153,6 +161,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"basic label selector",
@@ -169,6 +178,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"multi-label selector",
@@ -185,6 +195,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"fully specified valid config",
@@ -205,6 +216,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			true,
 			nil,
+			[]Federation{},
 		},
 		// negative
 		{
@@ -220,6 +232,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"kubernetes keyword without a zone",
@@ -234,6 +247,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"endpoint keyword without an endpoint value",
@@ -250,6 +264,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"namespace keyword without a namespace value",
@@ -266,6 +281,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"resyncperiod keyword without a duration value",
@@ -282,6 +298,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"resync period no units",
@@ -298,6 +315,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"resync period invalid",
@@ -314,6 +332,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"labels with no selector value",
@@ -330,6 +349,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		{
 			"labels with invalid selector value",
@@ -346,6 +366,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// pods disabled
 		{
@@ -363,6 +384,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// pods insecure
 		{
@@ -380,6 +402,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// pods verified
 		{
@@ -397,6 +420,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// pods invalid
 		{
@@ -414,6 +438,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// cidrs ok
 		{
@@ -431,6 +456,7 @@ func TestKubernetesParse(t *testing.T) {
 			[]net.IPNet{parseCidr("10.0.0.0/24"), parseCidr("10.0.1.0/24")},
 			false,
 			nil,
+			[]Federation{},
 		},
 		// cidrs ok
 		{
@@ -448,6 +474,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// fallthrough invalid
 		{
@@ -465,6 +492,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
 		},
 		// Valid upstream
 		{
@@ -482,6 +510,7 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			[]string{"13.14.15.16:53"},
+			[]Federation{},
 		},
 		// Invalid upstream
 		{
@@ -499,6 +528,47 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			false,
 			nil,
+			[]Federation{},
+		},
+		// Valid federations
+		{
+			"valid upstream",
+			`kubernetes coredns.local {
+	federation foo bar.crawl.com
+	federation fed era.tion.com
+}`,
+			false,
+			"",
+			1,
+			0,
+			defaultResyncPeriod,
+			"",
+			defaultPodMode,
+			nil,
+			false,
+			nil,
+			[]Federation{
+				{name: "foo", zone: "bar.crawl.com"},
+				{name: "fed", zone: "era.tion.com"},
+			},
+		},
+		// Invalid federations
+		{
+			"valid upstream",
+			`kubernetes coredns.local {
+	federation starship
+}`,
+			true,
+			`Incorrect number of arguments for federation. Got 1, expect 2.`,
+			-1,
+			0,
+			defaultResyncPeriod,
+			"",
+			defaultPodMode,
+			nil,
+			false,
+			nil,
+			[]Federation{},
 		},
 	}
 


### PR DESCRIPTION
This adds support for cross-cluster service discovery of federated services. Specifically, this implements the current beta proposed specification for k8s federation service discovery.

When querying CoreDNS for an A record of a federated service (e.g. service.ns.fed1.svc.cluster.local), coredns first checks the local cluster.  

- If the service is present and healthy, CoreDNS returns an A record for the service.  
- If the service is not present or unhealthy, CoreDNS returns a CNAME record for the service in the federated format (e.g. service.ns.fed1.svc.availability-zone.region.domain). Also included in the response is the CNAME chain and A record from the upstream server.