### PR TITLE
mw/kubernetes: warn about deprecating cidr

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -1,29 +1,32 @@
 # kubernetes
 
-The *kubernetes* middleware enables the reading zone data from a Kubernetes cluster.  It implements the [Kubernetes DNS-Based Service Discovery Specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md). 
+The *kubernetes* middleware enables the reading zone data from a Kubernetes cluster.  It implements
+the [Kubernetes DNS-Based Service Discovery
+Specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md).
 
-CoreDNS running the kubernetes middleware can be used as a replacement of kube-dns in a kubernetes cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
+CoreDNS running the kubernetes middleware can be used as a replacement of kube-dns in a kubernetes
+cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how
+to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
 
 ## Syntax
 
 ```
 kubernetes ZONE [ZONE...] [{
-	[resyncperiod DURATION]
-	[endpoint URL
-	[tls CERT KEY CACERT]]
-	[namespaces NAMESPACE [NAMESPACE...]]
-	[labels EXPRESSION]
-	[pods POD-MODE]
-	[cidrs CIDR [CIDR...]]
-	[upstream ADDRESS [ADDRESS...]]
-	[federation NAME DOMAIN]
-	[autopath [NDOTS [RESPONSE [RESOLV-CONF]]]
-	[fallthrough]
+	resyncperiod DURATION
+	endpoint URL
+	tls CERT KEY CACERT]
+	namespaces NAMESPACE [NAMESPACE...]
+	labels EXPRESSION
+	pods POD-MODE]
+	upstream ADDRESS [ADDRESS...]
+	federation NAME DOMAIN
+	autopath [NDOTS [RESPONSE [RESOLV-CONF]]
+	fallthrough
 }]
 ```
 
 * `resyncperiod` **DURATION**
-	
+
   The Kubernetes data API resynchronization period. Default is 5m. Example values: 60s, 5m, 1h
 
   Example:
@@ -35,8 +38,8 @@ kubernetes ZONE [ZONE...] [{
   ```
 
 * `endpoint` **URL**
-	
-  Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account. 
+
+  Use **URL** for a remote k8s API endpoint.  If omitted, it will connect to k8s in-cluster using the cluster service account.
 
   Example:
 
@@ -52,7 +55,7 @@ kubernetes ZONE [ZONE...] [{
 specified).
 
   Example:
- 
+
   ```
 	kubernetes cluster.local. {
 		endpoint https://k8s-endpoint:8443
@@ -65,7 +68,7 @@ specified).
   Only expose the k8s namespaces listed.  If this option is omitted all namespaces are exposed
 
   Example:
- 
+
   ```
 	kubernetes cluster.local. {
 		namespaces demo default
@@ -73,7 +76,7 @@ specified).
   ```
 
 * `labels` **EXPRESSION**
-	
+
   Only expose the records for Kubernetes objects that match this label selector. The label selector syntax is described in the  [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/).
 
   Example:
@@ -85,7 +88,7 @@ specified).
 		labels environment in (staging, qa),application=nginx
 	}
   ```
- 
+
 * `pods` **POD-MODE**
 
   Set the mode for handling IP-based pod A records, e.g. `1-2-3-4.ns.pod.cluster.local. in A 1.2.3.4`.  This option is provided to facilitate use of SSL certs when connecting directly to pods.
@@ -95,45 +98,31 @@ specified).
   * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
 
   * `insecure`: Always return an A record with IP from request (without checking k8s).  This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This option is provided for backward compatibility with kube-dns.
-	            
+
   * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods.
-	 
+
   Example:
 
-  
+
   ```
 	kubernetes cluster.local. {
 		pods verified
 	}
   ```
 
-* `cidrs` **CIDR [CIDR...]**
-	
-  Expose cidr ranges to reverse lookups.  Include any number of space delimited cidrs, and/or multiple cidrs options on separate lines. The Kubernetes middleware will respond to PTR requests for ip addresses that fall within these ranges.
-
-  Example:
- 
- 
-  ```
-	kubernetes cluster.local. {
-		cidrs 10.0.0.0/24 10.0.10.0/25
-	}
- 
-  ```
-
 * `upstream` **ADDRESS [ADDRESS...]**
 
   Defines upstream resolvers used for resolving services that point to external hosts (External Services).  **ADDRESS** can be an ip, an ip:port, or a path to a file structured like resolv.conf.
-	
+
   Example:
- 
+
    ```
 	kubernetes cluster.local. {
 		upstream 12.34.56.78:5053
 	}
- 
+
    ```
- 
+
 * `federation` **NAME DOMAIN**
 
   Defines federation membership.  One line for each federation membership. Each line consists of the name of the federation, and the domain.
@@ -154,7 +143,7 @@ specified).
   search ns1.svc.cluster.local svc.cluster.local cluster.local foo.com
   ```
 
-  If no domains in the path produce an answer, a lookup on the bare question will be attempted.	
+  If no domains in the path produce an answer, a lookup on the bare question will be attempted.
 
   A successful response will contain a question section with the original question, and an answer section containing the record for the question that actually had an answer.  This means that the question and answer will not match. To avoid potential client confusion, a dynamically generated CNAME entry is added to join the two. For example:
 
@@ -180,14 +169,14 @@ specified).
 	# host -t a google.com
 	google.com has address 216.58.194.206
 	google.com.default.svc.cluster.local is an alias for google.com.
