### PR TITLE
Consolidation of Makefile and Makefile.release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 GITCOMMIT:=$(shell git describe --dirty --always)
+BINARY:=coredns
+SYSTEM:=
 
 all: coredns
 
@@ -6,7 +8,7 @@ all: coredns
 # TODO: Add .go file dependencies.
 .PHONY: coredns
 coredns: check godeps
-	CGO_ENABLED=0 go build -v -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)"
+	CGO_ENABLED=0 $(SYSTEM) go build -v -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
 check: fmt core/zmiddleware.go core/dnsserver/zdirectives.go godeps

--- a/Makefile.release
+++ b/Makefile.release
@@ -1,15 +1,11 @@
 # Makefile for releasing CoreDNS
 #
 # The release binaries are built through docker run like
-# docker run --rm -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns golang:$(GOVERSION) make coredns
+# make coredns
 #
-# There advantage of the above command is that we could control the golang version
-# through $(GOVERSION) in the release.
-# In this way, anyone could build the same release binary without
-# installing a specific version of the golang.
-# Note that the default `Makefile` does not use the golang docker image so
-# invoking `make` is platform dependent in development, and will use
-# the golang installed on the dev machine by default.
+# There advantage of the above command is that we could control reused
+# the binary generation from the default `Makefile`, instread of repeating
+# in `Makefile.release`.
 #
 # The release is controlled from coremain/version.go. The version found
 # there is used to tag the git repo and to build the assets that are
@@ -50,8 +46,6 @@ GITHUB:=coredns
 DOCKER:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 GITCOMMIT:=$(shell git describe --dirty --always)
-GOVERSION:=1.8.3
-BUILD:=docker run --rm -v $(PWD):/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns golang:$(GOVERSION) make
 
 all:
 	@echo Use the 'release' target to start a release
@@ -73,11 +67,11 @@ commit:
 .PHONY: build
 build:
 	@echo Building: linux  $(VERSION)
-	mkdir -p build/Linux      && $(BUILD) coredns BINARY=build/Linux/$(NAME) SYSTEM="GOOS=linux"
+	mkdir -p build/Linux      && $(MAKE) coredns BINARY=build/Linux/$(NAME) SYSTEM="GOOS=linux"
 	@echo Building: darwin $(VERSION)
-	mkdir -p build/Darwin     && $(BUILD) coredns BINARY=build/Darwin/$(NAME) SYSTEM="GOOS=darwin"
+	mkdir -p build/Darwin     && $(MAKE) coredns BINARY=build/Darwin/$(NAME) SYSTEM="GOOS=darwin"
 	@echo Building: arm    $(VERSION)
-	mkdir -p build/Linux/Arm  && $(BUILD) coredns BINARY=build/Linux/Arm/$(NAME) SYSTEM="GOOS=linux GOARCH=arm"
+	mkdir -p build/Linux/Arm  && $(MAKE) coredns BINARY=build/Linux/Arm/$(NAME) SYSTEM="GOOS=linux GOARCH=arm"
 
 .PHONY: tar
 tar:
@@ -93,7 +87,7 @@ upload:
 
 .PHONY: docker-build
 docker-build:
-	$(BUILD) coredns SYSTEM="GOOS=linux"
+	$(MAKE) coredns SYSTEM="GOOS=linux"
 	docker build -t $(DOCKER_IMAGE_NAME) .
 	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(VERSION)
 

--- a/Makefile.release
+++ b/Makefile.release
@@ -1,5 +1,16 @@
 # Makefile for releasing CoreDNS
 #
+# The release binaries are built through docker run like
+# docker run --rm -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns golang:$(GOVERSION) make coredns
+#
+# There advantage of the above command is that we could control the golang version
+# through $(GOVERSION) in the release.
+# In this way, anyone could build the same release binary without
+# installing a specific version of the golang.
+# Note that the default `Makefile` does not use the golang docker image so
+# invoking `make` is platform dependent in development, and will use
+# the golang installed on the dev machine by default.
+#
 # The release is controlled from coremain/version.go. The version found
 # there is used to tag the git repo and to build the assets that are
 # uploaded to github (after some sanity checks).
@@ -39,11 +50,13 @@ GITHUB:=coredns
 DOCKER:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 GITCOMMIT:=$(shell git describe --dirty --always)
+GOVERSION:=1.8.3
+BUILD:=docker run --rm -v $(PWD):/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns golang:$(GOVERSION) make
 
 all:
 	@echo Use the 'release' target to start a release
 
-release:	generate commit push build tar upload
+release: commit push build tar upload
 
 docker: docker-build docker-upload
 
@@ -57,28 +70,14 @@ commit:
 	@echo Committing
 	git commit -am"Release $(VERSION)"
 
-.PHONY: generate
-generate: 
-	go generate
-
 .PHONY: build
-build: build-arm build-darwin build-linux
-
-.PHONY: build-linux
-build-linux:
-	@echo Building: linux $(VERSION)
-	mkdir -p build/Linux      && CGO_ENABLED=0 GOOS=linux             go build -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o build/Linux/$(NAME)
-
-.PHONY: build-darwin
-build-darwin:
+build:
+	@echo Building: linux  $(VERSION)
+	mkdir -p build/Linux      && $(BUILD) coredns BINARY=build/Linux/$(NAME) SYSTEM="GOOS=linux"
 	@echo Building: darwin $(VERSION)
-	mkdir -p build/Darwin     && CGO_ENABLED=0 GOOS=darwin            go build -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o build/Darwin/$(NAME)
-
-.PHONY: build-arm
-build-arm:
-	@echo Building: arm $(VERSION)
-	mkdir -p build/Linux/Arm  && CGO_ENABLED=0 GOOS=linux GOARCH=arm  go build -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o build/Linux/Arm/$(NAME)
-
+	mkdir -p build/Darwin     && $(BUILD) coredns BINARY=build/Darwin/$(NAME) SYSTEM="GOOS=darwin"
+	@echo Building: arm    $(VERSION)
+	mkdir -p build/Linux/Arm  && $(BUILD) coredns BINARY=build/Linux/Arm/$(NAME) SYSTEM="GOOS=linux GOARCH=arm"
 
 .PHONY: tar
 tar:
@@ -94,7 +93,7 @@ upload:
 
 .PHONY: docker-build
 docker-build:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w"
+	$(BUILD) coredns SYSTEM="GOOS=linux"
 	docker build -t $(DOCKER_IMAGE_NAME) .
 	docker tag $(DOCKER_IMAGE_NAME):latest $(DOCKER_IMAGE_NAME):$(VERSION)
 


### PR DESCRIPTION
Several changes:
1. All go specific target like `go generate`, etc. has
been moved to Makefile. Now Makefile.release does not
repeat go build, etc. related rules.
2. In Makefile.release, the binary build is done through
`docker run` and with a fixed specific go version (currently 1.8.3).
This will help making sure build process could be reproduced
on any dev platform, with no dependency to the golang version
installed on the dev machine used.
3. Platform related flags (e.g., "GOOS=darwin") are passed through
Makefile (not Makefile.release).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>