### PR TITLE
Use gometalinter and enforcing go fmt/lint/vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ gen:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --disable-all --enable=gofmt --enable=golint --enable=vet --exclude=^vendor/ --exclude=^pb/ ./...
+	gometalinter --deadline=1m --disable-all --enable=gofmt --enable=golint --enable=vet --exclude=^vendor/ --exclude=^pb/ ./...
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ coredns: check godeps
 	CGO_ENABLED=0 $(SYSTEM) go build -v -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
-check: fmt core/zplugin.go core/dnsserver/zdirectives.go godeps
+check: linter core/zplugin.go core/dnsserver/zdirectives.go godeps
 
 .PHONY: test
 test: check
@@ -62,17 +62,11 @@ core/zplugin.go core/dnsserver/zdirectives.go: plugin.cfg
 gen:
 	go generate coredns.go
 
-.PHONY: fmt
-fmt:
-	## run go fmt
-	@test -z "$$(find . -type d | grep -vE '(/vendor|^\.$$|/.git|/.travis)' | xargs gofmt -s -l  | tee /dev/stderr)" || \
-		(echo "please format Go code with 'gofmt -s -w'" && false)
-
-.PHONY: lint
-lint:
-	go get -u github.com/golang/lint/golint
-	@test -z "$$(find . -type d | grep -vE '(/vendor|^\.$$|/.git|/.travis)' | grep -vE '(^\./pb)' | xargs golint \
-		| grep -vE "context\.Context should be the first parameter of a function" | tee /dev/stderr)"
+.PHONY: linter
+linter:
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install golint
+	gometalinter --disable-all --enable=gofmt --enable=golint --enable=vet --exclude=^vendor/ --exclude=^pb/ ./...
 
 .PHONY: clean
 clean:

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -69,7 +69,7 @@ func Error(name string, err error) error { return fmt.Errorf("%s/%s: %s", "plugi
 
 // NextOrFailure calls next.ServeDNS when next is not nill, otherwise it will return, a ServerFailure
 // and a nil error.
-func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+func NextOrFailure(name string, next Handler, ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) { // nolint: golint
 	if next != nil {
 		if span := ot.SpanFromContext(ctx); span != nil {
 			child := span.Tracer().StartSpan(next.Name(), ot.ChildOf(span.Context()))

--- a/test/etcd_cache_test.go
+++ b/test/etcd_cache_test.go
@@ -68,7 +68,7 @@ func checkResponse(t *testing.T, resp *dns.Msg) {
 		t.Errorf("Expected RR to A, got: %d", resp.Answer[0].Header().Rrtype)
 	}
 	if resp.Answer[0].(*dns.A).A.String() != "127.0.0.1" {
-		t.Errorf("Expected 127.0.0.1, got: %d", resp.Answer[0].(*dns.A).A.String())
+		t.Errorf("Expected 127.0.0.1, got: %s", resp.Answer[0].(*dns.A).A.String())
 	}
 }
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -49,6 +49,6 @@ func send(t *testing.T, server string) {
 		t.Fatalf("Expected successful reply, got %s", dns.RcodeToString[r.Rcode])
 	}
 	if len(r.Extra) != 2 {
-		t.Fatalf("Expected 2 RRs in additional, got %s", len(r.Extra))
+		t.Fatalf("Expected 2 RRs in additional, got %d", len(r.Extra))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Before this PR `go fmt` is enabled, `go lint` is suggest only.

From time to time we have to manually check for go lint and go vet for any issues.

This fix uses gometalinter (https://github.com/alecthomas/gometalinter) and enforcing go fmt/lint/vet, for several reasons:
- gometalinter could handle multiple linters concurrently
- gometalinter supports suppression with `// nolint[: <linter>]`

Previously one reason we didn't enable go lint was due to the
```
warning: context.Context should be the first parameter of a function (golint)
```
this is now possible to suppress the above with gometalinter and `// nolint: golint` (See changes).

This fix also discovered several go vet issues and fixes it.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>