### PR TITLE
Disable codecov/patch and codecov/changes status report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,5 @@ coverage:
       default:
         target: 40%
         threshold: null
+    patch: false
+    changes: false


### PR DESCRIPTION
This fix disables codecov/patch and codecov/changes status
report as the project has already been well covered by
codecov/project status. The codecov/patch and codecov/changes status
are misleading.

This fix fixes #752.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>