### PR TITLE
Fix autopath crash when pods verified not enabled

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -368,6 +368,9 @@ func (dns *dnsControl) ServiceList() []*api.Service {
 }
 
 func (dns *dnsControl) PodIndex(ip string) []interface{} {
+	if dns.podLister.Indexer == nil {
+		return nil
+	}
 	pods, err := dns.podLister.Indexer.ByIndex(podIPIndex, ip)
 	if err != nil {
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Fixes a crash if `autopath @kubernetes` is enabled without `pods verified` enabled.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.