### PR TITLE
tests: CoreDNSServerAndPorts

### DIFF
--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -29,14 +29,9 @@ func TestAuto(t *testing.T) {
 	}
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatal("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -26,14 +26,9 @@ func TestLookupCache(t *testing.T) {
        file ` + name + `
 }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 
@@ -43,14 +38,9 @@ func TestLookupCache(t *testing.T) {
 	cache
 }
 `
-	i, err = CoreDNSServer(corefile)
+	i, udp, _, err = CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ = CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/chaos_test.go
+++ b/test/chaos_test.go
@@ -18,17 +18,11 @@ func TestChaos(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-	// Stop the server.
 	defer i.Stop()
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
-	}
 
 	log.SetOutput(ioutil.Discard)
 

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -43,14 +43,9 @@ func TestLookupDS(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -14,14 +14,9 @@ func TestLookupAutoPathErratic(t *testing.T) {
 	debug
     }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/etcd_cache_debug_test.go
+++ b/test/etcd_cache_debug_test.go
@@ -27,7 +27,7 @@ func TestEtcdCacheAndDebug(t *testing.T) {
     cache skydns.test
 }`
 
-	ex, udp_, _, err := CoreDNSServerAndPorts(corefile)
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}

--- a/test/etcd_cache_debug_test.go
+++ b/test/etcd_cache_debug_test.go
@@ -27,14 +27,9 @@ func TestEtcdCacheAndDebug(t *testing.T) {
     cache skydns.test
 }`
 
-	ex, err := CoreDNSServer(corefile)
+	ex, udp_, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(ex, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer ex.Stop()
 

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -47,14 +47,9 @@ func TestEtcdStubAndProxyLookup(t *testing.T) {
     proxy . 8.8.8.8:53
 }`
 
-	ex, err := CoreDNSServer(corefile)
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(ex, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer ex.Stop()
 

--- a/test/file_cname_proxy_test.go
+++ b/test/file_cname_proxy_test.go
@@ -27,14 +27,9 @@ func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
        file ` + name + `
 }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 
@@ -68,14 +63,9 @@ func TestZoneExternalCNAMELookupWithProxy(t *testing.T) {
 	}
 }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -32,14 +32,9 @@ example.net:0 {
 	file ` + name + `
 }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/file_srv_additional_test.go
+++ b/test/file_srv_additional_test.go
@@ -27,14 +27,9 @@ func TestZoneSRVAdditional(t *testing.T) {
        file ` + name + `
 }
 `
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -20,12 +20,10 @@ func TestGrpc(t *testing.T) {
 		whoami
 }
 `
-	g, err := CoreDNSServer(corefile)
+	g, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-
-	_, tcp := CoreDNSServerPorts(g, 0)
 	defer g.Stop()
 
 	conn, err := grpc.Dial(tcp, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(5*time.Second))

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -45,13 +45,11 @@ func TestMetricsRefused(t *testing.T) {
 	prometheus localhost:0
 }
 `
-	srv, err := CoreDNSServer(corefile)
+	srv, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer srv.Stop()
-
-	udp, _ := CoreDNSServerPorts(srv, 0)
 
 	m := new(dns.Msg)
 	m.SetQuestion("google.com.", dns.TypeA)

--- a/test/middleware_dnssec_test.go
+++ b/test/middleware_dnssec_test.go
@@ -30,12 +30,10 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
     loadbalance
 }
 `
-	ex, err := CoreDNSServer(corefile)
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-
-	udp, _ := CoreDNSServerPorts(ex, 0)
 	defer ex.Stop()
 
 	log.SetOutput(ioutil.Discard)

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -25,11 +25,10 @@ func benchmarkLookupBalanceRewriteCache(b *testing.B) {
 }
 `
 
-	ex, err := CoreDNSServer(corefile)
+	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-	udp, _ := CoreDNSServerPorts(ex, 0)
 	defer ex.Stop()
 
 	log.SetOutput(ioutil.Discard)

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -22,14 +22,9 @@ func TestProxyErratic(t *testing.T) {
 	}
 `
 
