### PR TITLE
core: drop invalid packets

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -179,6 +179,13 @@ func (s *Server) Address() string { return s.Addr }
 // defined in the request so that the correct zone
 // (configuration and plugin stack) will handle the request.
 func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) {
+	// our dns library protects us against really invalid packets, we can still
+	// get semi valid packets. Drop them here.
+	if r == nil || len(r.Question) == 0 {
+		DefaultErrorFunc(w, r, dns.RcodeServerFailure)
+		return
+	}
+
 	if !s.debug {
 		defer func() {
 			// In case the user doesn't enable error plugin, we still


### PR DESCRIPTION
We can still be on the receiving end of invalid packet. Drop them here.

See #925