### PR TITLE
cidr everywhere: check all middleware

### DIFF
--- a/middleware/auto/setup_test.go
+++ b/middleware/auto/setup_test.go
@@ -23,6 +23,12 @@ func TestAutoParse(t *testing.T) {
 			false, "/tmp", "${1}", `db\.(.*)`, []string{"127.0.0.1:53"},
 		},
 		{
+			`auto 10.0.0.0/24 {
+				directory /tmp
+			}`,
+			false, "/tmp", "${1}", `db\.(.*)`, nil,
+		},
+		{
 			`auto {
 				directory /tmp
 			}`,

--- a/middleware/dnssec/setup_test.go
+++ b/middleware/dnssec/setup_test.go
@@ -20,12 +20,15 @@ func TestSetupDnssec(t *testing.T) {
 			`dnssec`, false, nil, nil, defaultCap, "",
 		},
 		{
-			`dnssec miek.nl`, false, []string{"miek.nl."}, nil, defaultCap, "",
+			`dnssec example.org`, false, []string{"example.org."}, nil, defaultCap, "",
 		},
 		{
-			`dnssec miek.nl {
+			`dnssec 10.0.0.0/8`, false, []string{"10.in-addr.arpa."}, nil, defaultCap, "",
+		},
+		{
+			`dnssec example.org {
 				cache_capacity 100
-			}`, false, []string{"miek.nl."}, nil, 100, "",
+			}`, false, []string{"example.org."}, nil, 100, "",
 		},
 	}
 

--- a/middleware/etcd/lookup_test.go
+++ b/middleware/etcd/lookup_test.go
@@ -3,11 +3,25 @@
 package etcd
 
 import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/coredns/coredns/middleware/etcd/msg"
+	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/pkg/tls"
+	"github.com/coredns/coredns/middleware/proxy"
 	"github.com/coredns/coredns/middleware/test"
+	"github.com/skynetservices/skydns/singleflight"
 
 	"github.com/miekg/dns"
 )
+
+func init() {
+	ctxt, _ = context.WithTimeout(context.Background(), etcdTimeout)
+}
 
 // Note the key is encoded as DNS name, while in "reality" it is a etcd path.
 var services = []*msg.Service{
@@ -206,3 +220,70 @@ var dnsTestCases = []test.Case{
 		Answer: []dns.RR{test.PTR("1.0.0.10.in-addr.arpa. 300 PTR reverse.example.com.")},
 	},
 }
+
+func newEtcdMiddleware() *Etcd {
+	ctxt, _ = context.WithTimeout(context.Background(), etcdTimeout)
+
+	endpoints := []string{"http://localhost:2379"}
+	tlsc, _ := tls.NewTLSConfigFromArgs()
+	client, _ := newEtcdClient(endpoints, tlsc)
+
+	return &Etcd{
+		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53"}),
+		PathPrefix: "skydns",
+		Ctx:        context.Background(),
+		Inflight:   &singleflight.Group{},
+		Zones:      []string{"skydns.test.", "skydns_extra.test.", "in-addr.arpa."},
+		Client:     client,
+	}
+}
+
+func set(t *testing.T, e *Etcd, k string, ttl time.Duration, m *msg.Service) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Set(ctxt, path, string(b), &etcdc.SetOptions{TTL: ttl})
+}
+
+func delete(t *testing.T, e *Etcd, k string) {
+	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
+	e.Client.Delete(ctxt, path, &etcdc.DeleteOptions{Recursive: false})
+}
+
+func TestLookup(t *testing.T) {
+	etc := newEtcdMiddleware()
+	for _, serv := range services {
+		set(t, etc, serv.Key, 0, serv)
+		defer delete(t, etc, serv.Key)
+	}
+
+	for _, tc := range dnsTestCases {
+		m := tc.Msg()
+
+		rec := dnsrecorder.New(&test.ResponseWriter{})
+		etc.ServeDNS(ctxt, rec, m)
+
+		resp := rec.Msg
+		sort.Sort(test.RRSet(resp.Answer))
+		sort.Sort(test.RRSet(resp.Ns))
+		sort.Sort(test.RRSet(resp.Extra))
+
+		if !test.Header(t, tc, resp) {
+			t.Logf("%v\n", resp)
+			continue
+		}
+		if !test.Section(t, tc, test.Answer, resp.Answer) {
+			t.Logf("%v\n", resp)
+		}
+		if !test.Section(t, tc, test.Ns, resp.Ns) {
+			t.Logf("%v\n", resp)
+		}
+		if !test.Section(t, tc, test.Extra, resp.Extra) {
+			t.Logf("%v\n", resp)
+		}
+	}
+}
+
+var ctxt context.Context

--- a/middleware/etcd/lookup_test.go
+++ b/middleware/etcd/lookup_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/coredns/coredns/middleware/etcd/msg"
 	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/pkg/singleflight"
 	"github.com/coredns/coredns/middleware/pkg/tls"
 	"github.com/coredns/coredns/middleware/proxy"
 	"github.com/coredns/coredns/middleware/test"
-	"github.com/skynetservices/skydns/singleflight"
 
 	"github.com/miekg/dns"
 )

--- a/middleware/etcd/lookup_test.go
+++ b/middleware/etcd/lookup_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/coredns/coredns/middleware/proxy"
 	"github.com/coredns/coredns/middleware/test"
 
+	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
 )
 

