### PR TITLE
middleware/kubernetes: Rewrite/expand readme

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -12,7 +12,7 @@ kubernetes ZONE [ZONE...] [{
 	[endpoint URL
 	[tls CERT-FILE KEY-FILE CACERT-FILE]]
 	[namespaces NAMESPACE [NAMESPACE...]]
-	[labels EXPRESSION [,EXPRESSION...]]
+	[labels EXPRESSION]
 	[pods POD-MODE]
 	[cidrs CIDR [CIDR...]]
 	[upstream ADDRESS [ADDRESS...]]
@@ -72,7 +72,7 @@ specified).
 	}
   ```
 
-* *labels* **EXPRESSION [,EXPRESSION...]**
+* *labels* **EXPRESSION**
 	
   Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -57,7 +57,7 @@ Example:
 		endpoint https://k8s-endpoint:8443
 		tls cert key cacert
 	}
--
+
 ### namespaces
 
 	namespaces NAMESPACE [NAMESPACE...]

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -24,143 +24,142 @@ kubernetes ZONE [ZONE...] [{
 
 * **resyncperiod PERIOD**
 	
- The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
+  The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
 
- Example:
+  Example:
 
- ```
+  ```
 	kubernetes cluster.local. {
 		resyncperiod 15m
 	}
- ```
+  ```
 
 * **endpoint URL**
 	
- Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
+  Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
 
- Example:
+  Example:
 
- ```
+  ```
 	kubernetes cluster.local. {
 		endpoint http://k8s-endpoint:8080
 	}
- ```
+  ```
 
 * **tls CERT-FILE KEY-FILE CACERT-FILE**
 
- The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
+  The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
 specified).
 
- Example:
+  Example:
  
- ```
+  ```
 	kubernetes cluster.local. {
 		endpoint https://k8s-endpoint:8443
 		tls cert key cacert
 	}
- ```
+  ```
 
 * **namespaces NAMESPACE [NAMESPACE...]**
 
- Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
+  Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
 
- Example:
+  Example:
  
- ```
+  ```
 	kubernetes cluster.local. {
 		namespaces demo default
 	}
- ```
+  ```
 
 * **labels EXPRESSION [,EXPRESSION...]**
 	
- Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
+  Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 
- Example:
+  Example:
 
- The following example only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments.
+  The following example only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments.
 
- ```
+  ```
 	kubernetes cluster.local. {
 		labels environment in (staging, qa),application=nginx
 	}
- ```
+  ```
  
 * **pods POD-MODE**
 
- Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
+  Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
 
- Valid values for **POD-MODE**:
+  Valid values for **POD-MODE**:
 
- * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
+  * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
 
- * `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This option is provided for backward compatibility with kube-dns.
+  * `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This option is provided for backward compatibility with kube-dns.
 	            
- * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
+  * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
 	 
- Example:
+  Example:
 
   
- ```
+  ```
 	kubernetes cluster.local. {
 		pods verified
 	}
- ```
+  ```
 
 * **cidrs CIDR [CIDR...]**
 	
- Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
+  Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
 
- Example:
+  Example:
  
  
- ```
+  ```
 	kubernetes cluster.local. {
 		cidrs 10.0.0.0/24 10.0.10.0/25
 	}
  
- ```
+  ```
 
 * **upstream ADDRESS [ADDRESS...]**
 
- Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
+  Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
 	
  Example:
-
  
- ```
+  ```
 	kubernetes cluster.local. {
 		upstream 12.34.56.78:5053
 	}
  
- ```
+  ```
  
 * **federation NAME DOMAIN**
 
- Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
+  Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
 
- Example:
+  Example:
 
  
- ```
+  ```
  	kubernetes cluster.local. {
 		federation myfed foo.example.com
 	}
- ```
+  ```
 
 * **autopath [NDOTS [RESPONSE [RESOLV-CONF]]**
 
- Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
+  Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
 
- ```
+  ```
  search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
- ```
+  ```
 
- If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
+  If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
 
- A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. For example:
+  A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. For example:
 
- ```
+  ```
     # host -v -t a google.com
     Trying "google.com.default.svc.cluster.local"
     ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50957
@@ -171,39 +170,39 @@ specified).
 
     ;; ANSWER SECTION:
     google.com.		175	IN	A	216.58.194.206
- ```
+  ```
 
- **Fully Qualified Queries:** There is a known limitation of the autopath feature involving fully qualified queries. When the kubernetes middleware receives a query from a client, it cannot tell the difference between a query that was fully qualified by the user, and one that was expanded by the first search path on the client side.
+  **Fully Qualified Queries:** There is a known limitation of the autopath feature involving fully qualified queries. When the kubernetes middleware receives a query from a client, it cannot tell the difference between a query that was fully qualified by the user, and one that was expanded by the first search path on the client side.
 
- This means that the kubernetes middleware with autopath enabled will perform a server-side path search for the query `google.com.default.svc.cluster.local.` as if the client had queried just `google.com`.  In other words, a query for `google.com.default.svc.cluster.local.` will produce the IP address for `google.com` as seen below.
+  This means that the kubernetes middleware with autopath enabled will perform a server-side path search for the query `google.com.default.svc.cluster.local.` as if the client had queried just `google.com`.  In other words, a query for `google.com.default.svc.cluster.local.` will produce the IP address for `google.com` as seen below.
 
- ```
+  ```
 	# host -t a google.com
 	google.com has address 216.58.194.206
 	
 	# host -t a google.com.default.svc.cluster.local.
 	google.com has address 216.58.194.206
- ```
+  ```
  
- **NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
+  **NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
 	
- **RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
+  **RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
 
- **RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
+  **RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
 
- Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
+  Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
 
- Example:
+  Example:
  
- ```
+  ```
 	kubernetes cluster.local. {
 		autopath 0 NXDOMAIN /etc/resolv.conf
 	}
- ```
+  ```
 
 * **fallthrough**
 
- If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
+  If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
 
 
 ## Examples

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -1,204 +1,250 @@
 # kubernetes
 
-*kubernetes* enables reading zone data from a kubernetes cluster.
-It implements the [spec](https://github.com/kubernetes/dns/blob/master/docs/specification.md)
-defined for kubernetes DNS-Based service discovery:
-
-Service `A` records are constructed as "myservice.mynamespace.svc.coredns.local" where:
-
-* "myservice" is the name of the k8s service
-* "mynamespace" is the k8s namespace for the service, and
-* "svc" indicates this is a service
-* "coredns.local" is the zone
-
-Pod `A` records are constructed as "1-2-3-4.mynamespace.pod.coredns.local" where:
-
-* "1-2-3-4" is derived from the ip address of the pod (1.2.3.4 in this example)
-* "mynamespace" is the k8s namespace for the service, and
-* "pod" indicates this is a pod
-* "coredns.local" is the zone
-
-Endpoint `A` records are constructed as "epname.myservice.mynamespace.svc.coredns.local" where:
-
-* "epname" is the hostname (or name constructed from IP) of the endpoint
-* "myservice" is the name of the k8s service that the endpoint serves
-* "mynamespace" is the k8s namespace for the service, and
-* "svc" indicates this is a service
-* "coredns.local" is the zone
-
-Also supported are PTR and SRV records for services/endpoints.
+The *kubernetes* middleware enables the reading zone data from a Kubernetes cluster.  It implements the [Kubernetes DNS-Based Service Discovery Specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md).
 
 ## Syntax
 
-This is an example kubernetes configuration block, with all options described:
-
 ```