-	backend, err := CoreDNSServer(corefile)
+	backend, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(backend, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer backend.Stop()
 

--- a/test/proxy_http_health_test.go
+++ b/test/proxy_http_health_test.go
@@ -51,14 +51,9 @@ func TestProxyWithHTTPCheckOK(t *testing.T) {
 }
 `
 
-	authoritativeInstance, err := CoreDNSServer(authoritativeCorefile)
+	authoritativeInstance, authoritativeAddr, _, err := CoreDNSServerAndPorts(authoritativeCorefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS authoritative instance: %s", err)
-	}
-
-	authoritativeAddr, _ := CoreDNSServerPorts(authoritativeInstance, 0)
-	if authoritativeAddr == "" {
-		t.Fatalf("Could not get CoreDNS authoritative instance UDP listening port")
 	}
 	defer authoritativeInstance.Stop()
 
@@ -70,14 +65,9 @@ func TestProxyWithHTTPCheckOK(t *testing.T) {
 }
 `
 
-	proxyInstance, err := CoreDNSServer(proxyCorefile)
+	proxyInstance, proxyAddr, _, err := CoreDNSServerAndPorts(proxyCorefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS proxy instance: %s", err)
-	}
-
-	proxyAddr, _ := CoreDNSServerPorts(proxyInstance, 0)
-	if proxyAddr == "" {
-		t.Fatalf("Could not get CoreDNS proxy instance UDP listening port")
 	}
 	defer proxyInstance.Stop()
 

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -25,14 +25,9 @@ func TestLookupProxy(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 
@@ -69,14 +64,9 @@ func TestLookupDnsWithForcedTcp(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	_, tcp := CoreDNSServerPorts(i, 0)
-	if tcp == "" {
-		t.Fatalf("Could not get TCP listening port")
 	}
 	defer i.Stop()
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -45,6 +45,6 @@ func send(t *testing.T, server string) {
 		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
 	}
 	if len(r.Extra) != 2 {
-		t.Fatalf("Expected 2 RRs in additional, got %d", len(r.Extra))
+		t.Fatalf("Expected 2 RRs in additional, got %s", len(r.Extra))
 	}
 }

--- a/test/reverse_test.go
+++ b/test/reverse_test.go
@@ -29,14 +29,9 @@ func TestReverseFallthrough(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 
 	log.SetOutput(ioutil.Discard)

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -19,15 +19,11 @@ func TestRewrite(t *testing.T) {
 	}
 }`
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
-	}
 	defer i.Stop()
 
 	log.SetOutput(ioutil.Discard)

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -21,14 +21,9 @@ func TestEmptySecondaryZone(t *testing.T) {
 	}
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatal("Could not get UDP listening port")
 	}
 	defer i.Stop()
 

--- a/test/server.go
+++ b/test/server.go
@@ -48,6 +48,17 @@ func CoreDNSServerPorts(i *caddy.Instance, k int) (udp, tcp string) {
 	return
 }
 
+// CoreDNSServerAndPorts combines CoreDNSServer and CoreDNSServerPorts to start a CoreDNS
+// server and returns the udp and tcp ports of the first instance.
+func CoreDNSServerAndPorts(corefile string) (i *caddy.Instance, udp, tcp string, err error) {
+	i, err = CoreDNSServer(corefile)
+	if err != nil {
+		return nil, "", "", err
+	}
+	udp, tcp = CoreDNSServerPorts(i, 0)
+	return i, udp, tcp, nil
+}
+
 // Input implements the caddy.Input interface and acts as an easy way to use a string as a Corefile.
 type Input struct {
 	corefile []byte

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -13,24 +13,21 @@ func TestProxyToChaosServer(t *testing.T) {
 	chaos CoreDNS-001 miek@miek.nl
 }
 `
-	chaos, err := CoreDNSServer(corefile)
+	chaos, udpChaos, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 
-	udpChaos, _ := CoreDNSServerPorts(chaos, 0)
 	defer chaos.Stop()
 
 	corefileProxy := `.:0 {
 		proxy . ` + udpChaos + `
 }
 `
-	proxy, err := CoreDNSServer(corefileProxy)
+	proxy, udp, _, err := CoreDNSServerAndPorts(corefileProxy)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance")
 	}
-
-	udp, _ := CoreDNSServerPorts(proxy, 0)
 	defer proxy.Stop()
 
 	chaosTest(t, udpChaos)

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -25,14 +25,9 @@ func TestLookupWildcard(t *testing.T) {
 }
 `
 
-	i, err := CoreDNSServer(corefile)
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
-
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
 


### PR DESCRIPTION
Copy from kubernetes.go and renamed to fit the style, adapted almost
all callers.

This is a mechanicl change, no testdata was changed.