### PR TITLE
mw/k8s: remove k.defaultNsMsg()

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -130,8 +130,9 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.
 		if state.Type() == "A" && isDefaultNS(state.Name(), r) {
 			// If this is an A request for "ns.dns", respond with a "fake" record for coredns.
 			// SOA records always use this hardcoded name
-			svcs = append(svcs, k.defaultNSMsg(r))
-			return svcs, nil, nil
+			ns := k.nsAddr()
+			svc := msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), "coredns")}
+			return []msg.Service{svc}, nil, nil
 		}
 		s, e := k.Entries(r)
 		if state.QType() == dns.TypeAAAA {

--- a/middleware/kubernetes/ns.go
+++ b/middleware/kubernetes/ns.go
@@ -4,23 +4,9 @@ import (
 	"net"
 	"strings"
 
-	"github.com/coredns/coredns/middleware/etcd/msg"
-
 	"github.com/miekg/dns"
 	"k8s.io/client-go/1.5/pkg/api"
 )
-
-// DefaultNSMsg returns an msg.Service representing an A record for
-// ns.dns.[zone] -> dns service ip. This A record is needed to legitimize
-// the SOA response in middleware.NS(), which is hardcoded at ns.dns.[zone].
-func (k *Kubernetes) defaultNSMsg(r recordRequest) msg.Service {
-	ns := k.nsAddr()
-	s := msg.Service{
-		Key:  msg.Path(strings.Join([]string{defaultNSName, r.zone}, "."), "coredns"),
-		Host: ns.A.String(),
-	}
-	return s
-}
 
 func isDefaultNS(name string, r recordRequest) bool {
 	return strings.Index(name, defaultNSName) == 0 && strings.Index(name, r.zone) == len(defaultNSName)


### PR DESCRIPTION
Remove k.defaultNSMsg() it is just one line of getting the service and
it is another method that needlessly uses recordRequest.