-# kubernetes <zone> [<zone>] ...
-#
-# Use kubernetes middleware for domain "coredns.local"
-# Reverse domain zones can be defined here (e.g. 0.0.10.in-addr.arpa),
-# or instead with the "cidrs" option.
-#
-kubernetes coredns.local {
-
-	# resyncperiod <period>
-	#
-	# Kubernetes data API resync period. Default is 5m
-	# Example values: 60s, 5m, 1h
-	#
-	resyncperiod 5m
-
-	# endpoint <url>
-	#
-	# Use url for a remote k8s API endpoint.  If omitted, it will connect to
-	# k8s in-cluster using the cluster service account.
-	#
-	endpoint https://k8s-endpoint:8080
-
-	# tls <cert-filename> <key-filename> <cacert-filename>
-	#
-	# The tls cert, key and the CA cert filenanames for remote k8s connection.
-	# This option is ignored if connecting in-cluster (i.e. endpoint is not
-	# specified).
-	#
-	tls cert key cacert
-
-	# namespaces <namespace> [<namespace>] ...
-	#
-	# Only expose the k8s namespaces listed.  If this option is omitted
-	# all namespaces are exposed
-	#
-	namespaces demo
-
-	# lables <expression> [,<expression>] ...
-	#
-	# Only expose the records for kubernetes objects
-	# that match this label selector. The label
-	# selector syntax is described in the kubernetes
-	# API documentation: http://kubernetes.io/docs/user-guide/labels/
-	# Example selector below only exposes objects tagged as
-	# "application=nginx" in the staging or qa environments.
-	#
-	labels environment in (staging, qa),application=nginx
-
-	# pods <disabled|insecure|verified>
-	#
-	# Set the mode of responding to pod A record requests.
-	# e.g 1-2-3-4.ns.pod.zone.  This option is provided to allow use of
-	# SSL certs when connecting directly to pods.
-	# Valid values: disabled, verified, insecure
-	#  disabled: Do not process pod requests, always returning NXDOMAIN
-	#  insecure: Always return an A record with IP from request (without
-	#            checking k8s).  This option is is vulnerable to abuse if
-	#            used maliciously in conjuction with wildcard SSL certs.
-	#  verified: Return an A record if there exists a pod in same
-	#            namespace with matching IP.  This option requires
-	#            substantially more memory than in insecure mode, since it
-	#            will maintain a watch on all pods.
-	# Default value is "disabled".
-	#
-	pods disabled
-
-	# cidrs <cidr> [<cidr>] ...
-	#
-	# Expose cidr ranges to reverse lookups.  Include any number of space
-	# delimited cidrs, and or multiple cidrs options on separate lines.
-	# kubernetes middleware will respond to PTR requests for ip addresses
-	# that fall within these ranges.
-	#
-	cidrs 10.0.0.0/24 10.0.10.0/25
-
-	# upstream <address> [<address>] ...
-	#
-	# Defines upstream resolvers used for resolving services that point to
-	# external hosts (External Services).  <address> can be an ip, an ip:port, or
-	# a path to a file structured like resolv.conf.
-	upstream 12.34.56.78:53
-	
-	# federation <federation-name> <federation-domain>
-	#
-	# Defines federation membership.  One line for each federation membership.
-	# Each line consists of the name of the federation, and the domain.
-	federation myfed foo.example.com
-	
-	# autopath [NDOTS [RESPONSE [RESOLV-CONF]]
-	#
-	# Enables server side search path lookups for pods.  When enabled, coredns
-	# will identify search path queries from pods and perform the remaining
-	# lookups in the path on the pod's behalf.  The search path used mimics the
-	# resolv.conf search path deployed to pods. E.g.
-	#
-	#  search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
-	#
-	# If no domains in the path produce an answer, a lookup on the bare question
-	# will be attempted.	
-	#
-	# A successful response will contain a question section with the original
-	# question, and an answer section containing the record for the question that
-	# actually had an answer.  This means that the question and answer will not
-	# match. For example:
-	#
-	#    # host -v -t a google.com
-	#    Trying "google.com.default.svc.cluster.local"
-	#    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50957
-	#    ;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
-	#
-	#    ;; QUESTION SECTION:
-	#    ;google.com.default.svc.cluster.local. IN A
-	#
-	#    ;; ANSWER SECTION:
-	#    google.com.		175	IN	A	216.58.194.206
-	#
-	#
-	# NDOTS (default: 0) This provides an adjustable threshold to
-	# prevent server side lookups from triggering. If the number of dots before
-	# the first search domain is less than this number, then the search path will
-	# not executed on the server side.
-	#
-	# RESPONSE (default: SERVFAIL) RESPONSE can be either NXDOMAIN, SERVFAIL or
-	# NOERROR. This option causes coredns to return the given response instead of
-	# NXDOMAIN when the all searches in the path produce no results. Setting this
-	# to SERVFAIL or NOERROR should prevent the client from fruitlessly continuing
-	# the client side searches in the path after the server already checked them.
-	#
-	# RESOLV-CONF (default: /etc/resolv.conf) If specified, coredns uses this
-	# file to get the host's search domains. CoreDNS performs a lookup on these
-	# domains if the in-cluster search domains in the path fail to produce an
-	# answer. If not specified, the values will be read from the local resolv.conf
-	# file (i.e the resolv.conf file in the pod containing coredns).
-	#
-	# Enabling autopath causes coredns to use more memory since it needs to
-	# maintain a watch on all pods. If autopath and "pods verified" mode are
-	# both enabled, they will share the same watch. I.e. enabling both options
-	# should have an equivalent memory impact of just one.
-	autopath 0 SERVFAIL /etc/resolv.conf
-
-	# fallthrough
-	#
-	# If a query for a record in the cluster zone results in NXDOMAIN,
-	# normally that is what the response will be. However, if you specify
-	# this option, the query will instead be passed on down the middleware
-	# chain, which can include another middleware to handle the query.
+kubernetes ZONE [ZONE...] {
+	resyncperiod PERIOD
+	endpoint URL
+	tls CERT-FILE KEY-FILE CACERT-FILE
+	namespaces NAMESPACE [NAMESPACE...]
+	labels EXPRESSION [,EXPRESSION...]
+	pods POD-MODE
+	cidrs CIDR [CIDR...]
+	upstream ADDRESS [ADDRESS...]
+	federation NAME DOMAIN
+	autopath [NDOTS [RESPONSE [RESOLV-CONF]]
 	fallthrough
 }
-
 ```
+-
+### resyncperiod
+
+	resyncperiod PERIOD
+	
+The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
+
+Example:
+
+	kubernetes cluster.local. {
+		resyncperiod 15m
+	}
+-
+### endpoint
+
+	endpoint URL
+	
+Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
+
+Example:
+
+	kubernetes cluster.local. {
+		endpoint http://k8s-endpoint:8080
+	}
+-
+### tls
+
+	tls CERT-FILE KEY-FILE CACERT-FILE
+
+The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
+specified).
+
+Example:
+
+	kubernetes cluster.local. {
+		endpoint https://k8s-endpoint:8443
+		tls cert key cacert
+	}
+-
+### namespaces
+
+	namespaces NAMESPACE [NAMESPACE...]
+
+Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
+
+Example:
+
+	kubernetes cluster.local. {
+		namespaces demo default
+	}
+-
+### labels
+
+	labels EXPRESSION [,EXPRESSION...]
+	
+Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
+
+Example:
+
+The following example only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments.
+
+	kubernetes cluster.local. {
+		labels environment in (staging, qa),application=nginx
+	}
+-
+### pods
+
+	pods POD-MODE
+
+Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
+
+Valid values for **POD-MODE**:
+
+* `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
+
+* `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.
+	            
+* `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
+	 
+Example:
+ 
+	kubernetes cluster.local. {
+		pods verified
+	}
+-
+### cidrs
+
+	cidrs CIDR [CIDR...]
+	
+Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
+
+Example:
+
+	kubernetes cluster.local. {
+		cidrs 10.0.0.0/24 10.0.10.0/25
+	}
+-
+### upstream
+
+	upstream ADDRESS [ADDRESS...]
+
+Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
+	
+Example:
+
+	kubernetes cluster.local. {
+		upstream 12.34.56.78:5053
+	}
+-
+### federation
+
+	federation NAME DOMAIN
+
+Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
+
+Example:
+
+	federation myfed foo.example.com
+-
+### autopath
+
+	autopath [NDOTS [RESPONSE [RESOLV-CONF]]
+
+Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
+
+	search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
+
+If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
+
+A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. For example:
+
+    # host -v -t a google.com
+    Trying "google.com.default.svc.cluster.local"
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50957
+    ;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+
+    ;; QUESTION SECTION:
+    ;google.com.default.svc.cluster.local. IN A
+
+    ;; ANSWER SECTION:
+    google.com.		175	IN	A	216.58.194.206
+
+**Fully Qualified Queries:** There is a known limitation of the autopath feature involving fully qualified queries. When the kubernetes middleware receives a query from a client, it cannot tell the difference between a query that was fully qualified by the user, and one that was expanded by the first search path on the client side.
+
+This means that the kubernetes middleware with autopath enabled will perform a server-side path search for the query `google.com.default.svc.cluster.local.` as if the client had queried just `google.com`.  In other words, a query for `google.com.default.svc.cluster.local.` will produce the IP address for `google.com` as seen below.
+
+	# host -t a google.com
+	google.com has address 216.58.194.206
+	
+	# host -t a google.com.default.svc.cluster.local.
+	google.com has address 216.58.194.206
+
+**NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted on the server side.
+	
+**RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
+
+**RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
+
+Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and "pods verified" mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
+
+Example:
+
+	kubernetes cluster.local. {
+		autopath 0 NXDOMAIN /etc/resolv.conf
+	}
+-
+### fallthrough
+
+If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
+
+
+## Examples
+
+
+**Example 1:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Handle all `PTR` requests in the `10.0.0.0/16` cidr block. Verify the existence of pods when answering pod requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature.
+
+	kubernetes cluster.local {
+		cidrs 10.0.0.0/16
+		pods verified
+		upstream 10.102.3.10:53
+		autopath
+	}
+	
+**Selective Exposure Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Only expose objects in the test and staging namespaces. Handle all `PTR` requests that fall between `10.0.0.100` and `10.0.0.255` (expressed as CIDR blocks in the example below). Resolve upstream records using the servers configured in `/etc/resolv.conf`.
+
+	kubernetes cluster.local {
+		namespaces test staging
+		cidrs 10.0.0.100/30 10.0.0.104/29 10.0.0.112/28 10.0.0.128/25
+		upstream /etc/resolv.conf
+	}
+
+**Federation Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Handle federated service requests in the `prod` and `stage` federations. Handle all `PTR` requests in the `10.0.0.0/24` cidr block. Resolve upstream records using the servers configured in `/etc/resolv.conf`.
+
+	kubernetes cluster.local {
+		federation prod prod.feddomain.com
+		federation stage stage.feddomain.com
+		cidrs 10.0.0.0/24
+		upstream /etc/resolv.conf
+	}
+	
+**Out-Of-Cluster Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes from outside the cluster. Handle all `PTR` requests in the `10.0.0.0/24` cidr block. Verify the existence of pods when answering pod requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature, using the `cluster.conf` file instead of `/etc/resolv.conf`.
+
+	kubernetes cluster.local {
+		endpoint https://k8s-endpoint:8443
+		tls cert key cacert
+		cidrs 10.0.0.0/24
+		pods verified
+		upstream 10.102.3.10:53
+		autopath 0 SERVFAIL cluster.conf
+	}
+
+
 
 ## Wildcards
 
-Some query labels accept a wildcard value to match any value.
-If a label is a valid wildcard (\*, or the word "any"), then that label will match
-all values.  The labels that accept wildcards are:
-* _service_ in an `A` record request: _service_.namespace.svc.zone.
+Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (\*, or the word "any"), then that label will match all values.  The labels that accept wildcards are:
+
+ * _service_ in an `A` record request: _service_.namespace.svc.zone.
    * e.g. `*.ns.svc.myzone.local`
-* _namespace_ in an `A` record request: service._namespace_.svc.zone.
+ * _namespace_ in an `A` record request: service._namespace_.svc.zone.
    * e.g. `nginx.*.svc.myzone.local`
-* _port and/or protocol_ in an `SRV` request: __port_.__protocol_.service.namespace.svc.zone.
+ * _port and/or protocol_ in an `SRV` request: __port_.__protocol_.service.namespace.svc.zone.
    * e.g. `_http.*.service.ns.svc.`
-* multiple wild cards are allowed in a single query.
+ * multiple wild cards are allowed in a single query.
    * e.g. `A` Request `*.*.svc.zone.` or `SRV` request `*.*.*.*.svc.zone.`
 
 ## Deployment in Kubernetes
 
-See the [deployment](https://github.com/coredns/deployment) repository for details on how
-to deploy CoreDNS in Kubernetes.
+See the [deployment](https://github.com/coredns/deployment) repository for details on [how to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -110,7 +110,7 @@ Example:
 
 	cidrs CIDR [CIDR...]
 	
-Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
+Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
 
 Example:
 
@@ -173,13 +173,13 @@ This means that the kubernetes middleware with autopath enabled will perform a s
 	# host -t a google.com.default.svc.cluster.local.
 	google.com has address 216.58.194.206
 
-**NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted on the server side.
+**NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
 	
 **RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
 
 **RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
 
-Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and "pods verified" mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
+Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
 
 Example:
 
@@ -211,7 +211,8 @@ If a query for a record in the cluster zone results in NXDOMAIN, normally that i
 
 	kubernetes cluster.local {
 		namespaces test staging
-		cidrs 10.0.0.100/30 10.0.0.104/29 10.0.0.112/28 10.0.0.128/25
+		cidrs 10.0.0.100/30 10.0.0.104/29
+		cidrs 10.0.0.112/28 10.0.0.128/25
 		upstream /etc/resolv.conf
 	}
 

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -22,7 +22,7 @@ kubernetes ZONE [ZONE...] [{
 }]
 ```
 
-* *resyncperiod* **DURATION**
+* `resyncperiod` **DURATION**
 	
   The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
 
@@ -34,7 +34,7 @@ kubernetes ZONE [ZONE...] [{
 	}
   ```
 
-* *endpoint* **URL**
+* `endpoint` **URL**
 	
   Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
 
@@ -46,7 +46,7 @@ kubernetes ZONE [ZONE...] [{
 	}
   ```
 
-* *tls* **CERT-FILE KEY-FILE CACERT-FILE**
+* `tls` **CERT-FILE KEY-FILE CACERT-FILE**
 
   The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
 specified).
@@ -60,7 +60,7 @@ specified).
 	}
   ```
 
-* *namespaces* **NAMESPACE [NAMESPACE...]**
+* `namespaces` **NAMESPACE [NAMESPACE...]**
 
   Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
 
@@ -72,7 +72,7 @@ specified).
 	}
   ```
 
-* *labels* **EXPRESSION**
+* `labels` **EXPRESSION**
 	
   Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 
@@ -86,7 +86,7 @@ specified).
 	}
   ```
  
-* *pods* **POD-MODE**
+* `pods` **POD-MODE**
 
   Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
 
@@ -107,7 +107,7 @@ specified).
 	}
   ```
 
-* *cidrs* **CIDR [CIDR...]**
+* `cidrs` **CIDR [CIDR...]**
 	
   Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
 
@@ -121,7 +121,7 @@ specified).
  
   ```
 
-* *upstream* **ADDRESS [ADDRESS...]**
+* `upstream` **ADDRESS [ADDRESS...]**
 
   Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
 	
@@ -134,7 +134,7 @@ specified).
  
    ```
  
-* *federation* **NAME DOMAIN**
+* `federation` **NAME DOMAIN**
 
   Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
 
@@ -146,7 +146,7 @@ specified).
 	}
   ```
 
-* *autopath* **[NDOTS [RESPONSE [RESOLV-CONF]]**
+* `autopath` **[NDOTS [RESPONSE [RESOLV-CONF]]**
 
   Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
 
@@ -199,7 +199,7 @@ specified).
 	}
   ```
 
-* *fallthrough*
+* `fallthrough`
 
   If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
 

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -19,7 +19,7 @@ kubernetes ZONE [ZONE...] {
 	fallthrough
 }
 ```
--
+
 ### resyncperiod
 
 	resyncperiod PERIOD
@@ -31,7 +31,7 @@ Example:
 	kubernetes cluster.local. {
 		resyncperiod 15m
 	}
--
+
 ### endpoint
 
 	endpoint URL
@@ -43,7 +43,7 @@ Example:
 	kubernetes cluster.local. {
 		endpoint http://k8s-endpoint:8080
 	}
--
+
 ### tls
 
 	tls CERT-FILE KEY-FILE CACERT-FILE
@@ -69,7 +69,7 @@ Example:
 	kubernetes cluster.local. {
 		namespaces demo default
 	}
--
+
 ### labels
 
 	labels EXPRESSION [,EXPRESSION...]
@@ -83,7 +83,7 @@ The following example only exposes objects labeled as "application=nginx" in the
 	kubernetes cluster.local. {
 		labels environment in (staging, qa),application=nginx
 	}
--
+
 ### pods
 
 	pods POD-MODE
@@ -103,7 +103,7 @@ Example:
 	kubernetes cluster.local. {
 		pods verified
 	}
--
+
 ### cidrs
 
 	cidrs CIDR [CIDR...]
@@ -115,7 +115,7 @@ Example:
 	kubernetes cluster.local. {
 		cidrs 10.0.0.0/24 10.0.10.0/25
 	}
--
+
 ### upstream
 
 	upstream ADDRESS [ADDRESS...]
@@ -127,7 +127,7 @@ Example:
 	kubernetes cluster.local. {
 		upstream 12.34.56.78:5053
 	}
--
+
 ### federation
 
 	federation NAME DOMAIN
@@ -137,7 +137,7 @@ Defines federation membership.  One line for each federation membership. Each li
 Example:
 
 	federation myfed foo.example.com
--
+
 ### autopath
 
 	autopath [NDOTS [RESPONSE [RESOLV-CONF]]
@@ -184,7 +184,7 @@ Example:
 	kubernetes cluster.local. {
 		autopath 0 NXDOMAIN /etc/resolv.conf
 	}
--
+
 ### fallthrough
 
 If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -140,7 +140,6 @@ specified).
 
   Example:
 
- 
   ```
  	kubernetes cluster.local. {
 		federation myfed foo.example.com
@@ -152,7 +151,7 @@ specified).
   Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
 
   ```
- search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
+  search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
   ```
 
   If no domains in the path produce an answer, a lookup on the bare question will be attempted.	

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -22,136 +22,145 @@ kubernetes ZONE [ZONE...] [{
 }]
 ```
 
-### resyncperiod
-
-	resyncperiod PERIOD
+* **resyncperiod PERIOD**
 	
-The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
+ The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
 
-Example:
+ Example:
 
+ ```
 	kubernetes cluster.local. {
 		resyncperiod 15m
 	}
+ ```
 
-### endpoint
-
-	endpoint URL
+* **endpoint URL**
 	
-Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
+ Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
 
-Example:
+ Example:
 
+ ```
 	kubernetes cluster.local. {
 		endpoint http://k8s-endpoint:8080
 	}
+ ```
 
-### tls
+* **tls CERT-FILE KEY-FILE CACERT-FILE**
 
-	tls CERT-FILE KEY-FILE CACERT-FILE
-
-The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
+ The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
 specified).
 
