### PR TITLE
core: block CH queries earlier

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	// Middleware interested in announcing that they exist, so other middleware can call methods
 	// on them should register themselves here. The name should be the name as return by the
 	// Handler's Name method.
-	Registry map[string]middleware.Handler
+	registry map[string]middleware.Handler
 }
 
 // GetConfig gets the Config that corresponds to c.

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -127,12 +127,12 @@ func (c *Config) AddMiddleware(m middleware.Middleware) {
 // registerHandler adds a handler to a site's handler registration. Handlers
 //  use this to announce that they exist to other middleware.
 func (c *Config) registerHandler(h middleware.Handler) {
-	if c.Registry == nil {
-		c.Registry = make(map[string]middleware.Handler)
+	if c.registry == nil {
+		c.registry = make(map[string]middleware.Handler)
 	}
 
 	// Just overwrite...
-	c.Registry[h.Name()] = h
+	c.registry[h.Name()] = h
 }
 
 // Handler returns the middleware handler that has been added to the config under its name.
@@ -140,10 +140,10 @@ func (c *Config) registerHandler(h middleware.Handler) {
 // Note that this is order dependent and the order is defined in directives.go, i.e. if your middleware
 // comes before the middleware you are checking; it will not be there (yet).
 func (c *Config) Handler(name string) middleware.Handler {
-	if c.Registry == nil {
+	if c.registry == nil {
 		return nil
 	}
-	if h, ok := c.Registry[name]; ok {
+	if h, ok := c.registry[name]; ok {
 		return h
 	}
 	return nil

--- a/middleware/auto/auto.go
+++ b/middleware/auto/auto.go
@@ -2,7 +2,6 @@
 package auto
 
 import (
-	"errors"
 	"regexp"
 	"time"
 
@@ -43,9 +42,6 @@ type (
 // ServeDNS implements the middleware.Handle interface.
 func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
-	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(a.Name(), errors.New("can only deal with ClassINET"))
-	}
 	qname := state.Name()
 
 	// TODO(miek): match the qname better in the map

--- a/middleware/etcd/handler.go
+++ b/middleware/etcd/handler.go
@@ -1,8 +1,6 @@
 package etcd
 
 import (
-	"errors"
-
 	"github.com/coredns/coredns/middleware"
 	"github.com/coredns/coredns/middleware/etcd/msg"
 	"github.com/coredns/coredns/middleware/pkg/debug"
@@ -17,9 +15,7 @@ import (
 func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	opt := middleware.Options{}
 	state := request.Request{W: w, Req: r}
-	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(e.Name(), errors.New("can only deal with ClassINET"))
-	}
+
 	name := state.Name()
 	if e.Debugging {
 		if bug := debug.IsDebug(name); bug != "" {

--- a/middleware/file/file.go
+++ b/middleware/file/file.go
@@ -2,7 +2,6 @@
 package file
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -32,9 +31,6 @@ type (
 func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 
-	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(f.Name(), errors.New("can only deal with ClassINET"))
-	}
 	qname := state.Name()
 	// TODO(miek): match the qname better in the map
 	zone := middleware.Zones(f.Zones.Names).Matches(qname)

--- a/middleware/hosts/hosts.go
+++ b/middleware/hosts/hosts.go
@@ -1,7 +1,6 @@
 package hosts
 
 import (
-	"errors"
 	"net"
 
 	"golang.org/x/net/context"
@@ -23,9 +22,6 @@ type Hosts struct {
 // ServeDNS implements the middleware.Handle interface.
 func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
-	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(h.Name(), errors.New("can only deal with ClassINET"))
-	}
 	qname := state.Name()
 
 	answers := []dns.RR{}

--- a/middleware/kubernetes/handler.go
+++ b/middleware/kubernetes/handler.go
@@ -1,8 +1,6 @@
 package kubernetes
 
 import (
-	"errors"
-
 	"github.com/coredns/coredns/middleware"
 	"github.com/coredns/coredns/middleware/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
@@ -14,9 +12,6 @@ import (
 // ServeDNS implements the middleware.Handler interface.
 func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
-	if state.QClass() != dns.ClassINET {
-		return dns.RcodeServerFailure, middleware.Error(k.Name(), errors.New("can only deal with ClassINET"))
-	}
 
 	m := new(dns.Msg)
 	m.SetReply(r)


### PR DESCRIPTION
block chaos queries, unless the chaos middleware is loaded. We respond
with REFUSED.

This removes the need for each middleware to do this class != ClassINET
if-then.