### PR TITLE
auto: test

### DIFF
--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -58,7 +58,7 @@ func TestAuto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(1500 * time.Millisecond) // wait for it to be picked up
 
 	resp, err = p.Lookup(state, "www.example.org.", dns.TypeA)
 	if err != nil {


### PR DESCRIPTION
Increate the sleep duration; this is not a proper fix. The problem here
is that this is in test that just starts a CoreDNS instance and thus we
don't have levers to make "time speed up". It might be worth checking if
there is some LD_PRELOAD hackery that fakes time for the entire test?

Fixes #945 (not really, but closing with this)