-Example:
-
+ Example:
+ 
+ ```
 	kubernetes cluster.local. {
 		endpoint https://k8s-endpoint:8443
 		tls cert key cacert
 	}
+ ```
 
-### namespaces
+* **namespaces NAMESPACE [NAMESPACE...]**
 
-	namespaces NAMESPACE [NAMESPACE...]
+ Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
 
-Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
-
-Example:
-
+ Example:
+ 
+ ```
 	kubernetes cluster.local. {
 		namespaces demo default
 	}
+ ```
 
-### labels
-
-	labels EXPRESSION [,EXPRESSION...]
+* **labels EXPRESSION [,EXPRESSION...]**
 	
-Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
+ Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 
-Example:
+ Example:
 
-The following example only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments.
+ The following example only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments.
 
+ ```
 	kubernetes cluster.local. {
 		labels environment in (staging, qa),application=nginx
 	}
-
-### pods
-
-	pods POD-MODE
-
-Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
-
-Valid values for **POD-MODE**:
-
-* `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
-
-* `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This option is provided for backward compatibility with kube-dns.
-	            
-* `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
-	 
-Example:
+ ```
  
+* **pods POD-MODE**
+
+ Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
+
+ Valid values for **POD-MODE**:
+
+ * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
+
+ * `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This option is provided for backward compatibility with kube-dns.
+	            
+ * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
+	 
+ Example:
+
+  
+ ```
 	kubernetes cluster.local. {
 		pods verified
 	}
+ ```
 
