### PR TITLE
middleware/kubernetes: there are no invalid requests

### DIFF
--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/middleware/etcd/msg"
-	"github.com/miekg/dns"
 	"k8s.io/client-go/1.5/pkg/api"
 )
 
@@ -90,12 +89,12 @@ func TestFederationCNAMERecord(t *testing.T) {
 	k.APIConn = apiConnFedTest{}
 	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("10.9.8.7") }
 
-	r, _ := k.parseRequest("s1.ns.fed.svc.inter.webs", dns.TypeA)
+	r, _ := k.parseRequest("s1.ns.fed.svc.inter.webs")
 	testFederationCNAMERecord(t, k, r, msg.Service{Key: "/coredns/webs/inter/svc/fed/ns/s1", Host: "s1.ns.fed.svc.fd-az.fd-r.era.tion.com"})
 
-	r, _ = k.parseRequest("ep1.s1.ns.fed.svc.inter.webs", dns.TypeA)
+	r, _ = k.parseRequest("ep1.s1.ns.fed.svc.inter.webs")
 	testFederationCNAMERecord(t, k, r, msg.Service{Key: "/coredns/webs/inter/svc/fed/ns/s1/ep1", Host: "ep1.s1.ns.fed.svc.fd-az.fd-r.era.tion.com"})
 
-	r, _ = k.parseRequest("ep1.s1.ns.foo.svc.inter.webs", dns.TypeA)
+	r, _ = k.parseRequest("ep1.s1.ns.foo.svc.inter.webs")
 	testFederationCNAMERecord(t, k, r, msg.Service{Key: "", Host: ""})
 }

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -22,8 +22,8 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	m := new(dns.Msg)
 	m.SetReply(r)
 	m.Authoritative, m.RecursionAvailable, m.Compress = true, true, true
+
 	// Check that query matches one of the zones served by this middleware,
