### PR TITLE
mw/kubernetes: remove zone from parseRequest

### DIFF
--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -315,7 +315,7 @@ func (k *Kubernetes) Entries(state request.Request) ([]msg.Service, error) {
 		return nil, errNoItems
 	}
 
-	records := k.getRecordsForK8sItems(services, pods, r)
+	records := k.getRecordsForK8sItems(services, pods, state.Zone)
 	return records, nil
 }
 
@@ -332,8 +332,8 @@ func endpointHostname(addr api.EndpointAddress) string {
 	return ""
 }
 
-func (k *Kubernetes) getRecordsForK8sItems(services []kService, pods []kPod, r recordRequest) (records []msg.Service) {
-	zonePath := msg.Path(r.zone, "coredns")
+func (k *Kubernetes) getRecordsForK8sItems(services []kService, pods []kPod, zone string) (records []msg.Service) {
+	zonePath := msg.Path(zone, "coredns")
 
 	for _, svc := range services {
 		if svc.addr == api.ClusterIPNone || len(svc.endpoints) > 0 {

--- a/middleware/kubernetes/parse.go
+++ b/middleware/kubernetes/parse.go
@@ -20,7 +20,6 @@ type recordRequest struct {
 	// A each name can be for a pod or a service, here we track what we've seen. This value is true for
 	// pods and false for services. If we ever need to extend this well use a typed value.
 	podOrSvc string
-	zone     string
 }
 
 // parseRequest parses the qname to find all the elements we need for querying k8s.
@@ -33,8 +32,6 @@ func (k *Kubernetes) parseRequest(state request.Request) (r recordRequest, err e
 
 	base, _ := dnsutil.TrimZone(state.Name(), state.Zone)
 	segs := dns.SplitDomainName(base)
-
-	r.zone = state.Zone
 
 	offset := 0
 	if state.QType() == dns.TypeSRV {
@@ -101,6 +98,5 @@ func (r recordRequest) String() string {
 	s += "." + r.service
 	s += "." + r.namespace
 	s += "." + r.podOrSvc
-	s += "." + r.zone
 	return s
 }

--- a/middleware/kubernetes/parse_test.go
+++ b/middleware/kubernetes/parse_test.go
@@ -19,17 +19,17 @@ func TestParseRequest(t *testing.T) {
 		{
 			// valid SRV request
 			"_http._tcp.webs.mynamespace.svc.inter.webs.test.", dns.TypeSRV,
-			"http.tcp..webs.mynamespace.svc.intern.webs.tests.",
+			"http.tcp..webs.mynamespace.svc",
 		},
 		{
 			// wildcard acceptance
 			"*.any.*.any.svc.inter.webs.test.", dns.TypeSRV,
-			"*.any..*.any.svc.intern.webs.tests.",
+			"*.any..*.any.svc",
 		},
 		{
 			// A request of endpoint
 			"1-2-3-4.webs.mynamespace.svc.inter.webs.test.", dns.TypeA,
-			"..1-2-3-4.webs.mynamespace.svc.intern.webs.tests.",
+			"..1-2-3-4.webs.mynamespace.svc",
 		},
 	}
 	for i, tc := range tests {

--- a/middleware/kubernetes/parse_test.go
+++ b/middleware/kubernetes/parse_test.go
@@ -31,6 +31,12 @@ func TestParseRequest(t *testing.T) {
 			"1-2-3-4.webs.mynamespace.svc.inter.webs.test.", dns.TypeA,
 			"..1-2-3-4.webs.mynamespace.svc",
 		},
+		{
+
+			// 3 segments
+			"webs.mynamespace.svc.inter.webs.test.", dns.TypeSRV,
+			"*...webs.mynamespace.svc",
+		},
 	}
 	for i, tc := range tests {
 		m := new(dns.Msg)


### PR DESCRIPTION
State has the zone info as well, so don't need to have it in
parseRequest anymore.