### PR TITLE
mw/kubernetes: improve cname handling

### DIFF
--- a/middleware/kubernetes/handler_pod_disabled_test.go
+++ b/middleware/kubernetes/handler_pod_disabled_test.go
@@ -10,23 +10,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-var podModeDisabledCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
+var podModeDisabledCases = []test.Case{
+	{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Error:  errPodsDisabled,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
+		Error: errPodsDisabled,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
-
-	"A Record Pod mode = Case 2": {
+	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Error:  errPodsDisabled,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
+		Error: errPodsDisabled,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -41,14 +37,14 @@ func TestServeDNSModeDisabled(t *testing.T) {
 	k.podMode = podModeDisabled
 	ctx := context.TODO()
 
-	for testname, tc := range podModeDisabledCases {
+	for i, tc := range podModeDisabledCases {
 		r := tc.Msg()
 
 		w := dnsrecorder.New(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
 		if err != tc.Error {
-			t.Errorf("%v expected no error, got %v\n", testname, err)
+			t.Errorf("Test %d expected no error, got %v\n", i, err)
 			return
 		}
 		if tc.Error != nil {
@@ -57,7 +53,7 @@ func TestServeDNSModeDisabled(t *testing.T) {
 
 		resp := w.Msg
 		if resp == nil {
-			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+			t.Fatalf("Test %d, got nil message and no error for: %s %d", i, r.Question[0].Name, r.Question[0].Qtype)
 		}
 
 		test.SortAndCheck(t, resp, tc)

--- a/middleware/kubernetes/handler_pod_insecure_test.go
+++ b/middleware/kubernetes/handler_pod_insecure_test.go
@@ -10,17 +10,15 @@ import (
 	"golang.org/x/net/context"
 )
 
-var podModeInsecureCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
+var podModeInsecureCases = []test.Case{
+	{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
 		},
 	},
-
-	"A Record Pod mode = Case 2": {
+	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
@@ -37,14 +35,14 @@ func TestServeDNSModeInsecure(t *testing.T) {
 	ctx := context.TODO()
 	k.podMode = podModeInsecure
 
-	for testname, tc := range podModeInsecureCases {
+	for i, tc := range podModeInsecureCases {
 		r := tc.Msg()
 
 		w := dnsrecorder.New(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
 		if err != tc.Error {
-			t.Errorf("%v expected no error, got %v\n", testname, err)
+			t.Errorf("Test %d, expected no error, got %v\n", i, err)
 			return
 		}
 		if tc.Error != nil {
@@ -53,7 +51,7 @@ func TestServeDNSModeInsecure(t *testing.T) {
 
 		resp := w.Msg
 		if resp == nil {
-			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+			t.Fatalf("Test %d, got nil message and no error for: %s %d", i, r.Question[0].Name, r.Question[0].Qtype)
 		}
 
 		test.SortAndCheck(t, resp, tc)

--- a/middleware/kubernetes/handler_pod_verified_test.go
+++ b/middleware/kubernetes/handler_pod_verified_test.go
@@ -10,20 +10,17 @@ import (
 	"golang.org/x/net/context"
 )
 
-var podModeVerifiedCases = map[string](test.Case){
-
-	"A Record Pod mode = Case 1": {
+var podModeVerifiedCases = []test.Case{
+	{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
 			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
 		},
 	},
-
-	"A Record Pod mode = Case 2": {
+	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeNameError,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -38,14 +35,14 @@ func TestServeDNSModeVerified(t *testing.T) {
 	ctx := context.TODO()
 	k.podMode = podModeVerified
 
-	for testname, tc := range podModeVerifiedCases {
+	for i, tc := range podModeVerifiedCases {
 		r := tc.Msg()
 
 		w := dnsrecorder.New(&test.ResponseWriter{})
 
 		_, err := k.ServeDNS(ctx, w, r)
 		if err != tc.Error {
-			t.Errorf("%v expected no error, got %v\n", testname, err)
+			t.Errorf("Test %d, expected no error, got %v\n", i, err)
 			return
 		}
 		if tc.Error != nil {
@@ -54,7 +51,7 @@ func TestServeDNSModeVerified(t *testing.T) {
 
 		resp := w.Msg
 		if resp == nil {
-			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
+			t.Fatalf("Test %d, got nil message and no error for: %s %d", i, r.Question[0].Name, r.Question[0].Qtype)
 		}
 
 		test.SortAndCheck(t, resp, tc)

--- a/middleware/kubernetes/handler_test.go
+++ b/middleware/kubernetes/handler_test.go
@@ -159,9 +159,6 @@ func TestServeDNS(t *testing.T) {
 			t.Fatalf("got nil message and no error for %q: %s %d", testname, r.Question[0].Name, r.Question[0].Qtype)
 		}
 
-		// Before sorting, make sure that CNAMES do not appear after their target records
-		test.CNAMEOrder(t, resp)
-
 		test.SortAndCheck(t, resp, tc)
 	}
 }

--- a/test/kubernetes_api_fallthrough.go
+++ b/test/kubernetes_api_fallthrough.go
@@ -37,14 +37,14 @@ func TestKubernetesAPIFallthrough(t *testing.T) {
 	// Work-around for timing condition that results in no-data being returned in test environment.
 	time.Sleep(3 * time.Second)
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 
 		c := new(dns.Client)
 		m := tc.Msg()
 
 		res, _, err := c.Exchange(m, udp)
 		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
+			t.Fatalf("Test %d, could not send query: %s", i, err)
 		}
 		test.SortAndCheck(t, res, tc)
 	}

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -43,14 +43,14 @@ func TestKubernetesNSExposed(t *testing.T) {
 	// Work-around for timing condition that results in no-data being returned in test environment.
 	time.Sleep(3 * time.Second)
 
-	for _, tc := range dnsTestCasesAllNSExposed {
+	for i, tc := range dnsTestCasesAllNSExposed {
 
 		c := new(dns.Client)
 		m := tc.Msg()
 
 		res, _, err := c.Exchange(m, udp)
 		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
+			t.Fatalf("Test %d, could not send query: %s", i, err)
 		}
 
 		test.SortAndCheck(t, res, tc)

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -93,14 +93,14 @@ func TestKubernetesPodsVerified(t *testing.T) {
 	// Work-around for timing condition that results in no-data being returned in test environment.
 	time.Sleep(3 * time.Second)
 
-	for _, tc := range dnsTestCasesPodsVerified {
+	for i, tc := range dnsTestCasesPodsVerified {
 
 		c := new(dns.Client)
 		m := tc.Msg()
 
 		res, _, err := c.Exchange(m, udp)
 		if err != nil {
-			t.Fatalf("Could not send query: %s", err)
+			t.Fatalf("Test %d, could not send query: %s", i, err)
 		}
 
 		test.SortAndCheck(t, res, tc)

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -526,8 +526,7 @@ var dnsTestCasesFallthrough = []test.Case{
 	},
 	{
 		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeServerFailure,
-		Answer: []dns.RR{},
+		Rcode: dns.RcodeServerFailure,
 	},
 	{
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,


### PR DESCRIPTION
Remove filtering for external services and when we encounter a CNAME in the resolution process only put that one record in the response.

Possibly fixes: #950 #984
