### PR TITLE
mw/autopath: correct type for type switch

### DIFF
--- a/middleware/autopath/setup.go
+++ b/middleware/autopath/setup.go
@@ -28,12 +28,11 @@ func setup(c *caddy.Controller) error {
 
 	// Do this in OnStartup, so all middleware has been initialized.
 	c.OnStartup(func() error {
-		// TODO(miek): fabricate test to proof this is not thread safe.
 		m := dnsserver.GetConfig(c).Handler(mw)
 		if m == nil {
 			return nil
 		}
-		if x, ok := m.(kubernetes.Kubernetes); ok {
+		if x, ok := m.(*kubernetes.Kubernetes); ok {
 			ap.searchFunc = x.AutoPath
 		}
 		if x, ok := m.(*erratic.Erratic); ok {

--- a/middleware/federation/setup.go
+++ b/middleware/federation/setup.go
@@ -38,7 +38,7 @@ func setup(c *caddy.Controller) error {
 
 	dnsserver.GetConfig(c).AddMiddleware(func(next middleware.Handler) middleware.Handler {
 		fed.Next = next
-		return nil
+		return fed
 	})
 
 	return nil

--- a/middleware/federation/setup.go
+++ b/middleware/federation/setup.go
@@ -30,7 +30,7 @@ func setup(c *caddy.Controller) error {
 		if m == nil {
 			return nil
 		}
-		if x, ok := m.(kubernetes.Kubernetes); ok {
+		if x, ok := m.(*kubernetes.Kubernetes); ok {
 			fed.Federations = x.Federations
 		}
 		return nil


### PR DESCRIPTION
Use pointer to kubernetes as that is what is registered. Fix up
federation which had the same mistake.

Fixes #1025 