### PR TITLE
mw/k8s: handle clusterIP endpoint queries

### DIFF
--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -348,7 +348,8 @@ func (APIConnServiceTest) EndpointsList() api.EndpointsList {
 					{
 						Addresses: []api.EndpointAddress{
 							{
-								IP: "172.0.0.1",
+								IP:       "172.0.0.1",
+								Hostname: "ep1a",
 							},
 						},
 						Ports: []api.EndpointPort{
@@ -455,6 +456,7 @@ func TestServices(t *testing.T) {
 		// Cluster IP Services
 		{qname: "svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "10.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1"}},
 		{qname: "_http._tcp.svc1.testns.svc.interwebs.test.", qtype: dns.TypeSRV, answer: svcAns{host: "10.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1"}},
+		{qname: "ep1a.svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "172.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1/ep1a"}},
 
 		// External Services
 		{qname: "external.testns.svc.interwebs.test.", qtype: dns.TypeCNAME, answer: svcAns{host: "coredns.io", key: "/coredns/test/interwebs/svc/testns/external"}},

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -30,6 +30,16 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{},
 	},
 	{
+		Qname: "bogusendpoint.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
+		Qname: "bogusendpoint.headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
+	{
 		Qname: "svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{


### PR DESCRIPTION
This addresses #729. 
The diff makes this look more complex than it is (specifically in findServices).
Adjusted the k8s service retrieval to properly answer endpoint queries for non-headless services.
Added addtl unit tests and integration tests to cover the case. 