### PR TITLE
Adds the dnstap I/O routines and should fix some issues

### DIFF
--- a/plugin/dnstap/dnstapio/io.go
+++ b/plugin/dnstap/dnstapio/io.go
@@ -1,0 +1,60 @@
+package dnstapio
+
+import (
+	"fmt"
+	"io"
+
+	tap "github.com/dnstap/golang-dnstap"
+	"github.com/golang/protobuf/proto"
+)
+
+type DnstapIO struct {
+	writer  io.WriteCloser
+	queue   chan tap.Dnstap
+	stop    chan bool
+	dropped int
+}
+
+func New(w io.WriteCloser) *DnstapIO {
+	dio := DnstapIO{}
+	dio.writer = w
+	dio.queue = make(chan tap.Dnstap, 10)
+	dio.stop = make(chan bool)
+	go dio.serve()
+	return &dio
+}
+
+func (dio *DnstapIO) Dnstap(payload tap.Dnstap) {
+	select {
+	case dio.queue <- payload:
+	default:
+		dio.dropped++
+		fmt.Println("[WARN] Dnstap payload dropped.")
+	}
+}
+
+func (dio *DnstapIO) serve() {
+	for {
+		select {
+		case payload := <-dio.queue:
+			frame, err := proto.Marshal(&payload)
+			if err == nil {
+				dio.writer.Write(frame)
+			} else {
+				dio.dropped++
+				fmt.Println("[ERROR] Invalid dnstap payload dropped.")
+			}
+		case <-dio.stop:
+			close(dio.queue)
+			dio.stop <- true
+			return
+		}
+	}
+}
+
+func (dio DnstapIO) Close() error {
+	dio.stop <- true
+	<-dio.stop
+	close(dio.stop)
+	return dio.writer.Close()
+}

--- a/plugin/dnstap/dnstapio/io.go
+++ b/plugin/dnstap/dnstapio/io.go
@@ -10,10 +10,9 @@ import (
 
 // DnstapIO wraps the dnstap I/O routine.
 type DnstapIO struct {
-	writer  io.WriteCloser
-	queue   chan tap.Dnstap
-	stop    chan bool
-	dropped int
+	writer io.WriteCloser
+	queue  chan tap.Dnstap
+	stop   chan bool
 }
 
 // Protocol is either `out.TCP` or `out.Socket`.
@@ -39,7 +38,6 @@ func (dio *DnstapIO) Dnstap(payload tap.Dnstap) {
 	select {
 	case dio.queue <- payload:
 	default:
-		dio.dropped++
 		fmt.Println("[WARN] Dnstap payload dropped.")
 	}
 }
@@ -52,7 +50,6 @@ func (dio *DnstapIO) serve() {
 			if err == nil {
 				dio.writer.Write(frame)
 			} else {
-				dio.dropped++
 				fmt.Println("[ERROR] Invalid dnstap payload dropped.")
 			}
 		case <-dio.stop:

--- a/plugin/dnstap/dnstapio/io_test.go
+++ b/plugin/dnstap/dnstapio/io_test.go
@@ -1,0 +1,41 @@
+package dnstapio
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	tap "github.com/dnstap/golang-dnstap"
+)
+
+type buf struct {
+	*bytes.Buffer
+}
+
+func (b buf) Close() error {
+	return nil
+}
+
+func TestClose(t *testing.T) {
+	done := make(chan bool)
+	var dio *DnstapIO
+	go func() {
+		b := buf{&bytes.Buffer{}}
+		dio = New(b)
+		dio.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Not closing.")
+	}
+	func() {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Fatal("Send on closed channel.")
+			}
+		}()
+		dio.Dnstap(tap.Dnstap{})
+	}()
+}

