### PR TITLE
Add Dockerfile for automatic build in DockerHub

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,9 @@ MAINTAINER Miek Gieben <miek@coredns.io> @miekg
 # only need ca-certificates & openssl if want to use https_google
 RUN apk --update add bind-tools ca-certificates openssl && update-ca-certificates && rm -rf /var/cache/apk/*
 
-ENV COREDNS_VERSION 010
+ARG COREDNS_VERSION=latest
+
+RUN echo build coredns v$COREDNS_VERSION
 
 ADD https://github.com/coredns/coredns/releases/download/v${COREDNS_VERSION}/coredns_${COREDNS_VERSION}_linux_x86_64.tgz /
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:latest
+MAINTAINER Miek Gieben <miek@coredns.io> @miekg
+
+# only need ca-certificates & openssl if want to use https_google
+RUN apk --update add bind-tools ca-certificates openssl && update-ca-certificates && rm -rf /var/cache/apk/*
+
+ENV COREDNS_VERSION 010
+
+ADD https://github.com/coredns/coredns/releases/download/v${COREDNS_VERSION}/coredns_${COREDNS_VERSION}_linux_x86_64.tgz /
+
+RUN tar -xzf coredns_${COREDNS_VERSION}_linux_x86_64.tgz && rm coredns_${COREDNS_VERSION}_linux_x86_64.tgz
+
+EXPOSE 53 53/udp
+ENTRYPOINT ["/coredns"]

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -x
+docker build --build-arg COREDNS_VERSION=$SOURCE_BRANCH -t $IMAGE_NAME .


### PR DESCRIPTION
Add Dockerfile for automatic build in DockerHub

We need a special Dockerfile that pulls the release binary and not by using `ADD coredns /coredns` locally in DockerHub.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>