### PR TITLE
Reverse middleware change ipseparator

### DIFF
--- a/middleware/reverse/README.md
+++ b/middleware/reverse/README.md
@@ -24,7 +24,7 @@ forward lookup back to an IP.
 #### `{ip}`
 
 The `{ip}` symbol is **required** to make reverse work.
-For IPv4 lookups the "." is replaced with a "-", e.g., 10.1.1.1 results in "10-1-1-1"
+For IPv4 lookups the IP is directly extracted
 With IPv6 lookups the ":" is removed, and any zero ranged are expanded, e.g.,
 "ffff::ffff" results in "ffff000000000000000000000000ffff"
 
@@ -42,8 +42,8 @@ arpa compute.internal {
     proxy . 8.8.8.8
 
     # answer requests for IPs in this network
-    # PTR 1.0.32.10.in-addr.arpa. 3600 ip-10-0-32-1.compute.internal.
-    # A ip-10-0-32-1.compute.internal. 3600 10.0.32.1
+    # PTR 1.0.32.10.in-addr.arpa. 3600 ip-10.0.32.1.compute.internal.
+    # A ip-10.0.32.1.compute.internal. 3600 10.0.32.1
     # v6 is also possible
     # PTR 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.1.0.d.f.ip6.arpa. 3600 ip-fd010000000000000000000000000001.compute.internal.
     # AAAA ip-fd010000000000000000000000000001.compute.internal. 3600 fd01::1

--- a/middleware/reverse/network.go
+++ b/middleware/reverse/network.go
@@ -18,7 +18,7 @@ type network struct {
 // TODO: we might want to get rid of these regexes.
 const hexDigit = "0123456789abcdef"
 const templateNameIP = "{ip}"
-const regexMatchV4 = "((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\-){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))"
+const regexMatchV4 = "((?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?))"
 const regexMatchV6 = "([0-9a-fA-F]{32})"
 
 // hostnameToIP converts the hostname back to an ip, based on the template
@@ -32,7 +32,7 @@ func (network *network) hostnameToIP(rname string) net.IP {
 	}
 
 	if network.IPnet.IP.To4() != nil {
-		matchedIP = net.ParseIP(strings.Replace(match[1], "-", ".", 4))
+		matchedIP = net.ParseIP(match[1])
 	} else {
 		// TODO: can probably just allocate a []byte and use that.
 		var buf bytes.Buffer
@@ -58,10 +58,7 @@ func (network *network) hostnameToIP(rname string) net.IP {
 func (network *network) ipToHostname(ip net.IP) (name string) {
 	if ipv4 := ip.To4(); ipv4 != nil {
 		// replace . to -
-		name = uitoa(ipv4[0]) + "-" +
-			uitoa(ipv4[1]) + "-" +
-			uitoa(ipv4[2]) + "-" +
-			uitoa(ipv4[3])
+		name = ipv4.String()
 	} else {
 		// assume v6
 		// ensure zeros are present in string

--- a/middleware/reverse/network_test.go
+++ b/middleware/reverse/network_test.go
@@ -27,7 +27,7 @@ func TestNetworkConversion(t *testing.T) {
 				Template:     "dns-{ip}.domain.internal.",
 				RegexMatchIP: regexIP4,
 			},
-			"dns-10-1-1-23.domain.internal.",
+			"dns-10.1.1.23.domain.internal.",
 			net.ParseIP("10.1.1.23"),
 		},
 		{
@@ -74,7 +74,7 @@ func TestNetworkHostnameToIP(t *testing.T) {
 				RegexMatchIP: regexIP4,
 			},
 			// domain does not match
-			"dns-10-1-1-23.domain.internals.",
+			"dns-10.1.1.23.domain.internals.",
 		},
 		{
 			network{
@@ -82,7 +82,7 @@ func TestNetworkHostnameToIP(t *testing.T) {
 				RegexMatchIP: regexIP4,
 			},
 			// IP does match / contain in subnet
-			"dns-200-1-1-23.domain.internals.",
+			"dns-200.1.1.23.domain.internals.",
 		},
 		{
 			network{
@@ -90,7 +90,7 @@ func TestNetworkHostnameToIP(t *testing.T) {
 				RegexMatchIP: regexIP4,
 			},
 			// template does not match
-			"dns-10-1-1-23-x.domain.internal.",
+			"dns-10.1.1.23-x.domain.internal.",
 		},
 		{
 			network{
@@ -98,7 +98,7 @@ func TestNetworkHostnameToIP(t *testing.T) {
 				RegexMatchIP: regexIP4,
 			},
 			// template does not match
-			"IP-dns-10-1-1-23.domain.internal.",
+			"IP-dns-10.1.1.23.domain.internal.",
 		},
 		{
 			network{


### PR DESCRIPTION
As discussed in https://github.com/coredns/coredns/issues/691 
This is a simple PR to change the "-" to "." for IPv4 in reverse middleware.

I haven't changed anything IPv6 related.