### PR TITLE
mw/k8s: cleanups

### DIFF
--- a/middleware/kubernetes/kubernetes_test.go
+++ b/middleware/kubernetes/kubernetes_test.go
@@ -10,15 +10,6 @@ import (
 	"k8s.io/client-go/1.5/pkg/api"
 )
 
-func TestPrimaryZone(t *testing.T) {
-	k := Kubernetes{Zones: []string{"inter.webs.test", "inter.nets.test"}}
-	expected := "inter.webs.test"
-	result := k.PrimaryZone()
-	if result != expected {
-		t.Errorf("Expected result '%v'. Instead got result '%v'.", expected, result)
-	}
-}
-
 func TestWildcard(t *testing.T) {
 	var tests = []struct {
 		s        string
@@ -104,7 +95,6 @@ func (APIConnServiceTest) ServiceList() []*api.Service {
 		},
 	}
 	return svcs
-
 }
 
 func (APIConnServiceTest) EndpointsList() api.EndpointsList {

--- a/middleware/kubernetes/reverse_test.go
+++ b/middleware/kubernetes/reverse_test.go
@@ -14,13 +14,13 @@ func TestIsRequestInReverseRange(t *testing.T) {
 	}{
 		{"1.2.3.0/24", "4.3.2.1.in-addr.arpa.", true},
 		{"1.2.3.0/24", "5.3.2.1.in-addr.arpa.", true},
+		{"5.6.0.0/16", "5.4.6.5.in-addr.arpa.", true},
 		{"1.2.3.0/24", "5.4.2.1.in-addr.arpa.", false},
 		{"5.6.0.0/16", "5.4.2.1.in-addr.arpa.", false},
-		{"5.6.0.0/16", "5.4.6.5.in-addr.arpa.", true},
 		{"5.6.0.0/16", "5.6.0.1.in-addr.arpa.", false},
 	}
 
-	k := Kubernetes{Zones: []string{"inter.webs.test"}}
+	k := Kubernetes{}
 
 	for _, test := range tests {
 		_, cidr, _ := net.ParseCIDR(test.cidr)

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -87,16 +87,16 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 				}
 			}
 
-			k8s.primaryZone = -1
+			k8s.primaryZoneIndex = -1
 			for i, z := range k8s.Zones {
 				if strings.HasSuffix(z, "in-addr.arpa.") || strings.HasSuffix(z, "ip6.arpa.") {
 					continue
 				}
-				k8s.primaryZone = i
+				k8s.primaryZoneIndex = i
 				break
 			}
 
-			if k8s.primaryZone == -1 {
+			if k8s.primaryZoneIndex == -1 {
 				return nil, errors.New("non-reverse zone name must be given for Kubernetes")
 			}
 
@@ -222,8 +222,4 @@ func searchFromResolvConf() []string {
 	return rc.Search
 }
 
-const (
-	defaultResyncPeriod = 5 * time.Minute
-	defautNdots         = 0
-	defaultOnNXDOMAIN   = dns.RcodeSuccess
-)
+const defaultResyncPeriod = 5 * time.Minute


### PR DESCRIPTION
Remove some constants that aren't used any more. Make PrimaryZone
private because it doesn't need to be exported. Remove test that
did not cover corner case as expressed in setup.go