### PR TITLE
middleware/proxy: async health checks

### DIFF
--- a/middleware/proxy/README.md
+++ b/middleware/proxy/README.md
@@ -41,9 +41,9 @@ proxy FROM TO... {
 * `max_fails` is the number of failures within fail_timeout that are needed before considering
   a backend to be down. If 0, the backend will never be marked as down. Default is 1.
 * `health_check` will check path (on port) on each backend. If a backend returns a status code of
-  200-399, then that backend is healthy. If it doesn't, the backend is marked as unhealthy for
-  duration and no requests are routed to it. If this option is not provided then health checks are
-  disabled. The default duration is 30 seconds ("30s").
+  200-399, then that backend is marked healthy for double the healthcheck duration.  If it doesn't,
+  it is marked as unhealthy and no requests are routed to it.  If this option is not provided then
+  health checks are disabled.  The default duration is 30 seconds ("30s").
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
   Requests that match none of these names will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -236,6 +237,8 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			}(upstream),
 			WithoutPathPrefix: upstream.WithoutPathPrefix,
 		}
+
+		log.Printf("Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
 		upstream.Hosts[i] = uh
 	}
 	return upstream

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -218,7 +218,7 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Now().Add(upstream.HealthCheck.Future),
+			OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -218,11 +218,12 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			Unhealthy:   false,
+			OkUntil:     time.Now().Add(upstream.HealthCheck.Future),
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {
-					if uh.Unhealthy {
+
+					if time.Now().After(uh.OkUntil) {
 						return true
 					}
 

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -242,7 +242,6 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			WithoutPathPrefix: upstream.WithoutPathPrefix,
 		}
 
-		log.Printf("[DEBUG] Ggl: Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
 		upstream.Hosts[i] = uh
 	}
 	return upstream

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -206,6 +206,7 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 		Spray:             nil,
 		FailTimeout:       10 * time.Second,
 		MaxFails:          3,
+		Future:            60 * time.Second,
 		ex:                old.ex,
 		WithoutPathPrefix: old.WithoutPathPrefix,
 		IgnoredSubDomains: old.IgnoredSubDomains,

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -219,7 +218,7 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
+			OkUntil:     time.Unix(4000000000, 0), // forever, initially
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/grpc_test.go
+++ b/middleware/proxy/grpc_test.go
@@ -27,6 +27,7 @@ func TestStartupShutdown(t *testing.T) {
 		Policy:      &Random{},
 		Spray:       nil,
 		FailTimeout: 10 * time.Second,
+		Future:      60 * time.Second,
 		MaxFails:    1,
 	}
 	g := newGrpcClient(nil, upstream)

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -4,6 +4,8 @@ package proxy
 
 import (
 	"context"
+	"log"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -56,6 +58,8 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			}(upstream),
 			WithoutPathPrefix: upstream.WithoutPathPrefix,
 		}
+
+		log.Printf("Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
 		upstream.Hosts[i] = uh
 	}
 	p.Upstreams = &[]Upstream{upstream}

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -39,11 +39,12 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
+			OkUntil:     time.Now().Add(upstream.HealthCheck.Future),
 
-			Unhealthy: false,
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {
-					if uh.Unhealthy {
+
+					if time.Now().After(uh.OkUntil) {
 						return true
 					}
 					fails := atomic.LoadInt32(&uh.Fails)

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -39,7 +39,7 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Now().Add(upstream.HealthCheck.Future),
+			OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -5,7 +5,6 @@ package proxy
 import (
 	"context"
 	"log"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -41,7 +40,7 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
+			OkUntil:     time.Unix(4000000000, 0), // forever, initially
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -4,7 +4,6 @@ package proxy
 
 import (
 	"context"
-	"log"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +30,7 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 		Spray:       nil,
 		FailTimeout: 10 * time.Second,
 		MaxFails:    3, // TODO(miek): disable error checking for simple lookups?
+		Future:      60 * time.Second,
 		ex:          newDNSExWithOption(opts),
 	}
 
@@ -63,7 +63,6 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			WithoutPathPrefix: upstream.WithoutPathPrefix,
 		}
 
-		log.Printf("[DEBUG] Lkp: Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
 		upstream.Hosts[i] = uh
 	}
 	p.Upstreams = &[]Upstream{upstream}

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -40,25 +40,30 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Unix(4000000000, 0), // forever, initially
+			OkUntil:     time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)), // now + 100 years
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {
 
+					down := false
+
+					uh.checkMu.Lock()
 					if time.Now().After(uh.OkUntil) {
-						return true
+						down = true
 					}
+					uh.checkMu.Unlock()
+
 					fails := atomic.LoadInt32(&uh.Fails)
 					if fails >= upstream.MaxFails && upstream.MaxFails != 0 {
-						return true
+						down = true
 					}
-					return false
+					return down
 				}
 			}(upstream),
 			WithoutPathPrefix: upstream.WithoutPathPrefix,
 		}
 
