### PR TITLE
middleware/file: consider no SOA a fatal error

### DIFF
--- a/middleware/file/file.go
+++ b/middleware/file/file.go
@@ -126,13 +126,17 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 				if s.Serial == uint32(serial) { // same zone
 					return nil, fmt.Errorf("no change in serial: %d", serial)
 				}
+				seenSOA = true
 			}
-			seenSOA = true
 		}
 
 		if err := z.Insert(x.RR); err != nil {
 			return nil, err
 		}
 	}
+	if !seenSOA {
+		return nil, fmt.Errorf("file %q has no SOA record", fileName)
+	}
+
 	return z, nil
 }

--- a/middleware/file/file_test.go
+++ b/middleware/file/file_test.go
@@ -10,3 +10,22 @@ func BenchmarkParseInsert(b *testing.B) {
 		Parse(strings.NewReader(dbMiekENTNL), testzone, "stdin", 0)
 	}
 }
+
+func TestParseNoSOA(t *testing.T) {
+	_, err := Parse(strings.NewReader(dbNoSOA), "example.org.", "stdin", 0)
+	if err == nil {
+		t.Fatalf("zone %q should have failed to load", "example.org.")
+	}
+	if !strings.Contains(err.Error(), "no SOA record") {
+		t.Fatalf("zone %q should have failed to load with no soa error: %s", "example.org.", err)
+	}
+}
+
+const dbNoSOA = `
+$TTL         1M
+$ORIGIN      example.org.
+
+www          IN  A      192.168.0.14
+mail         IN  A      192.168.0.15
+imap         IN  CNAME  mail
+`


### PR DESCRIPTION
Don't load a zone with a SOA record, barf with 'no SOA record' error.