### PR TITLE
mw/kubernetes: split up tests cases

### DIFF
--- a/middleware/kubernetes/handler_pod_disabled_test.go
+++ b/middleware/kubernetes/handler_pod_disabled_test.go
@@ -1,0 +1,65 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+var podModeDisabledCases = map[string](test.Case){
+
+	"A Record Pod mode = Case 1": {
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Error:  errPodsDisabled,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+
+	"A Record Pod mode = Case 2": {
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Error:  errPodsDisabled,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestServeDNSModeDisabled(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.podMode = podModeDisabled
+	ctx := context.TODO()
+
+	for testname, tc := range podModeDisabledCases {
+		r := tc.Msg()
+
+		w := dnsrecorder.New(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("%v expected no error, got %v\n", testname, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+		}
+
+		test.SortAndCheck(t, resp, tc)
+	}
+}

--- a/middleware/kubernetes/handler_pod_insecure_test.go
+++ b/middleware/kubernetes/handler_pod_insecure_test.go
@@ -1,0 +1,61 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+var podModeInsecureCases = map[string](test.Case){
+
+	"A Record Pod mode = Case 1": {
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
+		},
+	},
+
+	"A Record Pod mode = Case 2": {
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-2.podns.pod.cluster.local.	0	IN	A	172.0.0.2"),
+		},
+	},
+}
+
+func TestServeDNSModeInsecure(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+	k.podMode = podModeInsecure
+
+	for testname, tc := range podModeInsecureCases {
+		r := tc.Msg()
+
+		w := dnsrecorder.New(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("%v expected no error, got %v\n", testname, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+		}
+
+		test.SortAndCheck(t, resp, tc)
+	}
+}

--- a/middleware/kubernetes/handler_pod_verified_test.go
+++ b/middleware/kubernetes/handler_pod_verified_test.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/pkg/dnsrecorder"
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+var podModeVerifiedCases = map[string](test.Case){
+
+	"A Record Pod mode = Case 1": {
+		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
+		},
+	},
+
+	"A Record Pod mode = Case 2": {
+		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestServeDNSModeVerified(t *testing.T) {
+
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	ctx := context.TODO()
+	k.podMode = podModeVerified
+
+	for testname, tc := range podModeVerifiedCases {
+		r := tc.Msg()
+
+		w := dnsrecorder.New(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("%v expected no error, got %v\n", testname, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+		}
+
+		test.SortAndCheck(t, resp, tc)
+	}
+}

--- a/middleware/kubernetes/handler_test.go
+++ b/middleware/kubernetes/handler_test.go
@@ -133,88 +133,13 @@ var dnsTestCases = map[string](test.Case){
 	},
 }
 
-var podModeDisabledCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
-		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Error:  errPodsDisabled,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
-		},
-	},
-
-	"A Record Pod mode = Case 2": {
-		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Error:  errPodsDisabled,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
-		},
-	},
-}
-
-var podModeInsecureCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
-		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
-		},
-	},
-
-	"A Record Pod mode = Case 2": {
-		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("172-0-0-2.podns.pod.cluster.local.	0	IN	A	172.0.0.2"),
-		},
-	},
-}
-
-var podModeVerifiedCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
-		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
-		},
-	},
-
-	"A Record Pod mode = Case 2": {
-		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
-		},
-	},
-}
-
 func TestServeDNS(t *testing.T) {
 
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
-
 	ctx := context.TODO()
-	runServeDNSTests(ctx, t, dnsTestCases, k)
 
-	k.podMode = podModeDisabled
-	runServeDNSTests(ctx, t, podModeDisabledCases, k)
-
-	k.podMode = podModeInsecure
-	runServeDNSTests(ctx, t, podModeInsecureCases, k)
-
-	k.podMode = podModeVerified
-	runServeDNSTests(ctx, t, podModeVerifiedCases, k)
-}
-
-func runServeDNSTests(ctx context.Context, t *testing.T, dnsTestCases map[string](test.Case), k *Kubernetes) {
 	for testname, tc := range dnsTestCases {
 		r := tc.Msg()
 


### PR DESCRIPTION
Split up the handler_test in four files that all tests their specific
bits. Removed the CNAME sort as there was only 1 answer with a CNAME
and that was a single one.

See #942, this fixes (a bit) the tests in middleware.