--- a/plugin/dnstap/dnstapio/io_test.go
+++ b/plugin/dnstap/dnstapio/io_test.go
@@ -2,6 +2,7 @@ package dnstapio
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,17 +11,46 @@ import (
 
 type buf struct {
 	*bytes.Buffer
+	cost time.Duration
+}
+
+func (b buf) Write(frame []byte) (int, error) {
+	time.Sleep(b.cost)
+	return b.Buffer.Write(frame)
 }
 
 func (b buf) Close() error {
 	return nil
 }
 
+func TestRace(t *testing.T) {
+	b := buf{&bytes.Buffer{}, 100 * time.Millisecond}
+	dio := New(b)
+	wg := &sync.WaitGroup{}
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		timeout := time.After(time.Second)
+		go func() {
+			for {
+				select {
+				case <-timeout:
+					wg.Done()
+					return
+				default:
+					time.Sleep(50 * time.Millisecond)
+					dio.Dnstap(tap.Dnstap{})
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
 func TestClose(t *testing.T) {
 	done := make(chan bool)
 	var dio *DnstapIO
 	go func() {
-		b := buf{&bytes.Buffer{}}
+		b := buf{&bytes.Buffer{}, 0}
 		dio = New(b)
 		dio.Close()
 		close(done)

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -16,11 +16,14 @@ import (
 // Dnstap is the dnstap handler.
 type Dnstap struct {
 	Next plugin.Handler
-	Out  io.Writer
+	IO   IOThread
 	Pack bool
 }
 
 type (
+	IOThread interface {
+		Dnstap(tap.Dnstap)
+	}
 	// Tapper is implemented by the Context passed by the dnstap handler.
 	Tapper interface {
 		TapMessage(*tap.Message) error
@@ -49,7 +52,8 @@ func tapMessageTo(w io.Writer, m *tap.Message) error {
 
 // TapMessage implements Tapper.
 func (h Dnstap) TapMessage(m *tap.Message) error {
-	return tapMessageTo(h.Out, m)
+	h.IO.Dnstap(msg.Wrap(m))
+	return nil
 }
 
 // TapBuilder implements Tapper.

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -21,6 +21,7 @@ type Dnstap struct {
 }
 
 type (
+	// IORoutine is the dnstap I/O thread as defined by: <http://dnstap.info/Architecture>.
 	IORoutine interface {
 		Dnstap(tap.Dnstap)
 	}

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -16,12 +16,12 @@ import (
 // Dnstap is the dnstap handler.
 type Dnstap struct {
 	Next plugin.Handler
-	IO   IOThread
+	IO   IORoutine
 	Pack bool
 }
 
 type (
-	IOThread interface {
+	IORoutine interface {
 		Dnstap(tap.Dnstap)
 	}
 	// Tapper is implemented by the Context passed by the dnstap handler.

--- a/plugin/dnstap/msg/wrapper.go
+++ b/plugin/dnstap/msg/wrapper.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+// Wrap a dnstap message in the top-level dnstap type.
 func Wrap(m *lib.Message) lib.Dnstap {
 	t := lib.Dnstap_MESSAGE
 	return lib.Dnstap{

--- a/plugin/dnstap/msg/wrapper.go
+++ b/plugin/dnstap/msg/wrapper.go
@@ -7,9 +7,9 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func wrap(m *lib.Message) *lib.Dnstap {
+func Wrap(m *lib.Message) lib.Dnstap {
 	t := lib.Dnstap_MESSAGE
-	return &lib.Dnstap{
+	return lib.Dnstap{
 		Type:    &t,
 		Message: m,
 	}
@@ -17,7 +17,8 @@ func wrap(m *lib.Message) *lib.Dnstap {
 
 // Marshal encodes the message to a binary dnstap payload.
 func Marshal(m *lib.Message) (data []byte, err error) {
-	data, err = proto.Marshal(wrap(m))
+	payload := Wrap(m)
+	data, err = proto.Marshal(&payload)
 	if err != nil {
 		err = fmt.Errorf("proto: %s", err)
 		return

--- a/plugin/dnstap/out/tcp.go
+++ b/plugin/dnstap/out/tcp.go
@@ -32,7 +32,7 @@ func (s *TCP) Write(frame []byte) (n int, err error) {
 // Flush the remaining frames.
 func (s *TCP) Flush() error {
 	defer func() {
-		s.frames = s.frames[0:]
+		s.frames = s.frames[:0]
 	}()
 	c, err := net.DialTimeout("tcp", s.address, time.Second)
 	if err != nil {

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/dnstap/dnstapio"
 	"github.com/coredns/coredns/plugin/dnstap/out"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 
@@ -79,7 +80,7 @@ func setup(c *caddy.Controller) error {
 	} else {
 		o = out.NewTCP(conf.target)
 	}
-	dnstap.Out = o
+	dnstap.IO = dnstapio.New(o)
 
 	c.OnShutdown(func() error {
 		if err := o.Close(); err != nil {

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -80,11 +80,12 @@ func setup(c *caddy.Controller) error {
 	} else {
 		o = out.NewTCP(conf.target)
 	}
-	dnstap.IO = dnstapio.New(o)
+	dio := dnstapio.New(o)
+	dnstap.IO = dio
 
 	c.OnShutdown(func() error {
-		if err := o.Close(); err != nil {
-			return fmt.Errorf("output: %s", err)
+		if err := dio.Close(); err != nil {
+			return fmt.Errorf("dnstap io routine: %s", err)
 		}
 		return nil
 	})


### PR DESCRIPTION
As pointed out, dnstap's `out` package Socket and TCP structures were not thread safe while being used by several DNS worker. This PR adds a dnstap IO thread as specified by http://dnstap.info/Architecture/ which solves the issue because Socket and TCP are now being used in a single thread context.