### PR TITLE
backend.Records make it take request.Request

### DIFF
--- a/middleware/backend.go
+++ b/middleware/backend.go
@@ -28,7 +28,7 @@ type ServiceBackend interface {
 
 	// Returns _all_ services that matches a certain name.
 	// Note: it does not implement a specific service.
-	Records(name string, exact bool) ([]msg.Service, error)
+	Records(state request.Request, exact bool) ([]msg.Service, error)
 }
 
 // Options are extra options that can be specified for a lookup.

--- a/middleware/etcd/etcd.go
+++ b/middleware/etcd/etcd.go
@@ -37,7 +37,7 @@ type Etcd struct {
 
 // Services implements the ServiceBackend interface.
 func (e *Etcd) Services(state request.Request, exact bool, opt middleware.Options) (services, debug []msg.Service, err error) {
-	services, err = e.Records(state.Name(), exact)
+	services, err = e.Records(state, exact)
 	if err != nil {
 		return
 	}
@@ -73,7 +73,9 @@ func (e *Etcd) Debug() string {
 
 // Records looks up records in etcd. If exact is true, it will lookup just this
 // name. This is used when find matches when completing SRV lookups for instance.
-func (e *Etcd) Records(name string, exact bool) ([]msg.Service, error) {
+func (e *Etcd) Records(state request.Request, exact bool) ([]msg.Service, error) {
+	name := state.Name()
+
 	path, star := msg.PathWithWildcard(name, e.PathPrefix)
 	r, err := e.get(path, true)
 	if err != nil {

--- a/middleware/etcd/stub.go
+++ b/middleware/etcd/stub.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/coredns/coredns/middleware/etcd/msg"
 	"github.com/coredns/coredns/middleware/proxy"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -29,7 +30,11 @@ func (e *Etcd) UpdateStubZones() {
 // Only the first zone configured on e is used for the lookup.
 func (e *Etcd) updateStubZones() {
 	zone := e.Zones[0]
-	services, err := e.Records(stubDomain+"."+zone, false)
+
+	fakeState := request.Request{W: nil, Req: new(dns.Msg)}
+	fakeState.Req.SetQuestion(stubDomain+"."+zone, dns.TypeA)
+
+	services, err := e.Records(fakeState, false)
 	if err != nil {
 		return
 	}

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -136,7 +136,7 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt middleware.
 		return []msg.Service{svc}, nil, nil
 	}
 
-	s, e := k.Entries(state)
+	s, e := k.Records(state, false)
 
 	// SRV for external services is not yet implemented, so remove those records.
 
@@ -291,13 +291,8 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 	return err
 }
 
-// Records is not implemented.
-func (k *Kubernetes) Records(name string, exact bool) ([]msg.Service, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-// Entries looks up services in kubernetes.
-func (k *Kubernetes) Entries(state request.Request) ([]msg.Service, error) {
+// Records looks up services in kubernetes.
+func (k *Kubernetes) Records(state request.Request, exact bool) ([]msg.Service, error) {
 	r, e := k.parseRequest(state)
 	if e != nil {
 		return nil, e


### PR DESCRIPTION
This is more general and aligns well with the other methods.
Also allows the kubernetes middleware to use it.

Fixes #940