### PR TITLE
middleware/kubernetes: define consts

### DIFF
--- a/middleware/kubernetes/federation_test.go
+++ b/middleware/kubernetes/federation_test.go
@@ -25,8 +25,8 @@ func TestStripFederation(t *testing.T) {
 	k := Kubernetes{Zones: []string{"inter.webs.test"}}
 	k.Federations = []Federation{{name: "fed", zone: "era.tion.com"}}
 
-	testStripFederation(t, k, []string{"service", "ns", "fed", "svc"}, "fed", "service.ns.svc")
-	testStripFederation(t, k, []string{"service", "ns", "foo", "svc"}, "", "service.ns.foo.svc")
+	testStripFederation(t, k, []string{"service", "ns", "fed", Svc}, "fed", "service.ns.svc")
+	testStripFederation(t, k, []string{"service", "ns", "foo", Svc}, "", "service.ns.foo.svc")
 	testStripFederation(t, k, []string{"foo", "bar"}, "", "foo.bar")
 
 }

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -411,9 +411,9 @@ func (k *Kubernetes) getRecordsForK8sItems(services []service, pods []pod, r rec
 					Port: int(ep.port.Port),
 				}
 				if r.federation != "" {
-					s.Key = strings.Join([]string{zonePath, "svc", r.federation, svc.namespace, svc.name, endpointHostname(ep.addr)}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, r.federation, svc.namespace, svc.name, endpointHostname(ep.addr)}, "/")
 				} else {
-					s.Key = strings.Join([]string{zonePath, "svc", svc.namespace, svc.name, endpointHostname(ep.addr)}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, svc.namespace, svc.name, endpointHostname(ep.addr)}, "/")
 				}
 				records = append(records, s)
 			}
@@ -425,22 +425,22 @@ func (k *Kubernetes) getRecordsForK8sItems(services []service, pods []pod, r rec
 					Port: int(p.Port)}
 
 				if r.federation != "" {
-					s.Key = strings.Join([]string{zonePath, "svc", r.federation, svc.namespace, svc.name}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, r.federation, svc.namespace, svc.name}, "/")
 				} else {
-					s.Key = strings.Join([]string{zonePath, "svc", svc.namespace, svc.name}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, svc.namespace, svc.name}, "/")
 				}
 
 				records = append(records, s)
 			}
 			// If the addr is not an IP (i.e. an external service), add the record ...
 			s := msg.Service{
-				Key:  strings.Join([]string{zonePath, "svc", svc.namespace, svc.name}, "/"),
+				Key:  strings.Join([]string{zonePath, Svc, svc.namespace, svc.name}, "/"),
 				Host: svc.addr}
 			if t, _ := s.HostType(); t == dns.TypeCNAME {
 				if r.federation != "" {
-					s.Key = strings.Join([]string{zonePath, "svc", r.federation, svc.namespace, svc.name}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, r.federation, svc.namespace, svc.name}, "/")
 				} else {
-					s.Key = strings.Join([]string{zonePath, "svc", svc.namespace, svc.name}, "/")
+					s.Key = strings.Join([]string{zonePath, Svc, svc.namespace, svc.name}, "/")
 				}
 				records = append(records, s)
 			}
@@ -450,7 +450,7 @@ func (k *Kubernetes) getRecordsForK8sItems(services []service, pods []pod, r rec
 
 	for _, p := range pods {
 		s := msg.Service{
-			Key:  strings.Join([]string{zonePath, "pod", p.namespace, p.name}, "/"),
+			Key:  strings.Join([]string{zonePath, Pod, p.namespace, p.name}, "/"),
 			Host: p.addr,
 		}
 		records = append(records, s)
@@ -525,7 +525,7 @@ func (k *Kubernetes) findPods(namespace, podname string) (pods []pod, err error)
 // get retrieves matching data from the cache.
 func (k *Kubernetes) get(r recordRequest) (services []service, pods []pod, err error) {
 	switch {
-	case r.typeName == "pod":
+	case r.typeName == Pod:
 		pods, err = k.findPods(r.namespace, r.service)
 		return nil, pods, err
 	default:
@@ -622,7 +622,7 @@ func (k *Kubernetes) getServiceRecordForIP(ip, name string) []msg.Service {
 			continue
 		}
 		if service.Spec.ClusterIP == ip {
-			domain := strings.Join([]string{service.Name, service.Namespace, "svc", k.PrimaryZone()}, ".")
+			domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.PrimaryZone()}, ".")
 			return []msg.Service{{Host: domain}}
 		}
 	}
@@ -635,7 +635,7 @@ func (k *Kubernetes) getServiceRecordForIP(ip, name string) []msg.Service {
 		for _, eps := range ep.Subsets {
 			for _, addr := range eps.Addresses {
 				if addr.IP == ip {
-					domain := strings.Join([]string{endpointHostname(addr), ep.ObjectMeta.Name, ep.ObjectMeta.Namespace, "svc", k.PrimaryZone()}, ".")
+					domain := strings.Join([]string{endpointHostname(addr), ep.ObjectMeta.Name, ep.ObjectMeta.Namespace, Svc, k.PrimaryZone()}, ".")
 					return []msg.Service{{Host: domain}}
 				}
 			}
@@ -667,9 +667,14 @@ func localPodIP() net.IP {
 }
 
 func splitSearch(zone, question, namespace string) (name, search string, ok bool) {
-	search = strings.Join([]string{namespace, "svc", zone}, ".")
+	search = strings.Join([]string{namespace, Svc, zone}, ".")
 	if dns.IsSubDomain(search, question) {
 		return question[:len(question)-len(search)-1], search, true
 	}
 	return "", "", false
 }
+
+const (
+	Svc = "svc"
+	Pod = "pod"
+)

--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -128,7 +128,7 @@ func TestParseRequest(t *testing.T) {
 		"endpoint":  "",
 		"service":   "webs",
 		"namespace": "mynamespace",
-		"typeName":  "svc",
+		"typeName":  Svc,
 		"zone":      "inter.webs.test",
 	}
 	for field, expected := range tcs {
@@ -149,7 +149,7 @@ func TestParseRequest(t *testing.T) {
 		"endpoint":  "",
 		"service":   "*",
 		"namespace": "any",
-		"typeName":  "svc",
+		"typeName":  Svc,
 		"zone":      "inter.webs.test",
 	}
 	for field, expected := range tcs {
@@ -168,7 +168,7 @@ func TestParseRequest(t *testing.T) {
 		"endpoint":  "1-2-3-4",
 		"service":   "webs",
 		"namespace": "mynamespace",
-		"typeName":  "svc",
+		"typeName":  Svc,
 		"zone":      "inter.webs.test",
 	}
 	for field, expected := range tcs {


### PR DESCRIPTION
Define two consts Pod and Svc, makes it stand out a little more
when used in switches in case.

We have opted for a new type, but then you need to convert them
all the time with string(Foo).