### PR TITLE
middleware/kubernetes: Server side path lookups

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -121,7 +121,7 @@ kubernetes coredns.local {
 	# Each line consists of the name of the federation, and the domain.
 	federation myfed foo.example.com
 	
-	# autopath [ndots:NDOTS] [resolv:RESOLV-CONF-FILE] [onnxdomain:RESPONSE] ...
+	# autopath [NDOTS [RESPONSE [RESOLV-CONF]]
 	#
 	# Enables server side search path lookups for pods.  When enabled, coredns
 	# will identify search path queries from pods and perform the remaining
@@ -149,24 +149,23 @@ kubernetes coredns.local {
 	#    ;; ANSWER SECTION:
 	#    google.com.		175	IN	A	216.58.194.206
 	#
-	# All 3 arguments are optional:
-	# 
-	# resolv:RESOLV-CONF-FILE (default: /etc/resolv.conf) If specified, coredns
-	# uses this file to get the host's search domains. CoreDNS performs a lookup
-	# on these domains if the in-cluster search domains in the path fail to 
-	# produce an answer. If not specified, the values will be read from the local 
-	# resolv.conf file (i.e the resolv.conf file in the pod containing coredns).
 	#
-	# ndots:NDOTS (default: 1) This provides an adjustable threshold to
+	# NDOTS (default: 0) This provides an adjustable threshold to
 	# prevent server side lookups from triggering. If the number of dots before
 	# the first search domain is less than this number, then the search path will
 	# not executed on the server side.
 	#
-	# onnxdomain:RESPONSE (default: NXDOMAIN) RESPONSE can be either SERVFAIL or
+	# RESPONSE (default: SERVFAIL) RESPONSE can be either NXDOMAIN, SERVFAIL or
 	# NOERROR. This option causes coredns to return the given response instead of
-	# NXDOMAIN when the all searches in the path produce no results. Doing this
-	# should prevent the client from fruitlessly continuing the client side 
-	# searches in the path.
+	# NXDOMAIN when the all searches in the path produce no results. Setting this
+	# to SERVFAIL or NOERROR should prevent the client from fruitlessly continuing
+	# the client side searches in the path after the server already checked them.
+	#
+	# RESOLV-CONF (default: /etc/resolv.conf) If specified, coredns uses this
+	# file to get the host's search domains. CoreDNS performs a lookup on these
+	# domains if the in-cluster search domains in the path fail to produce an
+	# answer. If not specified, the values will be read from the local resolv.conf
+	# file (i.e the resolv.conf file in the pod containing coredns).
 	#
 	# Enabling autopath causes coredns to use more memory since it needs to
 	# maintain a watch on all pods. If autopath and "pods verified" mode are

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -121,6 +121,41 @@ kubernetes coredns.local {
 	# Each line consists of the name of the federation, and the domain.
 	federation myfed foo.example.com
 	
+	# autopath [<host-domain>]
+	#
+	# Enables server side search path lookups for pods.  When enabled, coredns
+	# will identify search path queries from pods and perform the remaining path
+	# lookups on the pod's behalf.  The search path used mimics the resolve.conf
+	# search path deployed to pods. E.g.
+	#
+	#     search namespace.svc.cluster.local svc.cluster.local cluster.local
+	#
+	# <host-domain> is optional. If specified, coredns performs a lookup on this
+	# path if the preceeding paths fail to produce an answer.
+	#
+	# If no paths produce an answer, coredns attempts the empty (.) path.
+	#
+	# A successful response will contain a question section with the original
+	# question, and an answer section containing the a record for a diffrent
+	# question.  The question and answer will not match. For example:
+	#
+	#    # host -v -t a google.com
+	#    Trying "google.com.default.svc.cluster.local"
+	#    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50957
+	#    ;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+	#
+	#    ;; QUESTION SECTION:
+	#    ;google.com.default.svc.cluster.local. IN A
+	#
+	#    ;; ANSWER SECTION:
+	#    google.com.		175	IN	A	216.58.194.206
+	#
+	# Enabling autopath causes coredns to use more memory since it needs to
+	# maintain a watch on all pods. If autopath and "pods verified" mode are
+	# both enabled, they will use share the same watch. I.e. enabling both options
+	# should have an equivalent memory impact of just one.
+	autopath foo.example.com.
+
 	# fallthrough
 	#
 	# If a query for a record in the cluster zone results in NXDOMAIN,

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -121,19 +121,22 @@ kubernetes coredns.local {
 	# Each line consists of the name of the federation, and the domain.
 	federation myfed foo.example.com
 	
-	# autopath [<host-domain>]
+	# autopath [ndots:NDOTS] [HOST-DOMAIN] [HOST-DOMAIN] ...
 	#
 	# Enables server side search path lookups for pods.  When enabled, coredns
-	# will identify search path queries from pods and perform the remaining path
-	# lookups on the pod's behalf.  The search path used mimics the resolve.conf
-	# search path deployed to pods. E.g.
+	# will identify search path queries from pods and perform the remaining
+	# lookups in the path on the pod's behalf.  The search path used mimics the
+	# resolv.conf search path deployed to pods. E.g.
 	#
 	#     search namespace.svc.cluster.local svc.cluster.local cluster.local
 	#
-	# <host-domain> is optional. If specified, coredns performs a lookup on this
-	# path if the preceeding paths fail to produce an answer.
+	# HOST-DOMAIN are optional. If specified, coredns performs a lookup on these
+	# domains if the preceeding searches fail to produce an answer. If not
+	# specified, the values will be read from the local resolv.conf file (i.e
+	# the resolv.conf file in the pod containing coredns).
 	#
-	# If no paths produce an answer, coredns attempts the empty (.) path.
+	# If no domains in the path produce an answer, a lookup on the bare question
+	# attempted.	
 	#
 	# A successful response will contain a question section with the original
 	# question, and an answer section containing the record for the question that
@@ -151,11 +154,16 @@ kubernetes coredns.local {
 	#    ;; ANSWER SECTION:
 	#    google.com.		175	IN	A	216.58.194.206
 	#
+	# NDOTS is optional, defaulting to 1. This provides an adjustable threshold to
+	# prevent server side lookups from triggering. If the number of dots before
+	# the first search domain is less than this number, then the search path will
+	# not executed on the server side.
+	#
 	# Enabling autopath causes coredns to use more memory since it needs to
 	# maintain a watch on all pods. If autopath and "pods verified" mode are
 	# both enabled, they will use share the same watch. I.e. enabling both options
 	# should have an equivalent memory impact of just one.
-	autopath foo.example.com.
+	autopath ndots:1 foo.example.com.
 
 	# fallthrough
 	#

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -131,7 +131,7 @@ kubernetes coredns.local {
 	#  search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
 	#
 	# If no domains in the path produce an answer, a lookup on the bare question
-	# attempted.	
+	# will be attempted.	
 	#
 	# A successful response will contain a question section with the original
 	# question, and an answer section containing the record for the question that
@@ -171,7 +171,7 @@ kubernetes coredns.local {
 	# maintain a watch on all pods. If autopath and "pods verified" mode are
 	# both enabled, they will share the same watch. I.e. enabling both options
 	# should have an equivalent memory impact of just one.
-	autopath ndots:1 foo.example.com.
+	autopath 0 SERVFAIL /etc/resolv.conf
 
 	# fallthrough
 	#

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -136,8 +136,9 @@ kubernetes coredns.local {
 	# If no paths produce an answer, coredns attempts the empty (.) path.
 	#
 	# A successful response will contain a question section with the original
-	# question, and an answer section containing the a record for a diffrent
-	# question.  The question and answer will not match. For example:
+	# question, and an answer section containing the record for the question that
+	# actually had an answer.  This means that the question and answer will not
+	# match. For example:
 	#
 	#    # host -v -t a google.com
 	#    Trying "google.com.default.svc.cluster.local"

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -121,19 +121,14 @@ kubernetes coredns.local {
 	# Each line consists of the name of the federation, and the domain.
 	federation myfed foo.example.com
 	
-	# autopath [ndots:NDOTS] [HOST-DOMAIN] [HOST-DOMAIN] ...
+	# autopath [ndots:NDOTS] [resolv:RESOLV-CONF-FILE] [onnxdomain:RESPONSE] ...
 	#
 	# Enables server side search path lookups for pods.  When enabled, coredns
 	# will identify search path queries from pods and perform the remaining
 	# lookups in the path on the pod's behalf.  The search path used mimics the
 	# resolv.conf search path deployed to pods. E.g.
 	#
-	#     search namespace.svc.cluster.local svc.cluster.local cluster.local
-	#
-	# HOST-DOMAIN are optional. If specified, coredns performs a lookup on these
-	# domains if the preceeding searches fail to produce an answer. If not
-	# specified, the values will be read from the local resolv.conf file (i.e
-	# the resolv.conf file in the pod containing coredns).
+	#  search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
 	#
 	# If no domains in the path produce an answer, a lookup on the bare question
 	# attempted.	
@@ -154,14 +149,28 @@ kubernetes coredns.local {
 	#    ;; ANSWER SECTION:
 	#    google.com.		175	IN	A	216.58.194.206
 	#
-	# NDOTS is optional, defaulting to 1. This provides an adjustable threshold to
+	# All 3 arguments are optional:
+	# 
+	# resolv:RESOLV-CONF-FILE (default: /etc/resolv.conf) If specified, coredns
+	# uses this file to get the host's search domains. CoreDNS performs a lookup
+	# on these domains if the in-cluster search domains in the path fail to 
+	# produce an answer. If not specified, the values will be read from the local 
+	# resolv.conf file (i.e the resolv.conf file in the pod containing coredns).
+	#
+	# ndots:NDOTS (default: 1) This provides an adjustable threshold to
 	# prevent server side lookups from triggering. If the number of dots before
 	# the first search domain is less than this number, then the search path will
 	# not executed on the server side.
 	#
+	# onnxdomain:RESPONSE (default: NXDOMAIN) RESPONSE can be either SERVFAIL or
+	# NOERROR. This option causes coredns to return the given response instead of
+	# NXDOMAIN when the all searches in the path produce no results. Doing this
+	# should prevent the client from fruitlessly continuing the client side 
+	# searches in the path.
+	#
 	# Enabling autopath causes coredns to use more memory since it needs to
 	# maintain a watch on all pods. If autopath and "pods verified" mode are
-	# both enabled, they will use share the same watch. I.e. enabling both options
+	# both enabled, they will share the same watch. I.e. enabling both options
 	# should have an equivalent memory impact of just one.
 	autopath ndots:1 foo.example.com.
 

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -50,12 +50,12 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 			if !ok {
 				break
 			}
-			if strings.Count(name, ".") < k.AutoPath.NDots {
+			if (dns.CountLabel(name) - 1) < k.AutoPath.NDots {
 				break
 			}
 			// Search "svc.cluster.local" and "cluster.local"
 			for i := 0; i < 2; i++ {
-				path = strings.Join(strings.Split(path, ".")[1:], ".")
+				path = strings.Join(dns.SplitDomainName(path)[1:], ".")
 				state = state.NewWithQuestion(strings.Join([]string{name, path}, "."), state.QType())
 				records, extra, _, err = k.routeRequest(zone, state)
 				if !k.IsNameError(err) {

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -2,9 +2,11 @@ package kubernetes
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/coredns/coredns/middleware"
 	"github.com/coredns/coredns/middleware/pkg/dnsutil"
+	"github.com/coredns/coredns/middleware/rewrite"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -39,37 +41,40 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		zone = state.Name()
 	}
 
-	var (
-		records, extra []dns.RR
-		err            error
-	)
-	switch state.Type() {
-	case "A":
-		records, _, err = middleware.A(&k, zone, state, nil, middleware.Options{})
-	case "AAAA":
-		records, _, err = middleware.AAAA(&k, zone, state, nil, middleware.Options{})
-	case "TXT":
-		records, _, err = middleware.TXT(&k, zone, state, middleware.Options{})
-	case "CNAME":
-		records, _, err = middleware.CNAME(&k, zone, state, middleware.Options{})
-	case "PTR":
-		records, _, err = middleware.PTR(&k, zone, state, middleware.Options{})
-	case "MX":
-		records, extra, _, err = middleware.MX(&k, zone, state, middleware.Options{})
-	case "SRV":
-		records, extra, _, err = middleware.SRV(&k, zone, state, middleware.Options{})
-	case "SOA":
-		records, _, err = middleware.SOA(&k, zone, state, middleware.Options{})
-	case "NS":
-		if state.Name() == zone {
-			records, extra, _, err = middleware.NS(&k, zone, state, middleware.Options{})
-			break
+	records, extra, _, err := k.routeRequest(zone, state)
+
+	if k.IsNameError(err) {
+		p := k.findPodWithIP(state.IP())
+		if p != nil {
+			name, path, ok := splitSearchPath(zone, state.QName(), p.Namespace)
+			if ok {
+				// try the "svc.cluster.local" and "cluster.local" paths
+				for i := 0; i < 2; i++ {
+					path = strings.Join(strings.Split(path, ".")[1:], ".")
+					state = state.NewWithQuestion(strings.Join([]string{name, path}, "."), state.QType())
+					records, extra, _, err = k.routeRequest(zone, state)
+					if !k.IsNameError(err) {
+						break
+					}
+				}
+				if k.IsNameError(err) {
+					// Fallthrough with the host domain path (if set)
+					wr := rewrite.NewResponseReverter(w, r)
+					if k.HostDomainPath != "" {
+						r = state.NewWithQuestion(strings.Join([]string{name, k.HostDomainPath}, "."), state.QType()).Req
+						rcode, nextErr := middleware.NextOrFailure(k.Name(), k.Next, ctx, wr, r)
+						if rcode == dns.RcodeSuccess {
+							return rcode, nextErr
+						}
+					}
+					// Fallthrough with the . path
+					r = state.NewWithQuestion(strings.Join([]string{name, ""}, "."), state.QType()).Req
+					return middleware.NextOrFailure(k.Name(), k.Next, ctx, wr, r)
+				}
+			}
 		}
-		fallthrough
-	default:
-		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
-		_, _, err = middleware.A(&k, zone, state, nil, middleware.Options{})
 	}
+
 	if k.IsNameError(err) {
 		if k.Fallthrough {
 			return middleware.NextOrFailure(k.Name(), k.Next, ctx, w, r)
@@ -93,6 +98,37 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	m, _ = state.Scrub(m)
 	w.WriteMsg(m)
 	return dns.RcodeSuccess, nil
+}
+
+func (k *Kubernetes) routeRequest(zone string, state request.Request) (records []dns.RR, extra []dns.RR, debug []dns.RR, err error) {
+	switch state.Type() {
+	case "A":
+		records, _, err = middleware.A(k, zone, state, nil, middleware.Options{})
+	case "AAAA":
+		records, _, err = middleware.AAAA(k, zone, state, nil, middleware.Options{})
+	case "TXT":
+		records, _, err = middleware.TXT(k, zone, state, middleware.Options{})
+	case "CNAME":
+		records, _, err = middleware.CNAME(k, zone, state, middleware.Options{})
+	case "PTR":
+		records, _, err = middleware.PTR(k, zone, state, middleware.Options{})
+	case "MX":
+		records, extra, _, err = middleware.MX(k, zone, state, middleware.Options{})
+	case "SRV":
+		records, extra, _, err = middleware.SRV(k, zone, state, middleware.Options{})
+	case "SOA":
+		records, _, err = middleware.SOA(k, zone, state, middleware.Options{})
+	case "NS":
+		if state.Name() == zone {
+			records, extra, _, err = middleware.NS(k, zone, state, middleware.Options{})
+			break
+		}
+		fallthrough
+	default:
+		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
+		_, _, err = middleware.A(k, zone, state, nil, middleware.Options{})
+	}
+	return records, extra, nil, err
 }
 
 // Name implements the Handler interface.

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -43,7 +43,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	records, extra, _, err := k.routeRequest(zone, state)
 
-	if k.IsNameError(err) {
+	if k.AnticipatePaths && k.IsNameError(err) {
 		p := k.findPodWithIP(state.IP())
 		if p != nil {
 			name, path, ok := splitSearchPath(zone, state.QName(), p.Namespace)

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -193,7 +193,7 @@ func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dn
 
 // IsNameError implements the ServiceBackend interface.
 func (k *Kubernetes) IsNameError(err error) bool {
-	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest
+	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest || err == errZoneNotFound
 }
 
 // Debug implements the ServiceBackend interface.

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -247,7 +247,7 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 	}
 
 	opts := dnsControlOpts{
-		initPodCache: k.PodMode == PodModeVerified,
+		initPodCache: (k.PodMode == PodModeVerified || k.AnticipatePaths),
 	}
 	k.APIConn = newdnsController(kubeClient, k.ResyncPeriod, k.Selector, opts)
 

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -192,7 +192,7 @@ func (k *Kubernetes) IsNameError(err error) bool {
 func (k *Kubernetes) Debug() string { return "debug" }
 
 func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
-	loadingRules := &clientcmd.ClientConfigLoadingRules{}
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	overrides := &clientcmd.ConfigOverrides{}
 	clusterinfo := clientcmdapi.Cluster{}
 	authinfo := clientcmdapi.AuthInfo{}

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -28,27 +28,33 @@ import (
 
 // Kubernetes implements a middleware that connects to a Kubernetes cluster.
 type Kubernetes struct {
-	Next           middleware.Handler
-	Zones          []string
-	primaryZone    int
-	Proxy          proxy.Proxy // Proxy for looking up names during the resolution process
-	APIEndpoint    string
-	APICertAuth    string
-	APIClientCert  string
-	APIClientKey   string
-	APIConn        dnsController
-	ResyncPeriod   time.Duration
-	Namespaces     []string
-	Federations    []Federation
-	LabelSelector  *unversionedapi.LabelSelector
-	Selector       *labels.Selector
-	PodMode        string
-	ReverseCidrs   []net.IPNet
-	Fallthrough    bool
-	AutoPath       bool
-	HostSearchPath []string
-	AutoPathNdots  int
+	Next          middleware.Handler
+	Zones         []string
+	primaryZone   int
+	Proxy         proxy.Proxy // Proxy for looking up names during the resolution process
+	APIEndpoint   string
+	APICertAuth   string
+	APIClientCert string
+	APIClientKey  string
+	APIConn       dnsController
+	ResyncPeriod  time.Duration
+	Namespaces    []string
+	Federations   []Federation
+	LabelSelector *unversionedapi.LabelSelector
+	Selector      *labels.Selector
+	PodMode       string
+	ReverseCidrs  []net.IPNet
+	Fallthrough   bool
+	AutoPath
 	interfaceAddrs interfaceAddrser
+}
+
+type AutoPath struct {
+	Enabled        bool
+	NDots          int
+	ResolvConfFile string
+	HostSearchPath []string
+	OnNXDOMAIN     int
 }
 
 const (
@@ -249,7 +255,7 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 	}
 
 	opts := dnsControlOpts{
-		initPodCache: (k.PodMode == PodModeVerified || k.AutoPath),
+		initPodCache: (k.PodMode == PodModeVerified || k.AutoPath.Enabled),
 	}
 	k.APIConn = newdnsController(kubeClient, k.ResyncPeriod, k.Selector, opts)
 

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -483,23 +483,23 @@ func TestServices(t *testing.T) {
 
 func TestSplitSearchPath(t *testing.T) {
 	type testCase struct {
-		question     string
-		namespace    string
-		expectedName string
-		expectedPath string
-		expectedOk   bool
+		question       string
+		namespace      string
+		expectedName   string
+		expectedSearch string
+		expectedOk     bool
 	}
 	tests := []testCase{
-		{question: "test.blah.com", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
-		{question: "foo.com.ns2.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
-		{question: "foo.com.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
-		{question: "foo.com.ns1.svc.interwebs.nets", namespace: "ns1", expectedName: "foo.com", expectedPath: "ns1.svc.interwebs.nets", expectedOk: true},
+		{question: "test.blah.com", namespace: "ns1", expectedName: "", expectedSearch: "", expectedOk: false},
+		{question: "foo.com.ns2.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedSearch: "", expectedOk: false},
+		{question: "foo.com.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedSearch: "", expectedOk: false},
+		{question: "foo.com.ns1.svc.interwebs.nets", namespace: "ns1", expectedName: "foo.com", expectedSearch: "ns1.svc.interwebs.nets", expectedOk: true},
 	}
 	zone := "interwebs.nets"
 	for _, c := range tests {
-		name, path, ok := splitSearchPath(zone, c.question, c.namespace)
-		if c.expectedName != name || c.expectedPath != path || c.expectedOk != ok {
-			t.Errorf("Case %v: Expected name'%v', path:'%v', ok:'%v'. Got name:'%v', path:'%v', ok:'%v'.", c.question, c.expectedName, c.expectedPath, c.expectedOk, name, path, ok)
+		name, search, ok := splitSearch(zone, c.question, c.namespace)
+		if c.expectedName != name || c.expectedSearch != search || c.expectedOk != ok {
+			t.Errorf("Case %v: Expected name'%v', search:'%v', ok:'%v'. Got name:'%v', search:'%v', ok:'%v'.", c.question, c.expectedName, c.expectedSearch, c.expectedOk, name, search, ok)
 		}
 	}
 

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -480,3 +480,27 @@ func TestServices(t *testing.T) {
 	}
 
 }
+
+func TestSplitSearchPath(t *testing.T) {
+	type testCase struct {
+		question     string
+		namespace    string
+		expectedName string
+		expectedPath string
+		expectedOk   bool
+	}
+	tests := []testCase{
+		{question: "test.blah.com", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
+		{question: "foo.com.ns2.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
+		{question: "foo.com.svc.interwebs.nets", namespace: "ns1", expectedName: "", expectedPath: "", expectedOk: false},
+		{question: "foo.com.ns1.svc.interwebs.nets", namespace: "ns1", expectedName: "foo.com", expectedPath: "ns1.svc.interwebs.nets", expectedOk: true},
+	}
+	zone := "interwebs.nets"
+	for _, c := range tests {
+		name, path, ok := splitSearchPath(zone, c.question, c.namespace)
+		if c.expectedName != name || c.expectedPath != path || c.expectedOk != ok {
+			t.Errorf("Case %v: Expected name'%v', path:'%v', ok:'%v'. Got name:'%v', path:'%v', ok:'%v'.", c.question, c.expectedName, c.expectedPath, c.expectedOk, name, path, ok)
+		}
+	}
+
+}

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -187,7 +187,16 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 						continue
 					}
 					return nil, fmt.Errorf("incorrect number of arguments for federation, got %v, expected 2", len(args))
-
+				case "autopath": // name zone
+					args := c.RemainingArgs()
+					if len(args) > 1 {
+						return nil, fmt.Errorf("incorrect number of arguments for autopath, got %v, expected at most 1", len(args))
+					}
+					k8s.AnticipatePaths = true
+					if len(args) == 1 {
+						k8s.HostDomainPath = args[0]
+					}
+					continue
 				}
 			}
 			return k8s, nil

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -194,7 +194,7 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 					}
 					k8s.AnticipatePaths = true
 					if len(args) == 1 {
-						k8s.HostDomainPath = args[0]
+						k8s.HostDomainPath = middleware.Name(args[0]).Normalize()
 					}
 					continue
 				}

--- a/middleware/kubernetes/setup_test.go
+++ b/middleware/kubernetes/setup_test.go
@@ -618,7 +618,7 @@ func TestKubernetesParse(t *testing.T) {
 		{
 			"valid autopath",
 			`kubernetes coredns.local {
-	autopath ndots:0 resolv:` + autoPathResolvConfFile + `
+	autopath 1 NXDOMAIN ` + autoPathResolvConfFile + `
 }`,
 			false,
 			"",
@@ -633,68 +633,19 @@ func TestKubernetesParse(t *testing.T) {
 			nil,
 			AutoPath{
 				Enabled:        true,
-				NDots:          0,
+				NDots:          1,
 				HostSearchPath: []string{"bar.com.", "baz.com."},
 				ResolvConfFile: autoPathResolvConfFile,
-				OnNXDOMAIN:     defaultOnNXDOMAIN,
+				OnNXDOMAIN:     dns.RcodeNameError,
 			},
 		},
 		{
-			"valid autopath",
+			"invalid autopath RESPONSE",
 			`kubernetes coredns.local {
-	autopath resolv:` + autoPathResolvConfFile + ` onnxdomain:NOERROR
-}`,
-			false,
-			"",
-			1,
-			0,
-			defaultResyncPeriod,
-			"",
-			defaultPodMode,
-			nil,
-			false,
-			nil,
-			nil,
-			AutoPath{
-				Enabled:        true,
-				NDots:          defautNdots,
-				HostSearchPath: []string{"bar.com.", "baz.com."},
-				ResolvConfFile: autoPathResolvConfFile,
-				OnNXDOMAIN:     dns.RcodeSuccess,
-			},
-		},
-		{
-			"valid autopath",
-			`kubernetes coredns.local {
-	autopath resolv:` + autoPathResolvConfFile + ` onnxdomain:SERVFAIL
-}`,
-			false,
-			"",
-			1,
-			0,
-			defaultResyncPeriod,
-			"",
-			defaultPodMode,
-			nil,
-			false,
-			nil,
-			nil,
-			AutoPath{
-				Enabled:        true,
-				NDots:          defautNdots,
-				HostSearchPath: []string{"bar.com.", "baz.com."},
-				ResolvConfFile: autoPathResolvConfFile,
-				OnNXDOMAIN:     dns.RcodeServerFailure,
-			},
-		},
-
-		{
-			"invalid autopath onnxdomain option",
-			`kubernetes coredns.local {
-	autopath onnxdomain:CRY
+	autopath 0 CRY
 }`,
 			true,
-			"invalid onnxdomain: option for autopath",
+			"invalid RESPONSE argument for autopath",
 			-1,
 			0,
 			defaultResyncPeriod,
@@ -707,12 +658,12 @@ func TestKubernetesParse(t *testing.T) {
 			AutoPath{},
 		},
 		{
-			"invalid autopath ndots option",
+			"invalid autopath NDOTS",
 			`kubernetes coredns.local {
-	autopath ndots:polka
+	autopath polka
 }`,
 			true,
-			"invalid ndots: option for autopath",
+			"invalid NDOTS argument for autopath",
 			-1,
 			0,
 			defaultResyncPeriod,
@@ -725,9 +676,9 @@ func TestKubernetesParse(t *testing.T) {
 			AutoPath{},
 		},
 		{
-			"invalid autopath resolv option",
+			"invalid autopath RESOLV-CONF",
 			`kubernetes coredns.local {
-	autopath resolv:/wrong/path/to/resolv.conf
+	autopath 1 NOERROR /wrong/path/to/resolv.conf
 }`,
 			true,
 			"error when parsing",
@@ -745,10 +696,10 @@ func TestKubernetesParse(t *testing.T) {
 		{
 			"invalid autopath invalid option",
 			`kubernetes coredns.local {
-	autopath npolkas:dots
+	autopath 1 SERVFAIL ` + autoPathResolvConfFile + ` foo
 }`,
 			true,
-			"invalid option",
+			"incorrect number of arguments",
 			-1,
 			0,
 			defaultResyncPeriod,

--- a/middleware/kubernetes/setup_test.go
+++ b/middleware/kubernetes/setup_test.go
@@ -657,7 +657,7 @@ func TestKubernetesParse(t *testing.T) {
 		{
 			"valid autopath with host domain",
 			`kubernetes coredns.local {
-	autopath host.domain.com.
+	autopath host.domain.com
 }`,
 			false,
 			"",


### PR DESCRIPTION
Implements #747 as proposed.

I've added docs inline with the current format. Will restructure and expand the docs later (#728)
I have not added a test in Travis CI k8s integration, since it currently doesn't run tests from within a pod.
