### PR TITLE
Add k8s tags to related tests

### DIFF
--- a/middleware/dnstap/msg/msg.go
+++ b/middleware/dnstap/msg/msg.go
@@ -65,9 +65,8 @@ func (d *Data) HostPort(addr string) error {
 			d.SocketFam = tap.SocketFamily_INET6
 		}
 		return nil
-	} else {
-		return errors.New("not an ip address")
 	}
+	return errors.New("not an ip address")
 }
 
 // RemoteAddr parses the information about the remote address into Data.

--- a/middleware/dnstap/out/tcp_test.go
+++ b/middleware/dnstap/out/tcp_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func sendOneTcp(tcp *TCP) error {
+func sendOneTCP(tcp *TCP) error {
 	if _, err := tcp.Write([]byte("frame")); err != nil {
 		return err
 	}
@@ -14,10 +14,10 @@ func sendOneTcp(tcp *TCP) error {
 	}
 	return nil
 }
-func TestTcp(t *testing.T) {
+func TestTCP(t *testing.T) {
 	tcp := NewTCP("localhost:14000")
 
-	if err := sendOneTcp(tcp); err == nil {
+	if err := sendOneTCP(tcp); err == nil {
 		t.Fatal("Not listening but no error.")
 		return
 	}
@@ -34,7 +34,7 @@ func TestTcp(t *testing.T) {
 		wait <- true
 	}()
 
-	if err := sendOneTcp(tcp); err != nil {
+	if err := sendOneTCP(tcp); err != nil {
 		t.Fatalf("send one: %s", err)
 		return
 	}
@@ -44,7 +44,7 @@ func TestTcp(t *testing.T) {
 	// TODO: When the server isn't responding according to the framestream protocol
 	// the thread is blocked.
 	/*
-		if err := sendOneTcp(tcp); err == nil {
+		if err := sendOneTCP(tcp); err == nil {
 			panic("must fail")
 		}
 	*/
@@ -54,7 +54,7 @@ func TestTcp(t *testing.T) {
 		wait <- true
 	}()
 
-	if err := sendOneTcp(tcp); err != nil {
+	if err := sendOneTCP(tcp); err != nil {
 		t.Fatalf("send one: %s", err)
 		return
 	}

--- a/middleware/kubernetes/federation.go
+++ b/middleware/kubernetes/federation.go
@@ -30,6 +30,9 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 		return msg.Service{}, err
 	}
 	r, err := parseRequest(state)
+	if err != nil {
+		return msg.Service{}, err
+	}
 
 	lz := node.Labels[LabelZone]
 	lr := node.Labels[LabelRegion]

--- a/test/health_reload_test.go
+++ b/test/health_reload_test.go
@@ -42,6 +42,9 @@ func TestHealthReload(t *testing.T) {
 		t.Fatalf("Could not get health: %s", err)
 	}
 	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Could not get resp.Body: %s", err)
+	}
 	if x := string(body); x != "OK" {
 		t.Fatalf("Expect OK, got %s", x)
 	}

--- a/test/kubernetes_api_fallthrough_test.go
+++ b/test/kubernetes_api_fallthrough_test.go
@@ -1,3 +1,5 @@
+// +build k8s
+
 package test
 
 import (

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -1,3 +1,5 @@
+// +build k8s
+
 package test
 
 import (

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -1,3 +1,5 @@
+// +build k8s
+
 package test
 
 import (


### PR DESCRIPTION
Add `k8s` tags to related tests, so that `make test` from local command will pass by default.

Also fixed several ineffassign and golint issues.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>