### PR TITLE
plugin/dnstap: drop payload dropped

### DIFF
--- a/plugin/dnstap/dnstapio/io.go
+++ b/plugin/dnstap/dnstapio/io.go
@@ -46,11 +46,8 @@ func (dio *DnstapIO) serve() {
 	for {
 		select {
 		case payload := <-dio.queue:
-			frame, err := proto.Marshal(&payload)
-			if err == nil {
+			if frame, err := proto.Marshal(&payload); err == nil {
 				dio.writer.Write(frame)
-			} else {
-				fmt.Println("[ERROR] Invalid dnstap payload dropped.")
 			}
 		case <-dio.stop:
 			close(dio.queue)


### PR DESCRIPTION
This spams the travis logs hard and I wonder how useful it is in
practise. Also didn't list the actual error it saw.
