### PR TITLE
core: hide registerHandler

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -124,9 +124,9 @@ func (c *Config) AddMiddleware(m middleware.Middleware) {
 	c.Middleware = append(c.Middleware, m)
 }
 
-// RegisterHandler adds a handler to a site's handler registration. Handlers
-// should use this if the want to announce that they exist to other middleware.
-func (c *Config) RegisterHandler(h middleware.Handler) {
+// registerHandler adds a handler to a site's handler registration. Handlers
+//  use this to announce that they exist to other middleware.
+func (c *Config) registerHandler(h middleware.Handler) {
 	if c.Registry == nil {
 		c.Registry = make(map[string]middleware.Handler)
 	}
@@ -139,7 +139,6 @@ func (c *Config) RegisterHandler(h middleware.Handler) {
 // This is useful to inspect if a certain middleware is active in this server.
 // Note that this is order dependent and the order is defined in directives.go, i.e. if your middleware
 // comes before the middleware you are checking; it will not be there (yet).
-// See RegisterHandler on how to register the middleware with this server.
 func (c *Config) GetHandler(name string) middleware.Handler {
 	if c.Registry == nil {
 		return nil

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -135,11 +135,11 @@ func (c *Config) registerHandler(h middleware.Handler) {
 	c.Registry[h.Name()] = h
 }
 
-// GetHandler returns the middleware handler that has been added to the config under its name.
+// Handler returns the middleware handler that has been added to the config under its name.
 // This is useful to inspect if a certain middleware is active in this server.
 // Note that this is order dependent and the order is defined in directives.go, i.e. if your middleware
 // comes before the middleware you are checking; it will not be there (yet).
-func (c *Config) GetHandler(name string) middleware.Handler {
+func (c *Config) Handler(name string) middleware.Handler {
 	if c.Registry == nil {
 		return nil
 	}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -66,6 +66,10 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		var stack middleware.Handler
 		for i := len(site.Middleware) - 1; i >= 0; i-- {
 			stack = site.Middleware[i](stack)
+
+			// register the *handler* also
+			site.registerHandler(stack)
+
 			if s.trace == nil && stack.Name() == "trace" {
 				// we have to stash away the middleware, not the
 				// Tracer object, because the Tracer won't be initialized yet

--- a/middleware/auto/setup.go
+++ b/middleware/auto/setup.go
@@ -31,13 +31,14 @@ func setup(c *caddy.Controller) error {
 		return middleware.Error("auto", err)
 	}
 
-	// If we have enabled prometheus we should add newly discovered zones to it.
-	// This does not have to happen in a on.Startup because monitoring is one of the first
-	// to be initialized.
-	met := dnsserver.GetConfig(c).GetHandler("prometheus")
-	if met != nil {
-		a.metrics = met.(*metrics.Metrics)
-	}
+	c.OnStartup(func() error {
+		m := dnsserver.GetConfig(c).Handler("prometheus")
+		if m == nil {
+			return nil
+		}
+		(&a).metrics = m.(*metrics.Metrics)
+		return nil
+	})
 
 	walkChan := make(chan bool)
 

--- a/middleware/autopath/setup.go
+++ b/middleware/autopath/setup.go
@@ -50,8 +50,7 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-// allowedMiddleware has a list of middleware that can be used by autopath. For this to work, they
-// need to register themselves with dnsserver.RegisterHandler.
+// allowedMiddleware has a list of middleware that can be used by autopath.
 var allowedMiddleware = map[string]bool{
 	"@kubernetes": true,
 	"@erratic":    true,

--- a/middleware/autopath/setup.go
+++ b/middleware/autopath/setup.go
@@ -29,7 +29,7 @@ func setup(c *caddy.Controller) error {
 	// Do this in OnStartup, so all middleware has been initialized.
 	c.OnStartup(func() error {
 		// TODO(miek): fabricate test to proof this is not thread safe.
-		m := dnsserver.GetConfig(c).GetHandler(mw)
+		m := dnsserver.GetConfig(c).Handler(mw)
 		if m == nil {
 			return nil
 		}

--- a/middleware/erratic/setup.go
+++ b/middleware/erratic/setup.go
@@ -28,9 +28,6 @@ func setupErratic(c *caddy.Controller) error {
 		return e
 	})
 
-	// Also register erratic for use in autopath.
-	dnsserver.GetConfig(c).RegisterHandler(e)
-
 	return nil
 }
 

--- a/middleware/erratic/setup_test.go
+++ b/middleware/erratic/setup_test.go
@@ -47,13 +47,32 @@ func TestParseErratic(t *testing.T) {
 			delay 3 1ms
 
 		}`, false, 0, 3, 2},
+		{`erraric {
+			drop 3
+			delay
+		}`, false, 3, 2, 0},
 		// fails
 		{`erratic {
 			drop -1
 		}`, true, 0, 0, 0},
+		{`erratic {
+			delay -1
+		}`, true, 0, 0, 0},
+		{`erratic {
+			delay 1 2 4
+		}`, true, 0, 0, 0},
+		{`erratic {
+			delay 15.a
+		}`, true, 0, 0, 0},
 		{`erraric {
 			drop 3
 			delay 3 bla
+		}`, true, 0, 0, 0},
+		{`erraric {
+			truncate 15.a
+		}`, true, 0, 0, 0},
+		{`erraric {
+			something-else
 		}`, true, 0, 0, 0},
 	}
 	for i, test := range tests {

--- a/middleware/federation/setup.go
+++ b/middleware/federation/setup.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 
 	// Do this in OnStartup, so all middleware has been initialized.
 	c.OnStartup(func() error {
-		m := dnsserver.GetConfig(c).GetHandler("kubernetes")
+		m := dnsserver.GetConfig(c).Handler("kubernetes")
 		if m == nil {
 			return nil
 		}

--- a/middleware/kubernetes/setup.go
+++ b/middleware/kubernetes/setup.go
@@ -55,9 +55,6 @@ func setup(c *caddy.Controller) error {
 		return kubernetes
 	})
 
-	// Also register kubernetes for use in autopath.
-	dnsserver.GetConfig(c).RegisterHandler(kubernetes)
-
 	return nil
 }
 

--- a/middleware/metrics/setup.go
+++ b/middleware/metrics/setup.go
@@ -38,9 +38,6 @@ func setup(c *caddy.Controller) error {
 	}
 	c.OnFinalShutdown(m.OnShutdown)
 
-	// Also register metrics for use in other middleware.
-	dnsserver.GetConfig(c).RegisterHandler(m)
-
 	return nil
 }
 

--- a/middleware/metrics/setup.go
+++ b/middleware/metrics/setup.go
@@ -72,24 +72,6 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 		default:
 			return met, c.ArgErr()
 		}
-		for c.NextBlock() {
-			switch c.Val() {
-			case "address":
-				args = c.RemainingArgs()
-				if len(args) != 1 {
-					return met, c.ArgErr()
-				}
-				met.Addr = args[0]
-				// expecting something that resembles a host-port
-				_, _, e := net.SplitHostPort(met.Addr)
-				if e != nil {
-					return met, e
-				}
-			default:
-				return met, c.Errf("unknown property: %s", c.Val())
-			}
-
-		}
 	}
 	return met, err
 }

--- a/middleware/metrics/setup_test.go
+++ b/middleware/metrics/setup_test.go
@@ -18,6 +18,7 @@ func TestPrometheusParse(t *testing.T) {
 		// fails
 		{`prometheus {}`, true, ""},
 		{`prometheus /foo`, true, ""},
+		{`prometheus a b c`, true, ""},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)

--- a/middleware/proxy/setup.go
+++ b/middleware/proxy/setup.go
@@ -20,7 +20,7 @@ func setup(c *caddy.Controller) error {
 		return middleware.Error("proxy", err)
 	}
 
-	t := dnsserver.GetConfig(c).GetHandler("trace")
+	t := dnsserver.GetConfig(c).Handler("trace")
 	P := &Proxy{Trace: t}
 	dnsserver.GetConfig(c).AddMiddleware(func(next middleware.Handler) middleware.Handler {
 		P.Next = next


### PR DESCRIPTION
Remove RegisterHandler and just make it implicit when we look at the
handler compilation step.