### PR TITLE
Adjust codecov config (codecov.yml) for commit status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 40%
+        threshold: null


### PR DESCRIPTION
This fix adjusted codecov config (codecov.yml) so that
commit status is success as long as coverage > 40%.

This fix fixes #752.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>