### PR TITLE
middleware/kubernetes: api client should ignore local kubectl context

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -190,9 +190,7 @@ func (k *Kubernetes) IsNameError(err error) bool {
 func (k *Kubernetes) Debug() string { return "debug" }
 
 func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
-	// For a custom api server or running outside a k8s cluster
-	// set URL in env.KUBERNETES_MASTER or set endpoint in Corefile
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules := &clientcmd.ClientConfigLoadingRules{}
 	overrides := &clientcmd.ConfigOverrides{}
 	clusterinfo := clientcmdapi.Cluster{}
 	authinfo := clientcmdapi.AuthInfo{}


### PR DESCRIPTION
This dispels the magic described in #690 

When initializing the k8s conf client, start with an empty set of config settings instead of starting with a "default" set. The default set pulls in configs from the current env KUBECONFIG var, which causes the client to ignore the api endpoint configuration overrides.

This change means that developers testing locally will need to proxy localhost:8080 to their kubernetes api instance (e.g. minikube) using the `kubectl proxy` command. for example:

`kubectl proxy --port=8080 &`

Travis integration may be depending on the "magic".  If so, it will break, and we'll need to add a step to run the proxy.