### PR TITLE
mw/kubernete: small cleanup

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -100,13 +100,15 @@ type recordRequest struct {
 
 var localPodIP net.IP
 
-var errNoItems = errors.New("no items found")
-var errNsNotExposed = errors.New("namespace is not exposed")
-var errInvalidRequest = errors.New("invalid query name")
-var errZoneNotFound = errors.New("zone not found")
-var errAPIBadPodType = errors.New("expected type *api.Pod")
-var errPodsDisabled = errors.New("pod records disabled")
-var errResolvConfReadErr = errors.New("resolv.conf read error")
+var (
+	errNoItems           = errors.New("no items found")
+	errNsNotExposed      = errors.New("namespace is not exposed")
+	errInvalidRequest    = errors.New("invalid query name")
+	errZoneNotFound      = errors.New("zone not found")
+	errAPIBadPodType     = errors.New("expected type *api.Pod")
+	errPodsDisabled      = errors.New("pod records disabled")
+	errResolvConfReadErr = errors.New("resolv.conf read error")
+)
 
 // Services implements the ServiceBackend interface.
 func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) (svcs []msg.Service, debug []msg.Service, err error) {
@@ -139,26 +141,30 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.
 		}
 		return noext, nil, e
 	case "TXT":
-		err := k.recordsForTXT(r, &svcs)
+		if srv := k.recordsForTXT(r); srv != nil {
+			svcs = append(svcs, srv)
+		}
 		return svcs, nil, err
 	case "NS":
-		err = k.recordsForNS(r, &svcs)
+		srv = k.recordsForNS(r)
+		svcs = append(svcs, srv)
 		return svcs, nil, err
 	}
 	return nil, nil, nil
 }
 
-func (k *Kubernetes) recordsForTXT(r recordRequest, svcs *[]msg.Service) (err error) {
-	switch r.typeName {
-	case "dns-version":
-		s := msg.Service{
-			Text: DNSSchemaVersion,
-			TTL:  28800,
-			Key:  msg.Path(strings.Join([]string{r.typeName, r.zone}, "."), "coredns")}
-		*svcs = append(*svcs, s)
+func (k *Kubernetes) recordsForTXT(r recordRequest) []msg.Service {
+	if r.typeName != "dns-version" {
 		return nil
 	}
-	return nil
+	return msg.Service{Text: DNSSchemaVersion, TTL: 28800,
+		Key: msg.Path(strings.Join([]string{r.typeName, r.zone}, "."), "coredns")}
+}
+
+func (k *Kubernetes) recordsForNS(r recordRequest) []msg.Service {
+	ns := k.coreDNSRecord()
+	return msg.Service{Host: ns.A.String(),
+		Key: msg.Path(strings.Join([]string{ns.Hdr.Name, r.zone}, "."), "coredns")}
 }
 
 // PrimaryZone will return the first non-reverse zone being handled by this middleware

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -141,27 +141,25 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.
 		}
 		return noext, nil, e
 	case "TXT":
-		if srv := k.recordsForTXT(r); srv != nil {
+		if r.typeName == "dns-version" {
+			srv := k.recordsForTXT(r)
 			svcs = append(svcs, srv)
 		}
 		return svcs, nil, err
 	case "NS":
-		srv = k.recordsForNS(r)
+		srv := k.recordsForNS(r)
 		svcs = append(svcs, srv)
 		return svcs, nil, err
 	}
 	return nil, nil, nil
 }
 
