### PR TITLE
mw/kubernetes: fix parseTests

### DIFF
--- a/middleware/kubernetes/parse_test.go
+++ b/middleware/kubernetes/parse_test.go
@@ -1,27 +1,13 @@
 package kubernetes
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 )
 
-func expectString(t *testing.T, function, qtype, query string, r *recordRequest, field, expected string) {
-	ref := reflect.ValueOf(r)
-	refField := reflect.Indirect(ref).FieldByName(field)
-	got := refField.String()
-	if got != expected {
-		t.Errorf("Expected %v(%v, \"%v\") to get %v == \"%v\". Instead got \"%v\".", function, query, qtype, field, expected, got)
-	}
-}
-
 func TestParseRequest(t *testing.T) {
-	const zone = "intern.webs.tests."
-
 	k := Kubernetes{Zones: []string{zone}}
-	f := "parseRequest"
-	var tcs map[string]string
 
 	tests := []struct {
 		query    string
@@ -29,9 +15,23 @@ func TestParseRequest(t *testing.T) {
 		expected string // output from r.String()
 	}{
 		{
-			"_http._tcp.webs.mynamespace.svc.inter.webs.test.",
-			dns.TypeSRV,
+			// valid SRV request
+			"_http._tcp.webs.mynamespace.svc.inter.webs.test.", dns.TypeSRV,
 			"http.tcp..webs.mynamespace.svc.intern.webs.tests..",
+		},
+		{
+			// wildcard acceptance
+			"*.any.*.any.svc.inter.webs.test.", dns.TypeSRV,
+			"*.any..*.any.svc.intern.webs.tests..",
+		},
+		{
+			// A request of endpoint
+			"1-2-3-4.webs.mynamespace.svc.inter.webs.test.", dns.TypeA,
+			"..1-2-3-4.webs.mynamespace.svc.intern.webs.tests..",
+		},
+		{
+			"inter.webs.test.", dns.TypeNS,
+			"......intern.webs.tests..",
 		},
 	}
 	for i, tc := range tests {
@@ -41,112 +41,27 @@ func TestParseRequest(t *testing.T) {
 		}
 		rs := r.String()
 		if rs != tc.expected {
-			t.Errorf("Test %d, expected (stringyfied) recordRequest: %s, got %s", tc.expected, rs)
-		}
-	}
-
-	// Test a valid SRV request
-	//
-	var (
-		query string
-		r     recordRequest
-		e     error
-	)
-
-	tcs = map[string]string{
-		"port":      "http",
-		"protocol":  "tcp",
-		"endpoint":  "",
-		"service":   "webs",
-		"namespace": "mynamespace",
-		"podOrSvc":  Svc,
-		"zone":      zone,
-	}
-	for field, expected := range tcs {
-		expectString(t, f, "SRV", query, &r, field, expected)
-	}
-
-	// Test wildcard acceptance
-	//
-	query = "*.any.*.any.svc.inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeSRV, zone)
-	if e != nil {
-		t.Errorf("Expected no error from parseRequest(\"%v\", \"SRV\"). Instead got '%v'.", query, e)
-	}
-
-	tcs = map[string]string{
-		"port":      "*",
-		"protocol":  "any",
-		"endpoint":  "",
-		"service":   "*",
-		"namespace": "any",
-		"podOrSvc":  Svc,
-		"zone":      zone,
-	}
-	for field, expected := range tcs {
-		expectString(t, f, "SRV", query, &r, field, expected)
-	}
-
-	// Test A request of endpoint
-	query = "1-2-3-4.webs.mynamespace.svc.inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeA, zone)
-	if e != nil {
-		t.Errorf("Expected no error from parseRequest(\"%v\", \"A\"). Instead got '%v'.", query, e)
-	}
-	tcs = map[string]string{
-		"port":      "",
-		"protocol":  "",
-		"endpoint":  "1-2-3-4",
-		"service":   "webs",
-		"namespace": "mynamespace",
-		"podOrSvc":  Svc,
-		"zone":      zone,
-	}
-	for field, expected := range tcs {
-		expectString(t, f, "A", query, &r, field, expected)
-	}
-
-	// Test NS request
-	query = "inter.webs.test."
-	r, e = k.parseRequest(query, dns.TypeNS, zone)
-	if e != nil {
-		t.Errorf("Expected no error from parseRequest(\"%v\", \"NS\"). Instead got '%v'.", query, e)
-	}
-	tcs = map[string]string{
-		"port":      "",
-		"protocol":  "",
-		"endpoint":  "",
-		"service":   "",
-		"namespace": "",
-		"podOrSvc":  "",
-		"zone":      zone,
-	}
-	for field, expected := range tcs {
-		expectString(t, f, "NS", query, &r, field, expected)
-	}
-
-	// Invalid query tests
-	invalidAQueries := []string{
-		"_http._tcp.webs.mynamespace.svc.inter.webs.test.", // A requests cannot have port or protocol TODO(miek): this must return NODATA
-
-	}
-	for _, q := range invalidAQueries {
-		_, e = k.parseRequest(q, dns.TypeA, zone)
-		if e == nil {
-			t.Errorf("Expected error from %v(\"%v\", \"A\").", f, q)
-		}
-	}
-
-	invalidSRVQueries := []string{
-		"_http._pcp.webs.mynamespace.svc.inter.webs.test.", // SRV protocol must be tcp or udp
-		"_http._tcp.ep.webs.ns.svc.inter.webs.test.",       // SRV requests cannot have an endpoint
-		"_*._*.webs.mynamespace.svc.inter.webs.test.",      // SRV request with invalid wildcards
-	}
-
-	for _, q := range invalidSRVQueries {
-		_, e = k.parseRequest(q, dns.TypeSRV, zone)
-		if e == nil {
-			t.Errorf("Expected error from %v(\"%v\", \"SRV\").", f, q)
+			t.Errorf("Test %d, expected (stringyfied) recordRequest: %s, got %s", i, tc.expected, rs)
 		}
 	}
 }
+
+func TestParseInvalidRequest(t *testing.T) {
+	k := Kubernetes{Zones: []string{zone}}
+
+	invalid := map[string]uint16{
+		"_http._tcp.webs.mynamespace.svc.inter.webs.test.": dns.TypeA,   // A requests cannot have port or protocol
+		"_http._pcp.webs.mynamespace.svc.inter.webs.test.": dns.TypeSRV, // SRV protocol must be tcp or udp
+		"_http._tcp.ep.webs.ns.svc.inter.webs.test.":       dns.TypeSRV, // SRV requests cannot have an endpoint
+		"_*._*.webs.mynamespace.svc.inter.webs.test.":      dns.TypeSRV, // SRV request with invalid wildcards
+
+	}
+
+	for query, qtype := range invalid {
+		if _, e := k.parseRequest(query, qtype, zone); e == nil {
+			t.Errorf("Expected error from %s:%d, got none", query, qtype)
+		}
+	}
+}
+
+const zone = "intern.webs.tests."


### PR DESCRIPTION
Make parse tests table driven to remove a duplicate code, i.e. most
of the contents of parse_test.go can be removed as well as the
expectString helper function.