### PR TITLE
Make CoreDNS build on Go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 
 language: go
 go:
+  - 1.7
   - 1.8
 
 go_import_path: github.com/coredns/coredns

--- a/middleware/kubernetes/apiproxy.go
+++ b/middleware/kubernetes/apiproxy.go
@@ -72,5 +72,5 @@ func (p *apiProxy) Run() {
 
 func (p *apiProxy) Stop() {
 	p.handler.Stop()
-	p.Close()
+	p.listener.Close()
 }


### PR DESCRIPTION
Two changes:
* Added a compiler target in .travis.yml to build against Go 1.7
* Replaced a call to `http.Server.Close` into a call to `net.Listener.Close`, since the former is not implemented in Go 1.7. Go 1.8 implements this as a wrapper that closes all the listeners, so this should be correct here.

The latter needs review from someone with more context on the specific code to make sure this doesn't introduce any regression. Additionally this should go away as soon as Go 1.7 will not be supported anymore. Further discussion on https://github.com/coredns/coredns/issues/917 .

The build on my branch passes correctly, https://travis-ci.org/insomniacslk/coredns/builds/264472119 .
