### PR TITLE
mw/kubernetes: split integration tests

### DIFF
--- a/test/kubernetes_api_fallthrough.go
+++ b/test/kubernetes_api_fallthrough.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestKubernetesAPIFallthrough(t *testing.T) {
+	tests := []test.Case{
+		{
+			Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+			},
+		},
+	}
+
+	corefile :=
+		`.:0 {
+    kubernetes cluster.local {
+        endpoint http://nonexistance:8080,http://invalidip:8080,http://localhost:8080
+        namespaces test-1
+        pods disabled
+    }`
+
+	server, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer server.Stop()
+
+	for _, tc := range tests {
+
+		c := new(dns.Client)
+		m := tc.Msg()
+
+		res, _, err := c.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Could not send query: %s", err)
+		}
+		test.SortAndCheck(t, res, tc)
+	}
+}

--- a/test/kubernetes_api_fallthrough.go
+++ b/test/kubernetes_api_fallthrough.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
@@ -32,6 +33,9 @@ func TestKubernetesAPIFallthrough(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range tests {
 

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesAllNSExposed = []test.Case{
+	{
+		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
+		},
+	},
+	{
+		Qname: "svc-c.test-2.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc-c.test-2.svc.cluster.local.      303    IN      A       10.0.0.120"),
+		},
+	},
+}
+
+func TestKubernetesNSExposed(t *testing.T) {
+	corefile :=
+		`.:0 {
+    kubernetes cluster.local {
+                endpoint http://localhost:8080
+    }
+`
+
+	server, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer server.Stop()
+
+	for _, tc := range dnsTestCasesAllNSExposed {
+
+		c := new(dns.Client)
+		m := tc.Msg()
+
+		res, _, err := c.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Could not send query: %s", err)
+		}
+
+		test.SortAndCheck(t, res, tc)
+	}
+}

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -9,11 +9,6 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() {
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
-}
-
 var dnsTestCasesAllNSExposed = []test.Case{
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
@@ -44,6 +39,9 @@ func TestKubernetesNSExposed(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesAllNSExposed {
 

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -2,11 +2,17 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
 	"github.com/miekg/dns"
 )
+
+func init() {
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
+}
 
 var dnsTestCasesAllNSExposed = []test.Case{
 	{

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -1,0 +1,104 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+)
+
+var dnsTestCasesPodsInsecure = []test.Case{
+	{
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("10-20-0-101.test-1.pod.cluster.local. 303 IN A    10.20.0.101"),
+		},
+	},
+	{
+		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307903 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestKubernetesPodsInsecure(t *testing.T) {
+	corefile := `.:0 {
+    kubernetes cluster.local 0.0.10.in-addr.arpa {
+                endpoint http://localhost:8080
+                namespaces test-1
+                pods verified
+    }
+`
+
+	server, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer server.Stop()
+
+	for _, tc := range dnsTestCasesPodsInsecure {
+
+		c := new(dns.Client)
+		m := tc.Msg()
+
+		res, _, err := c.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Could not send query: %s", err)
+		}
+
+		test.SortAndCheck(t, res, tc)
+	}
+}
+
+var dnsTestCasesPodsVerified = []test.Case{
+	{
+		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502308197 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode:  dns.RcodeNameError,
+		Answer: []dns.RR{},
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307960 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestKubernetesPodsVerified(t *testing.T) {
+	corefile := `.:0 {
+    kubernetes cluster.local 0.0.10.in-addr.arpa {
+                endpoint http://localhost:8080
+                namespaces test-1
+                pods verified
+    }
+`
+
+	server, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer server.Stop()
+
+	for _, tc := range dnsTestCasesPodsVerified {
+
+		c := new(dns.Client)
+		m := tc.Msg()
+
+		res, _, err := c.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Could not send query: %s", err)
+		}
+
+		test.SortAndCheck(t, res, tc)
+	}
+}

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
@@ -39,6 +40,9 @@ func TestKubernetesPodsInsecure(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesPodsInsecure {
 
@@ -85,6 +89,9 @@ func TestKubernetesPodsVerified(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesPodsVerified {
 

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -18,8 +18,7 @@ var dnsTestCasesPodsInsecure = []test.Case{
 	},
 	{
 		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307903 7200 1800 86400 60"),
 		},
@@ -31,7 +30,7 @@ func TestKubernetesPodsInsecure(t *testing.T) {
     kubernetes cluster.local 0.0.10.in-addr.arpa {
                 endpoint http://localhost:8080
                 namespaces test-1
-                pods verified
+                pods insecure
     }
 `
 
@@ -58,16 +57,14 @@ func TestKubernetesPodsInsecure(t *testing.T) {
 var dnsTestCasesPodsVerified = []test.Case{
 	{
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502308197 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307960 7200 1800 86400 60"),
 		},

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
@@ -581,9 +580,6 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range testCases {
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -33,24 +33,21 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "bogusendpoint.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "bogusendpoint.headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -71,16 +68,14 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "bogusservice.*.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "bogusservice.any.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -109,16 +104,14 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "any.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "*.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -152,8 +145,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*.*.bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -182,16 +174,14 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*.*.bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "*.*.bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -221,16 +211,14 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*.*.any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
 	},
 	{
 		Qname: "*.*.*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -255,8 +243,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502313310 7200 1800 86400 60"),
 		},
@@ -274,8 +261,7 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeServerFailure,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeServerFailure,
 	},
 	{
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
@@ -311,24 +297,21 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	 303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "bogusendpoint.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "bogusendpoint.headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -349,16 +332,14 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "bogusservice.*.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "bogusservice.any.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -387,16 +368,14 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "any.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "*.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -430,8 +409,7 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "*.*.bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -460,16 +438,14 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "*.*.bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "*.*.bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -500,16 +476,14 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "*.*.any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
 	},
 	{
 		Qname: "*.*.*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -534,8 +508,7 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
 		},
@@ -698,7 +671,7 @@ func TestKubernetesIntegrationFallthrough(t *testing.T) {
 	doIntegrationTests(t, corefile, dnsTestCasesFallthrough)
 }
 
-//headlessAResponse returns the answer to an A request for the specific name and namespace
+// headlessAResponse returns the answer to an A request for the specific name and namespace.
 func headlessAResponse(qname, namespace, name string) []dns.RR {
 	rr := []dns.RR{}
 
@@ -716,7 +689,7 @@ func headlessAResponse(qname, namespace, name string) []dns.RR {
 }
 
 // srvResponse returns the answer to a SRV request for the specific name and namespace
-// qtype is the type of answer to generate, eg: TypeSRV ( for answer section) or TypeA (for extra section)
+// qtype is the type of answer to generate, eg: TypeSRV (for answer section) or TypeA (for extra section).
 func srvResponse(qname string, qtype uint16, namespace, name string) []dns.RR {
 	rr := []dns.RR{}
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/middleware/test"
 
@@ -580,6 +581,9 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	// Work-around for timing condition that results in no-data being returned in test environment.
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range testCases {
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -23,8 +23,6 @@ func init() {
 	log.SetOutput(ioutil.Discard)
 }
 
-// Test data
-
 var dnsTestCases = []test.Case{
 	{
 		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
@@ -201,10 +199,10 @@ var dnsTestCases = []test.Case{
 	{
 		Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
-		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", "TypeSRV", "headless-svc", "test-1"),
+		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeSRV, "headless-svc", "test-1"),
 			[]dns.RR{
 				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 33 1234 svc-c.test-1.svc.cluster.local.")}...),
-		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", "TypeA", "headless-svc", "test-1"),
+		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeA, "headless-svc", "test-1"),
 			[]dns.RR{
 				test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.0.0.115")}...),
 	},
@@ -252,8 +250,8 @@ var dnsTestCases = []test.Case{
 	{
 		Qname: "*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode:  dns.RcodeSuccess,
-		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", "TypeSRV", "svc-1-a", "test-1"),
-		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", "TypeA", "svc-1-a", "test-1"),
+		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeSRV, "svc-1-a", "test-1"),
+		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeA, "svc-1-a", "test-1"),
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
@@ -299,60 +297,6 @@ var dnsTestCases = []test.Case{
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
-		},
-	},
-}
-
-var dnsTestCasesPodsInsecure = []test.Case{
-	{
-		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("10-20-0-101.test-1.pod.cluster.local. 303 IN A    10.20.0.101"),
-		},
-	},
-	{
-		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307903 7200 1800 86400 60"),
-		},
-	},
-}
-
-var dnsTestCasesPodsVerified = []test.Case{
-	{
-		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502308197 7200 1800 86400 60"),
-		},
-	},
-	{
-		Qname: "10-20-0-101.test-X.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1502307960 7200 1800 86400 60"),
-		},
-	},
-}
-
-var dnsTestCasesAllNSExposed = []test.Case{
-	{
-		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-		},
-	},
-	{
-		Qname: "svc-c.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-c.test-2.svc.cluster.local.      303    IN      A       10.0.0.120"),
 		},
 	},
 }
@@ -533,10 +477,10 @@ var dnsTestCasesFallthrough = []test.Case{
 	{
 		Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
-		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", "TypeSRV", "headless-svc", "test-1"),
+		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeSRV, "headless-svc", "test-1"),
 			[]dns.RR{
 				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 33 1234 svc-c.test-1.svc.cluster.local.")}...),
-		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", "TypeA", "headless-svc", "test-1"),
+		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeA, "headless-svc", "test-1"),
 			[]dns.RR{
 				test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.0.0.115"),
 			}...),
@@ -585,8 +529,8 @@ var dnsTestCasesFallthrough = []test.Case{
 	{
 		Qname: "*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode:  dns.RcodeSuccess,
-		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", "TypeSRV", "svc-1-a", "test-1"),
-		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", "TypeA", "svc-1-a", "test-1"),
+		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeSRV, "svc-1-a", "test-1"),
+		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeA, "svc-1-a", "test-1"),
 	},
 	{
 		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
@@ -654,16 +598,6 @@ var dnsTestCasesFallthrough = []test.Case{
 		Ns: []dns.RR{
 			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
 			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
-		},
-	},
-}
-
-var dnsTestCasesAPIProxy = []test.Case{
-	{
-		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
 		},
 	},
 }
@@ -737,61 +671,6 @@ func TestKubernetesIntegration(t *testing.T) {
 	doIntegrationTests(t, corefile, dnsTestCases)
 }
 
-func TestKubernetesIntegrationAPIProxy(t *testing.T) {
-
-	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
-	defer upstreamServer.Stop()
-	defer removeUpstreamConfig()
-
-	corefile :=
-		`.:0 {
-    kubernetes cluster.local 0.0.10.in-addr.arpa {
-        endpoint http://nonexistance:8080,http://invalidip:8080,http://localhost:8080
-        namespaces test-1
-        pods disabled
-        upstream ` + udp + `
-    }
-    erratic . {
-        drop 0
-    }
-`
-	doIntegrationTests(t, corefile, dnsTestCasesAPIProxy)
-}
-
-func TestKubernetesIntegrationPodsInsecure(t *testing.T) {
-	corefile :=
-		`.:0 {
-    kubernetes cluster.local 0.0.10.in-addr.arpa {
-                endpoint http://localhost:8080
-		namespaces test-1
-		pods insecure
-    }
-`
-	doIntegrationTests(t, corefile, dnsTestCasesPodsInsecure)
-}
-
-func TestKubernetesIntegrationPodsVerified(t *testing.T) {
-	corefile :=
-		`.:0 {
-    kubernetes cluster.local 0.0.10.in-addr.arpa {
-                endpoint http://localhost:8080
-                namespaces test-1
-                pods verified
-    }
-`
-	doIntegrationTests(t, corefile, dnsTestCasesPodsVerified)
-}
-
-func TestKubernetesIntegrationAllNSExposed(t *testing.T) {
-	corefile :=
-		`.:0 {
-    kubernetes cluster.local {
-                endpoint http://localhost:8080
-    }
-`
-	doIntegrationTests(t, corefile, dnsTestCasesAllNSExposed)
-}
-
 func TestKubernetesIntegrationFallthrough(t *testing.T) {
 	dbfile, rmFunc, err := TempFile(os.TempDir(), clusterLocal)
 	if err != nil {
@@ -837,8 +716,8 @@ func headlessAResponse(qname, namespace, name string) []dns.RR {
 }
 
 // srvResponse returns the answer to a SRV request for the specific name and namespace
-// responsetype is the type of answer to generate, eg: TypeSRV ( for answer section) or TypeA (for extra section)
-func srvResponse(qname, responsetype, namespace, name string) []dns.RR {
+// qtype is the type of answer to generate, eg: TypeSRV ( for answer section) or TypeA (for extra section)
+func srvResponse(qname string, qtype uint16, namespace, name string) []dns.RR {
 	rr := []dns.RR{}
 
 	str, err := endpointIPs(name, namespace)
@@ -852,15 +731,17 @@ func srvResponse(qname, responsetype, namespace, name string) []dns.RR {
 	for i := 0; i < lr; i++ {
 		ip := strings.Replace(result[i], ".", "-", -1)
 		t := strconv.Itoa(100 / (lr + 1))
-		if responsetype == "TypeA" {
+
+		switch qtype {
+		case dns.TypeA:
 			rr = append(rr, test.A(ip+"."+namespace+"."+name+".svc.cluster.local.	303	IN	A	"+result[i]))
-		}
-		if responsetype == "TypeSRV" && namespace == "headless-svc" {
-			rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 1234  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
-		}
-		if responsetype == "TypeSRV" && namespace != "headless-svc" {
-			rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 443  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
-			rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 80  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
+		case dns.TypeSRV:
+			if namespace == "headless-svc" {
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 1234  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
+			} else {
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 443  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
+				rr = append(rr, test.SRV(qname+"   303    IN    SRV 0 "+t+" 80  "+ip+"."+namespace+"."+name+".svc.cluster.local."))
+			}
 		}
 	}
 	return rr


### PR DESCRIPTION
* separate file and test for api fallthrough, does not need all other
  servers to be started.
* more split ups: make it clear when or when not we need an upstream server,
  as just needlessly start it in doIntegrationTests.