-### cidrs
-
-	cidrs CIDR [CIDR...]
+* **cidrs CIDR [CIDR...]**
 	
-Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
+ Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
 
-Example:
-
+ Example:
+ 
+ 
+ ```
 	kubernetes cluster.local. {
 		cidrs 10.0.0.0/24 10.0.10.0/25
 	}
+ 
+ ```
 
-### upstream
+* **upstream ADDRESS [ADDRESS...]**
 
-	upstream ADDRESS [ADDRESS...]
-
-Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
+ Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
 	
-Example:
+ Example:
 
+ 
+ ```
 	kubernetes cluster.local. {
 		upstream 12.34.56.78:5053
 	}
+ 
+ ```
+ 
+* **federation NAME DOMAIN**
 
-### federation
+ Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
 
-	federation NAME DOMAIN
+ Example:
 
-Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
+ 
+ ```
+ 	kubernetes cluster.local. {
+		federation myfed foo.example.com
+	}
+ ```
 
-Example:
+* **autopath [NDOTS [RESPONSE [RESOLV-CONF]]**
 
-	federation myfed foo.example.com
+ Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
 
-### autopath
+ ```
+ search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
+ ```
 
-	autopath [NDOTS [RESPONSE [RESOLV-CONF]]
+ If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
 
-Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
+ A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. For example:
 
-	search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
-
-If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
-
-A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. For example:
-
+ ```
     # host -v -t a google.com
     Trying "google.com.default.svc.cluster.local"
     ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50957
@@ -162,34 +171,39 @@ A successful response will contain a question section with the original question
 
     ;; ANSWER SECTION:
     google.com.		175	IN	A	216.58.194.206
+ ```
 
-**Fully Qualified Queries:** There is a known limitation of the autopath feature involving fully qualified queries. When the kubernetes middleware receives a query from a client, it cannot tell the difference between a query that was fully qualified by the user, and one that was expanded by the first search path on the client side.
+ **Fully Qualified Queries:** There is a known limitation of the autopath feature involving fully qualified queries. When the kubernetes middleware receives a query from a client, it cannot tell the difference between a query that was fully qualified by the user, and one that was expanded by the first search path on the client side.
 
-This means that the kubernetes middleware with autopath enabled will perform a server-side path search for the query `google.com.default.svc.cluster.local.` as if the client had queried just `google.com`.  In other words, a query for `google.com.default.svc.cluster.local.` will produce the IP address for `google.com` as seen below.
+ This means that the kubernetes middleware with autopath enabled will perform a server-side path search for the query `google.com.default.svc.cluster.local.` as if the client had queried just `google.com`.  In other words, a query for `google.com.default.svc.cluster.local.` will produce the IP address for `google.com` as seen below.
 
+ ```
 	# host -t a google.com
 	google.com has address 216.58.194.206
 	
 	# host -t a google.com.default.svc.cluster.local.
 	google.com has address 216.58.194.206
-
-**NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
+ ```
+ 
+ **NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
 	
-**RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
+ **RESPONSE** (default: `SERVFAIL`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
 
-**RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
+ **RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
 
-Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
+ Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
 
-Example:
-
+ Example:
+ 
+ ```
 	kubernetes cluster.local. {
 		autopath 0 NXDOMAIN /etc/resolv.conf
 	}
+ ```
 
-### fallthrough
+* **fallthrough**
 
-If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
+ If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
 
 
 ## Examples

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -206,7 +206,7 @@ specified).
 
 ## Examples
 
-**Example 1:** This minimal configuration with no options other then zone will... Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. It will not provide PTR records for services, or A records for pods.
+**Example 1:** This is a minimal configuration with no options other than zone. It will handle all queries in the `cluster.local` zone and connect to Kubernetes in-cluster, but it will not provide PTR records for services, or A records for pods.
 
 	kubernetes cluster.local
 

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -125,14 +125,14 @@ specified).
 
   Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
 	
- Example:
+  Example:
  
-  ```
+   ```
 	kubernetes cluster.local. {
 		upstream 12.34.56.78:5053
 	}
  
-  ```
+   ```
  
 * **federation NAME DOMAIN**
 

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -8,7 +8,7 @@ CoreDNS running the kubernetes middleware can be used as a replacement of kube-d
 
 ```
 kubernetes ZONE [ZONE...] [{
-	[resyncperiod PERIOD]
+	[resyncperiod DURATION]
 	[endpoint URL
 	[tls CERT-FILE KEY-FILE CACERT-FILE]]
 	[namespaces NAMESPACE [NAMESPACE...]]
@@ -22,7 +22,7 @@ kubernetes ZONE [ZONE...] [{
 }]
 ```
 
-* **resyncperiod PERIOD**
+* *resyncperiod* **DURATION**
 	
   The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
 
@@ -34,7 +34,7 @@ kubernetes ZONE [ZONE...] [{
 	}
   ```
 
-* **endpoint URL**
+* *endpoint* **URL**
 	
   Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
 
@@ -46,7 +46,7 @@ kubernetes ZONE [ZONE...] [{
 	}
   ```
 
-* **tls CERT-FILE KEY-FILE CACERT-FILE**
+* *tls* **CERT-FILE KEY-FILE CACERT-FILE**
 
   The TLS cert, key and the CA cert file names for remote k8s connection. This option is ignored if connecting in-cluster (i.e. endpoint is not
 specified).
@@ -60,7 +60,7 @@ specified).
 	}
   ```
 
-* **namespaces NAMESPACE [NAMESPACE...]**
+* *namespaces* **NAMESPACE [NAMESPACE...]**
 
   Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
 
@@ -72,7 +72,7 @@ specified).
 	}
   ```
 
