### PR TITLE
Add Autopath section to k8s readme

### DIFF
--- a/middleware/kubernetes/README.md
+++ b/middleware/kubernetes/README.md
@@ -108,6 +108,15 @@ And finally we can connect to Kubernetes from outside the cluster:
 		tls cert key cacert
 	}
 
+## Enabling server-side domain search path completion with *autopath*
+
+The *kubernetes* middleware can be used in conjunction with the *autopath* middleware.  Using this feature enables server-side domain search path completion in kubernetes clusters.  Note: `pods` must be set to `verified` for this to function properly.
+
+	autopath @kubernetes
+	kubernetes cluster.local {
+		pods verified
+	}
+
 
 ## Wildcard
 


### PR DESCRIPTION
The primary driver for autopath was the kubernetes long-path/high-ndots problem.  It addresses that specific issue in kubernetes, so it deserves a mention in the K8s README, with an example, so people know the option is there.