-		log.Printf("Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
+		log.Printf("[DEBUG] Lkp: Host %s marked healthy until %s.\n", uh.Name, uh.OkUntil.Local())
 		upstream.Hosts[i] = uh
 	}
 	p.Upstreams = &[]Upstream{upstream}

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -40,7 +40,6 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-			OkUntil:     time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)), // now + 100 years
 
 			CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 				return func(uh *UpstreamHost) bool {
@@ -48,10 +47,12 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 					down := false
 
 					uh.checkMu.Lock()
-					if time.Now().After(uh.OkUntil) {
+					until := uh.OkUntil
+					uh.checkMu.Unlock()
+
+					if !until.IsZero() && time.Now().After(until) {
 						down = true
 					}
-					uh.checkMu.Unlock()
 
 					fails := atomic.LoadInt32(&uh.Fails)
 					if fails >= upstream.MaxFails && upstream.MaxFails != 0 {

--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -54,7 +54,7 @@ func TestRoundRobinPolicy(t *testing.T) {
 		t.Error("Expected second round robin host to be third host in the pool.")
 	}
 	// mark host as down
-	pool[0].Unhealthy = true
+	pool[0].OkUntil = time.Unix(0, 0)
 	h = rrPolicy.Select(pool)
 	if h != pool[1] {
 		t.Error("Expected third round robin host to be first host in the pool.")

--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 )
 
 var workableServer *httptest.Server

--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,7 +13,6 @@ var workableServer *httptest.Server
 func TestMain(m *testing.M) {
 	workableServer = httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			log.Printf("[INFO] Health check of workableServer.\n")
 			// do nothing
 		}))
 	r := m.Run()

--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -29,16 +29,13 @@ func (r *customPolicy) Select(pool HostPool) *UpstreamHost {
 func testPool() HostPool {
 	pool := []*UpstreamHost{
 		{
-			Name:    workableServer.URL, // this should resolve (healthcheck test)
-			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
+			Name: workableServer.URL, // this should resolve (healthcheck test)
 		},
 		{
-			Name:    "http://shouldnot.resolve", // this shouldn't
-			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
+			Name: "http://shouldnot.resolve", // this shouldn't
 		},
 		{
-			Name:    "http://C",
-			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
+			Name: "http://C",
 		},
 	}
 	return HostPool(pool)

--- a/middleware/proxy/policy_test.go
+++ b/middleware/proxy/policy_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,7 @@ var workableServer *httptest.Server
 func TestMain(m *testing.M) {
 	workableServer = httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("[INFO] Health check of workableServer.\n")
 			// do nothing
 		}))
 	r := m.Run()
@@ -29,13 +31,16 @@ func (r *customPolicy) Select(pool HostPool) *UpstreamHost {
 func testPool() HostPool {
 	pool := []*UpstreamHost{
 		{
-			Name: workableServer.URL, // this should resolve (healthcheck test)
+			Name:    workableServer.URL, // this should resolve (healthcheck test)
+			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
 		},
 		{
-			Name: "http://shouldnot.resolve", // this shouldn't
+			Name:    "http://shouldnot.resolve", // this shouldn't
+			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
 		},
 		{
-			Name: "http://C",
+			Name:    "http://C",
+			OkUntil: time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)),
 		},
 	}
 	return HostPool(pool)

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -59,7 +59,7 @@ type UpstreamHost struct {
 	Name              string // IP address (and port) of this upstream host
 	Fails             int32
 	FailTimeout       time.Duration
-	Unhealthy         bool
+	OkUntil           time.Time
 	CheckDown         UpstreamHostDownFunc
 	WithoutPathPrefix string
 	checkMu           sync.Mutex
@@ -72,7 +72,7 @@ func (uh *UpstreamHost) Down() bool {
 	if uh.CheckDown == nil {
 		// Default settings
 		fails := atomic.LoadInt32(&uh.Fails)
-		return uh.Unhealthy || fails > 0
+		return time.Now().After(uh.OkUntil) || fails > 0
 	}
 	return uh.CheckDown(uh)
 }

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -62,6 +62,7 @@ type UpstreamHost struct {
 	OkUntil           time.Time
 	CheckDown         UpstreamHostDownFunc
 	WithoutPathPrefix string
+	Checking          bool
 	checkMu           sync.Mutex
 }
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -80,7 +80,7 @@ func (uh *UpstreamHost) Down() bool {
 		until := uh.OkUntil
 		uh.checkMu.Unlock()
 
-		if time.Now().After(until) {
+		if !until.IsZero() && time.Now().After(until) {
 			after = true
 		}
 

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -3,7 +3,6 @@ package proxy
 
 import (
 	"errors"
-	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -82,7 +81,6 @@ func (uh *UpstreamHost) Down() bool {
 
 		if time.Now().After(until) {
 			after = true
-			log.Printf("[INFO] Host %s tested as down: OkUntil was %s\n", uh.Name, until.Local())
 		}
 
 		return after || fails > 0

--- a/middleware/proxy/proxy.go
+++ b/middleware/proxy/proxy.go
@@ -61,6 +61,7 @@ type UpstreamHost struct {
 	FailTimeout       time.Duration
 	OkUntil           time.Time
 	CheckDown         UpstreamHostDownFunc
+	CheckUrl          string
 	WithoutPathPrefix string
 	Checking          bool
 	checkMu           sync.Mutex

--- a/middleware/proxy/proxy_test.go
+++ b/middleware/proxy/proxy_test.go
@@ -74,8 +74,10 @@ func TestStop(t *testing.T) {
 				t.Error("Expected healthchecks to hit test server. Got no healthchecks.")
 			}
 
+			// health checks are in a go routine now, so one may well occur after we shutdown,
+			// but we only ever expect one more
 			counterValueAfterWaiting := atomic.LoadInt64(&counter)
-			if counterValueAfterWaiting != counterValueAfterShutdown {
+			if counterValueAfterWaiting > (counterValueAfterShutdown + 1) {
 				t.Errorf("Expected no more healthchecks after shutdown. Got: %d healthchecks after shutdown", counterValueAfterWaiting-counterValueAfterShutdown)
 			}
 

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -293,17 +293,16 @@ func healthCheckUrl(url string, nextTs time.Time, host *UpstreamHost) {
 		r.Body.Close()
 
 		if r.StatusCode < 200 || r.StatusCode >= 400 {
-
-			log.Printf("[WARNING] Health check URL %s returned HTTP code %d\n",
-				url, r.StatusCode)
 			host.OkUntil = time.Unix(0, 0)
+			log.Printf("[WARNING] Host %s health check URL %s returned HTTP code %d\n",
+				host.Name, url, r.StatusCode)
 		} else {
-			log.Printf("[DEBUG] Host healthy until %s\n", nextTs.Local())
 			host.OkUntil = nextTs
+			log.Printf("[DEBUG] Host %s marked healthy until %s.\n", host.Name, host.OkUntil.Local())
 		}
 	} else {
-		log.Printf("[WARNING] Health check probe failed: %v\n", err)
 		host.OkUntil = time.Unix(0, 0)
+		log.Printf("[WARNING] Host %s health check probe failed: %v\n", host.Name, err)
 	}
 
 	host.checkMu.Lock()

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -90,7 +90,7 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 				Conns:       0,
 				Fails:       0,
 				FailTimeout: upstream.FailTimeout,
-				OkUntil:     time.Now().Add(upstream.HealthCheck.Future),
+				OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
 
 				CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 					return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -91,7 +90,7 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 				Conns:       0,
 				Fails:       0,
 				FailTimeout: upstream.FailTimeout,
-				OkUntil:     time.Unix(math.MaxInt64, 0), // forever, initially
+				OkUntil:     time.Unix(4000000000, 0), // forever, initially
 
 				CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
 					return func(uh *UpstreamHost) bool {

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"io/ioutil"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -42,13 +42,13 @@ func TestSelect(t *testing.T) {
 		FailTimeout: 10 * time.Second,
 		MaxFails:    1,
 	}
-	upstream.Hosts[0].Unhealthy = true
-	upstream.Hosts[1].Unhealthy = true
-	upstream.Hosts[2].Unhealthy = true
+	upstream.Hosts[0].OkUntil = time.Unix(0, 0)
+	upstream.Hosts[1].OkUntil = time.Unix(0, 0)
+	upstream.Hosts[2].OkUntil = time.Unix(0, 0)
 	if h := upstream.Select(); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].Unhealthy = false
+	upstream.Hosts[2].OkUntil = time.Now().Add(1 * time.Hour)
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -48,7 +48,7 @@ func TestSelect(t *testing.T) {
 	if h := upstream.Select(); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].OkUntil = time.Now().Add(1 * time.Hour)
+	upstream.Hosts[2].OkUntil = time.Unix(math.MaxInt64, 0)
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"io/ioutil"
 	"log"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,6 +26,9 @@ func TestHealthCheck(t *testing.T) {
 		MaxFails:    1,
 	}
 	upstream.healthCheck()
+	// sleep a bit, it's async now
+	time.Sleep(time.Duration(3 * time.Second))
+
 	if upstream.Hosts[0].Down() {
 		t.Error("Expected first host in testpool to not fail healthcheck.")
 	}
@@ -49,7 +51,7 @@ func TestSelect(t *testing.T) {
 	if h := upstream.Select(); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].OkUntil = time.Unix(4000000000, 0)
+	upstream.Hosts[2].OkUntil = time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)) // now + 100 years
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -49,7 +49,7 @@ func TestSelect(t *testing.T) {
 	if h := upstream.Select(); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].OkUntil = time.Unix(math.MaxInt64, 0)
+	upstream.Hosts[2].OkUntil = time.Unix(4000000000, 0)
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
+	//log.SetOutput(ioutil.Discard)
 
 	upstream := &staticUpstream{
 		from:        ".",
@@ -23,11 +22,13 @@ func TestHealthCheck(t *testing.T) {
 		Policy:      &Random{},
 		Spray:       nil,
 		FailTimeout: 10 * time.Second,
+		Future:      60 * time.Second,
 		MaxFails:    1,
 	}
+
 	upstream.healthCheck()
 	// sleep a bit, it's async now
-	time.Sleep(time.Duration(3 * time.Second))
+	time.Sleep(time.Duration(2 * time.Second))
 
 	if upstream.Hosts[0].Down() {
 		t.Error("Expected first host in testpool to not fail healthcheck.")
@@ -43,6 +44,7 @@ func TestSelect(t *testing.T) {
 		Hosts:       testPool()[:3],
 		Policy:      &Random{},
 		FailTimeout: 10 * time.Second,
+		Future:      60 * time.Second,
 		MaxFails:    1,
 	}
 	upstream.Hosts[0].OkUntil = time.Unix(0, 0)

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -54,7 +54,7 @@ func TestSelect(t *testing.T) {
 	if h := upstream.Select(); h != nil {
 		t.Error("Expected select to return nil as all host are down")
 	}
-	upstream.Hosts[2].OkUntil = time.Now().Add(time.Duration(24 * 365 * 100 * time.Hour)) // now + 100 years
+	upstream.Hosts[2].OkUntil = time.Time{}
 	if h := upstream.Select(); h == nil {
 		t.Error("Expected select to not return nil")
 	}

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHealthCheck(t *testing.T) {
-	//log.SetOutput(ioutil.Discard)
+	log.SetOutput(ioutil.Discard)
 
 	upstream := &staticUpstream{
 		from:        ".",


### PR DESCRIPTION
Update to middleware/proxy:

The approach to this was discussed in the issue, but tl;dr -

Health checks are now done asynchronously in a go routine.  Rather than a healthy/unhealthy bool state, servers are marked healthy until a timestamp.  This is typically 2 * healthcheck-interval.  If they fail a health check, they are marked healthy until Unix(0, 0).

The mutex that was around the health check is now only around updating the health status (necessary to prevent a race).  The upshot of all this is that:

If a host is gone (and so health checking takes a very long time to discover it is dead) it's healthy-until will have expired already, and we do not block anything, critically the mutex, while we find this out.  A check in progress bool prevents concurrent checks overlapping.

The failure count mechanism is untouched.