-* **labels EXPRESSION [,EXPRESSION...]**
+* *labels* **EXPRESSION [,EXPRESSION...]**
 	
   Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 
@@ -86,7 +86,7 @@ specified).
 	}
   ```
  
-* **pods POD-MODE**
+* *pods* **POD-MODE**
 
   Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
 
@@ -107,7 +107,7 @@ specified).
 	}
   ```
 
-* **cidrs CIDR [CIDR...]**
+* *cidrs* **CIDR [CIDR...]**
 	
   Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
 
@@ -121,7 +121,7 @@ specified).
  
   ```
 
-* **upstream ADDRESS [ADDRESS...]**
+* *upstream* **ADDRESS [ADDRESS...]**
 
   Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
 	
@@ -134,7 +134,7 @@ specified).
  
    ```
  
-* **federation NAME DOMAIN**
+* *federation* **NAME DOMAIN**
 
   Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
 
@@ -146,7 +146,7 @@ specified).
 	}
   ```
 
-* **autopath [NDOTS [RESPONSE [RESOLV-CONF]]**
+* *autopath* **[NDOTS [RESPONSE [RESOLV-CONF]]**
 
   Enables server side search path lookups for pods.  When enabled, the kubernetes middleware will identify search path queries from pods and perform the remaining lookups in the path on the pod's behalf.  The search path used mimics the resolv.conf search path deployed to pods by the "cluster-first" dns-policy. E.g.
 
@@ -199,7 +199,7 @@ specified).
 	}
   ```
 
-* **fallthrough**
+* *fallthrough*
 
   If a query for a record in the cluster zone results in NXDOMAIN, normally that is what the response will be. However, if you specify this option, the query will instead be passed on down the middleware chain, which can include another middleware to handle the query.
 


### PR DESCRIPTION
* Match formatting and style to other middleware READMEs.
* Expand the autopath 
* Add examples section

I'm using a new visual markdown editor (macdown)... so I dont know how compatible it _really_ is with github yet.  Will see - I'll tweak it if things look off.