### PR TITLE
mw/kubernetes: move fallthrough tests out

### DIFF
--- a/test/kubernetes_fallthrough_test.go
+++ b/test/kubernetes_fallthrough_test.go
@@ -1,0 +1,75 @@
+// +build k8s
+
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/coredns/coredns/middleware/test"
+
+	"github.com/miekg/dns"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+var dnsTestCasesFallthrough = []test.Case{
+	{
+		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("example.net.		303	IN	A	13.14.15.16"),
+			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
+		},
+	},
+	{
+		Qname: "f.b.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("f.b.svc.cluster.local.      303    IN      A       10.10.10.11"),
+		},
+		Ns: []dns.RR{
+			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
+			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
+		},
+	},
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("foo.cluster.local.      303    IN      A       10.10.10.10"),
+		},
+		Ns: []dns.RR{
+			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
+			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
+		},
+	},
+}
+
+func TestKubernetesFallthrough(t *testing.T) {
+	dbfile, rmFunc, err := TempFile(os.TempDir(), clusterLocal)
+	if err != nil {
+		t.Fatalf("Could not create zonefile for fallthrough server: %s", err)
+	}
+	defer rmFunc()
+
+	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
+	defer upstreamServer.Stop()
+	defer removeUpstreamConfig()
+
+	corefile :=
+		`.:0 {
+    file ` + dbfile + ` cluster.local
+    kubernetes cluster.local {
+                endpoint http://localhost:8080
+		namespaces test-1
+		upstream ` + udp + `
+		fallthrough
+    }
+`
+	doIntegrationTests(t, corefile, dnsTestCasesFallthrough)
+}

--- a/test/kubernetes_fallthrough_test.go
+++ b/test/kubernetes_fallthrough_test.go
@@ -57,9 +57,9 @@ func TestKubernetesFallthrough(t *testing.T) {
 	}
 	defer rmFunc()
 
