### PR TITLE
WIP: healthcheck: move to DNS checks

### DIFF
--- a/plugin/pkg/dnstest/server.go
+++ b/plugin/pkg/dnstest/server.go
@@ -11,7 +11,8 @@ import (
 type Server struct {
 	Addr string // Address where the server listening.
 
-	s *dns.Server
+	s1 *dns.Server // udp
+	s2 *dns.Server // tcp
 }
 
 // NewServer starts and returns a new Server. The caller should call Close when
@@ -19,14 +20,27 @@ type Server struct {
 func NewServer(f dns.HandlerFunc) *Server {
 	dns.HandleFunc(".", f)
 
+	ch1 := make(chan bool)
+	ch2 := make(chan bool)
+
 	p, _ := net.ListenPacket("udp", ":0")
 	l, _ := net.Listen("tcp", p.LocalAddr().String())
 
-	s := &dns.Server{PacketConn: p, Listener: l}
-	go s.ActivateAndServe()
+	s1 := &dns.Server{PacketConn: p}
+	s2 := &dns.Server{Listener: l}
+	s1.NotifyStartedFunc = func() { close(ch1) }
+	s2.NotifyStartedFunc = func() { close(ch2) }
+	go s1.ActivateAndServe()
+	go s2.ActivateAndServe()
 
-	return &Server{s: s, Addr: p.LocalAddr().String()}
+	<-ch1
+	<-ch2
+
+	return &Server{s1: s1, s2: s2, Addr: p.LocalAddr().String()}
 }
 
 // Close shuts down the server.
-func (s *Server) Close() { s.s.Shutdown() }
+func (s *Server) Close() {
+	s.s1.Shutdown()
+	s.s2.Shutdown()
+}

--- a/plugin/pkg/dnstest/server.go
+++ b/plugin/pkg/dnstest/server.go
@@ -1,0 +1,32 @@
+package dnstest
+
+import (
+	"net"
+
+	"github.com/miekg/dns"
+)
+
+// A Server is an DNS server listening on a system-chosen port on the local
+// loopback interface, for use in end-to-end DNS tests.
+type Server struct {
+	Addr string // Address where the server listening.
+
+	s *dns.Server
+}
+
+// NewServer starts and returns a new Server. The caller should call Close when
+// finished, to shut it down.
+func NewServer(f dns.HandlerFunc) *Server {
+	dns.HandleFunc(".", f)
+
+	p, _ := net.ListenPacket("udp", ":0")
+	l, _ := net.Listen("tcp", p.LocalAddr().String())
+
+	s := &dns.Server{PacketConn: p, Listener: l}
+	go s.ActivateAndServe()
+
+	return &Server{s: s, Addr: p.LocalAddr().String()}
+}
+
+// Close shuts down the server.
+func (s *Server) Close() { s.s.Shutdown() }

--- a/plugin/pkg/dnstest/server_test.go
+++ b/plugin/pkg/dnstest/server_test.go
@@ -1,0 +1,28 @@
+package dnstest
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestNewServer(t *testing.T) {
+	s := NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	c := new(dns.Client)
+	c.Net = "tcp"
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeSOA)
+	ret, _, err := c.Exchange(m, s.Addr)
+	if err != nil {
+		t.Fatalf("Could not send message to dnstest.Server: %s", err)
+	}
+	if ret.Id != m.Id {
+		t.Fatalf("Msg ID's should match, expected %d, got %d", m.Id, ret.Id)
+	}
+}

--- a/plugin/pkg/healthcheck/healthcheck.go
+++ b/plugin/pkg/healthcheck/healthcheck.go
@@ -123,6 +123,7 @@ func healthCheckDNS(nextTs time.Time, host *UpstreamHost) {
 
 	ping := newPingMsg()
 
+	// TODO: check returned packet, consider Success, NXDOMAIN, refused Ok
 	_, _, err := host.client.Exchange(ping, host.Name)
 
 	// Ping our upstream. This has been moved into a go func because

--- a/plugin/pkg/healthcheck/ping.go
+++ b/plugin/pkg/healthcheck/ping.go
@@ -1,0 +1,13 @@
+package healthcheck
+
+import "github.com/miekg/dns"
+
+// newPingMsg returns a dns.Msg that is used for the health check ping.
+// The message's RD flag is not set. The name, type and class or
+// ".", NS, IN repectively.
+func newPingMsg() *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(".", dns.TypeNS)
+	m.RecursionDesired = false
+	return m
+}

--- a/plugin/pkg/healthcheck/ping.go
+++ b/plugin/pkg/healthcheck/ping.go
@@ -3,11 +3,11 @@ package healthcheck
 import "github.com/miekg/dns"
 
 // newPingMsg returns a dns.Msg that is used for the health check ping.
-// The message's RD flag is not set. The name, type and class or
-// ".", NS, IN repectively.
-func newPingMsg() *dns.Msg {
+// The message's RD flag is not set. The name, type and class are
+// "name", NS, IN repectively. Name must be fully qualified.
+func newPingMsg(name string) *dns.Msg {
 	m := new(dns.Msg)
-	m.SetQuestion(".", dns.TypeNS)
+	m.SetQuestion(name, dns.TypeNS)
 	m.RecursionDesired = false
 	return m
 }

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -24,7 +24,7 @@ proxy FROM TO... {
     policy random|least_conn|round_robin
     fail_timeout DURATION
     max_fails INTEGER
-    health_check NAME:PORT [DURATION]
+    health_check [[NAME:PORT] [DURATION]]
     except IGNORED_NAMES...
     spray
     protocol [dns [force_tcp]|https_google [bootstrap ADDRESS...]|grpc [insecure|CACERT|KEY CERT|KEY CERT CACERT]]
@@ -39,12 +39,15 @@ proxy FROM TO... {
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
   communicate with it. The default value is 3 seconds ("3s").
-* `max_fails` is the number of failures within fail_timeout that are needed before considering
+* `max_fails` is the number of failures within `fail_timeout` that are needed before considering
   a backend to be down. If 0, the backend will never be marked as down. Default is 1.
-* `health_check` will use **NAME** (on **PORT**) to send DNS pings on each backend. If a backend
+* `health_check` will health check each backend, by sending (over TCP) an DNS control message
+  (".", NS, IN) to it. If a backend
   returns an (TODO: check Rcodes) then that backend is marked healthy for double the healthcheck duration.
   If it doesn't, it is marked as unhealthy and no requests are routed to it. 
   The default **DURATION** is 5 seconds ("5s").
+  **NAME:PORT** can be used to change the domain name used (default is `.`). **PORT** defaults
+  to 53 if not specified.
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
   Requests that match none of these names will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -24,7 +24,7 @@ proxy FROM TO... {
     policy random|least_conn|round_robin
     fail_timeout DURATION
     max_fails INTEGER
-    health_check PATH:PORT [DURATION]
+    health_check NAME:PORT [DURATION]
     except IGNORED_NAMES...
     spray
     protocol [dns [force_tcp]|https_google [bootstrap ADDRESS...]|grpc [insecure|CACERT|KEY CERT|KEY CERT CACERT]]
@@ -41,10 +41,10 @@ proxy FROM TO... {
   communicate with it. The default value is 10 seconds ("10s").
 * `max_fails` is the number of failures within fail_timeout that are needed before considering
   a backend to be down. If 0, the backend will never be marked as down. Default is 1.
-* `health_check` will check path (on port) on each backend. If a backend returns a status code of
-  200-399, then that backend is marked healthy for double the healthcheck duration.  If it doesn't,
-  it is marked as unhealthy and no requests are routed to it.  If this option is not provided then
-  health checks are disabled.  The default duration is 30 seconds ("30s").
+* `health_check` will use **NAME** (on **PORT**) to send DNS pings on each backend. If a backend
+  returns an (TODO: check Rcodes) then that backend is marked healthy for double the healthcheck duration.
+  If it doesn't, it is marked as unhealthy and no requests are routed to it. 
+  The default **DURATION** is 30 seconds ("30s").
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
   Requests that match none of these names will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -38,13 +38,13 @@ proxy FROM TO... {
   random, least_conn, or round_robin. Default is random.
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
-  communicate with it. The default value is 10 seconds ("10s").
+  communicate with it. The default value is 3 seconds ("3s").
 * `max_fails` is the number of failures within fail_timeout that are needed before considering
   a backend to be down. If 0, the backend will never be marked as down. Default is 1.
 * `health_check` will use **NAME** (on **PORT**) to send DNS pings on each backend. If a backend
   returns an (TODO: check Rcodes) then that backend is marked healthy for double the healthcheck duration.
   If it doesn't, it is marked as unhealthy and no requests are routed to it. 
-  The default **DURATION** is 30 seconds ("30s").
+  The default **DURATION** is 5 seconds ("5s").
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
   Requests that match none of these names will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is

--- a/plugin/proxy/lookup.go
+++ b/plugin/proxy/lookup.go
@@ -27,8 +27,9 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 		from: ".",
 		HealthCheck: healthcheck.HealthCheck{
 			FailTimeout: 10 * time.Second,
-			MaxFails:    3, // TODO(miek): disable error checking for simple lookups?
+			MaxFails:    3,
 			Future:      60 * time.Second,
+			client:      &dns.Client{net: "tcp"},
 		},
 		ex: newDNSExWithOption(opts),
 	}

--- a/plugin/proxy/proxy_test.go
+++ b/plugin/proxy/proxy_test.go
@@ -80,8 +80,6 @@ func TestStop(t *testing.T) {
 			if counterValueAfterWaiting > (counterValueAfterShutdown + 1) {
 				t.Errorf("Expected no more healthchecks after shutdown. Got: %d healthchecks after shutdown", counterValueAfterWaiting-counterValueAfterShutdown)
 			}
-
 		})
-
 	}
 }

--- a/plugin/proxy/proxy_test.go
+++ b/plugin/proxy/proxy_test.go
@@ -43,15 +43,13 @@ func TestStop(t *testing.T) {
 			// Set up proxy.
 			var counter int64
 			backend := dnstest.NewServer(dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-				println("DFD")
 				w.WriteMsg(r)
 				atomic.AddInt64(&counter, 1)
 			}))
 
 			defer backend.Close()
 
-			corefile := fmt.Sprintf(config, backend.UDPAddr, backend.TCPAddr, test.intervalInMilliseconds)
-			println(corefile)
+			corefile := fmt.Sprintf(config, backend.Addr, backend.Addr, test.intervalInMilliseconds)
 
 			c := caddyfile.NewDispenser("Testfile", strings.NewReader(corefile))
 			upstreams, err := NewStaticUpstreams(&c)

--- a/plugin/proxy/proxy_test.go
+++ b/plugin/proxy/proxy_test.go
@@ -2,18 +2,19 @@ package proxy
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+
 	"github.com/mholt/caddy/caddyfile"
+	"github.com/miekg/dns"
 )
 
 func TestStop(t *testing.T) {
-	config := "proxy . %s {\n health_check /healthcheck:%s %dms \n}"
+	config := "proxy . %s {\n health_check %s %dms \n}"
 	tests := []struct {
 		name                    string
 		intervalInMilliseconds  int
@@ -41,16 +42,18 @@ func TestStop(t *testing.T) {
 
 			// Set up proxy.
 			var counter int64
-			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				r.Body.Close()
+			backend := dnstest.NewServer(dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+				println("DFD")
+				w.WriteMsg(r)
 				atomic.AddInt64(&counter, 1)
 			}))
 
 			defer backend.Close()
 
-			port := backend.URL[17:] // Remove all crap up to the port
-			back := backend.URL[7:]  // Remove http://
-			c := caddyfile.NewDispenser("Testfile", strings.NewReader(fmt.Sprintf(config, back, port, test.intervalInMilliseconds)))
+			corefile := fmt.Sprintf(config, backend.UDPAddr, backend.TCPAddr, test.intervalInMilliseconds)
+			println(corefile)
+
+			c := caddyfile.NewDispenser("Testfile", strings.NewReader(corefile))
 			upstreams, err := NewStaticUpstreams(&c)
 			if err != nil {
 				t.Error("Expected no error. Got:", err.Error())

--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -33,9 +33,10 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 		upstream := &staticUpstream{
 			from: ".",
 			HealthCheck: healthcheck.HealthCheck{
-				FailTimeout: 10 * time.Second,
+				FailTimeout: 3 * time.Second,
 				MaxFails:    1,
 				Future:      60 * time.Second,
+				client:      &dns.Client{net: "tcp"},
 			},
 			ex: newDNSEx(),
 		}
@@ -144,7 +145,7 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 		if err != nil {
 			return err
 		}
-		u.HealthCheck.Interval = 30 * time.Second
+		u.HealthCheck.Interval = 5 * time.Second
 		if c.NextArg() {
 			dur, err := time.ParseDuration(c.Val())
 			if err != nil {


### PR DESCRIPTION
This removes HTTP healthchecks and moves to DNS (via tcp) system.
This directly queries the upstream DNS server by using a . NS
no-recursive query. Any non-error DNS rcode ?? TODO(miek): if this makes
sense is taken as success.

The proxy and lookup code does not set an upstream unhealthy anymore,
but relies on the healthcheck to do is things.

Obviously tests fails.