### PR TITLE
add wildcard parameter to allow resolving multiple name to the same IP

### DIFF
--- a/middleware/reverse/README.md
+++ b/middleware/reverse/README.md
@@ -9,6 +9,7 @@ reverse NETWORK... {
     hostname TEMPLATE
     [ttl TTL]
     [fallthrough]
+    [wildcard]
 ~~~
 
 * **NETWORK** one or more CIDR formatted networks to respond on.
@@ -33,6 +34,12 @@ With IPv6 lookups the ":" is removed, and any zero ranged are expanded, e.g.,
 The `{zone[i]}` symbol is **optional** and can be replaced by a fixed (zone) string.
 The zone will be matched by the zones listed in *this* configuration stanza.
 `i` needs to be replaced with the index of the configured listener zones, starting with 1.
+
+### `wildcard`
+
+If `wildcard` is true :
+any.thing.ip-1.2.3.4.example.org resolves to 1.2.3.4 (ip-{ip}.{zone} is the hostname/template)
+
 
 ## Examples
 

--- a/middleware/reverse/reverse_test.go
+++ b/middleware/reverse/reverse_test.go
@@ -1,0 +1,71 @@
+package reverse
+
+import (
+	"net"
+	"regexp"
+	"testing"
+
+	"github.com/coredns/coredns/middleware"
+	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+func TestReverse(t *testing.T) {
+	_, net4, _ := net.ParseCIDR("10.1.1.0/24")
+	regexIP4, _ := regexp.Compile("^.*ip-" + regexMatchV4 + "\\.example\\.org\\.$")
+
+	em := Reverse{
+		Networks: networks{network{
+			IPnet:        net4,
+			Zone:         "example.org",
+			Template:     "ip-{ip}.example.org.",
+			RegexMatchIP: regexIP4,
+		}},
+		Fallthrough: false,
+	}
+
+	tests := []struct {
+		next          middleware.Handler
+		qname         string
+		qtype         uint16
+		expectedCode  int
+		expectedReply string
+		expectedErr   error
+	}{
+		{
+			next:          test.NextHandler(dns.RcodeSuccess, nil),
+			qname:         "test.ip-10.1.1.2.example.org",
+			expectedCode:  dns.RcodeSuccess,
+			expectedReply: "10.1.1.2",
+			expectedErr:   nil,
+		},
+	}
+
+	ctx := context.TODO()
+
+	for i, tr := range tests {
+		req := new(dns.Msg)
+
+		tr.qtype = dns.TypeA
+		req.SetQuestion(dns.Fqdn(tr.qname), tr.qtype)
+
+		rec := dnsrecorder.New(&test.ResponseWriter{})
+		code, err := em.ServeDNS(ctx, rec, req)
+
+		if err != tr.expectedErr {
+			t.Errorf("Test %d: Expected error %v, but got %v", i, tr.expectedErr, err)
+		}
+		if code != int(tr.expectedCode) {
+			t.Errorf("Test %d: Expected status code %d, but got %d", i, tr.expectedCode, code)
+		}
+		if tr.expectedReply != "" {
+			answer := rec.Msg.Answer[0].(*dns.A).A.String()
+			if answer != tr.expectedReply {
+				t.Errorf("Test %d: Expected answer %s, but got %s", i, tr.expectedReply, answer)
+			}
+		}
+	}
+}

--- a/middleware/reverse/setup_test.go
+++ b/middleware/reverse/setup_test.go
@@ -14,6 +14,7 @@ func TestSetupParse(t *testing.T) {
 	_, net4, _ := net.ParseCIDR("10.1.1.0/24")
 	_, net6, _ := net.ParseCIDR("fd01::/64")
 
+	regexIP4wildcard, _ := regexp.Compile("^.*ip-" + regexMatchV4 + "\\.domain\\.com\\.$")
 	regexIP6, _ := regexp.Compile("^ip-" + regexMatchV6 + "\\.domain\\.com\\.$")
 	regexIpv4dynamic, _ := regexp.Compile("^dynamic-" + regexMatchV4 + "-intern\\.dynamic\\.domain\\.com\\.$")
 	regexIpv6dynamic, _ := regexp.Compile("^dynamic-" + regexMatchV6 + "-intern\\.dynamic\\.domain\\.com\\.$")
@@ -158,9 +159,20 @@ func TestSetupParse(t *testing.T) {
 			}},
 		},
 		{
-			`wildcard`,
+			`reverse 10.1.1.0/24 {
+				hostname ip-{ip}.{zone[1]}
+				ttl 50
+			    wildcard
+				fallthrough
+			}`,
 			false,
-			networks{},
+			networks{network{
+				IPnet:        net4,
+				Template:     "ip-{ip}.domain.com.",
+				Zone:         "domain.com.",
+				TTL:          50,
+				RegexMatchIP: regexIP4wildcard,
+			}},
 		},
 	}
 	for i, test := range tests {

--- a/middleware/reverse/setup_test.go
+++ b/middleware/reverse/setup_test.go
@@ -157,6 +157,11 @@ func TestSetupParse(t *testing.T) {
 				RegexMatchIP: regexIpv6dynamic,
 			}},
 		},
+		{
+			`wildcard`,
+			false,
+			networks{},
+		},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputFileRules)


### PR DESCRIPTION
See discussion https://github.com/coredns/coredns/issues/691

Implementation of a separate wildcard keyword to allow to resolve
any.thing.ip-1.2.3.4.example.org to 1.2.3.4
