### PR TITLE
Change the style from flat to regular for consistency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CoreDNS
 
-[![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](https://godoc.org/github.com/coredns/coredns)
-[![Build Status](https://img.shields.io/travis/coredns/coredns/master.svg?style=flat-square&label=build)](https://travis-ci.org/coredns/coredns)
-[![Code Coverage](https://img.shields.io/codecov/c/github/coredns/coredns/master.svg?style=flat-square)](https://codecov.io/github/coredns/coredns?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/coredns/coredns?style=flat-square)](https://goreportcard.com/report/coredns/coredns)
+[![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/coredns/coredns)
+[![Build Status](https://img.shields.io/travis/coredns/coredns/master.svg?label=build)](https://travis-ci.org/coredns/coredns)
+[![Code Coverage](https://img.shields.io/codecov/c/github/coredns/coredns/master.svg)](https://codecov.io/github/coredns/coredns?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/coredns/coredns)](https://goreportcard.com/report/coredns/coredns)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcoredns%2Fcoredns.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fcoredns%2Fcoredns?ref=badge_shield)
 
 CoreDNS is a DNS server that started as a fork of [Caddy](https://github.com/mholt/caddy/). It has


### PR DESCRIPTION
The current badge styles have 4 flat and 1 regular, which were
rather inconsistent. This fix changes to one style and matches
with Caddy.

Also, SourceGraph shows that there are 4 projects using CoreDNS (see badge below):
[![Sourcegraph](https://sourcegraph.com/github.com/coredns/coredns/-/badge.svg)](https://sourcegraph.com/github.com/coredns/coredns?badge)

We may want to add that badge at some point.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>