### PR TITLE
mw/authpath: hook in kubernetees

### DIFF
--- a/middleware/autopath/setup.go
+++ b/middleware/autopath/setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/middleware"
+	"github.com/coredns/coredns/middleware/kubernetes"
 
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
@@ -25,14 +26,14 @@ func setup(c *caddy.Controller) error {
 	}
 
 	c.OnStartup(func() error {
-		// So we know for sure the mw is initialized.
+		// Do this in OnStartup, so all middleware has been initialized.
+		// TODO(miek): fabricate test to proof this is not thread safe.
 		m := dnsserver.GetMiddleware(c, mw)
 		switch mw {
 		case "kubernetes":
-			m = m
-			//if k, ok := m.(kubernetes.Kubernetes); ok {
-			//&ap.searchFunc = k.AutoPath
-			//}
+			if k, ok := m.(kubernetes.Kubernetes); ok {
+				ap.searchFunc = k.AutoPath
+			}
 		}
 		return nil
 	})

--- a/middleware/kubernetes/autopath.go
+++ b/middleware/kubernetes/autopath.go
@@ -1,11 +1,32 @@
 package kubernetes
 
-import "k8s.io/client-go/1.5/pkg/api"
+import (
+	"fmt"
 
-// TODO(miek): rename and put in autopath.go file. This will be for the
-// external middleware autopath to use. Mostly to get the namespace:
-//name, path, ok := autopath.SplitSearch(zone, state.QName(), p.Namespace)
-func (k *Kubernetes) findPodWithIP(ip string) (p *api.Pod) {
+	"github.com/coredns/coredns/request"
+
+	"k8s.io/client-go/1.5/pkg/api"
+)
+
+func (k *Kubernetes) AutoPath(state request.Request) ([]string, error) {
+	ip := state.IP()
+
+	pod := k.PodWithIP(ip)
+	if pod == nil {
+		return nil, fmt.Errorf("kubernets: no pod found for %s", ip)
+	}
+
+	// something something namespace
+	namespace := pod.Namespace
+
+	search := []string{namespace} // TODO: way more
+
+	search = append(search, "") // sentinal
+	return search, nil
+}
+
+// PodWithIP return the api.Pod for source IP ip. It return nil if nothing can be found.
+func (k *Kubernetes) PodWithIP(ip string) (p *api.Pod) {
 	objList := k.APIConn.PodIndex(ip)
 	for _, o := range objList {
 		p, ok := o.(*api.Pod)

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -203,8 +203,7 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 }
 
 const (
-	defaultResyncPeriod   = 5 * time.Minute
-	defautNdots           = 0
-	defaultResolvConfFile = "/etc/resolv.conf"
-	defaultOnNXDOMAIN     = dns.RcodeSuccess
+	defaultResyncPeriod = 5 * time.Minute
+	defautNdots         = 0
+	defaultOnNXDOMAIN   = dns.RcodeSuccess
 )


### PR DESCRIPTION
Call out to kubernetes to get the search path - this still needs
to return something sensible, but all infrastructure has landed
to make it work.