### PR TITLE
mw/autopath: a minimal bug section

### DIFF
--- a/middleware/autopath/README.md
+++ b/middleware/autopath/README.md
@@ -38,3 +38,8 @@ autopath @kubernetes
 ~~~
 
 Use the search path dynamically retrieved from the kubernetes middleware.
+
+## Bugs
+
+When the *cache* middleware is enabled it is possible for pods in different namespaces to get the
+same answer.


### PR DESCRIPTION
Briefly highlight that autopath might return the wrong results to pods
in different namespaces.

Fixes #778