### PR TITLE
travis: remove -bench and -race from coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   - TEST_TYPE=integration ETCD_VERSION=2.3.1 K8S_VERSION=1.5.0 KUBECTL="docker exec hyperkube /hyperkube kubectl"
   - TEST_TYPE=core ETCD_VERSION=2.3.1 K8S_VERSION=1.5.0 KUBECTL="docker exec hyperkube /hyperkube kubectl"
   - TEST_TYPE=middleware ETCD_VERSION=2.3.1 K8S_VERSION=1.5.0 KUBECTL="docker exec hyperkube /hyperkube kubectl"
-  
+
 # In the Travis VM-based build environment, IPv6 networking is not
 # enabled by default. The sysctl operations below enable IPv6.
 # IPv6 is needed by some of the CoreDNS test cases. The VM environment

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(TEST_TYPE),middleware)
 endif
 ifeq ($(TEST_TYPE),coverage)
 	for d in `go list ./... | grep -v vendor`; do \
-		go test -v  -tags 'etcd k8s' -race -coverprofile=cover.out -covermode=atomic -bench=. $$d || exit 1; \
+		go test -v  -tags 'etcd k8s' -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
 		if [ -f cover.out ]; then \
 			cat cover.out >> coverage.txt; \
 			rm cover.out; \


### PR DESCRIPTION
Not needed and already done in the other test (bench is not looked at
at all)