-	
+
 	# host -t a google.com.default.svc.cluster.local.
 	google.com has address 216.58.194.206
 	google.com.default.svc.cluster.local is an alias for google.com.
   ```
- 
+
   **NDOTS** (default: `0`) This provides an adjustable threshold to prevent server side lookups from triggering. If the number of dots before the first search domain is less than this number, then the search path will not executed on the server side.  When autopath is enabled with default settings, the search path is always conducted when the query is in the first search domain `<pod-namespace>.svc.<zone>.`.
-	
+
   **RESPONSE** (default: `NOERROR`) This option causes the kubernetes middleware to return the given response instead of NXDOMAIN when the all searches in the path produce no results. Valid values: `NXDOMAIN`, `SERVFAIL` or `NOERROR`. Setting this to `SERVFAIL` or `NOERROR` should prevent the client from fruitlessly continuing the client side searches in the path after the server already checked them.
 
   **RESOLV-CONF** (default: `/etc/resolv.conf`) If specified, the kubernetes middleware uses this file to get the host's search domains. The kubernetes middleware performs a lookup on these domains if the in-cluster search domains in the path fail to produce an answer. If not specified, the values will be read from the local resolv.conf file (i.e the resolv.conf file in the pod containing CoreDNS).  In practice, this option should only need to be used if running CoreDNS outside of the cluster and the search path in /etc/resolv.conf does not match the cluster's "default" dns-policiy.
@@ -195,7 +184,7 @@ specified).
   Enabling autopath requires more memory, since it needs to maintain a watch on all pods. If autopath and `pods verified` mode are both enabled, they will share the same watch. Enabling both options should have an equivalent memory impact of just one.
 
   Example:
- 
+
   ```
 	kubernetes cluster.local. {
 		autopath 0 NXDOMAIN /etc/resolv.conf
@@ -213,39 +202,41 @@ specified).
 
 	kubernetes cluster.local
 
-**Example 2:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Handle all `PTR` requests in the `10.0.0.0/16` cidr block. Verify the existence of pods when answering pod requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature.
+**Example 2:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster.
+ Handle all `PTR` requests for `10.0.0.0/16` . Verify the existence of pods when answering pod
+ requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature.
 
-	kubernetes cluster.local {
-		cidrs 10.0.0.0/16
-		pods verified
-		upstream 10.102.3.10:53
-		autopath
-	}
-	
-**Selective Exposure Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Only expose objects in the test and staging namespaces. Handle all `PTR` requests that fall between `10.0.0.100` and `10.0.0.255` (expressed as CIDR blocks in the example below). Resolve upstream records using the servers configured in `/etc/resolv.conf`.
+    10.0.0.0/16 cluster.local {
+        kubernetes {
+            pods verified
+            upstream 10.102.3.10:53
+            autopath
+        }
+    }
+
+**Selective Exposure Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Only expose objects in the test and staging namespaces.
+  Resolve upstream records using the servers configured in `/etc/resolv.conf`.
 
 	kubernetes cluster.local {
 		namespaces test staging
-		cidrs 10.0.0.100/30 10.0.0.104/29
-		cidrs 10.0.0.112/28 10.0.0.128/25
-		upstream /etc/resolv.conf
-	}
 
-**Federation Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Handle federated service requests in the `prod` and `stage` federations. Handle all `PTR` requests in the `10.0.0.0/24` cidr block. Resolve upstream records using the servers configured in `/etc/resolv.conf`.
+**Federation Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Handle federated service requests in the `prod` and `stage` federations.
+  Resolve upstream records using the servers configured in `/etc/resolv.conf`.
 
-	kubernetes cluster.local {
-		federation prod prod.feddomain.com
-		federation stage stage.feddomain.com
-		cidrs 10.0.0.0/24
-		upstream /etc/resolv.conf
-	}
-	
-**Out-Of-Cluster Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes from outside the cluster. Handle all `PTR` requests in the `10.0.0.0/24` cidr block. Verify the existence of pods when answering pod requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature, using the `cluster.conf` file instead of `/etc/resolv.conf`.
+    cluster.local {
+        kubernetes {
+		    federation prod prod.feddomain.com
+		    federation stage stage.feddomain.com
+		    upstream /etc/resolv.conf
+    	}
+    }
+
+**Out-Of-Cluster Example:** Handle all queries in the `cluster.local` zone. Connect to Kubernetes from outside the cluster.
+  Verify the existence of pods when answering pod requests.  Resolve upstream records against `10.102.3.10`. Enable the autopath feature, using the `cluster.conf` file instead of `/etc/resolv.conf`.
 
 	kubernetes cluster.local {
 		endpoint https://k8s-endpoint:8443
 		tls cert key cacert
-		cidrs 10.0.0.0/24
 		pods verified
 		upstream 10.102.3.10:53
 		autopath 0 NOERROR cluster.conf
@@ -253,7 +244,7 @@ specified).
 
 
 
-## Wildcards
+## Wildcard
 
 Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (\*, or the word "any"), then that label will match all values.  The labels that accept wildcards are:
 

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"strconv"
 	"strings"
@@ -95,6 +96,10 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 			for c.NextBlock() {
 				switch c.Val() {
 				case "cidrs":
+
+					// DEPRECATION WARNING
+					log.Printf("[WARNING] \"cidrs\" will be removed for CoreDNS soon. See https://coredns.io/2017/07/23/corefile-explained#reverse-zones for the replacement")
+
 					args := c.RemainingArgs()
 					if len(args) > 0 {
 						for _, cidrStr := range args {


### PR DESCRIPTION
Add log statement pointing to replacement.
remove cidr from README and use replacement syntax.

Fixes #851