### PR TITLE
Warn if the hosts file is a directory

### DIFF
--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -50,13 +50,16 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			if !path.IsAbs(h.path) && config.Root != "" {
 				h.path = path.Join(config.Root, h.path)
 			}
-			_, err := os.Stat(h.path)
+			s, err := os.Stat(h.path)
 			if err != nil {
 				if os.IsNotExist(err) {
 					log.Printf("[WARNING] File does not exist: %s", h.path)
 				} else {
 					return h, c.Errf("unable to access hosts file '%s': %v", h.path, err)
 				}
+			}
+			if s != nil && s.IsDir() {
+				log.Printf("[WARNING] hosts file %q is a directory", h.path)
 			}
 		}
 


### PR DESCRIPTION
### 1. What does this pull request do?

Prints a warning if the hosts file given for the `hosts` plugin is a directory. In case someone accidentally puts in `hosts .` thinking it is a zone.

### 2. Which issues (if any) are related?

#1125 

### 3. Which documentation changes (if any) need to be made?

None.