### PR TITLE
Kubernetes srv

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -297,34 +297,42 @@ func (k *Kubernetes) parseRequest(lowerCasedName string, qtype uint16) (r record
 
 	offset := 0
 	if qtype == dns.TypeSRV {
-		if len(segs) != 5 {
-			return r, errInvalidRequest
-		}
-		// This is a SRV style request, get first two elements as port and
-		// protocol, stripping leading underscores if present.
-		if segs[0][0] == '_' {
-			r.port = segs[0][1:]
+		// The kubernetes peer-finder expects queries with empty port and service to resolve
+		// If neither is specified, treat it as a wildcard
+		if len(segs) == 3 {
+			r.port = "*"
+			r.service = "*"
+			offset = 0
 		} else {
-			r.port = segs[0]
-			if !symbolContainsWildcard(r.port) {
+			if len(segs) != 5 {
 				return r, errInvalidRequest
 			}
-		}
-		if segs[1][0] == '_' {
-			r.protocol = segs[1][1:]
-			if r.protocol != "tcp" && r.protocol != "udp" {
+			// This is a SRV style request, get first two elements as port and
+			// protocol, stripping leading underscores if present.
+			if segs[0][0] == '_' {
+				r.port = segs[0][1:]
+			} else {
+				r.port = segs[0]
+				if !symbolContainsWildcard(r.port) {
+					return r, errInvalidRequest
+				}
+			}
+			if segs[1][0] == '_' {
+				r.protocol = segs[1][1:]
+				if r.protocol != "tcp" && r.protocol != "udp" {
+					return r, errInvalidRequest
+				}
+			} else {
+				r.protocol = segs[1]
+				if !symbolContainsWildcard(r.protocol) {
+					return r, errInvalidRequest
+				}
+			}
+			if r.port == "" || r.protocol == "" {
 				return r, errInvalidRequest
 			}
-		} else {
-			r.protocol = segs[1]
-			if !symbolContainsWildcard(r.protocol) {
-				return r, errInvalidRequest
-			}
+			offset = 2
 		}
-		if r.port == "" || r.protocol == "" {
-			return r, errInvalidRequest
-		}
-		offset = 2
 	}
 	if (qtype == dns.TypeA || qtype == dns.TypeAAAA) && len(segs) == 4 {
 		// This is an endpoint A/AAAA record request. Get first element as endpoint.

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -229,7 +229,6 @@ func TestParseRequest(t *testing.T) {
 	}
 
 	invalidSRVQueries := []string{
-		"webs.mynamespace.svc.inter.webs.test.",            // SRV requests must have port and protocol
 		"_http._pcp.webs.mynamespace.svc.inter.webs.test.", // SRV protocol must be tcp or udp
 		"_http._tcp.ep.webs.ns.svc.inter.webs.test.",       // SRV requests cannot have an endpoint
 		"_*._*.webs.mynamespace.svc.inter.webs.test.",      // SRV request with invalid wildcards

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -207,8 +207,11 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode:  dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
+			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),
+		},
 	},
 	{
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -207,7 +207,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeSuccess,
+		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.SRV("_http._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 80 svc-1-a.test-1.svc.cluster.local."),
 			test.SRV("_https._tcp.svc-1-a.test-1.svc.cluster.local.      303    IN    SRV 10 100 443 svc-1-a.test-1.svc.cluster.local."),


### PR DESCRIPTION
Changes behaviour of the k8s-middleware so that SRV-requests without a specified port & service are handled as wildcards.
Some applications use the k8s [peer-finder](https://github.com/kubernetes/contrib/tree/master/peer-finder) for bootstrapping during deployment. This uses net.LookupSRV("", "", service_name) for peer-discovery. If such requests are not treated as valid, these applications will not deploy.

Implements behaviour of #808