### PR TITLE
Add inline support for middleware/hosts

### DIFF
--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -11,6 +11,7 @@ available hosts files that block access to advertising servers.
 
 ~~~
 hosts [FILE [ZONES...]] {
+    [INLINE]
     fallthrough
 }
 ~~~
@@ -18,7 +19,10 @@ hosts [FILE [ZONES...]] {
 * **FILE** the hosts file to read and parse. If the path is relative the path from the *root*
   directive will be prepended to it. Defaults to /etc/hosts if omitted
 * **ZONES** zones it should be authoritative for. If empty, the zones from the configuration block
-    are used.
+   are used.
+* **INLINE** the hosts file contents inlined in Corefile. If there are any lines before fallthrough
+   then all of them will be treated as the additional content for hosts file. The specified hosts
+   file path will still be read but entries will be overrided.
 * `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
 
 ## Examples
@@ -40,6 +44,15 @@ next plugin if query doesn't match.
 
 ~~~
 hosts example.hosts example.org example.net {
+    fallthrough
+}
+~~~
+
+Load hosts file inlined in Corefile.
+
+~~~
+hosts example.hosts example.org {
+    10.0.0.1 example.org
     fallthrough
 }
 ~~~

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
@@ -80,6 +81,11 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 				}
 				return h, c.ArgErr()
 			default:
+				if !h.Fallthrough {
+					line := strings.Join(append([]string{c.Val()}, c.RemainingArgs()...), " ")
+					h.inline = append(h.inline, line)
+					continue
+				}
 				return h, c.Errf("unknown property '%s'", c.Val())
 			}
 		}

--- a/test/hosts_file_test.go
+++ b/test/hosts_file_test.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestHostsInlineLookup(t *testing.T) {
+	corefile := `example.org:0 {
+                       hosts highly_unlikely_to_exist_hosts_file example.org {
+                         10.0.0.1 example.org
+                         fallthrough
+                      }	
+                    }`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	log.SetOutput(ioutil.Discard)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "example.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect answer section with A record in it
+	if len(resp.Answer) == 0 {
+		t.Fatal("Expected to at least one RR in the answer section, got none")
+	}
+	if resp.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
+	}
+	if resp.Answer[0].(*dns.A).A.String() != "10.0.0.1" {
+		t.Errorf("Expected 10.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
+	}
+}


### PR DESCRIPTION
This fix add inline support for middleware/hosts so that
it is possible to specify hosts file insides the Corefile:
```
hosts {
    127.0.0.1 localhost localhost.domain
    10.0.0.1 example.org
    fallthrough
}
```

This fix fixes #999.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>