### PR TITLE
middleware/backend: separate etcd and backend struct

### DIFF
--- a/middleware/backend/handler.go
+++ b/middleware/backend/handler.go
@@ -14,14 +14,14 @@ import (
 )
 
 // ServeDNS implements the middleware.Handler interface.
-func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func (b *Backend) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	opt := middleware.Options{}
 	state := request.Request{W: w, Req: r}
 	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(e.Name(), errors.New("can only deal with ClassINET"))
+		return dns.RcodeServerFailure, middleware.Error(b.ServiceName, errors.New("can only deal with ClassINET"))
 	}
 	name := state.Name()
-	if e.Debugging {
+	if b.Debugging {
 		if bug := debug.IsDebug(name); bug != "" {
 			opt.Debug = r.Question[0].Name
 			state.Clear()
@@ -32,21 +32,21 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	// We need to check stubzones first, because we may get a request for a zone we
 	// are not auth. for *but* do have a stubzone forward for. If we do the stubzone
 	// handler will handle the request.
-	if e.Stubmap != nil && len(*e.Stubmap) > 0 {
-		for zone := range *e.Stubmap {
+	if b.Stubmap != nil && len(*b.Stubmap) > 0 {
+		for zone := range *b.Stubmap {
 			if middleware.Name(zone).Matches(name) {
-				stub := Stub{Etcd: e, Zone: zone}
+				stub := Stub{Backend: b, Zone: zone}
 				return stub.ServeDNS(ctx, w, r)
 			}
 		}
 	}
 
-	zone := middleware.Zones(e.Zones).Matches(state.Name())
+	zone := middleware.Zones(b.Zones).Matches(state.Name())
 	if zone == "" {
 		if opt.Debug != "" {
 			r.Question[0].Name = opt.Debug
 		}
-		return middleware.NextOrFailure(e.Name(), e.Next, ctx, w, r)
+		return middleware.NextOrFailure(b.ServiceName, b.Next, ctx, w, r)
 	}
 
 	var (
@@ -56,30 +56,30 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	)
 	switch state.Type() {
 	case "A":
-		records, debug, err = middleware.A(e, zone, state, nil, opt)
+		records, debug, err = middleware.A(b.ServiceBackend, zone, state, nil, opt)
 	case "AAAA":
-		records, debug, err = middleware.AAAA(e, zone, state, nil, opt)
+		records, debug, err = middleware.AAAA(b.ServiceBackend, zone, state, nil, opt)
 	case "TXT":
-		records, debug, err = middleware.TXT(e, zone, state, opt)
+		records, debug, err = middleware.TXT(b.ServiceBackend, zone, state, opt)
 	case "CNAME":
-		records, debug, err = middleware.CNAME(e, zone, state, opt)
+		records, debug, err = middleware.CNAME(b.ServiceBackend, zone, state, opt)
 	case "PTR":
-		records, debug, err = middleware.PTR(e, zone, state, opt)
+		records, debug, err = middleware.PTR(b.ServiceBackend, zone, state, opt)
 	case "MX":
-		records, extra, debug, err = middleware.MX(e, zone, state, opt)
+		records, extra, debug, err = middleware.MX(b.ServiceBackend, zone, state, opt)
 	case "SRV":
-		records, extra, debug, err = middleware.SRV(e, zone, state, opt)
+		records, extra, debug, err = middleware.SRV(b.ServiceBackend, zone, state, opt)
 	case "SOA":
-		records, debug, err = middleware.SOA(e, zone, state, opt)
+		records, debug, err = middleware.SOA(b.ServiceBackend, zone, state, opt)
 	case "NS":
 		if state.Name() == zone {
-			records, extra, debug, err = middleware.NS(e, zone, state, opt)
+			records, extra, debug, err = middleware.NS(b.ServiceBackend, zone, state, opt)
 			break
 		}
 		fallthrough
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
-		_, debug, err = middleware.A(e, zone, state, nil, opt)
+		_, debug, err = middleware.A(b.ServiceBackend, zone, state, nil, opt)
 	}
 
 	if opt.Debug != "" {
@@ -88,16 +88,16 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		state.Req.Question[0].Name = opt.Debug
 	}
 
-	if e.IsNameError(err) {
+	if b.ServiceBackend.IsNameError(err) {
 		// Make err nil when returning here, so we don't log spam for NXDOMAIN.
-		return middleware.BackendError(e, zone, dns.RcodeNameError, state, debug, nil /* err */, opt)
+		return middleware.BackendError(b.ServiceBackend, zone, dns.RcodeNameError, state, debug, nil /* err */, opt)
 	}
 	if err != nil {
-		return middleware.BackendError(e, zone, dns.RcodeServerFailure, state, debug, err, opt)
+		return middleware.BackendError(b.ServiceBackend, zone, dns.RcodeServerFailure, state, debug, err, opt)
 	}
 
 	if len(records) == 0 {
-		return middleware.BackendError(e, zone, dns.RcodeSuccess, state, debug, err, opt)
+		return middleware.BackendError(b.ServiceBackend, zone, dns.RcodeSuccess, state, debug, err, opt)
 	}
 
 	m := new(dns.Msg)
@@ -117,4 +117,4 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 }
 
 // Name implements the Handler interface.
-func (e *Etcd) Name() string { return "etcd" }
+func (b *Backend) Name() string { return b.ServiceName }

--- a/middleware/backend/proxy_lookup_test.go
+++ b/middleware/backend/proxy_lookup_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestProxyLookupFailDebug(t *testing.T) {
 	etc := newEtcdMiddleware()
-	etc.Proxy = proxy.NewLookup([]string{"127.0.0.1:154"})
+	etc.ServiceBackend.(*EtcdV2).Proxy = proxy.NewLookup([]string{"127.0.0.1:154"})
 	etc.Debugging = true
 
 	for _, serv := range servicesProxy {

--- a/middleware/backend/stub.go
+++ b/middleware/backend/stub.go
@@ -14,10 +14,10 @@ import (
 )
 
 // UpdateStubZones checks etcd for an update on the stubzones.
-func (e *Etcd) UpdateStubZones() {
+func (b *Backend) UpdateStubZones() {
 	go func() {
 		for {
-			e.updateStubZones()
+			b.updateStubZones()
 			time.Sleep(15 * time.Second)
 		}
 	}()
@@ -25,11 +25,11 @@ func (e *Etcd) UpdateStubZones() {
 
 // Look in .../dns/stub/<zone>/xx for msg.Services. Loop through them
 // extract <zone> and add them as forwarders (ip:port-combos) for
-// the stub zones. Only numeric (i.e. IP address) hosts are used.
-// Only the first zone configured on e is used for the lookup.
-func (e *Etcd) updateStubZones() {
-	zone := e.Zones[0]
-	services, err := e.Records(stubDomain+"."+zone, false)
+// the stub zones. Only numeric (i.b. IP address) hosts are used.
+// Only the first zone configured on b is used for the lookup.
+func (b *Backend) updateStubZones() {
+	zone := b.Zones[0]
+	services, err := b.ServiceBackend.Records(stubDomain+"."+zone, false)
 	if err != nil {
 		return
 	}
@@ -53,7 +53,7 @@ Services:
 		labels := dns.SplitDomainName(domain)
 
 		// If the remaining name equals any of the zones we have, we ignore it.
-		for _, z := range e.Zones {
+		for _, z := range b.Zones {
 			// Chop of left most label, because that is used as the nameserver place holder
 			// and drop the right most labels that belong to zone.
 			// We must *also* chop of dns.stub. which means cutting two more labels.
@@ -71,7 +71,7 @@ Services:
 	}
 	// atomic swap (at least that's what we hope it is)
 	if len(stubmap) > 0 {
-		e.Stubmap = &stubmap
+		b.Stubmap = &stubmap
 	}
 	return
 }

--- a/middleware/backend/stub_handler.go
+++ b/middleware/backend/stub_handler.go
@@ -10,9 +10,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Stub wraps an Etcd. We have this type so that it can have a ServeDNS method.
+// Stub wraps a middleware. We have this type so that it can have a ServeDNS method.
 type Stub struct {
-	*Etcd
+	*Backend
 	Zone string // for what zone (and thus what nameservers are we called)
 }
 
@@ -23,7 +23,7 @@ func (s Stub) ServeDNS(ctx context.Context, w dns.ResponseWriter, req *dns.Msg) 
 		return dns.RcodeRefused, errors.New("stub forward cycle")
 	}
 	req = addStubEdns0(req)
-	proxy, ok := (*s.Etcd.Stubmap)[s.Zone]
+	proxy, ok := (*s.Backend.Stubmap)[s.Zone]
 	if !ok { // somebody made a mistake..
 		return dns.RcodeServerFailure, nil
 	}

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -20,13 +20,13 @@ import (
 	"golang.org/x/net/context"
 )
 
-func etcdMiddleware() *etcd.Etcd {
+func etcdMiddleware() *etcd.EtcdV2 {
 	etcdCfg := etcdc.Config{
 		Endpoints: []string{"http://localhost:2379"},
 	}
 	cli, _ := etcdc.New(etcdCfg)
 	client := etcdc.NewKeysAPI(cli)
-	return &etcd.Etcd{Client: client, PathPrefix: "/skydns"}
+	return &etcd.EtcdV2{Client: client, PathPrefix: "/skydns"}
 }
 
 // This test starts two coredns servers (and needs etcd). Configure a stubzones in both (that will loop) and
@@ -92,7 +92,7 @@ var servicesStub = []*msg.Service{
 }
 
 // Copied from middleware/backend/setup_test.go
-func set(ctx context.Context, t *testing.T, e *etcd.Etcd, k string, ttl time.Duration, m *msg.Service) {
+func set(ctx context.Context, t *testing.T, e *etcd.EtcdV2, k string, ttl time.Duration, m *msg.Service) {
 	b, err := json.Marshal(m)
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func set(ctx context.Context, t *testing.T, e *etcd.Etcd, k string, ttl time.Dur
 }
 
 // Copied from middleware/backend/setup_test.go
-func delete(ctx context.Context, t *testing.T, e *etcd.Etcd, k string) {
+func delete(ctx context.Context, t *testing.T, e *etcd.EtcdV2, k string) {
 	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
 	e.Client.Delete(ctx, path, &etcdc.DeleteOptions{Recursive: false})
 }


### PR DESCRIPTION
**This PR does:**
- New `Backend struct` (built in parts with the `Etcd struct`)
- Rename what was left of `Etcd struct` to `EtcdV2`

Everything else in this PR is related to renaming.

**Next steps**
- Move etcdv2 to it's own package
- Make tests pass without imports shenanigans? 