-	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
-	defer upstreamServer.Stop()
-	defer removeUpstreamConfig()
+	rmFunc, upstream, udp := upstreamServer(t)
+	defer upstream.Stop()
+	defer rmFunc()
 
 	corefile :=
 		`.:0 {

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -270,309 +270,6 @@ var dnsTestCases = []test.Case{
 			test.TXT(`dns-version.cluster.local. 303 IN TXT "1.0.1"`),
 		},
 	},
-	{
-		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("example.net.		303	IN	A	13.14.15.16"),
-			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
-		},
-	},
-	{
-		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeCNAME,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
-		},
-	},
-}
-
-var dnsTestCasesFallthrough = []test.Case{
-	{
-		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-		},
-	},
-	{
-		Qname: "bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	 303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "bogusendpoint.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "bogusendpoint.headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-1-a.*.svc.cluster.local.      303    IN      A       10.0.0.100"),
-		},
-	},
-	{
-		Qname: "svc-1-a.any.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("svc-1-a.any.svc.cluster.local.      303    IN      A       10.0.0.100"),
-		},
-	},
-	{
-		Qname: "bogusservice.*.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "bogusservice.any.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: append([]dns.RR{
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
-			test.A("*.test-1.svc.cluster.local.      303    IN      A       10.0.0.115"),
-			test.CNAME("*.test-1.svc.cluster.local.  303    IN	     CNAME	  example.net."),
-			test.A("example.net.		303	IN	A	13.14.15.16"),
-		}, headlessAResponse("*.test-1.svc.cluster.local.", "headless-svc", "test-1")...),
-	},
-	{
-		Qname: "any.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: append([]dns.RR{
-			test.A("any.test-1.svc.cluster.local.      303    IN      A       10.0.0.100"),
-			test.A("any.test-1.svc.cluster.local.      303    IN      A       10.0.0.110"),
-			test.A("any.test-1.svc.cluster.local.      303    IN      A       10.0.0.115"),
-			test.CNAME("any.test-1.svc.cluster.local.  303    IN	     CNAME	  example.net."),
-			test.A("example.net.		303	IN	A	13.14.15.16"),
-		}, headlessAResponse("any.test-1.svc.cluster.local.", "headless-svc", "test-1")...),
-	},
-	{
-		Qname: "any.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.test-2.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.*.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: append([]dns.RR{
-			test.A("*.*.svc.cluster.local.      303    IN      A       10.0.0.100"),
-			test.A("*.*.svc.cluster.local.      303    IN      A       10.0.0.110"),
-			test.A("*.*.svc.cluster.local.      303    IN      A       10.0.0.115"),
-			test.CNAME("*.*.svc.cluster.local.  303    IN	     CNAME	  example.net."),
-			test.A("example.net.		303	IN	A	13.14.15.16"),
-		}, headlessAResponse("*.*.svc.cluster.local.", "headless-svc", "test-1")...),
-	},
-	{
-		Qname: "headless-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeSuccess,
-		Answer: headlessAResponse("headless-svc.test-1.svc.cluster.local.", "headless-svc", "test-1"),
-	},
-	{
-		Qname: "*._TcP.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("*._TcP.svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	 0  50  443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("*._TcP.svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	 0  50   80 svc-1-a.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-		},
-	},
-	{
-		Qname: "*.*.bogusservice.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.any.svc-1-a.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("*.any.svc-1-a.*.svc.cluster.local.      303    IN    SRV 0 50 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("*.any.svc-1-a.*.svc.cluster.local.      303    IN    SRV 0 50  80 svc-1-a.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-		},
-	},
-	{
-		Qname: "ANY.*.svc-1-a.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("ANY.*.svc-1-a.any.svc.cluster.local.      303    IN    SRV 0 50 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("ANY.*.svc-1-a.any.svc.cluster.local.      303    IN    SRV 0 50  80 svc-1-a.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-		},
-	},
-	{
-		Qname: "*.*.bogusservice.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.*.bogusservice.any.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "_c-port._UDP.*.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeSRV, "headless-svc", "test-1"),
-			[]dns.RR{
-				test.SRV("_c-port._UDP.*.test-1.svc.cluster.local.      303    IN    SRV 0 33 1234 svc-c.test-1.svc.cluster.local.")}...),
-		Extra: append(srvResponse("_c-port._UDP.*.test-1.svc.cluster.local.", dns.TypeA, "headless-svc", "test-1"),
-			[]dns.RR{
-				test.A("svc-c.test-1.svc.cluster.local.	303	IN	A	10.0.0.115"),
-			}...),
-	},
-	{
-		Qname: "*._tcp.any.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33  80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("*._tcp.any.test-1.svc.cluster.local.      303    IN    SRV 0 33  80 svc-1-b.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
-		},
-	},
-	{
-		Qname: "*.*.any.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "*.*.*.test-2.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "_http._tcp.*.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("_http._tcp.*.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("_http._tcp.*.*.svc.cluster.local.      303    IN    SRV 0 50 80 svc-1-b.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-			test.A("svc-1-b.test-1.svc.cluster.local.	303	IN	A	10.0.0.110"),
-		},
-	},
-	{
-		Qname: "*.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode:  dns.RcodeSuccess,
-		Answer: srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeSRV, "svc-1-a", "test-1"),
-		Extra:  srvResponse("*.svc-1-a.test-1.svc.cluster.local.", dns.TypeA, "svc-1-a", "test-1"),
-	},
-	{
-		Qname: "*._not-udp-or-tcp.svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	303	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600"),
-		},
-	},
-	{
-		Qname: "svc-1-a.test-1.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.SRV("svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	0 50 443 svc-1-a.test-1.svc.cluster.local."),
-			test.SRV("svc-1-a.test-1.svc.cluster.local.	303	IN	SRV	0 50 80 svc-1-a.test-1.svc.cluster.local."),
-		},
-		Extra: []dns.RR{
-			test.A("svc-1-a.test-1.svc.cluster.local.	303	IN	A	10.0.0.100"),
-		},
-	},
-	{
-		Qname: "10-20-0-101.test-1.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode:  dns.RcodeServerFailure,
-		Answer: []dns.RR{},
-	},
-	{
-		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.TXT("dns-version.cluster.local. 28800 IN TXT \"1.0.1\""),
-		},
-	},
-	{
-		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("example.net.		303	IN	A	13.14.15.16"),
-			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
-		},
-	},
-	{
-		Qname: "ext-svc.test-1.svc.cluster.local.", Qtype: dns.TypeCNAME,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.CNAME("ext-svc.test-1.svc.cluster.local. 303 IN	CNAME	example.net."),
-		},
-	},
-	{
-		Qname: "f.b.svc.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("f.b.svc.cluster.local.      303    IN      A       10.10.10.11"),
-		},
-		Ns: []dns.RR{
-			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
-			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
-		},
-	},
-	{
-		Qname: "foo.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeSuccess,
-		Answer: []dns.RR{
-			test.A("foo.cluster.local.      303    IN      A       10.10.10.10"),
-		},
-		Ns: []dns.RR{
-			test.NS("cluster.local.	303	IN	NS	a.iana-servers.net."),
-			test.NS("cluster.local.	303	IN	NS	b.iana-servers.net."),
-		},
-	},
 }
 
 func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
@@ -605,29 +302,26 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 	}
 }
 
-func createUpstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
-	upfile, rmfile, err := TempFile(os.TempDir(), exampleNet)
+func UpstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
+	upfile, rmFunc, err := TempFile(os.TempDir(), exampleNet)
 	if err != nil {
 		t.Fatalf("Could not create file for CNAME upstream lookups: %s", err)
 	}
-	upstreamServerCorefile := `.:0 {
+	upstreamCorefile := `.:0 {
     file ` + upfile + ` example.net
-	erratic . {
-		drop 0
-	}
-	`
-	server, udp, _, err := CoreDNSServerAndPorts(upstreamServerCorefile)
+`
+	server, udp, _, err := CoreDNSServerAndPorts(upstreamCorefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
-	return rmfile, server, udp
+	return rmFunc, server, udp
 }
 
-func TestKubernetesIntegration(t *testing.T) {
+func TestKubernetes(t *testing.T) {
 
-	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
-	defer upstreamServer.Stop()
-	defer removeUpstreamConfig()
+	rmFunc, upstream, udp := createUpstreamServer(t)
+	defer upstream.Stop()
+	defer rmFunc()
 
 	corefile :=
 		`.:0 {
@@ -637,38 +331,8 @@ func TestKubernetesIntegration(t *testing.T) {
 		pods disabled
 		upstream ` + udp + `
     }
-	erratic . {
-		drop 0
-	}
 `
 	doIntegrationTests(t, corefile, dnsTestCases)
-}
-
-func TestKubernetesIntegrationFallthrough(t *testing.T) {
-	dbfile, rmFunc, err := TempFile(os.TempDir(), clusterLocal)
-	if err != nil {
-		t.Fatalf("Could not create TempFile for fallthrough: %s", err)
-	}
-	defer rmFunc()
-
-	removeUpstreamConfig, upstreamServer, udp := createUpstreamServer(t)
-	defer upstreamServer.Stop()
-	defer removeUpstreamConfig()
-
-	corefile :=
-		`.:0 {
-    file ` + dbfile + ` cluster.local
-    kubernetes cluster.local {
-                endpoint http://localhost:8080
-		namespaces test-1
-		upstream ` + udp + `
-		fallthrough
-    }
-    erratic {
-	drop 0
-    }
-`
-	doIntegrationTests(t, corefile, dnsTestCasesFallthrough)
 }
 
 // headlessAResponse returns the answer to an A request for the specific name and namespace.

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -302,7 +302,7 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 	}
 }
 
-func UpstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
+func upstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
 	upfile, rmFunc, err := TempFile(os.TempDir(), exampleNet)
 	if err != nil {
 		t.Fatalf("Could not create file for CNAME upstream lookups: %s", err)
@@ -319,7 +319,7 @@ func UpstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
 
 func TestKubernetes(t *testing.T) {
 
-	rmFunc, upstream, udp := createUpstreamServer(t)
+	rmFunc, upstream, udp := upstreamServer(t)
 	defer upstream.Stop()
 	defer rmFunc()
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -309,7 +309,7 @@ func upstreamServer(t *testing.T) (func(), *caddy.Instance, string) {
 	}
 	upstreamCorefile := `.:0 {
     file ` + upfile + ` example.net
-`
+}`
 	server, udp, _, err := CoreDNSServerAndPorts(upstreamCorefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)


### PR DESCRIPTION
Remove the testcase duplication and put fallthrough tests in separate
file.