--- a/middleware/etcd/setup_test.go
+++ b/middleware/etcd/setup_test.go
@@ -1,94 +1,11 @@
-// +build etcd
-
 package etcd
 
 import (
-	"encoding/json"
-	"sort"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/coredns/coredns/middleware/etcd/msg"
-	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
-	"github.com/coredns/coredns/middleware/pkg/singleflight"
-	"github.com/coredns/coredns/middleware/pkg/tls"
-	"github.com/coredns/coredns/middleware/proxy"
-	"github.com/coredns/coredns/middleware/test"
-
-	etcdc "github.com/coreos/etcd/client"
 	"github.com/mholt/caddy"
-	"golang.org/x/net/context"
 )
-
-func init() {
-	ctxt, _ = context.WithTimeout(context.Background(), etcdTimeout)
-}
-
-func newEtcdMiddleware() *Etcd {
-	ctxt, _ = context.WithTimeout(context.Background(), etcdTimeout)
-
-	endpoints := []string{"http://localhost:2379"}
-	tlsc, _ := tls.NewTLSConfigFromArgs()
-	client, _ := newEtcdClient(endpoints, tlsc)
-
-	return &Etcd{
-		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53"}),
-		PathPrefix: "skydns",
-		Ctx:        context.Background(),
-		Inflight:   &singleflight.Group{},
-		Zones:      []string{"skydns.test.", "skydns_extra.test.", "in-addr.arpa."},
-		Client:     client,
-	}
-}
-
-func set(t *testing.T, e *Etcd, k string, ttl time.Duration, m *msg.Service) {
-	b, err := json.Marshal(m)
-	if err != nil {
-		t.Fatal(err)
-	}
-	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
-	e.Client.Set(ctxt, path, string(b), &etcdc.SetOptions{TTL: ttl})
-}
-
-func delete(t *testing.T, e *Etcd, k string) {
-	path, _ := msg.PathWithWildcard(k, e.PathPrefix)
-	e.Client.Delete(ctxt, path, &etcdc.DeleteOptions{Recursive: false})
-}
-
-func TestLookup(t *testing.T) {
-	etc := newEtcdMiddleware()
-	for _, serv := range services {
-		set(t, etc, serv.Key, 0, serv)
-		defer delete(t, etc, serv.Key)
-	}
-
-	for _, tc := range dnsTestCases {
-		m := tc.Msg()
-
-		rec := dnsrecorder.New(&test.ResponseWriter{})
-		etc.ServeDNS(ctxt, rec, m)
-
-		resp := rec.Msg
-		sort.Sort(test.RRSet(resp.Answer))
-		sort.Sort(test.RRSet(resp.Ns))
-		sort.Sort(test.RRSet(resp.Extra))
-
-		if !test.Header(t, tc, resp) {
-			t.Logf("%v\n", resp)
-			continue
-		}
-		if !test.Section(t, tc, test.Answer, resp.Answer) {
-			t.Logf("%v\n", resp)
-		}
-		if !test.Section(t, tc, test.Ns, resp.Ns) {
-			t.Logf("%v\n", resp)
-		}
-		if !test.Section(t, tc, test.Extra, resp.Extra) {
-			t.Logf("%v\n", resp)
-		}
-	}
-}
 
 func TestSetupEtcd(t *testing.T) {
 	tests := []struct {
@@ -145,5 +62,3 @@ func TestSetupEtcd(t *testing.T) {
 		}
 	}
 }
-
-var ctxt context.Context

--- a/middleware/file/setup_test.go
+++ b/middleware/file/setup_test.go
@@ -48,6 +48,11 @@ func TestFileParse(t *testing.T) {
 			false,
 			Zones{Names: []string{"dnssex.nl."}},
 		},
+		{
+			`file ` + zoneFileName2 + ` 10.0.0.0/8`,
+			false,
+			Zones{Names: []string{"10.in-addr.arpa."}},
+		},
 	}
 
 	for i, test := range tests {

--- a/middleware/hosts/setup_test.go
+++ b/middleware/hosts/setup_test.go
@@ -50,10 +50,10 @@ func TestHostsParse(t *testing.T) {
 			false, "/etc/hosts", []string{"miek.nl."}, true,
 		},
 		{
-			`hosts /etc/hosts miek.nl. pun.gent. {
+			`hosts /etc/hosts miek.nl 10.0.0.9/8 {
 				fallthrough
 			}`,
-			false, "/etc/hosts", []string{"miek.nl.", "pun.gent."}, true,
+			false, "/etc/hosts", []string{"miek.nl.", "10.in-addr.arpa."}, true,
 		},
 	}
 

--- a/middleware/proxy/upstream.go
+++ b/middleware/proxy/upstream.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -44,6 +43,8 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 		if !c.Args(&upstream.from) {
 			return upstreams, c.ArgErr()
 		}
+		upstream.from = middleware.Host(upstream.from).Normalize()
+
 		to := c.RemainingArgs()
 		if len(to) == 0 {
 			return upstreams, c.ArgErr()
@@ -168,7 +169,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			return c.ArgErr()
 		}
 		for i := 0; i < len(ignoredDomains); i++ {
-			ignoredDomains[i] = strings.ToLower(dns.Fqdn(ignoredDomains[i]))
+			ignoredDomains[i] = middleware.Host(ignoredDomains[i]).Normalize()
 		}
 		u.IgnoredSubDomains = ignoredDomains
 	case "spray":


### PR DESCRIPTION
Add tests for cidr in only that middleware that already tests for this.
Check the other ones manually (and put reverse in the tests cases
anyway).

Make etcd setup_test run without +build etcd tag - it is not needed
for this test - move rest of the code to lookup_test.go.

Cleanup proxy test a bit and remove TempDir as there is test.TempFile
that does the same thing.

Fixes #909