### PR TITLE
Fix log output of the version string.

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -156,11 +156,15 @@ func defaultLoader(serverType string) (caddy.Input, error) {
 }
 
 // logVersion logs the version that is starting.
-func logVersion() { log.Print("[INFO] " + versionString()) }
+func logVersion() {
+	log.Print("[INFO] " + versionString())
+	log.Print("[INFO] " + releaseString())
+}
 
 // showVersion prints the version that is starting.
 func showVersion() {
 	fmt.Print(versionString())
+	fmt.Print(releaseString())
 	if devBuild && gitShortStat != "" {
 		fmt.Printf("%s\n%s\n", gitShortStat, gitFilesModified)
 	}
@@ -168,7 +172,15 @@ func showVersion() {
 
 // versionString returns the CoreDNS version as a string.
 func versionString() string {
-	return fmt.Sprintf("%s-%s\n%s/%s, %s, %s\n", caddy.AppName, caddy.AppVersion, runtime.GOOS, runtime.GOARCH, runtime.Version(), gitCommit)
+	return fmt.Sprintf("%s-%s\n", caddy.AppName, caddy.AppVersion)
+}
+
+// releaseString returns the release information related to CoreDNS version:
+// <OS>/<ARCH>, <go version>, <commit>
+// e.g.,
+// linux/amd64, go1.8.3, a6d2d7b5
+func releaseString() string {
+	return fmt.Sprintf("%s/%s, %s, %s\n", runtime.GOOS, runtime.GOARCH, runtime.Version(), gitCommit)
 }
 
 // setVersion figures out the version information


### PR DESCRIPTION
Split version string into two, before:
```
2017/08/12 19:43:08 [INFO] CoreDNS-010
linux/amd64, go1.8.3, a6d2d7b5
CoreDNS-010
linux/amd64, go1.8.3, a6d2d7b5
```
After:
```
root@9bd51ffc39aa:/go/src/github.com/coredns/coredns# ./coredns
.:53
2017/08/12 19:12:59 [INFO] CoreDNS-010
2017/08/12 19:12:59 [INFO] linux/amd64, go1.8, a6d2d7b
CoreDNS-010
linux/amd64, go1.8, a6d2d7b
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>