### PR TITLE
plugin/proxy: detect dead upstream

### DIFF
--- a/plugin/proxy/lookup.go
+++ b/plugin/proxy/lookup.go
@@ -120,7 +120,7 @@ func (p Proxy) lookup(state request.Request) (*dns.Msg, error) {
 			}
 			// If we get a network error, *our* upstream is broken, not us, SERVFAIL request to client.
 			if _, ok := backendErr.(*net.OpError); ok {
-				return dns.RcodeServerFailure, fmt.Errorf("bad upstream %s: %s", host.Name, backendErr)
+				return nil, fmt.Errorf("bad upstream %s: %s", host.Name, backendErr)
 			}
 			timeout := host.FailTimeout
 			if timeout == 0 {


### PR DESCRIPTION
When the upstream query returns a *network* error, don't mark our
upstream as bad, but instead return an error and return SERVFAIL.
A question remains: is this too lenient ? Should we double check for
timeout?

See the following sequence when querying example.org and isc.org:

::1 - [19/Sep/2017:21:12:48 +0100] "ANY IN isc.org. udp 37 false 4096" SERVFAIL qr,rd 37 5.000933527s
19/Sep/2017:21:12:48 +0100 [ERROR 0 isc.org. ANY] bad upstream 8.8.8.8:53: read udp 192.168.1.148:47547->8.8.8.8:53: i/o timeout
read udp 192.168.1.148:46653->8.8.8.8:53: i/o timeout
127.0.0.1 - [19/Sep/2017:21:12:49 +0100] "ANY IN isc.org. udp 37 false 4096" SERVFAIL qr,rd 37 5.001221543s
19/Sep/2017:21:12:49 +0100 [ERROR 0 isc.org. ANY] bad upstream 8.8.8.8:53: read udp 192.168.1.148:46653->8.8.8.8:53: i/o timeout
::1 - [19/Sep/2017:21:12:50 +0100] "MX IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 104 24.634596ms

Fixes #486

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

