### PR TITLE
mw/errors: doc

### DIFF
--- a/middleware/errors/README.md
+++ b/middleware/errors/README.md
@@ -2,26 +2,21 @@
 
 *errors* enables error logging.
 
-Any errors encountered during the query processing will be printed on standard output.
+Any errors encountered during the query processing will be printed to standard output.
 
 ## Syntax
-
-~~~
-errors [FILE]
-~~~
-
-* **FILE** is the log file to create (or append to). The *only* valid name for **FILE** is *stdout*
-
-## Examples
-
-Log errors to *stdout*.
 
 ~~~
 errors
 ~~~
 
-Log errors to *stdout*.
+## Examples
 
-~~~
-errors stdout
+Use the *whoami* to respond to queries and Log errors to standard output.
+
+~~~ corefile
+. {
+    whoami
+    errors
+}
 ~~~


### PR DESCRIPTION
Remove the [FILE] option from the docs, we still allow it, but this one
value that we allow now *stdout* isn't shown anymore.

Also test the snippet with readme_test.go by adding `~~ corefile`.

Fixes #1052