### PR TITLE
core: small cleanup

### DIFF
--- a/middleware/dnssec/setup.go
+++ b/middleware/dnssec/setup.go
@@ -42,36 +42,34 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, error) {
 
 	capacity := defaultCap
 	for c.Next() {
-		if c.Val() == "dnssec" {
-			// dnssec [zones...]
-			zones = make([]string, len(c.ServerBlockKeys))
-			copy(zones, c.ServerBlockKeys)
-			args := c.RemainingArgs()
-			if len(args) > 0 {
-				zones = args
-			}
+		// dnssec [zones...]
+		zones = make([]string, len(c.ServerBlockKeys))
+		copy(zones, c.ServerBlockKeys)
+		args := c.RemainingArgs()
+		if len(args) > 0 {
+			zones = args
+		}
 
-			for c.NextBlock() {
-				switch c.Val() {
-				case "key":
-					k, e := keyParse(c)
-					if e != nil {
-						return nil, nil, 0, e
-					}
-					keys = append(keys, k...)
-				case "cache_capacity":
-					if !c.NextArg() {
-						return nil, nil, 0, c.ArgErr()
-					}
-					value := c.Val()
-					cacheCap, err := strconv.Atoi(value)
-					if err != nil {
-						return nil, nil, 0, err
-					}
-					capacity = cacheCap
+		for c.NextBlock() {
+			switch c.Val() {
+			case "key":
+				k, e := keyParse(c)
+				if e != nil {
+					return nil, nil, 0, e
 				}
-
+				keys = append(keys, k...)
+			case "cache_capacity":
+				if !c.NextArg() {
+					return nil, nil, 0, c.ArgErr()
+				}
+				value := c.Val()
+				cacheCap, err := strconv.Atoi(value)
+				if err != nil {
+					return nil, nil, 0, err
+				}
+				capacity = cacheCap
 			}
+
 		}
 	}
 	for i := range zones {

--- a/middleware/normalize.go
+++ b/middleware/normalize.go
@@ -30,7 +30,8 @@ func (z Zones) Matches(qname string) string {
 	return zone
 }
 
-// Normalize fully qualifies all zones in z.
+// Normalize fully qualifies all zones in z. The zones in Z must be domain names, without
+// a port or protocol prefix.
 func (z Zones) Normalize() {
 	for i := range z {
 		z[i] = Name(z[i]).Normalize()
@@ -54,7 +55,7 @@ func (n Name) Normalize() string { return strings.ToLower(dns.Fqdn(string(n))) }
 
 type (
 	// Host represents a host from the Corefile, may contain port.
-	Host string // Host represents a host from the Corefile, may contain port.
+	Host string
 )
 
 // Normalize will return the host portion of host, stripping

--- a/middleware/reverse/setup.go
+++ b/middleware/reverse/setup.go
@@ -34,115 +34,110 @@ func setupReverse(c *caddy.Controller) error {
 }
 
 func reverseParse(c *caddy.Controller) (nets networks, fall bool, err error) {
-
-	// normalize zones, validation is almost done by dnsserver
-	// TODO(miek): need sane helpers for these.
 	zones := make([]string, len(c.ServerBlockKeys))
 	wildcard := false
 
+	// We copy from the serverblock, these contains Hosts.
 	for i, str := range c.ServerBlockKeys {
 		zones[i] = middleware.Host(str).Normalize()
 	}
 
 	for c.Next() {
-		if c.Val() == "reverse" {
+		var cidrs []*net.IPNet
 
-			var cidrs []*net.IPNet
-
-			// parse all networks
-			for _, cidr := range c.RemainingArgs() {
-				if cidr == "{" {
-					break
-				}
-				_, ipnet, err := net.ParseCIDR(cidr)
-				if err != nil {
-					return nil, false, c.Errf("network needs to be CIDR formatted: %q\n", cidr)
-				}
-				cidrs = append(cidrs, ipnet)
+		// parse all networks
+		for _, cidr := range c.RemainingArgs() {
+			if cidr == "{" {
+				break
 			}
-			if len(cidrs) == 0 {
-				return nil, false, c.ArgErr()
+			_, ipnet, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return nil, false, c.Errf("network needs to be CIDR formatted: %q\n", cidr)
 			}
+			cidrs = append(cidrs, ipnet)
+		}
+		if len(cidrs) == 0 {
+			return nil, false, c.ArgErr()
+		}
 
-			// set defaults
-			var (
-				template = "ip-" + templateNameIP + ".{zone[1]}"
-				ttl      = 60
-			)
-			for c.NextBlock() {
-				switch c.Val() {
-				case "hostname":
-					if !c.NextArg() {
-						return nil, false, c.ArgErr()
-					}
-					template = c.Val()
-
-				case "ttl":
-					if !c.NextArg() {
-						return nil, false, c.ArgErr()
-					}
-					ttl, err = strconv.Atoi(c.Val())
-					if err != nil {
-						return nil, false, err
-					}
-
-				case "wildcard":
-					wildcard = true
-
-				case "fallthrough":
-					fall = true
-
-				default:
+		// set defaults
+		var (
+			template = "ip-" + templateNameIP + ".{zone[1]}"
+			ttl      = 60
+		)
+		for c.NextBlock() {
+			switch c.Val() {
+			case "hostname":
+				if !c.NextArg() {
 					return nil, false, c.ArgErr()
 				}
-			}
+				template = c.Val()
 
-			// prepare template
-			// replace {zone[index]} by the listen zone/domain of this config block
-			for i, zone := range zones {
-				// TODO: we should be smarter about actually replacing this. This works, but silently allows "zone[-1]"
-				// for instance.
-				template = strings.Replace(template, "{zone["+strconv.Itoa(i+1)+"]}", zone, 1)
-			}
-			if !strings.HasSuffix(template, ".") {
-				template += "."
-			}
-
-			// extract zone from template
-			templateZone := strings.SplitAfterN(template, ".", 2)
-			if len(templateZone) != 2 || templateZone[1] == "" {
-				return nil, false, c.Errf("cannot find domain in template '%v'", template)
-			}
-
-			// Create for each configured network in this stanza
-			for _, ipnet := range cidrs {
-				// precompile regex for hostname to ip matching
-				regexIP := regexMatchV4
-				if ipnet.IP.To4() == nil {
-					regexIP = regexMatchV6
+			case "ttl":
+				if !c.NextArg() {
+					return nil, false, c.ArgErr()
 				}
-				prefix := "^"
-				if wildcard {
-					prefix += ".*"
-				}
-				regex, err := regexp.Compile(
-					prefix + strings.Replace( // inject ip regex into template
-						regexp.QuoteMeta(template), // escape dots
-						regexp.QuoteMeta(templateNameIP),
-						regexIP,
-						1) + "$")
+				ttl, err = strconv.Atoi(c.Val())
 				if err != nil {
 					return nil, false, err
 				}
 
-				nets = append(nets, network{
-					IPnet:        ipnet,
-					Zone:         templateZone[1],
-					Template:     template,
-					RegexMatchIP: regex,
-					TTL:          uint32(ttl),
-				})
+			case "wildcard":
+				wildcard = true
+
+			case "fallthrough":
+				fall = true
+
+			default:
+				return nil, false, c.ArgErr()
 			}
+		}
+
+		// prepare template
+		// replace {zone[index]} by the listen zone/domain of this config block
+		for i, zone := range zones {
+			// TODO: we should be smarter about actually replacing this. This works, but silently allows "zone[-1]"
+			// for instance.
+			template = strings.Replace(template, "{zone["+strconv.Itoa(i+1)+"]}", zone, 1)
+		}
+		if !strings.HasSuffix(template, ".") {
+			template += "."
+		}
+
+		// extract zone from template
+		templateZone := strings.SplitAfterN(template, ".", 2)
+		if len(templateZone) != 2 || templateZone[1] == "" {
+			return nil, false, c.Errf("cannot find domain in template '%v'", template)
+		}
+
+		// Create for each configured network in this stanza
+		for _, ipnet := range cidrs {
+			// precompile regex for hostname to ip matching
+			regexIP := regexMatchV4
+			if ipnet.IP.To4() == nil {
+				regexIP = regexMatchV6
+			}
+			prefix := "^"
+			if wildcard {
+				prefix += ".*"
+			}
+			regex, err := regexp.Compile(
+				prefix + strings.Replace( // inject ip regex into template
+					regexp.QuoteMeta(template), // escape dots
+					regexp.QuoteMeta(templateNameIP),
+					regexIP,
+					1) + "$")
+			if err != nil {
+				return nil, false, err
+			}
+
+			nets = append(nets, network{
+				IPnet:        ipnet,
+				Zone:         templateZone[1],
+				Template:     template,
+				RegexMatchIP: regex,
+				TTL:          uint32(ttl),
+			})
 		}
 	}
 


### PR DESCRIPTION
Add some docs about normalize.Host and normalize.Name. They are used
correctly in the middleware even though they are somewhat confusing,
esp when you copy from ServerBlockKeys in your middleware.