### PR TITLE
mw/kubernetes: remove kPod and kServices

### DIFF
--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -29,7 +29,7 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 	if err != nil {
 		return msg.Service{}, err
 	}
-	r, err := k.parseRequest(state)
+	r, err := parseRequest(state)
 
 	lz := node.Labels[LabelZone]
 	lr := node.Labels[LabelRegion]

--- a/middleware/kubernetes/handler_test.go
+++ b/middleware/kubernetes/handler_test.go
@@ -47,7 +47,7 @@ var dnsTestCases = map[string](test.Case){
 	},
 	"SRV Service Not udp/tcp": {
 		Qname: "*._not-udp-or-tcp.svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -91,16 +91,21 @@ var dnsTestCases = map[string](test.Case){
 	},
 	"AAAA Service (existing service)": {
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
-		Rcode:  dns.RcodeSuccess,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
 	"AAAA Service (non-existing service)": {
 		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	"A Service (non-existing service)": {
+		Qname: "svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -110,6 +115,20 @@ var dnsTestCases = map[string](test.Case){
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.TXT("dns-version.cluster.local 28800 IN TXT 1.0.1"),
+		},
+	},
+	"A Service (Headless) does not exist": {
+		Qname: "bogusendpoint.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	"A Service does not exist": {
+		Qname: "bogusendpoint.svc0.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
 }

--- a/middleware/kubernetes/parse.go
+++ b/middleware/kubernetes/parse.go
@@ -26,7 +26,7 @@ type recordRequest struct {
 // parseRequest parses the qname to find all the elements we need for querying k8s. Anything
 // that is not parsed will have the wildcard "*" value (except r.endpoint).
 // Potential underscores are stripped from _port and _protocol.
-func (k *Kubernetes) parseRequest(state request.Request) (r recordRequest, err error) {
+func parseRequest(state request.Request) (r recordRequest, err error) {
 	// 3 Possible cases:
 	// 1. _port._protocol.service.namespace.pod|svc.zone
 	// 2. (endpoint): endpoint.service.namespace.pod|svc.zone

--- a/middleware/kubernetes/parse_test.go
+++ b/middleware/kubernetes/parse_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestParseRequest(t *testing.T) {
-	k := New([]string{zone})
-
 	tests := []struct {
 		query    string
 		expected string // output from r.String()
@@ -27,7 +25,7 @@ func TestParseRequest(t *testing.T) {
 		m.SetQuestion(tc.query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		r, e := k.parseRequest(state)
+		r, e := parseRequest(state)
 		if e != nil {
 			t.Errorf("Test %d, expected no error, got '%v'.", i, e)
 		}
@@ -39,8 +37,6 @@ func TestParseRequest(t *testing.T) {
 }
 
 func TestParseInvalidRequest(t *testing.T) {
-	k := New([]string{zone})
-
 	invalid := []string{
 		"webs.mynamespace.pood.inter.webs.test.",                 // Request must be for pod or svc subdomain.
 		"too.long.for.what.I.am.trying.to.pod.inter.webs.tests.", // Too long.
@@ -51,7 +47,7 @@ func TestParseInvalidRequest(t *testing.T) {
 		m.SetQuestion(query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		if _, e := k.parseRequest(state); e == nil {
+		if _, e := parseRequest(state); e == nil {
 			t.Errorf("Test %d: expected error from %s, got none", i, query)
 		}
 	}

--- a/middleware/kubernetes/reverse.go
+++ b/middleware/kubernetes/reverse.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"strings"
+
 	"github.com/coredns/coredns/middleware"
 	"github.com/coredns/coredns/middleware/etcd/msg"
 	"github.com/coredns/coredns/middleware/pkg/dnsutil"
@@ -17,4 +19,37 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt middleware.O
 
 	records := k.serviceRecordForIP(ip, state.Name())
 	return records, nil, nil
+}
+
+// serviceRecordForIP gets a service record with a cluster ip matching the ip argument
+// If a service cluster ip does not match, it checks all endpoints
+func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
+	// First check services with cluster ips
+	svcList := k.APIConn.ServiceList()
+
+	for _, service := range svcList {
+		if (len(k.Namespaces) > 0) && !k.namespaceExposed(service.Namespace) {
+			continue
+		}
+		if service.Spec.ClusterIP == ip {
+			domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
+			return []msg.Service{{Host: domain}}
+		}
+	}
+	// If no cluster ips match, search endpoints
+	epList := k.APIConn.EndpointsList()
+	for _, ep := range epList.Items {
+		if (len(k.Namespaces) > 0) && !k.namespaceExposed(ep.ObjectMeta.Namespace) {
+			continue
+		}
+		for _, eps := range ep.Subsets {
+			for _, addr := range eps.Addresses {
+				if addr.IP == ip {
+					domain := strings.Join([]string{endpointHostname(addr), ep.ObjectMeta.Name, ep.ObjectMeta.Namespace, Svc, k.primaryZone()}, ".")
+					return []msg.Service{{Host: domain}}
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -214,7 +214,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},


### PR DESCRIPTION
Based up on: #939, but redone in a new PR with some cherry-picked
commits:
aacb91ef0b927683b21d6ee39dbddbd001334854
5dc34247b7d0136d9fe035f6b10d6b3e14ee7f2c

This removes kPod and Kservice and creates []msg.Service from k.findPods
and k.findServices.

Updated few tests which I *think* are correct; they look correct to me.