### PR TITLE
middleware/cache: fix race

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -113,7 +113,6 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		cacheSize.WithLabelValues(Denial).Set(float64(w.ncache.Len()))
 	}
 
-	setMsgTTL(res, uint32(duration.Seconds()))
 	if w.prefetch {
 		return nil
 	}

--- a/middleware/cache/handler.go
+++ b/middleware/cache/handler.go
@@ -29,6 +29,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	i, ttl := c.get(now, qname, qtype, do)
 	if i != nil && ttl > 0 {
 		resp := i.toMsg(r)
+
 		state.SizeAndDo(resp)
 		resp, _ = state.Scrub(resp)
 		w.WriteMsg(resp)

--- a/middleware/cache/item.go
+++ b/middleware/cache/item.go
@@ -63,39 +63,35 @@ func (i *item) toMsg(m *dns.Msg) *dns.Msg {
 	m1.Rcode = i.Rcode
 	m1.Compress = true
 
-	m1.Answer = i.Answer
-	m1.Ns = i.Ns
-	m1.Extra = i.Extra
+	m1.Answer = make([]dns.RR, len(i.Answer))
+	m1.Ns = make([]dns.RR, len(i.Ns))
+	m1.Extra = make([]dns.RR, len(i.Extra))
 
-	ttl := int(i.origTTL) - int(time.Now().UTC().Sub(i.stored).Seconds())
-	setMsgTTL(m1, uint32(ttl))
+	ttl := uint32(i.ttl(time.Now()))
+	if ttl < minTTL {
+		ttl = minTTL
+	}
+
+	for j, r := range i.Answer {
+		m1.Answer[j] = dns.Copy(r)
+		m1.Answer[j].Header().Ttl = ttl
+	}
+	for j, r := range i.Ns {
+		m1.Ns[j] = dns.Copy(r)
+		m1.Ns[j].Header().Ttl = ttl
+	}
+	for j, r := range i.Extra {
+		m1.Extra[j] = dns.Copy(r)
+		if m1.Extra[j].Header().Rrtype != dns.TypeOPT {
+			m1.Extra[j].Header().Ttl = ttl
+		}
+	}
 	return m1
 }
 
 func (i *item) ttl(now time.Time) int {
 	ttl := int(i.origTTL) - int(now.UTC().Sub(i.stored).Seconds())
 	return ttl
-}
-
-// setMsgTTL sets the ttl on all RRs in all sections. If ttl is smaller than minTTL
-// that value is used.
-func setMsgTTL(m *dns.Msg, ttl uint32) {
-	if ttl < minTTL {
-		ttl = minTTL
-	}
-
-	for _, r := range m.Answer {
-		r.Header().Ttl = ttl
-	}
-	for _, r := range m.Ns {
-		r.Header().Ttl = ttl
-	}
-	for _, r := range m.Extra {
-		if r.Header().Rrtype == dns.TypeOPT {
-			continue
-		}
-		r.Header().Ttl = ttl
-	}
 }
 
 func minMsgTTL(m *dns.Msg, mt response.Type) time.Duration {


### PR DESCRIPTION
While adding a parallel performance benchmark I stumbled on a race
condition (another reason to add performance benchmarks!), so this
PR makes sure the msg is created in a race free manor and adds the
parallel benchmark.