-func (k *Kubernetes) recordsForTXT(r recordRequest) []msg.Service {
-	if r.typeName != "dns-version" {
-		return nil
-	}
+func (k *Kubernetes) recordsForTXT(r recordRequest) msg.Service {
 	return msg.Service{Text: DNSSchemaVersion, TTL: 28800,
 		Key: msg.Path(strings.Join([]string{r.typeName, r.zone}, "."), "coredns")}
 }
 
-func (k *Kubernetes) recordsForNS(r recordRequest) []msg.Service {
+func (k *Kubernetes) recordsForNS(r recordRequest) msg.Service {
 	ns := k.coreDNSRecord()
 	return msg.Service{Host: ns.A.String(),
 		Key: msg.Path(strings.Join([]string{ns.Hdr.Name, r.zone}, "."), "coredns")}

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -6,23 +6,21 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/coredns/coredns/middleware"
+	"github.com/coredns/coredns/request"
+
 	"github.com/miekg/dns"
 	"k8s.io/client-go/1.5/pkg/api"
-
-	"github.com/coredns/coredns/middleware"
-	"github.com/coredns/coredns/middleware/etcd/msg"
-	"github.com/coredns/coredns/request"
 )
 
 func TestRecordForTXT(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
 	r, _ := k.parseRequest("dns-version.inter.webs.test", dns.TypeTXT)
-	expected := DNSSchemaVersion
 
-	var svcs []msg.Service
-	k.recordsForTXT(r, &svcs)
-	if svcs[0].Text != expected {
-		t.Errorf("Expected result '%v'. Instead got result '%v'.", expected, svcs[0].Text)
+	expected := DNSSchemaVersion
+	svc := k.recordsForTXT(r)
+	if svc.Text != expected {
+		t.Errorf("Expected result '%v'. Instead got result '%v'.", expected, svc.Text)
 	}
 }
 

--- a/middleware/kubernetes/ns.go
+++ b/middleware/kubernetes/ns.go
@@ -24,15 +24,6 @@ func (i interfaceAddrs) interfaceAddrs() ([]net.Addr, error) {
 	return net.InterfaceAddrs()
 }
 
-func (k *Kubernetes) recordsForNS(r recordRequest, svcs *[]msg.Service) error {
-	ns := k.coreDNSRecord()
-	s := msg.Service{
-		Host: ns.A.String(),
-		Key:  msg.Path(strings.Join([]string{ns.Hdr.Name, r.zone}, "."), "coredns")}
-	*svcs = append(*svcs, s)
-	return nil
-}
-
 // DefaultNSMsg returns an msg.Service representing an A record for
 // ns.dns.[zone] -> dns service ip. This A record is needed to legitimize
 // the SOA response in middleware.NS(), which is hardcoded at ns.dns.[zone].

--- a/middleware/kubernetes/ns_test.go
+++ b/middleware/kubernetes/ns_test.go
@@ -3,7 +3,6 @@ package kubernetes
 import "testing"
 import "net"
 
-import "github.com/coredns/coredns/middleware/etcd/msg"
 import "k8s.io/client-go/1.5/pkg/api"
 import "github.com/miekg/dns"
 
@@ -12,12 +11,11 @@ func TestRecordForNS(t *testing.T) {
 	corednsRecord.Hdr.Name = "coredns.kube-system."
 	corednsRecord.A = net.IP("1.2.3.4")
 	r, _ := k.parseRequest("inter.webs.test", dns.TypeNS)
-	expected := "/coredns/test/webs/inter/kube-system/coredns"
 
-	var svcs []msg.Service
-	k.recordsForNS(r, &svcs)
-	if svcs[0].Key != expected {
-		t.Errorf("Expected  result '%v'. Instead got result '%v'.", expected, svcs[0].Key)
+	expected := "/coredns/test/webs/inter/kube-system/coredns"
+	svc := k.recordsForNS(r)
+	if svc.Key != expected {
+		t.Errorf("Expected  result '%v'. Instead got result '%v'.", expected, svc.Key)
 	}
 }
 
@@ -26,8 +24,8 @@ func TestDefaultNSMsg(t *testing.T) {
 	corednsRecord.Hdr.Name = "coredns.kube-system."
 	corednsRecord.A = net.IP("1.2.3.4")
 	r, _ := k.parseRequest("ns.dns.inter.webs.test", dns.TypeA)
-	expected := "/coredns/test/webs/inter/dns/ns"
 
+	expected := "/coredns/test/webs/inter/dns/ns"
 	svc := k.defaultNSMsg(r)
 	if svc.Key != expected {
 		t.Errorf("Expected  result '%v'. Instead got result '%v'.", expected, svc.Key)


### PR DESCRIPTION
Small cleanup, avoid pointer to []msg.Services and just returns the
msg.Service.