### PR TITLE
mw/file: rename to BenchmarkFileLookup

### DIFF
--- a/middleware/file/dnssec_test.go
+++ b/middleware/file/dnssec_test.go
@@ -169,7 +169,7 @@ func TestLookupDNSSEC(t *testing.T) {
 	}
 }
 
-func BenchmarkLookupDNSSEC(b *testing.B) {
+func BenchmarkFileLookupDNSSEC(b *testing.B) {
 	zone, err := Parse(strings.NewReader(dbMiekNLSigned), testzone, "stdin", 0)
 	if err != nil {
 		return

--- a/middleware/file/file_test.go
+++ b/middleware/file/file_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func BenchmarkParseInsert(b *testing.B) {
+func BenchmarkFileParseInsert(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Parse(strings.NewReader(dbMiekENTNL), testzone, "stdin", 0)
 	}

--- a/middleware/file/lookup_test.go
+++ b/middleware/file/lookup_test.go
@@ -154,7 +154,7 @@ func TestLookupNil(t *testing.T) {
 	fm.ServeDNS(ctx, rec, m)
 }
 
-func BenchmarkLookup(b *testing.B) {
+func BenchmarkFileLookup(b *testing.B) {
 	zone, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
 	if err != nil {
 		return

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -100,7 +100,7 @@ func TestLookupDnsWithForcedTcp(t *testing.T) {
 	}
 }
 
-func BenchmarkLookupProxy(b *testing.B) {
+func BenchmarkProxyLookup(b *testing.B) {
 	t := new(testing.T)
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {


### PR DESCRIPTION
In grafana we miss the context of where this is called, make the name
more descriptive.

Also test the GH webhook.