### PR TITLE
Change default MaxIdleConnsPerHost of Etcd client’s http.Transport

### DIFF
--- a/middleware/pkg/tls/tls.go
+++ b/middleware/pkg/tls/tls.go
@@ -121,6 +121,7 @@ func NewHTTPSTransport(cc *tls.Config) *http.Transport {
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     cc,
+		MaxIdleConnsPerHost: 25,
 	}
 
 	return tr


### PR DESCRIPTION
Default MaxIdleConnsPerHost in Golang is just 2, the transport will frequently close the extra connections, left a lot of TIME_WAIT. Increase MaxIdleConnsPerHost is useful, under our 12000 qps/single process, it works well.