### PR TITLE
core: errors on junk in the command line

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -60,6 +60,10 @@ func Run() {
 
 	flag.Parse()
 
+	if len(flag.Args()) > 0 {
+		mustLogFatal(fmt.Errorf("extra command line arguments: %s", flag.Args()))
+	}
+
 	// Set up process log before anything bad happens
 	if logfile {
 		log.SetOutput(os.Stdout)


### PR DESCRIPTION
We would silently ignore anything that we couldn't parse on the command
line, this change make this an error.

Fixes #743