-	// otherwise delegate to the next in the pipeline.
 	zone := middleware.Zones(k.Zones).Matches(state.Name())
 	if zone == "" {
 		if state.Type() != "PTR" {
@@ -38,6 +38,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		// Set the zone to this specific request.
 		zone = state.Name()
 	}
+
 	records, extra, _, err := k.routeRequest(zone, state)
 
 	// Check for Autopath search eligibility

--- a/middleware/kubernetes/handler_test.go
+++ b/middleware/kubernetes/handler_test.go
@@ -286,7 +286,6 @@ func TestServeDNS(t *testing.T) {
 	//Set PodMode to Verified
 	k.PodMode = PodModeVerified
 	runServeDNSTests(t, podModeVerifiedCases, k, ctx)
-
 	// Set ndots to 2 for the ndots test cases
 	k.AutoPath.NDots = 2
 	runServeDNSTests(t, autopath2NDotsCases, k, ctx)
@@ -295,20 +294,18 @@ func TestServeDNS(t *testing.T) {
 	k.OnNXDOMAIN = dns.RcodeNameError
 	runServeDNSTests(t, autopathCases, k, ctx)
 	runServeDNSTests(t, autopathBareSearchExpectNameErr, k, ctx)
-
 }
 
 func runServeDNSTests(t *testing.T, dnsTestCases map[string](*test.Case), k Kubernetes, ctx context.Context) {
 	for testname, tc := range dnsTestCases {
-		testname = "\nTest Case \"" + testname + "\""
 		r := tc.Msg()
 
 		w := dnsrecorder.New(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
 		if err != tc.Error {
-			t.Errorf("%v expected no error, got %v\n", testname, err)
-			return
+			t.Errorf("%v expected no error, got %v for %s\n", testname, err, r.Question[0].Name)
+			continue
 		}
 		if tc.Error != nil {
 			continue
@@ -326,8 +323,6 @@ func runServeDNSTests(t *testing.T, dnsTestCases map[string](*test.Case), k Kube
 					continue
 				}
 				t.Errorf("%v: CNAME found after target record\n", testname)
-				t.Logf("%v Received:\n %v\n", testname, resp)
-
 			}
 		}
 

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -261,7 +261,8 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 }
 
 func (k *Kubernetes) parseRequest(name string) (r recordRequest, err error) {
-	// 3 Possible cases
+	// Try parsing the request so we can route it to the appropiate backend.
+	// 3 Possible cases:
 	//   SRV Request: _port._protocol.service.namespace.[federation.]type.zone
 	//   A Request (endpoint): endpoint.service.namespace.[federation.]type.zone
 	//   A Request (service): service.namespace.[federation.]type.zone
@@ -275,7 +276,7 @@ func (k *Kubernetes) parseRequest(name string) (r recordRequest, err error) {
 
 			segs = dns.SplitDomainName(name)
 			segs = segs[:len(segs)-dns.CountLabel(r.zone)]
-			break // TODO(miek): this first match, should do longest match: BUG.
+			break
 		}
 	}
 	if r.zone == "" {

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -101,7 +101,6 @@ type recordRequest struct {
 var (
 	errNoItems           = errors.New("no items found")
 	errNsNotExposed      = errors.New("namespace is not exposed")
-	errInvalidRequest    = errors.New("invalid query name")
 	errZoneNotFound      = errors.New("zone not found")
 	errAPIBadPodType     = errors.New("expected type *api.Pod")
 	errPodsDisabled      = errors.New("pod records disabled")
@@ -109,8 +108,8 @@ var (
 )
 
 // Services implements the ServiceBackend interface.
-func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) (svcs []msg.Service, debug []msg.Service, err error) {
-	r, e := k.parseRequest(state.Name(), state.QType())
+func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.Options) (svcs, debug []msg.Service, err error) {
+	r, e := k.parseRequest(state.Name())
 	if e != nil {
 		return nil, nil, e
 	}
@@ -195,11 +194,6 @@ func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dn
 	return k.Proxy.Lookup(state, name, typ)
 }
 
-// IsNameError implements the ServiceBackend interface.
-func (k *Kubernetes) IsNameError(err error) bool {
-	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest || err == errZoneNotFound
-}
-
 // Debug implements the ServiceBackend interface.
 func (k *Kubernetes) Debug() string { return "debug" }
 
@@ -266,21 +260,22 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 	return err
 }
 
-func (k *Kubernetes) parseRequest(lowerCasedName string, qtype uint16) (r recordRequest, err error) {
+func (k *Kubernetes) parseRequest(name string) (r recordRequest, err error) {
 	// 3 Possible cases
 	//   SRV Request: _port._protocol.service.namespace.[federation.]type.zone
 	//   A Request (endpoint): endpoint.service.namespace.[federation.]type.zone
 	//   A Request (service): service.namespace.[federation.]type.zone
 
-	// separate zone from rest of lowerCasedName
+	// This is already done in ServeDNS - TODO(miek): remove completely and
+	// plumb current zone through; if we keep parseRequest.
 	var segs []string
 	for _, z := range k.Zones {
-		if dns.IsSubDomain(z, lowerCasedName) {
+		if dns.IsSubDomain(z, name) {
 			r.zone = z
 
-			segs = dns.SplitDomainName(lowerCasedName)
+			segs = dns.SplitDomainName(name)
 			segs = segs[:len(segs)-dns.CountLabel(r.zone)]
-			break
+			break // TODO(miek): this first match, should do longest match: BUG.
 		}
 	}
 	if r.zone == "" {
@@ -289,74 +284,40 @@ func (k *Kubernetes) parseRequest(lowerCasedName string, qtype uint16) (r record
 
 	r.federation, segs = k.stripFederation(segs)
 
-	if qtype == dns.TypeNS {
-		return r, nil
-	}
-
-	if qtype == dns.TypeA && isDefaultNS(lowerCasedName, r) {
-		return r, nil
-	}
-
-	offset := 0
-	if qtype == dns.TypeSRV {
-		// The kubernetes peer-finder expects queries with empty port and service to resolve
-		// If neither is specified, treat it as a wildcard
-		if len(segs) == 3 {
-			r.port = "*"
-			r.service = "*"
-			offset = 0
+	// Try to parse the name and fill out the fields.
+	parsedLabels := 0
+	switch len(segs) {
+	case 5:
+		// Might have a SRV request, that specifies the full
+		if segs[0][0] == '_' {
+			r.port = segs[0][1:] // TODO(miek) port is officially named service in the RFC
 		} else {
-			if len(segs) != 5 {
-				return r, errInvalidRequest
-			}
-			// This is a SRV style request, get first two elements as port and
-			// protocol, stripping leading underscores if present.
-			if segs[0][0] == '_' {
-				r.port = segs[0][1:]
-			} else {
-				r.port = segs[0]
-				if !symbolContainsWildcard(r.port) {
-					return r, errInvalidRequest
-				}
-			}
-			if segs[1][0] == '_' {
-				r.protocol = segs[1][1:]
-				if r.protocol != "tcp" && r.protocol != "udp" {
-					return r, errInvalidRequest
-				}
-			} else {
-				r.protocol = segs[1]
-				if !symbolContainsWildcard(r.protocol) {
-					return r, errInvalidRequest
-				}
-			}
-			if r.port == "" || r.protocol == "" {
-				return r, errInvalidRequest
-			}
-			offset = 2
+			r.port = segs[0]
 		}
-	}
-	if (qtype == dns.TypeA || qtype == dns.TypeAAAA) && len(segs) == 4 {
-		// This is an endpoint A/AAAA record request. Get first element as endpoint.
+
+		if segs[1][0] == '_' {
+			r.protocol = segs[1][1:]
+		} else {
+			r.protocol = segs[1]
+		}
+
+		parsedLabels = 2
+	case 4:
 		r.endpoint = segs[0]
-		offset = 1
-	}
+		parsedLabels = 1
 
-	if len(segs) == (offset + 3) {
-		r.service = segs[offset]
-		r.namespace = segs[offset+1]
-		r.typeName = segs[offset+2]
-
-		return r, nil
-	}
-
-	if len(segs) == 1 && qtype == dns.TypeTXT {
+	case 1:
 		r.typeName = segs[0]
+	}
+
+	if len(segs) == (parsedLabels + 3) {
+		r.service = segs[parsedLabels]
+		r.namespace = segs[parsedLabels+1]
+		r.typeName = segs[parsedLabels+2]
 		return r, nil
 	}
 
-	return r, errInvalidRequest
-
+	return r, nil
 }
 
 // Records not implemented, see Entries().
@@ -680,4 +641,10 @@ func splitSearch(zone, question, namespace string) (name, search string, ok bool
 		return question[:len(question)-len(search)-1], search, true
 	}
 	return "", "", false
+}
+
+// IsNameError returns true is err indicated a non existent k8s entity.
+func (k *Kubernetes) IsNameError(err error) bool {
+	// TODO(miek): remove ZoneNotFound
+	return err == errNoItems || err == errNsNotExposed || err == errZoneNotFound
 }

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"errors"
 	"net"
 	"reflect"
 	"testing"
@@ -15,7 +14,7 @@ import (
 
 func TestRecordForTXT(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
-	r, _ := k.parseRequest("dns-version.inter.webs.test", dns.TypeTXT)
+	r, _ := k.parseRequest("dns-version.inter.webs.test")
 
 	expected := DNSSchemaVersion
 	svc := k.recordsForTXT(r)
@@ -60,23 +59,6 @@ func TestIsRequestInReverseRange(t *testing.T) {
 	}
 }
 
-func TestIsNameError(t *testing.T) {
-	k := Kubernetes{Zones: []string{"inter.webs.test"}}
-	if !k.IsNameError(errNoItems) {
-		t.Errorf("Expected 'true' for '%v'", errNoItems)
-	}
-	if !k.IsNameError(errNsNotExposed) {
-		t.Errorf("Expected 'true' for '%v'", errNsNotExposed)
-	}
-	if !k.IsNameError(errInvalidRequest) {
-		t.Errorf("Expected 'true' for '%v'", errInvalidRequest)
-	}
-	otherErr := errors.New("Some other error occured")
-	if k.IsNameError(otherErr) {
-		t.Errorf("Expected 'true' for '%v'", otherErr)
-	}
-}
-
 func TestSymbolContainsWildcard(t *testing.T) {
 	var testdataSymbolContainsWildcard = []struct {
 		Symbol         string
@@ -117,7 +99,7 @@ func TestParseRequest(t *testing.T) {
 	// Test a valid SRV request
 	//
 	query := "_http._tcp.webs.mynamespace.svc.inter.webs.test."
-	r, e := k.parseRequest(query, dns.TypeSRV)
+	r, e := k.parseRequest(query)
 	if e != nil {
 		t.Errorf("Expected no error from parseRequest(%v, \"SRV\"). Instead got '%v'.", query, e)
 	}
@@ -138,7 +120,7 @@ func TestParseRequest(t *testing.T) {
 	// Test wildcard acceptance
 	//
 	query = "*.any.*.any.svc.inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeSRV)
+	r, e = k.parseRequest(query)
 	if e != nil {
 		t.Errorf("Expected no error from parseRequest(\"%v\", \"SRV\"). Instead got '%v'.", query, e)
 	}
@@ -158,7 +140,7 @@ func TestParseRequest(t *testing.T) {
 
 	// Test A request of endpoint
 	query = "1-2-3-4.webs.mynamespace.svc.inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeA)
+	r, e = k.parseRequest(query)
 	if e != nil {
 		t.Errorf("Expected no error from parseRequest(\"%v\", \"A\"). Instead got '%v'.", query, e)
 	}
@@ -177,7 +159,7 @@ func TestParseRequest(t *testing.T) {
 
 	// Test NS request
 	query = "inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeNS)
+	r, e = k.parseRequest(query)
 	if e != nil {
 		t.Errorf("Expected no error from parseRequest(\"%v\", \"NS\"). Instead got '%v'.", query, e)
 	}
@@ -196,7 +178,7 @@ func TestParseRequest(t *testing.T) {
 
 	// Test TXT request
 	query = "dns-version.inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeTXT)
+	r, e = k.parseRequest(query)
 	if e != nil {
 		t.Errorf("Expected no error from parseRequest(\"%v\", \"TXT\"). Instead got '%v'.", query, e)
 	}
@@ -211,35 +193,6 @@ func TestParseRequest(t *testing.T) {
 	}
 	for field, expected := range tcs {
 		expectString(t, f, "TXT", query, &r, field, expected)
-	}
-
-	// Invalid query tests
-	invalidAQueries := []string{
-		"_http._tcp.webs.mynamespace.svc.inter.webs.test.", // A requests cannot have port or protocol
-		"servname.ns1.srv.inter.nets.test.",                // A requests must have zone that matches corefile
-
-	}
-	for _, q := range invalidAQueries {
-		_, e = k.parseRequest(q, dns.TypeA)
-		if e == nil {
-			t.Errorf("Expected error from %v(\"%v\", \"A\").", f, q)
-		}
-	}
-
-	invalidSRVQueries := []string{
-		"_http._pcp.webs.mynamespace.svc.inter.webs.test.", // SRV protocol must be tcp or udp
-		"_http._tcp.ep.webs.ns.svc.inter.webs.test.",       // SRV requests cannot have an endpoint
-		"_*._*.webs.mynamespace.svc.inter.webs.test.",      // SRV request with invalid wildcards
-		"_http._tcp",
-		"_tcp.test.",
-		".",
-	}
-
-	for _, q := range invalidSRVQueries {
-		_, e = k.parseRequest(q, dns.TypeSRV)
-		if e == nil {
-			t.Errorf("Expected error from %v(\"%v\", \"SRV\").", f, q)
-		}
 	}
 }
 

--- a/middleware/kubernetes/ns_test.go
+++ b/middleware/kubernetes/ns_test.go
@@ -10,7 +10,7 @@ func TestRecordForNS(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
 	corednsRecord.Hdr.Name = "coredns.kube-system."
 	corednsRecord.A = net.IP("1.2.3.4")
-	r, _ := k.parseRequest("inter.webs.test", dns.TypeNS)
+	r, _ := k.parseRequest("inter.webs.test")
 
 	expected := "/coredns/test/webs/inter/kube-system/coredns"
 	svc := k.recordsForNS(r)
@@ -23,7 +23,7 @@ func TestDefaultNSMsg(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
 	corednsRecord.Hdr.Name = "coredns.kube-system."
 	corednsRecord.A = net.IP("1.2.3.4")
-	r, _ := k.parseRequest("ns.dns.inter.webs.test", dns.TypeA)
+	r, _ := k.parseRequest("ns.dns.inter.webs.test")
 
 	expected := "/coredns/test/webs/inter/dns/ns"
 	svc := k.defaultNSMsg(r)
@@ -34,7 +34,7 @@ func TestDefaultNSMsg(t *testing.T) {
 
 func TestIsDefaultNS(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
-	r, _ := k.parseRequest("ns.dns.inter.webs.test", dns.TypeA)
+	r, _ := k.parseRequest("ns.dns.inter.webs.test")
 
 	var name string
 	var expected bool

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -199,7 +199,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{},
 	},
 	{
@@ -469,8 +469,6 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 		if len(res.Answer) != len(tc.Answer) {
 			t.Errorf("Expected %d answers but got %d for query %s, %d", len(tc.Answer), len(res.Answer), tc.Qname, tc.Qtype)
 		}
-
-		//TODO: Check the actual RR values
 	}
 }
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -13,9 +13,6 @@ import (
 	"github.com/miekg/dns"
 )
 
-// Test data
-// TODO: Fix the actual RR values
-
 var dnsTestCases = []test.Case{
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
@@ -543,7 +540,7 @@ func TestKubernetesIntegrationCidrReverseZone(t *testing.T) {
     kubernetes cluster.local {
                 endpoint http://localhost:8080
                 namespaces test-1
-				cidrs 10.0.0.0/24				
+				cidrs 10.0.0.0/24
     }
 	erratic . {
 		drop 0


### PR DESCRIPTION
First step to centralize the qtype checking in the kubernetes
middleware. Let parseRequest just take the name and find things there.
Remove the ErrInvalidRequest is such a thing does not exist, it also
makes it harder to return NODATA for responses that need it.