### PR TITLE
mw/kubernets: no need for interfaces

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -46,7 +46,6 @@ type Kubernetes struct {
 	ReverseCidrs  []net.IPNet
 	Fallthrough   bool
 	AutoPath
-	interfaceAddrs interfaceAddrser
 }
 
 type AutoPath struct {
@@ -651,7 +650,7 @@ func (k *Kubernetes) localPodIP() net.IP {
 	if localPodIP != nil {
 		return localPodIP
 	}
-	addrs, _ := k.interfaceAddrs.interfaceAddrs()
+	addrs, _ := net.InterfaceAddrs()
 
 	for _, addr := range addrs {
 		ip, _, _ := net.ParseCIDR(addr.String())

--- a/middleware/kubernetes/ns_test.go
+++ b/middleware/kubernetes/ns_test.go
@@ -97,31 +97,3 @@ func (APIConnTest) EndpointsList() api.EndpointsList {
 }
 
 func (APIConnTest) GetNodeByName(name string) (api.Node, error) { return api.Node{}, nil }
-
-type interfaceAddrsTest struct{}
-
-func (i interfaceAddrsTest) interfaceAddrs() ([]net.Addr, error) {
-	_, ipnet, _ := net.ParseCIDR("172.0.40.10/32")
-	return []net.Addr{ipnet}, nil
-}
-
-func TestDoCoreDNSRecord(t *testing.T) {
-
-	corednsRecord = dns.A{}
-	k := Kubernetes{Zones: []string{"inter.webs.test"}}
-
-	k.interfaceAddrs = &interfaceAddrsTest{}
-	k.APIConn = &APIConnTest{}
-
-	cdr := k.coreDNSRecord()
-
-	expected := "10.0.0.111"
-
-	if cdr.A.String() != expected {
-		t.Errorf("Expected A to be '%v', got '%v'", expected, cdr.A.String())
-	}
-	expected = "dns-service.kube-system.svc."
-	if cdr.Hdr.Name != expected {
-		t.Errorf("Expected Hdr.Name to be '%v', got '%v'", expected, cdr.Hdr.Name)
-	}
-}

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -56,10 +56,9 @@ func setup(c *caddy.Controller) error {
 
 func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 	k8s := &Kubernetes{
-		ResyncPeriod:   defaultResyncPeriod,
-		interfaceAddrs: &interfaceAddrs{},
-		PodMode:        PodModeDisabled,
-		Proxy:          proxy.Proxy{},
+		ResyncPeriod: defaultResyncPeriod,
+		PodMode:      PodModeDisabled,
+		Proxy:        proxy.Proxy{},
 	}
 
 	for c.Next() {


### PR DESCRIPTION
Clean up the internfaces - they are not needed. And use k.LocalIP to
get the local IP.