### PR TITLE
travis: drop 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ services:
 language: go
 go:
   - 1.8
-  - 1.7
 
 go_import_path: github.com/coredns/coredns
 


### PR DESCRIPTION
Yes, the previous Go version is important but this doubles the wait on
travis. This drops 1.7 from travis. This means we wait for bug reports
to show up, or tell people to use the precompiled binaries are docker
containers.