### PR TITLE
mw/health: call Shutdown on FinalShutdown

### DIFF
--- a/middleware/health/setup.go
+++ b/middleware/health/setup.go
@@ -47,7 +47,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(h.Startup)
-	c.OnShutdown(h.Shutdown)
+	c.OnFinalShutdown(h.Shutdown)
 
 	// Don't do AddMiddleware, as health is not *really* a middleware just a separate webserver running.
 	return nil


### PR DESCRIPTION
Reloading caddy won't kill the health handler. Only on final shutdown
we stop the handler.

Currently when reloading CoreDNS with -SIGUSR1 the health handler stops
answering - there is a test for this but it doesn't capture whole
process reloading, sadly. This PR keeps the handler alive during reloads
and only stops on process shutdown.

Fixes #979