### PR TITLE
plugin/{file,auto}: improve reload robustness

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -70,3 +70,7 @@ org {
     }
 }
 ~~~
+
+## Also See
+
+See the README.md of the *file* plugin for details on the reload behavior.

--- a/plugin/auto/zone.go
+++ b/plugin/auto/zone.go
@@ -2,6 +2,7 @@
 package auto
 
 import (
+	"log"
 	"sync"
 
 	"github.com/coredns/coredns/plugin/file"
@@ -51,7 +52,10 @@ func (z *Zones) Add(zo *file.Zone, name string) {
 
 	z.Z[name] = zo
 	z.names = append(z.names, name)
-	zo.Reload()
+	err := zo.Reload()
+	if err != nil {
+		log.Printf("[ERROR] Failed to reload %q: %s", name, err)
+	}
 
 	z.Unlock()
 }

--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -20,9 +20,6 @@ file DBFILE [ZONES...]
 
 If you want to round robin A and AAAA responses look at the *loadbalance* plugin.
 
-TSIG key configuration is TODO; directive format for transfer will probably be extended with
-TSIG key information, something like `transfer out [ADDRESS...] key [NAME[:ALG]] [BASE64]`
-
 ~~~
 file DBFILE [ZONES... ] {
     transfer to ADDRESS...
@@ -41,6 +38,10 @@ file DBFILE [ZONES... ] {
   pointing to external names. This is only really useful when CoreDNS is configured as a proxy, for
   normal authoritative serving you don't need *or* want to use this. **ADDRESS** can be an IP
   address, and IP:port or a string pointing to a file that is structured as /etc/resolv.conf.
+
+By default zone file will get *reloaded* when CoreDNS detects a new file on disk. This detection
+*only* happens when a file is created (not written). This means you need to `mv` files into place;
+as this triggers a create and is an atomic operation.
 
 ## Examples
 

--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -46,10 +46,9 @@ func (w *watch) remove(dir string) error {
 	}
 	i--
 	if i == 0 {
-		if err := w.w.Remove(dir); err != nil {
-			return err
-		}
+		err := w.w.Remove(dir)
 		delete(w.d, dir)
+		return err
 	}
 	w.d[dir]--
 	return nil

--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -69,8 +69,8 @@ func (z *Zone) Reload() error {
 			select {
 			case event := <-watcher.w.Events:
 				if path.Clean(event.Name) == z.file {
-
-					if event.Op&fsnotify.Write != fsnotify.Write {
+					// You should move stuff into place!
+					if event.Op&fsnotify.Create != fsnotify.Create {
 						continue
 					}
 

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 
@@ -34,7 +35,10 @@ func setup(c *caddy.Controller) error {
 				if len(z.TransferTo) > 0 {
 					z.Notify()
 				}
-				z.Reload()
+				err := z.Reload()
+				if err != nil {
+					log.Printf("[ERROR] Failed to reload %q: %s", z.file, err)
+				}
 			})
 			return nil
 		})

--- a/plugin/file/watcher_test.go
+++ b/plugin/file/watcher_test.go
@@ -1,0 +1,31 @@
+package file
+
+import (
+	"testing"
+)
+
+func TestWatcher(t *testing.T) {
+	w := newWatch()
+	d := "/tmp"
+
+	tests := []struct {
+		funcs    []func(string) error
+		expected int
+	}{
+		{[]func(string) error{w.remove}, 0},
+		{[]func(string) error{w.add}, 1},
+		{[]func(string) error{w.add}, 2},
+		{[]func(string) error{w.remove}, 1},
+		{[]func(string) error{w.remove}, 0},
+		{[]func(string) error{w.remove}, 0},
+	}
+
+	for i, tc := range tests {
+		for _, f := range tc.funcs {
+			f(d)
+		}
+		if x := w.d[d]; x != tc.expected {
+			t.Errorf("Test %d, expected %d, go %d", i, tc.expected, x)
+		}
+	}
+}

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestZoneReload(t *testing.T) {
-	t.Parallel()
 	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", exampleOrg)
@@ -52,7 +51,7 @@ example.net:0 {
 	// Remove RR from the Apex
 	ioutil.WriteFile(name, []byte(exampleOrgUpdated), 0644)
 
-	time.Sleep(1 * time.Second) // fsnotify
+	time.Sleep(600 * time.Millisecond) // fsnotify
 
 	resp, err = p.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {


### PR DESCRIPTION
The reload (fsnotify) mechanism seems to "stop working" for some users,
it has been hard to pin down, what exactly. This PR makes a couple of
changes to help (hopefully) with this:

* Add more logging, including a panic (on startup) when the fsnotify
  can't be set
* Makes the fsnotify.Watcher global (we only need one), and keeps track
  a what directories we watch, as there may be a limit (there is a limit
  somewhere) to how many watcher you can have per directly.
* Only tries reloading a zone when there was a *write* to the zone, so
  moves are not seen anymore.

Testing this was a lot of zones is tricky-ish, so current test-suite
hasn't been updated. This might happen in subsequent comments because
the `watcher` struct does need unit tests.

### 2. Which issues (if any) are related?
#1013

