### PR TITLE
update dockerfile to allow use of https_google - fixes #738

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:latest
 MAINTAINER Miek Gieben <miek@miek.nl> @miekg
 
-RUN apk --update add bind-tools && rm -rf /var/cache/apk/*
-
-# need to uncomment if want to use https_google
-#RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
+# only need ca-certificates & openssl if want to use https_google
+RUN apk --update add bind-tools ca-certificates openssl && update-ca-certificates && rm -rf /var/cache/apk/*
 
 ADD coredns /coredns
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Miek Gieben <miek@miek.nl> @miekg
 
 RUN apk --update add bind-tools && rm -rf /var/cache/apk/*
 
+# need to uncomment if want to use https_google
+#RUN apk update && apk add ca-certificates && update-ca-certificates && apk add openssl
+
 ADD coredns /coredns
 
 EXPOSE 53 53/udp


### PR DESCRIPTION
to use TLS in a docker container (based on Alpine linux) you need to also include the CA certificate files