### PR TITLE
Support multiple k8s api servers specification and load balance among api servers

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -27,6 +27,9 @@ kubernetes ZONE [ZONE...] [
 * `resyncperiod` specifies the Kubernetes data API **DURATION** period.
 * `endpoint` specifies the **URL** for a remove k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
+   Multiple k8s API endpoints could be specified, separated by `,`s, e.g.
+   `endpoint http://k8s-endpoint1:8080,http://k8s-endpoint2:8080`. CoreDNS
+   will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.   
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]**, exposed only the k8s namespaces listed.

--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -29,7 +29,7 @@ kubernetes ZONE [ZONE...] [
    If omitted, it will connect to k8s in-cluster using the cluster service account.
    Multiple k8s API endpoints could be specified, separated by `,`s, e.g.
    `endpoint http://k8s-endpoint1:8080,http://k8s-endpoint2:8080`. CoreDNS
-   will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.   
+   will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]**, exposed only the k8s namespaces listed.

--- a/middleware/kubernetes/apiproxy.go
+++ b/middleware/kubernetes/apiproxy.go
@@ -1,0 +1,169 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type proxyUpstream struct {
+	network   string
+	address   string
+	stop      chan struct{}
+	wait      sync.WaitGroup
+	unhealthy int32
+}
+
+type proxyHandler struct {
+	upstreams []proxyUpstream
+	pickIndex int32
+}
+
+type apiProxy struct {
+	http.Server
+	listener net.Listener
+	handler  proxyHandler
+}
+
+func (p proxyUpstream) Network() string {
+	return p.network
+}
+
+func (p proxyUpstream) String() string {
+	return p.address
+}
+
+func (p *proxyUpstream) Healthcheck() {
+	p.wait.Add(1)
+	defer p.wait.Done()
+
+	status := func(unhealthy int32) string {
+		if unhealthy == 0 {
+			return "healthy"
+		}
+		return "unhealthy"
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return net.Dial(p.Network(), p.String())
+			},
+		},
+		Timeout: 5 * time.Second,
+	}
+	tick := time.NewTicker(5 * time.Second)
+	// Start healthcheck immediately
+	unhealthy := int32(1)
+	if resp, err := client.Get("http://kubernetes/"); err == nil {
+		defer resp.Body.Close()
+		unhealthy = 0
+	}
+	log.Printf("[INFO] Healthcheck upstream %s://%s: %s", p.Network(), p.String(), status(unhealthy))
+	atomic.StoreInt32(&(p.unhealthy), unhealthy)
+
+	// Continue healthcheck in the next tick
+	for {
+		select {
+		case <-tick.C:
+			unhealthy := int32(1)
+			if resp, err := client.Get("http://docker/"); err == nil {
+				defer resp.Body.Close()
+				unhealthy = 0
+			}
+			log.Printf("[INFO] Healthcheck upstream %s://%s: %s", p.Network(), p.String(), status(unhealthy))
+			atomic.StoreInt32(&(p.unhealthy), unhealthy)
+		case <-p.stop:
+			return
+		}
+	}
+
+}
+
+func (p *proxyHandler) StartHealthcheck() {
+	for i := range p.upstreams {
+		go p.upstreams[i].Healthcheck()
+	}
+}
+
+func (p *proxyHandler) StopHealthcheck() {
+	for i := range p.upstreams {
+		close(p.upstreams[i].stop)
+	}
+	for i := range p.upstreams {
+		p.upstreams[i].wait.Wait()
+	}
+}
+
+func (p *proxyHandler) SelectUpstream() net.Addr {
+	pickIndex := atomic.LoadInt32(&(p.pickIndex))
+	if atomic.LoadInt32(&(p.upstreams[pickIndex].unhealthy)) != 0 {
+		log.Printf("[WARNING] Upstream status: %v %s://%s unhealthy", pickIndex, p.upstreams[pickIndex].Network(), p.upstreams[pickIndex].String())
+		length := int32(len(p.upstreams))
+		for index := (pickIndex + int32(1)) % length; index != pickIndex; index = (index + int32(1)) % length {
+			if atomic.LoadInt32(&(p.upstreams[index].unhealthy)) == 0 {
+				atomic.StoreInt32(&(p.pickIndex), index)
+				pickIndex = index
+				log.Printf("[INFO] Upstream update: %v %s://%s healthy", pickIndex, p.upstreams[pickIndex].Network(), p.upstreams[pickIndex].String())
+				break
+			}
+		}
+	}
+	return p.upstreams[pickIndex]
+}
+
+func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	upstream := p.SelectUpstream()
+	d, err := net.Dial(upstream.Network(), upstream.String())
+	if err != nil {
+		log.Printf("[ERROR] Unable to establish connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err)
+		http.Error(w, fmt.Sprintf("Unable to establish connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err), 500)
+		return
+	}
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		log.Printf("[ERROR] Unable to establish connection: no hijacker")
+		http.Error(w, "Unable to establish connection: no hijacker", 500)
+		return
+	}
+	nc, _, err := hj.Hijack()
+	if err != nil {
+		log.Printf("[ERROR] Unable to hijack connection: %s", err)
+		http.Error(w, fmt.Sprintf("Unable to hijack connection: %s", err), 500)
+		return
+	}
+	defer nc.Close()
+	defer d.Close()
+
+	err = r.Write(d)
+	if err != nil {
+		log.Printf("[ERROR] Unable to copy connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err)
+		http.Error(w, fmt.Sprintf("Unable to copy connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err), 500)
+		return
+	}
+
+	errChan := make(chan error, 2)
+	cp := func(dst io.Writer, src io.Reader) {
+		_, err := io.Copy(dst, src)
+		errChan <- err
+	}
+	go cp(d, nc)
+	go cp(nc, d)
+	<-errChan
+}
+
+func (p *apiProxy) Run() {
+	p.handler.StartHealthcheck()
+	p.Serve(p.listener)
+}
+
+func (p *apiProxy) Stop() {
+	p.handler.StopHealthcheck()
+	p.Close()
+}

--- a/middleware/kubernetes/apiproxy.go
+++ b/middleware/kubernetes/apiproxy.go
@@ -1,28 +1,17 @@
 package kubernetes
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
-	"sync"
-	"sync/atomic"
-	"time"
+
+	"github.com/coredns/coredns/middleware/pkg/healthcheck"
 )
 
-type proxyUpstream struct {
-	network   string
-	address   string
-	stop      chan struct{}
-	wait      sync.WaitGroup
-	unhealthy int32
-}
-
 type proxyHandler struct {
-	upstreams []proxyUpstream
-	pickIndex int32
+	healthcheck.HealthCheck
 }
 
 type apiProxy struct {
@@ -31,123 +20,17 @@ type apiProxy struct {
 	handler  proxyHandler
 }
 
-func (p proxyUpstream) Network() string {
-	return p.network
-}
-
-func (p proxyUpstream) String() string {
-	return p.address
-}
-
-func (p *proxyUpstream) Healthcheck(once bool) {
-	p.wait.Add(1)
-	defer p.wait.Done()
-
-	status := func(unhealthy int32) string {
-		if unhealthy == 0 {
-			return "healthy"
-		}
-		return "unhealthy"
-	}
-
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return net.Dial(p.Network(), p.String())
-			},
-		},
-		Timeout: 5 * time.Second,
-	}
-	tick := time.NewTicker(5 * time.Second)
-	// Start healthcheck immediately
-	unhealthy := int32(1)
-	if resp, err := client.Get("http://kubernetes/"); err == nil {
-		defer resp.Body.Close()
-		unhealthy = 0
-	}
-	log.Printf("[INFO] Healthcheck upstream %s://%s: %s", p.Network(), p.String(), status(unhealthy))
-	atomic.StoreInt32(&(p.unhealthy), unhealthy)
-	if once {
-		return
-	}
-
-	// Continue healthcheck in the next tick
-	for {
-		select {
-		case <-tick.C:
-			unhealthy := int32(1)
-			if resp, err := client.Get("http://docker/"); err == nil {
-				defer resp.Body.Close()
-				unhealthy = 0
-			}
-			log.Printf("[INFO] Healthcheck upstream %s://%s: %s", p.Network(), p.String(), status(unhealthy))
-			atomic.StoreInt32(&(p.unhealthy), unhealthy)
-		case <-p.stop:
-			return
-		}
-	}
-
-}
-
-func (p *proxyHandler) SetupHealthcheck() {
-	var wait sync.WaitGroup
-	wait.Add(len(p.upstreams))
-	for index := int32(0); index < int32(len(p.upstreams)); index += int32(1) {
-		go func(index int32) {
-			defer wait.Done()
-			p.upstreams[index].Healthcheck(true)
-			if atomic.LoadInt32(&(p.upstreams[index].unhealthy)) == 0 {
-				pickIndex := atomic.LoadInt32(&(p.pickIndex))
-				if atomic.LoadInt32(&(p.upstreams[pickIndex].unhealthy)) != 0 {
-					atomic.StoreInt32(&(p.pickIndex), index)
-					pickIndex = index
-					log.Printf("[INFO] Upstream update: %v %s://%s healthy", pickIndex, p.upstreams[pickIndex].Network(), p.upstreams[pickIndex].String())
-				}
-			}
-
-		}(index)
-	}
-	wait.Wait()
-}
-
-func (p *proxyHandler) StartHealthcheck() {
-	for i := range p.upstreams {
-		go p.upstreams[i].Healthcheck(false)
-	}
-}
-
-func (p *proxyHandler) StopHealthcheck() {
-	for i := range p.upstreams {
-		close(p.upstreams[i].stop)
-	}
-	for i := range p.upstreams {
-		p.upstreams[i].wait.Wait()
-	}
-}
-
-func (p *proxyHandler) SelectUpstream() net.Addr {
-	pickIndex := atomic.LoadInt32(&(p.pickIndex))
-	if atomic.LoadInt32(&(p.upstreams[pickIndex].unhealthy)) != 0 {
-		log.Printf("[WARNING] Upstream status: %v %s://%s unhealthy", pickIndex, p.upstreams[pickIndex].Network(), p.upstreams[pickIndex].String())
-		length := int32(len(p.upstreams))
-		for index := (pickIndex + int32(1)) % length; index != pickIndex; index = (index + int32(1)) % length {
-			if atomic.LoadInt32(&(p.upstreams[index].unhealthy)) == 0 {
-				atomic.StoreInt32(&(p.pickIndex), index)
-				pickIndex = index
-				log.Printf("[INFO] Upstream update: %v %s://%s healthy", pickIndex, p.upstreams[pickIndex].Network(), p.upstreams[pickIndex].String())
-				break
-			}
-		}
-	}
-	return p.upstreams[pickIndex]
-}
-
 func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	upstream := p.SelectUpstream()
-	d, err := net.Dial(upstream.Network(), upstream.String())
+	upstream := p.Select()
+	network := "tcp"
+	if upstream.Network != "" {
+		network = upstream.Network
+	}
+	address := upstream.Name
+	d, err := net.Dial(network, address)
 	if err != nil {
-		log.Printf("[ERROR] Unable to establish connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err)
-		http.Error(w, fmt.Sprintf("Unable to establish connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err), 500)
+		log.Printf("[ERROR] Unable to establish connection to upstream %s://%s: %s", network, address, err)
+		http.Error(w, fmt.Sprintf("Unable to establish connection to upstream %s://%s: %s", network, address, err), 500)
 		return
 	}
 	hj, ok := w.(http.Hijacker)
@@ -167,8 +50,8 @@ func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err = r.Write(d)
 	if err != nil {
-		log.Printf("[ERROR] Unable to copy connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err)
-		http.Error(w, fmt.Sprintf("Unable to copy connection to upstream %s://%s: %s", upstream.Network(), upstream.String(), err), 500)
+		log.Printf("[ERROR] Unable to copy connection to upstream %s://%s: %s", network, address, err)
+		http.Error(w, fmt.Sprintf("Unable to copy connection to upstream %s://%s: %s", network, address, err), 500)
 		return
 	}
 
@@ -183,12 +66,11 @@ func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p *apiProxy) Run() {
-	p.handler.SetupHealthcheck()
-	p.handler.StartHealthcheck()
+	p.handler.Start()
 	p.Serve(p.listener)
 }
 
 func (p *apiProxy) Stop() {
-	p.handler.StopHealthcheck()
+	p.handler.Stop()
 	p.Close()
 }

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -146,7 +146,9 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 				case "endpoint":
 					args := c.RemainingArgs()
 					if len(args) > 0 {
-						k8s.APIServerList = strings.Split(args[0], ",")
+						for _, endpoint := range strings.Split(args[0], ",") {
+							k8s.APIServerList = append(k8s.APIServerList, strings.TrimSpace(endpoint))
+						}
 						continue
 					}
 					return nil, c.ArgErr()

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -39,10 +39,16 @@ func setup(c *caddy.Controller) error {
 	// Register KubeCache start and stop functions with Caddy
 	c.OnStartup(func() error {
 		go kubernetes.APIConn.Run()
+		if kubernetes.APIProxy != nil {
+			go kubernetes.APIProxy.Run()
+		}
 		return nil
 	})
 
 	c.OnShutdown(func() error {
+		if kubernetes.APIProxy != nil {
+			kubernetes.APIProxy.Stop()
+		}
 		return kubernetes.APIConn.Stop()
 	})
 
@@ -140,7 +146,7 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 				case "endpoint":
 					args := c.RemainingArgs()
 					if len(args) > 0 {
-						k8s.APIEndpoint = args[0]
+						k8s.APIServerList = strings.Split(args[0], ",")
 						continue
 					}
 					return nil, c.ArgErr()

--- a/middleware/pkg/healthcheck/healthcheck.go
+++ b/middleware/pkg/healthcheck/healthcheck.go
@@ -19,6 +19,7 @@ type UpstreamHostDownFunc func(*UpstreamHost) bool
 type UpstreamHost struct {
 	Conns             int64  // must be first field to be 64-bit aligned on 32-bit systems
 	Name              string // IP address (and port) of this upstream host
+	Network           string // Network (tcp, unix, etc) of the host, default "" is "tcp"
 	Fails             int32
 	FailTimeout       time.Duration
 	OkUntil           time.Time

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -450,7 +450,7 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 
 	// Work-around for timing condition that results in no-data being returned in
 	// test environment.
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range testCases {
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -513,6 +513,27 @@ func TestKubernetesIntegration(t *testing.T) {
 	doIntegrationTests(t, corefile, dnsTestCases)
 }
 
+func TestKubernetesIntegrationAPIProxy(t *testing.T) {
+
+	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
+	defer upstreamServer.Stop()
+	defer removeUpstreamConfig()
+
+	corefile :=
+		`.:0 {
+    kubernetes cluster.local 0.0.10.in-addr.arpa {
+        endpoint http://nonexistance:8080,http://invalidip:8080,http://localhost:8080
+        namespaces test-1
+        pods disabled
+        upstream ` + udp + `
+    }
+    erratic . {
+        drop 0
+    }
+`
+	doIntegrationTests(t, corefile, dnsTestCases)
+}
+
 func TestKubernetesIntegrationPodsInsecure(t *testing.T) {
 	corefile :=
 		`.:0 {


### PR DESCRIPTION
This fix adds supports for multiple k8s api servers specification,
load balance among api servers.

When two or more api servers are specified in kubernetes block (endpoint ...),
a proxy is created locally (with randomly generately port). The coredns
will points to the generated proxy so that load balancing could be achieved.

This fix fixes #819

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>