### PR TITLE
healhcheck: various cleanups

### DIFF
--- a/plugin/kubernetes/apiproxy.go
+++ b/plugin/kubernetes/apiproxy.go
@@ -23,10 +23,8 @@ type apiProxy struct {
 func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	upstream := p.Select()
 	network := "tcp"
-	if upstream.Network != "" {
-		network = upstream.Network
-	}
 	address := upstream.Name
+
 	d, err := net.Dial(network, address)
 	if err != nil {
 		log.Printf("[ERROR] Unable to establish connection to upstream %s://%s: %s", network, address, err)

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -190,9 +190,9 @@ func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
 
 						down := false
 
-						uh.CheckMu.Lock()
+						uh.Lock()
 						until := uh.OkUntil
-						uh.CheckMu.Unlock()
+						uh.Unlock()
 
 						if !until.IsZero() && time.Now().After(until) {
 							down = true

--- a/plugin/proxy/down.go
+++ b/plugin/proxy/down.go
@@ -1,0 +1,30 @@
+package proxy
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/healthcheck"
+)
+
+// Default CheckDown functions for use in the proxy plugin.
+var checkDownFunc = func(upstream *staticUpstream) healthcheck.UpstreamHostDownFunc {
+	return func(uh *healthcheck.UpstreamHost) bool {
+
+		down := false
+
+		uh.Lock()
+		until := uh.OkUntil
+		uh.Unlock()
+
+		if !until.IsZero() && time.Now().After(until) {
+			down = true
+		}
+
+		fails := atomic.LoadInt32(&uh.Fails)
+		if fails >= upstream.MaxFails && upstream.MaxFails != 0 {
+			down = true
+		}
+		return down
+	}
+}

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sync/atomic"
 	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/healthcheck"
@@ -198,7 +197,6 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			Future:      60 * time.Second,
 		},
 		ex:                old.ex,
-		WithoutPathPrefix: old.WithoutPathPrefix,
 		IgnoredSubDomains: old.IgnoredSubDomains,
 	}
 
@@ -209,28 +207,7 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-
-			CheckDown: func(upstream *staticUpstream) healthcheck.UpstreamHostDownFunc {
-				return func(uh *healthcheck.UpstreamHost) bool {
-
-					down := false
-
-					uh.CheckMu.Lock()
-					until := uh.OkUntil
-					uh.CheckMu.Unlock()
-
-					if !until.IsZero() && time.Now().After(until) {
-						down = true
-					}
-
-					fails := atomic.LoadInt32(&uh.Fails)
-					if fails >= upstream.MaxFails && upstream.MaxFails != 0 {
-						down = true
-					}
-					return down
-				}
-			}(upstream),
-			WithoutPathPrefix: upstream.WithoutPathPrefix,
+			CheckDown:   checkDownFunc(upstream),
 		}
 
 		upstream.Hosts[i] = uh

--- a/plugin/proxy/lookup.go
+++ b/plugin/proxy/lookup.go
@@ -40,28 +40,7 @@ func NewLookupWithOption(hosts []string, opts Options) Proxy {
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
-
-			CheckDown: func(upstream *staticUpstream) healthcheck.UpstreamHostDownFunc {
-				return func(uh *healthcheck.UpstreamHost) bool {
-
-					down := false
-
-					uh.CheckMu.Lock()
-					until := uh.OkUntil
-					uh.CheckMu.Unlock()
-
-					if !until.IsZero() && time.Now().After(until) {
-						down = true
-					}
-
-					fails := atomic.LoadInt32(&uh.Fails)
-					if fails >= upstream.MaxFails && upstream.MaxFails != 0 {
-						down = true
-					}
-					return down
-				}
-			}(upstream),
-			WithoutPathPrefix: upstream.WithoutPathPrefix,
+			CheckDown:   checkDownFunc(upstream),
 		}
 
 		upstream.Hosts[i] = uh

--- a/plugin/proxy/upstream_test.go
+++ b/plugin/proxy/upstream_test.go
@@ -85,13 +85,6 @@ proxy . 8.8.8.8:53 {
 		{
 			`
 proxy . 8.8.8.8:53 {
-    without without
-}`,
-			false,
-		},
-		{
-			`
-proxy . 8.8.8.8:53 {
     except miek.nl example.org 10.0.0.0/24
 }`,
 			false,


### PR DESCRIPTION
Network wasn't used. IgnorePaths wasn't used. Move checkdown function to
common function shared between proxy protocols. And some naming fixed.