### PR TITLE
Move Healthcheck to middleware/pkg/healthcheck

### DIFF
--- a/middleware/pkg/healthcheck/healthcheck.go
+++ b/middleware/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,236 @@
+package healthcheck
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// UpstreamHostDownFunc can be used to customize how Down behaves.
+type UpstreamHostDownFunc func(*UpstreamHost) bool
+
+// UpstreamHost represents a single proxy upstream
+type UpstreamHost struct {
+	Conns             int64  // must be first field to be 64-bit aligned on 32-bit systems
+	Name              string // IP address (and port) of this upstream host
+	Fails             int32
+	FailTimeout       time.Duration
+	OkUntil           time.Time
+	CheckDown         UpstreamHostDownFunc
+	CheckURL          string
+	WithoutPathPrefix string
+	Checking          bool
+	CheckMu           sync.Mutex
+}
+
+// Down checks whether the upstream host is down or not.
+// Down will try to use uh.CheckDown first, and will fall
+// back to some default criteria if necessary.
+func (uh *UpstreamHost) Down() bool {
+	if uh.CheckDown == nil {
+		// Default settings
+		fails := atomic.LoadInt32(&uh.Fails)
+		after := false
+
+		uh.CheckMu.Lock()
+		until := uh.OkUntil
+		uh.CheckMu.Unlock()
+
+		if !until.IsZero() && time.Now().After(until) {
+			after = true
+		}
+
+		return after || fails > 0
+	}
+	return uh.CheckDown(uh)
+}
+
+// HostPool is a collection of UpstreamHosts.
+type HostPool []*UpstreamHost
+
+type HealthCheck struct {
+	wg          sync.WaitGroup // Used to wait for running goroutines to stop.
+	stop        chan struct{}  // Signals running goroutines to stop.
+	Hosts       HostPool
+	Policy      Policy
+	Spray       Policy
+	FailTimeout time.Duration
+	MaxFails    int32
+	Future      time.Duration
+	Path        string
+	Port        string
+	Interval    time.Duration
+}
+
+func (u *HealthCheck) Start() {
+	u.stop = make(chan struct{})
+	if u.Path != "" {
+		u.wg.Add(1)
+		go func() {
+			defer u.wg.Done()
+			u.HealthCheckWorker(u.stop)
+		}()
+	}
+}
+
+// Stop sends a signal to all goroutines started by this staticUpstream to exit
+// and waits for them to finish before returning.
+func (u *HealthCheck) Stop() error {
+	close(u.stop)
+	u.wg.Wait()
+	return nil
+}
+
+// This was moved into a thread so that each host could throw a health
+// check at the same time.  The reason for this is that if we are checking
+// 3 hosts, and the first one is gone, and we spend minutes timing out to
+// fail it, we would not have been doing any other health checks in that
+// time.  So we now have a per-host lock and a threaded health check.
+//
+// We use the Checking bool to avoid concurrent checks against the same
+// host; if one is taking a long time, the next one will find a check in
+// progress and simply return before trying.
+//
+// We are carefully avoiding having the mutex locked while we check,
+// otherwise checks will back up, potentially a lot of them if a host is
+// absent for a long time.  This arrangement makes checks quickly see if
+// they are the only one running and abort otherwise.
+func healthCheckURL(nextTs time.Time, host *UpstreamHost) {
+
+	// lock for our bool check.  We don't just defer the unlock because
+	// we don't want the lock held while http.Get runs
+	host.CheckMu.Lock()
+
+	// are we mid check?  Don't run another one
+	if host.Checking {
+		host.CheckMu.Unlock()
+		return
+	}
+
+	host.Checking = true
+	host.CheckMu.Unlock()
+
+	//log.Printf("[DEBUG] Healthchecking %s, nextTs is %s\n", url, nextTs.Local())
+
+	// fetch that url.  This has been moved into a go func because
+	// when the remote host is not merely not serving, but actually
+	// absent, then tcp syn timeouts can be very long, and so one
+	// fetch could last several check intervals
+	if r, err := http.Get(host.CheckURL); err == nil {
+		io.Copy(ioutil.Discard, r.Body)
+		r.Body.Close()
+
+		if r.StatusCode < 200 || r.StatusCode >= 400 {
+			log.Printf("[WARNING] Host %s health check returned HTTP code %d\n",
+				host.Name, r.StatusCode)
+			nextTs = time.Unix(0, 0)
+		}
+	} else {
+		log.Printf("[WARNING] Host %s health check probe failed: %v\n", host.Name, err)
+		nextTs = time.Unix(0, 0)
+	}
+
+	host.CheckMu.Lock()
+	host.Checking = false
+	host.OkUntil = nextTs
+	host.CheckMu.Unlock()
+}
+
+func (u *HealthCheck) healthCheck() {
+	for _, host := range u.Hosts {
+
+		if host.CheckURL == "" {
+			var hostName, checkPort string
+
+			// The DNS server might be an HTTP server.  If so, extract its name.
+			ret, err := url.Parse(host.Name)
+			if err == nil && len(ret.Host) > 0 {
+				hostName = ret.Host
+			} else {
+				hostName = host.Name
+			}
+
+			// Extract the port number from the parsed server name.
+			checkHostName, checkPort, err := net.SplitHostPort(hostName)
+			if err != nil {
+				checkHostName = hostName
+			}
+
+			if u.Port != "" {
+				checkPort = u.Port
+			}
+
+			host.CheckURL = "http://" + net.JoinHostPort(checkHostName, checkPort) + u.Path
+		}
+
+		// calculate this before the get
+		nextTs := time.Now().Add(u.Future)
+
+		// locks/bools should prevent requests backing up
+		go healthCheckURL(nextTs, host)
+	}
+}
+
+func (u *HealthCheck) HealthCheckWorker(stop chan struct{}) {
+	ticker := time.NewTicker(u.Interval)
+	u.healthCheck()
+	for {
+		select {
+		case <-ticker.C:
+			u.healthCheck()
+		case <-stop:
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (u *HealthCheck) Select() *UpstreamHost {
+	pool := u.Hosts
+	if len(pool) == 1 {
+		if pool[0].Down() && u.Spray == nil {
+			return nil
+		}
+		return pool[0]
+	}
+	allDown := true
+	for _, host := range pool {
+		if !host.Down() {
+			allDown = false
+			break
+		}
+	}
+	if allDown {
+		if u.Spray == nil {
+			return nil
+		}
+		return u.Spray.Select(pool)
+	}
+
+	if u.Policy == nil {
+		h := (&Random{}).Select(pool)
+		if h != nil {
+			return h
+		}
+		if h == nil && u.Spray == nil {
+			return nil
+		}
+		return u.Spray.Select(pool)
+	}
+
+	h := u.Policy.Select(pool)
+	if h != nil {
+		return h
+	}
+
+	if u.Spray == nil {
+		return nil
+	}
+	return u.Spray.Select(pool)
+}

--- a/middleware/pkg/healthcheck/policy.go
+++ b/middleware/pkg/healthcheck/policy.go
@@ -1,4 +1,4 @@
-package proxy
+package healthcheck
 
 import (
 	"log"
@@ -6,8 +6,14 @@ import (
 	"sync/atomic"
 )
 
-// HostPool is a collection of UpstreamHosts.
-type HostPool []*UpstreamHost
+var (
+	SupportedPolicies = make(map[string]func() Policy)
+)
+
+// RegisterPolicy adds a custom policy to the proxy.
+func RegisterPolicy(name string, policy func() Policy) {
+	SupportedPolicies[name] = policy
+}
 
 // Policy decides how a host will be selected from a pool. When all hosts are unhealthy, it is assumed the
 // healthchecking failed. In this case each policy will *randomly* return a host from the pool to prevent

--- a/middleware/proxy/google.go
+++ b/middleware/proxy/google.go
@@ -200,13 +200,15 @@ func extractAnswer(m *dns.Msg) ([]string, error) {
 // newUpstream returns an upstream initialized with hosts.
 func newUpstream(hosts []string, old *staticUpstream) Upstream {
 	upstream := &staticUpstream{
-		from:              old.from,
-		Hosts:             nil,
-		Policy:            &Random{},
-		Spray:             nil,
-		FailTimeout:       10 * time.Second,
-		MaxFails:          3,
-		Future:            60 * time.Second,
+		from: old.from,
+		HealthCheck: HealthCheck{
+			Hosts:       nil,
+			Policy:      &Random{},
+			Spray:       nil,
+			FailTimeout: 10 * time.Second,
+			MaxFails:    3,
+			Future:      60 * time.Second,
+		},
 		ex:                old.ex,
 		WithoutPathPrefix: old.WithoutPathPrefix,
 		IgnoredSubDomains: old.IgnoredSubDomains,

--- a/middleware/proxy/grpc_test.go
+++ b/middleware/proxy/grpc_test.go
@@ -22,13 +22,15 @@ func TestStartupShutdown(t *testing.T) {
 	grpclog.SetLogger(discard{})
 
 	upstream := &staticUpstream{
-		from:        ".",
-		Hosts:       pool(),
-		Policy:      &Random{},
-		Spray:       nil,
-		FailTimeout: 10 * time.Second,
-		Future:      60 * time.Second,
-		MaxFails:    1,
+		from: ".",
+		HealthCheck: HealthCheck{
+			Hosts:       pool(),
+			Policy:      &Random{},
+			Spray:       nil,
+			FailTimeout: 10 * time.Second,
+			Future:      60 * time.Second,
+			MaxFails:    1,
+		},
 	}
 	g := newGrpcClient(nil, upstream)
 	upstream.ex = g

--- a/middleware/proxy/grpc_test.go
+++ b/middleware/proxy/grpc_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coredns/coredns/middleware/pkg/healthcheck"
+
 	"google.golang.org/grpc/grpclog"
 )
 
-func pool() []*UpstreamHost {
-	return []*UpstreamHost{
+func pool() []*healthcheck.UpstreamHost {
+	return []*healthcheck.UpstreamHost{
 		{
 			Name: "localhost:10053",
 		},
@@ -23,10 +25,8 @@ func TestStartupShutdown(t *testing.T) {
 
 	upstream := &staticUpstream{
 		from: ".",
-		HealthCheck: HealthCheck{
+		HealthCheck: healthcheck.HealthCheck{
 			Hosts:       pool(),
-			Policy:      &Random{},
-			Spray:       nil,
 			FailTimeout: 10 * time.Second,
 			Future:      60 * time.Second,
 			MaxFails:    1,

--- a/middleware/proxy/lookup.go
+++ b/middleware/proxy/lookup.go
@@ -24,14 +24,16 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 	// TODO(miek): this needs to be unified with upstream.go's NewStaticUpstreams, caddy uses NewHost
 	// we should copy/make something similar.
 	upstream := &staticUpstream{
-		from:        ".",
-		Hosts:       make([]*UpstreamHost, len(hosts)),
-		Policy:      &Random{},
-		Spray:       nil,
-		FailTimeout: 10 * time.Second,
-		MaxFails:    3, // TODO(miek): disable error checking for simple lookups?
-		Future:      60 * time.Second,
-		ex:          newDNSExWithOption(opts),
+		from: ".",
+		HealthCheck: HealthCheck{
+			Hosts:       make([]*UpstreamHost, len(hosts)),
+			Policy:      &Random{},
+			Spray:       nil,
+			FailTimeout: 10 * time.Second,
+			MaxFails:    3, // TODO(miek): disable error checking for simple lookups?
+			Future:      60 * time.Second,
+		},
+		ex: newDNSExWithOption(opts),
 	}
 
 	for i, host := range hosts {

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -2,47 +2,24 @@ package proxy
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
-	"log"
 	"net"
-	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/coredns/coredns/middleware"
 	"github.com/coredns/coredns/middleware/pkg/dnsutil"
+	"github.com/coredns/coredns/middleware/pkg/healthcheck"
 	"github.com/coredns/coredns/middleware/pkg/tls"
 	"github.com/mholt/caddy/caddyfile"
 	"github.com/miekg/dns"
 )
 
-var (
-	supportedPolicies = make(map[string]func() Policy)
-)
-
-type HealthCheck struct {
-	wg          sync.WaitGroup // Used to wait for running goroutines to stop.
-	stop        chan struct{}  // Signals running goroutines to stop.
-	Hosts       HostPool
-	Policy      Policy
-	Spray       Policy
-	FailTimeout time.Duration
-	MaxFails    int32
-	Future      time.Duration
-	Path        string
-	Port        string
-	Interval    time.Duration
-}
-
 type staticUpstream struct {
 	from string
 
-	HealthCheck
+	healthcheck.HealthCheck
 
 	WithoutPathPrefix string
 	IgnoredSubDomains []string
@@ -56,10 +33,7 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 	for c.Next() {
 		upstream := &staticUpstream{
 			from: ".",
-			HealthCheck: HealthCheck{
-				Hosts:       nil,
-				Policy:      &Random{},
-				Spray:       nil,
+			HealthCheck: healthcheck.HealthCheck{
 				FailTimeout: 10 * time.Second,
 				MaxFails:    1,
 				Future:      60 * time.Second,
@@ -87,22 +61,22 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 			}
 		}
 
-		upstream.Hosts = make([]*UpstreamHost, len(toHosts))
+		upstream.Hosts = make([]*healthcheck.UpstreamHost, len(toHosts))
 		for i, host := range toHosts {
-			uh := &UpstreamHost{
+			uh := &healthcheck.UpstreamHost{
 				Name:        host,
 				Conns:       0,
 				Fails:       0,
 				FailTimeout: upstream.FailTimeout,
 
-				CheckDown: func(upstream *staticUpstream) UpstreamHostDownFunc {
-					return func(uh *UpstreamHost) bool {
+				CheckDown: func(upstream *staticUpstream) healthcheck.UpstreamHostDownFunc {
+					return func(uh *healthcheck.UpstreamHost) bool {
 
 						down := false
 
-						uh.checkMu.Lock()
+						uh.CheckMu.Lock()
 						until := uh.OkUntil
-						uh.checkMu.Unlock()
+						uh.CheckMu.Unlock()
 
 						if !until.IsZero() && time.Now().After(until) {
 							down = true
@@ -127,30 +101,6 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 	return upstreams, nil
 }
 
-func (u *HealthCheck) Start() {
-	u.stop = make(chan struct{})
-	if u.Path != "" {
-		u.wg.Add(1)
-		go func() {
-			defer u.wg.Done()
-			u.HealthCheckWorker(u.stop)
-		}()
-	}
-}
-
-// Stop sends a signal to all goroutines started by this staticUpstream to exit
-// and waits for them to finish before returning.
-func (u *HealthCheck) Stop() error {
-	close(u.stop)
-	u.wg.Wait()
-	return nil
-}
-
-// RegisterPolicy adds a custom policy to the proxy.
-func RegisterPolicy(name string, policy func() Policy) {
-	supportedPolicies[name] = policy
-}
-
 func (u *staticUpstream) From() string {
 	return u.from
 }
@@ -161,7 +111,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		if !c.NextArg() {
 			return c.ArgErr()
 		}
-		policyCreateFunc, ok := supportedPolicies[c.Val()]
+		policyCreateFunc, ok := healthcheck.SupportedPolicies[c.Val()]
 		if !ok {
 			return c.ArgErr()
 		}
@@ -222,7 +172,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		}
 		u.IgnoredSubDomains = ignoredDomains
 	case "spray":
-		u.Spray = &Spray{}
+		u.Spray = &healthcheck.Spray{}
 	case "protocol":
 		encArgs := c.RemainingArgs()
 		if len(encArgs) == 0 {
@@ -265,154 +215,6 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		return c.Errf("unknown property '%s'", c.Val())
 	}
 	return nil
-}
-
-// This was moved into a thread so that each host could throw a health
-// check at the same time.  The reason for this is that if we are checking
-// 3 hosts, and the first one is gone, and we spend minutes timing out to
-// fail it, we would not have been doing any other health checks in that
-// time.  So we now have a per-host lock and a threaded health check.
-//
-// We use the Checking bool to avoid concurrent checks against the same
-// host; if one is taking a long time, the next one will find a check in
-// progress and simply return before trying.
-//
-// We are carefully avoiding having the mutex locked while we check,
-// otherwise checks will back up, potentially a lot of them if a host is
-// absent for a long time.  This arrangement makes checks quickly see if
-// they are the only one running and abort otherwise.
-func healthCheckURL(nextTs time.Time, host *UpstreamHost) {
-
-	// lock for our bool check.  We don't just defer the unlock because
-	// we don't want the lock held while http.Get runs
-	host.checkMu.Lock()
-
-	// are we mid check?  Don't run another one
-	if host.Checking {
-		host.checkMu.Unlock()
-		return
-	}
-
-	host.Checking = true
-	host.checkMu.Unlock()
-
-	//log.Printf("[DEBUG] Healthchecking %s, nextTs is %s\n", url, nextTs.Local())
-
-	// fetch that url.  This has been moved into a go func because
-	// when the remote host is not merely not serving, but actually
-	// absent, then tcp syn timeouts can be very long, and so one
-	// fetch could last several check intervals
-	if r, err := http.Get(host.CheckURL); err == nil {
-		io.Copy(ioutil.Discard, r.Body)
-		r.Body.Close()
-
-		if r.StatusCode < 200 || r.StatusCode >= 400 {
-			log.Printf("[WARNING] Host %s health check returned HTTP code %d\n",
-				host.Name, r.StatusCode)
-			nextTs = time.Unix(0, 0)
-		}
-	} else {
-		log.Printf("[WARNING] Host %s health check probe failed: %v\n", host.Name, err)
-		nextTs = time.Unix(0, 0)
-	}
-
-	host.checkMu.Lock()
-	host.Checking = false
-	host.OkUntil = nextTs
-	host.checkMu.Unlock()
-}
-
-func (u *HealthCheck) healthCheck() {
-	for _, host := range u.Hosts {
-
-		if host.CheckURL == "" {
-			var hostName, checkPort string
-
-			// The DNS server might be an HTTP server.  If so, extract its name.
-			ret, err := url.Parse(host.Name)
-			if err == nil && len(ret.Host) > 0 {
-				hostName = ret.Host
-			} else {
-				hostName = host.Name
-			}
-
-			// Extract the port number from the parsed server name.
-			checkHostName, checkPort, err := net.SplitHostPort(hostName)
-			if err != nil {
-				checkHostName = hostName
-			}
-
-			if u.Port != "" {
-				checkPort = u.Port
-			}
-
-			host.CheckURL = "http://" + net.JoinHostPort(checkHostName, checkPort) + u.Path
-		}
-
-		// calculate this before the get
-		nextTs := time.Now().Add(u.Future)
-
-		// locks/bools should prevent requests backing up
-		go healthCheckURL(nextTs, host)
-	}
-}
-
-func (u *HealthCheck) HealthCheckWorker(stop chan struct{}) {
-	ticker := time.NewTicker(u.Interval)
-	u.healthCheck()
-	for {
-		select {
-		case <-ticker.C:
-			u.healthCheck()
-		case <-stop:
-			ticker.Stop()
-			return
-		}
-	}
-}
-
-func (u *staticUpstream) Select() *UpstreamHost {
-	pool := u.Hosts
-	if len(pool) == 1 {
-		if pool[0].Down() && u.Spray == nil {
-			return nil
-		}
-		return pool[0]
-	}
-	allDown := true
-	for _, host := range pool {
-		if !host.Down() {
-			allDown = false
-			break
-		}
-	}
-	if allDown {
-		if u.Spray == nil {
-			return nil
-		}
-		return u.Spray.Select(pool)
-	}
-
-	if u.Policy == nil {
-		h := (&Random{}).Select(pool)
-		if h != nil {
-			return h
-		}
-		if h == nil && u.Spray == nil {
-			return nil
-		}
-		return u.Spray.Select(pool)
-	}
-
-	h := u.Policy.Select(pool)
-	if h != nil {
-		return h
-	}
-
-	if u.Spray == nil {
-		return nil
-	}
-	return u.Spray.Select(pool)
 }
 
 func (u *staticUpstream) IsAllowedDomain(name string) bool {

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -2,77 +2,15 @@ package proxy
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
 	"github.com/mholt/caddy"
 )
-
-func TestHealthCheck(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
-	upstream := &staticUpstream{
-		from: ".",
-		HealthCheck: HealthCheck{
-			Hosts:       testPool(),
-			Policy:      &Random{},
-			Spray:       nil,
-			FailTimeout: 10 * time.Second,
-			Future:      60 * time.Second,
-			MaxFails:    1,
-		},
-	}
-
-	upstream.healthCheck()
-	// sleep a bit, it's async now
-	time.Sleep(time.Duration(2 * time.Second))
-
-	if upstream.Hosts[0].Down() {
-		t.Error("Expected first host in testpool to not fail healthcheck.")
-	}
-	if !upstream.Hosts[1].Down() {
-		t.Error("Expected second host in testpool to fail healthcheck.")
-	}
-}
-
-func TestSelect(t *testing.T) {
-	upstream := &staticUpstream{
-		from: ".",
-		HealthCheck: HealthCheck{
-			Hosts:       testPool()[:3],
-			Policy:      &Random{},
-			FailTimeout: 10 * time.Second,
-			Future:      60 * time.Second,
-			MaxFails:    1,
-		},
-	}
-	upstream.Hosts[0].OkUntil = time.Unix(0, 0)
-	upstream.Hosts[1].OkUntil = time.Unix(0, 0)
-	upstream.Hosts[2].OkUntil = time.Unix(0, 0)
-	if h := upstream.Select(); h != nil {
-		t.Error("Expected select to return nil as all host are down")
-	}
-	upstream.Hosts[2].OkUntil = time.Time{}
-	if h := upstream.Select(); h == nil {
-		t.Error("Expected select to not return nil")
-	}
-}
-
-func TestRegisterPolicy(t *testing.T) {
-	name := "custom"
-	customPolicy := &customPolicy{}
-	RegisterPolicy(name, func() Policy { return customPolicy })
-	if _, ok := supportedPolicies[name]; !ok {
-		t.Error("Expected supportedPolicies to have a custom policy.")
-	}
-
-}
 
 func TestAllowedDomain(t *testing.T) {
 	upstream := &staticUpstream{

--- a/middleware/proxy/upstream_test.go
+++ b/middleware/proxy/upstream_test.go
@@ -18,13 +18,15 @@ func TestHealthCheck(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 
 	upstream := &staticUpstream{
-		from:        ".",
-		Hosts:       testPool(),
-		Policy:      &Random{},
-		Spray:       nil,
-		FailTimeout: 10 * time.Second,
-		Future:      60 * time.Second,
-		MaxFails:    1,
+		from: ".",
+		HealthCheck: HealthCheck{
+			Hosts:       testPool(),
+			Policy:      &Random{},
+			Spray:       nil,
+			FailTimeout: 10 * time.Second,
+			Future:      60 * time.Second,
+			MaxFails:    1,
+		},
 	}
 
 	upstream.healthCheck()
@@ -41,12 +43,14 @@ func TestHealthCheck(t *testing.T) {
 
 func TestSelect(t *testing.T) {
 	upstream := &staticUpstream{
-		from:        ".",
-		Hosts:       testPool()[:3],
-		Policy:      &Random{},
-		FailTimeout: 10 * time.Second,
-		Future:      60 * time.Second,
-		MaxFails:    1,
+		from: ".",
+		HealthCheck: HealthCheck{
+			Hosts:       testPool()[:3],
+			Policy:      &Random{},
+			FailTimeout: 10 * time.Second,
+			Future:      60 * time.Second,
+			MaxFails:    1,
+		},
 	}
 	upstream.Hosts[0].OkUntil = time.Unix(0, 0)
 	upstream.Hosts[1].OkUntil = time.Unix(0, 0)


### PR DESCRIPTION
So that it could be reused by other middleware.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>