### PR TITLE
plugin/proxy: kick of HC on every 3rd failure

### DIFF
--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -38,7 +38,7 @@ proxy FROM TO... {
   random, least_conn, or round_robin. Default is random.
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
-  communicate with it. The default value is 10 seconds ("10s").
+  communicate with it. The default value is 2 seconds ("2s").
 * `max_fails` is the number of failures within fail_timeout that are needed before considering
   a backend to be down. If 0, the backend will never be marked as down. Default is 1.
 * `health_check` will check **PATH** (on **PORT**) on each backend. If a backend returns a status code of

--- a/plugin/proxy/down.go
+++ b/plugin/proxy/down.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"sync/atomic"
-	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/healthcheck"
 )
@@ -10,21 +9,10 @@ import (
 // Default CheckDown functions for use in the proxy plugin.
 var checkDownFunc = func(upstream *staticUpstream) healthcheck.UpstreamHostDownFunc {
 	return func(uh *healthcheck.UpstreamHost) bool {
-
-		down := false
-
-		uh.Lock()
-		until := uh.OkUntil
-		uh.Unlock()
-
-		if !until.IsZero() && time.Now().After(until) {
-			down = true
-		}
-
 		fails := atomic.LoadInt32(&uh.Fails)
 		if fails >= upstream.MaxFails && upstream.MaxFails != 0 {
-			down = true
+			return true
 		}
-		return down
+		return false
 	}
 }

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -194,22 +194,20 @@ func newUpstream(hosts []string, old *staticUpstream) Upstream {
 		HealthCheck: healthcheck.HealthCheck{
 			FailTimeout: 5 * time.Second,
 			MaxFails:    3,
-			Future:      12 * time.Second,
 		},
 		ex:                old.ex,
 		IgnoredSubDomains: old.IgnoredSubDomains,
 	}
 
 	upstream.Hosts = make([]*healthcheck.UpstreamHost, len(hosts))
-	for i, h := range hosts {
+	for i, host := range hosts {
 		uh := &healthcheck.UpstreamHost{
-			Name:        h,
+			Name:        host,
 			Conns:       0,
 			Fails:       0,
 			FailTimeout: upstream.FailTimeout,
 			CheckDown:   checkDownFunc(upstream),
 		}
-
 		upstream.Hosts[i] = uh
 	}
 	return upstream

--- a/plugin/proxy/grpc_test.go
+++ b/plugin/proxy/grpc_test.go
@@ -28,7 +28,6 @@ func TestStartupShutdown(t *testing.T) {
 		HealthCheck: healthcheck.HealthCheck{
 			Hosts:       pool(),
 			FailTimeout: 10 * time.Second,
-			Future:      60 * time.Second,
 			MaxFails:    1,
 		},
 	}

--- a/plugin/proxy/healthcheck_test.go
+++ b/plugin/proxy/healthcheck_test.go
@@ -1,0 +1,66 @@
+package proxy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/mholt/caddy/caddyfile"
+	"github.com/miekg/dns"
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+func TestUnhealthy(t *testing.T) {
+	// High HC interval, we want to test the HC after failed queries.
+	config := "proxy . %s {\n health_check /healthcheck:%s 10s \nfail_timeout 100ms\n}"
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body.Close()
+		w.Write([]byte("OK"))
+	}))
+	defer backend.Close()
+
+	port := backend.URL[17:] // Remove all crap up to the port
+	back := backend.URL[7:]  // Remove http://
+
+	c := caddyfile.NewDispenser("testfile", strings.NewReader(fmt.Sprintf(config, back, port)))
+	upstreams, err := NewStaticUpstreams(&c)
+	if err != nil {
+		t.Errorf("Expected no error. Got: %s", err)
+	}
+	p := &Proxy{Upstreams: &upstreams}
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	state := request.Request{W: &test.ResponseWriter{}, Req: m}
+
+	// Should all fail.
+	for j := 0; j < failureCheck; j++ {
+		if _, err := p.Forward(state); err == nil {
+			t.Errorf("Expected error. Got: nil")
+		}
+	}
+
+	fails := atomic.LoadInt32(&upstreams[0].(*staticUpstream).Hosts[0].Fails)
+	if fails != 3 {
+		t.Errorf("Expected %d fails, got %d", 3, fails)
+	}
+	// HC should be kicked off, and reset the counter to 0
+	i := 0
+	for fails != 0 {
+		fails = atomic.LoadInt32(&upstreams[0].(*staticUpstream).Hosts[0].Fails)
+		time.Sleep(100 * time.Microsecond)
+		i++
+	}
+}

