### PR TITLE
Disable Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ go_import_path: github.com/coredns/coredns
 git:
   depth: 3
 
-cache:
-  directories:
-    - $GOPATH/src
-    - $GOPATH/pkg
-
 env:
   - TEST_TYPE=coverage ETCD_VERSION=2.3.1 K8S_VERSION=1.5.0 KUBECTL="docker exec hyperkube /hyperkube kubectl"
   - TEST_TYPE=integration ETCD_VERSION=2.3.1 K8S_VERSION=1.5.0 KUBECTL="docker exec hyperkube /hyperkube kubectl"


### PR DESCRIPTION
It looks like the cached path  `$GOPATH/src`  overlaps with the source path of `$GOPATH/src/github.com/coredns/coredns`.

Disable the cache for now.

May enable cache in the future if we could exclude `$GOPATH/src/github.com/coredns/coredns` from `$GOPATH/src`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>