### PR TITLE
middleware/secondary: pull all zones

### DIFF
--- a/middleware/secondary/setup.go
+++ b/middleware/secondary/setup.go
@@ -25,12 +25,13 @@ func setup(c *caddy.Controller) error {
 
 	// Add startup functions to retrieve the zone and keep it up to date.
 	for _, n := range zones.Names {
-		if len(zones.Z[n].TransferFrom) > 0 {
+		z := zones.Z[n]
+		if len(z.TransferFrom) > 0 {
 			c.OnStartup(func() error {
-				zones.Z[n].StartupOnce.Do(func() {
-					zones.Z[n].TransferIn()
+				z.StartupOnce.Do(func() {
+					z.TransferIn()
 					go func() {
-						zones.Z[n].Update()
+						z.Update()
 					}()
 				})
 				return nil


### PR DESCRIPTION
Use the same OnStartup setup as in the file middleware. We need to copy
the variable from range, otherwise it gets overwriten in the next loop
because of the async goroutine call.

Hard to test, we have secondary_test.go which we could extend with
multiple zones for instance. For now this fix does not have an test case
with it...