--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -33,7 +33,6 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 			HealthCheck: healthcheck.HealthCheck{
 				FailTimeout: 5 * time.Second,
 				MaxFails:    3,
-				Future:      12 * time.Second,
 			},
 			ex: newDNSEx(),
 		}
@@ -61,15 +60,13 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 		}
 
 		upstream.Hosts = make([]*healthcheck.UpstreamHost, len(toHosts))
+
 		for i, host := range toHosts {
 			uh := &healthcheck.UpstreamHost{
 				Name:        host,
-				Conns:       0,
-				Fails:       0,
 				FailTimeout: upstream.FailTimeout,
 				CheckDown:   checkDownFunc(upstream),
 			}
-
 			upstream.Hosts[i] = uh
 		}
 		upstream.Start()
@@ -77,10 +74,6 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 		upstreams = append(upstreams, upstream)
 	}
 	return upstreams, nil
-}
-
-func (u *staticUpstream) From() string {
-	return u.from
 }
 
 func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
@@ -128,12 +121,6 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 				return err
 			}
 			u.HealthCheck.Interval = dur
-			u.Future = 2 * dur
-
-			// set a minimum of 3 seconds
-			if u.Future < (3 * time.Second) {
-				u.Future = 3 * time.Second
-			}
 		}
 	case "except":
 		ignoredDomains := c.RemainingArgs()
@@ -204,3 +191,4 @@ func (u *staticUpstream) IsAllowedDomain(name string) bool {
 }
 
 func (u *staticUpstream) Exchanger() Exchanger { return u.ex }
+func (u *staticUpstream) From() string         { return u.from }

--- a/plugin/reverse/reverse_test.go
+++ b/plugin/reverse/reverse_test.go
@@ -20,7 +20,7 @@ func TestReverse(t *testing.T) {
 	em := Reverse{
 		Networks: networks{network{
 			IPnet:        net4,
-			Zone:         "example.org",
+			Zone:         "example.org.",
 			Template:     "ip-{ip}.example.org.",
 			RegexMatchIP: regexIP4,
 		}},
@@ -37,7 +37,7 @@ func TestReverse(t *testing.T) {
 	}{
 		{
 			next:          test.NextHandler(dns.RcodeSuccess, nil),
-			qname:         "test.ip-10.1.1.2.example.org",
+			qname:         "test.ip-10.1.1.2.example.org.",
 			expectedCode:  dns.RcodeSuccess,
 			expectedReply: "10.1.1.2",
 			expectedErr:   nil,
@@ -50,7 +50,7 @@ func TestReverse(t *testing.T) {
 		req := new(dns.Msg)
 
 		tr.qtype = dns.TypeA
-		req.SetQuestion(dns.Fqdn(tr.qname), tr.qtype)
+		req.SetQuestion(tr.qname, tr.qtype)
 
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		code, err := em.ServeDNS(ctx, rec, req)


### PR DESCRIPTION
### 1. What does this pull request do?

Changed the HC back to some older state and allow proxy.go and lookup.go to kick off HCs on every 3rd failure.
Also make the http.Get have a timeout so I won't wait forever (original impetus of pr #749)

### 2. Which issues (if any) are related?

#1109 #1035 and PR #749

### 3. Which documentation changes (if any) need to be made?
None yet, although we may need to describe how all various timeout interact.