### PR TITLE
plugin/forward: add new proxy implementation

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -36,6 +36,7 @@ var directives = []string{
 	"auto",
 	"secondary",
 	"etcd",
+	"forward",
 	"proxy",
 	"erratic",
 	"whoami",

--- a/core/zplugin.go
+++ b/core/zplugin.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/etcd"
 	_ "github.com/coredns/coredns/plugin/federation"
 	_ "github.com/coredns/coredns/plugin/file"
+	_ "github.com/coredns/coredns/plugin/forward"
 	_ "github.com/coredns/coredns/plugin/health"
 	_ "github.com/coredns/coredns/plugin/hosts"
 	_ "github.com/coredns/coredns/plugin/kubernetes"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -44,6 +44,7 @@
 220:auto:auto
 230:secondary:secondary
 240:etcd:etcd
+249:forward:forward
 250:proxy:proxy
 260:erratic:erratic
 270:whoami:whoami

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -22,8 +22,7 @@ health. Any reponse that is not an error is taken as a healthy upstream. Multi u
 randomized on first use. Note that when a healthy upstream fails to respond to a query this error
 is propegated to the client and no other upstream is tried.
 
-It uses a fixed buffer size of 4096 bytes for UDP packets. Extra knobs are available with an
-expanded syntax:
+Extra knobs are available with an expanded syntax:
 
 ~~~
 proxy FROM TO... {

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -1,0 +1,102 @@
+# forward
+
+*forward* facilitates proxying DNS messages to upstream resolvers.
+
+The *forward* plugin is generally faster (~30%) than *proxy* as it re-uses already openened sockets to the
+upstreams. It supports UDP and TCP and uses inband healthchecking that is enabled by default.
+
+## Syntax
+
+In its most basic form, a simple forwarder uses this syntax:
+
+~~~
+forward FROM TO...
+~~~
+
+* **FROM** is the base domain to match for the request to be forwared.
+* **TO...** are the destination endpoints to forward to.
+
+By default health checks are done every 0.5s. After two failed checks the upstream is
+considered unhealthy. The health checks use a non-recursive DNS query (`. IN NS`) to get upstream
+health. Any reponse that is not an error is taken as a healthy upstream. Multi upstreams are
+randomized on first use. Note that when a healthy upstream fails to respond to a query this error
+is propegated to the client and no other upstream is tried.
+
+It uses a fixed buffer size of 4096 bytes for UDP packets. Extra knobs are available with an
+expanded syntax:
+
+~~~
+proxy FROM TO... {
+    except IGNORED_NAMES...
+    force_tcp
+    health_check DURATION
+    max_fails INTEGER
+}
+~~~
+
+* **FROM** and **TO...** as above.
+* **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
+  Requests that match none of these names will be passed through.
+* `force_tcp`, use TCP even when the request comes in over UDP.
+* `health_checks`, use a different **DURATION** for health checking, the default duration is 500ms.
+* `max_fails` is the number of subsequent failed health checks that are needed before considering
+  a backend to be down. If 0, the backend will never be marked as down. Default is 2.
+
+## Metrics
+
+If monitoring is enabled (via the *prometheus* directive) then the following metric are exported:
+
+* `coredns_forward_request_duration_millisecond{proto, family, to}` - duration per upstream
+  interaction.
+* `coredns_forward_request_count_total{proto, family, to}` - query count per upstream.
+* `coredns_forward_socket_count_total{to}` - number of known sockets per upstream.
+
+Where `to` is one of the upstream servers (**TO** from the config), `proto` is the protocol used by
+the incoming query ("tcp" or "udp"), and family the transport family ("1" for IPv4, and "2" for
+IPv6).
+
+## Examples
+
+Proxy all requests within example.org. to a nameserver running on a different port:
+
+~~~ corefile
+example.org {
+    forward . 127.0.0.1:9005
+}
+~~~
+
+Load-balance all requests between three resolvers:
+
+~~~ corefile
+. {
+    forward . 10.0.0.10:53 10.0.0.11:1053 10.0.0.12
+}
+~~~
+
+Forward everything except requests to `miek.nl` or `example.org`
+
+~~~ corefile
+. {
+    forward . 10.0.0.10:1234 {
+        except miek.nl example.org
+    }
+}
+~~~
+
+Proxy everything except `example.org` using the host's `resolv.conf`'s nameservers:
+
+~~~ corefile
+. {
+    forward . /etc/resolv.conf {
+        except example.org
+    }
+}
+~~~
+
+Forward to a IPv6 host:
+
+~~~ corefile
+. {
+    forward . [::1]:1053
+}
+~~~

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -72,12 +72,12 @@ Load-balance all requests between three resolvers:
 }
 ~~~
 
-Forward everything except requests to `miek.nl` or `example.org`
+Forward everything except requests to `example.org`
 
 ~~~ corefile
 . {
     forward . 10.0.0.10:1234 {
-        except miek.nl example.org
+        except example.org
     }
 }
 ~~~
@@ -99,3 +99,7 @@ Forward to a IPv6 host:
     forward . [::1]:1053
 }
 ~~~
+
+## Bugs
+
+Tracing and dnstap is not supported (yet) for this proxy.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -1,0 +1,131 @@
+// Package forward implements a forwarding proxy. It caches an upstream net.Conn for some time, so if the same
+// client returns the upstream's Conn will be precached. Depending on how you benchmark this looks to be
+// 50% faster than just openening a new connection for every client. It works with UDP and TCP and uses
+// inband healthchecking.
+package forward
+
+import (
+	"errors"
+	"math/rand"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+// Forward represents a plugin instance that can proxy requests to another (DNS) server. It has a list
+// of proxies each representing one upstream proxy.
+type Forward struct {
+	proxies []*proxy
+
+	from       string
+	ignored    []string
+	forceTCP   bool          // here for testing
+	hcInterval time.Duration // here for testing
+
+	maxfails uint32
+
+	Next plugin.Handler
+}
+
+// Name implements plugin.Handler.
+func (f Forward) Name() string { return "forward" }
+
+// ServeDNS implements plugin.Handler.
+func (f Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+
+	state := request.Request{W: w, Req: r}
+	if !f.match(state) {
+		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+	}
+
+	for _, proxy := range f.selectp(w) {
+		if !proxy.host.down(f.maxfails) {
+			proxy.clientChan <- state
+
+			RequestCount.WithLabelValues(state.Proto(), familyToString(state.Family()), proxy.host.String()).Add(1)
+			SocketCount.WithLabelValues(proxy.host.String()).Set(float64(proxy.Len()))
+
+			return 0, nil
+		}
+	}
+
+	return dns.RcodeServerFailure, errNoHealthy
+}
+
+func (f Forward) match(state request.Request) bool {
+	from := f.from
+
+	if !plugin.Name(from).Matches(state.Name()) || !f.isAllowedDomain(state.Name()) {
+		return false
+	}
+
+	return true
+}
+
+func (f Forward) isAllowedDomain(name string) bool {
+	if dns.Name(name) == dns.Name(f.from) {
+		return true
+	}
+
+	for _, ignore := range f.ignored {
+		if plugin.Name(ignore).Matches(name) {
+			return false
+		}
+	}
+	return true
+}
+
+// selectp returns a randomized set of proxies to be used for this client. If the client was
+// know to any of the proxies it will be put first.
+func (f Forward) selectp(w dns.ResponseWriter) []*proxy {
+	switch len(f.proxies) {
+	case 1:
+		return f.proxies
+	case 2:
+		id, _ := clientID(w)
+		if f.proxies[0].knownClient(id) {
+			return f.proxies // normal order
+		}
+		if f.proxies[1].knownClient(id) {
+			return []*proxy{f.proxies[1], f.proxies[0]} // reverse
+		}
+		if rand.Int()%2 == 0 {
+			return []*proxy{f.proxies[1], f.proxies[0]} // swap
+
+		}
+		return f.proxies // normal
+	}
+
+	id, _ := clientID(w)
+	perms := rand.Perm(len(f.proxies))
+	rnd := make([]*proxy, len(f.proxies))
+
+	known := -1
+	put := -1
+	for i, p := range perms {
+		if f.proxies[p].knownClient(id) {
+			known = i
+			put = p
+		}
+
+		println(i, p)
+		rnd[i] = f.proxies[p]
+	}
+	// put known first, if we have one
+	if known != -1 {
+		x := rnd[1]
+		rnd[1] = rnd[put]
+		rnd[put] = x
+	}
+
+	return rnd
+}
+
+var (
+	errInvalidDomain = errors.New("invalid domain for proxy")
+	errNoHealthy     = errors.New("no healthy proxies")
+)

--- a/plugin/forward/forward_test.go
+++ b/plugin/forward/forward_test.go
@@ -1,0 +1,109 @@
+package forward
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+func TestForward(t *testing.T) {
+	config := "forward . %s {\nhealth_check 5ms\n}"
+	var counter int64
+
+	backend := dnstest.NewServer(dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		atomic.AddInt64(&counter, 1)
+		w.WriteMsg(r) // echo back
+	}))
+	defer backend.Close()
+
+	c := caddy.NewTestController("test", fmt.Sprintf(config, backend.Addr))
+
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Expected no error, got: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org", dns.TypeAAAA)
+	w := &test.ResponseWriter{}
+
+	f.ServeDNS(context.TODO(), w, m)
+
+	time.Sleep(50 * time.Millisecond)
+	cnt := atomic.LoadInt64(&counter)
+	// With all HCs going on, this should be more than 1
+	if cnt < 2 {
+		t.Errorf("Expecting more than %d requests, got %d", 1, cnt)
+	}
+}
+
+func TestForwardHealthCheck(t *testing.T) {
+	config := "forward . %s {\nhealth_check 5ms\n}"
+
+	var counter int64
+	backend := dnstest.NewServer(dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		// Healthchecks are TCP, don't reply
+		state := request.Request{W: w, Req: r}
+		if state.Proto() == "tcp" {
+			return
+		}
+
+		atomic.AddInt64(&counter, 1)
+		w.WriteMsg(r) // echo back
+	}))
+	defer backend.Close()
+
+	c := caddy.NewTestController("test", fmt.Sprintf(config, backend.Addr))
+
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Expected no error, got: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org", dns.TypeAAAA)
+	w := &test.ResponseWriter{}
+
+	// wait for HCs
+	time.Sleep(50 * time.Millisecond)
+
+	f.ServeDNS(context.TODO(), w, m)
+
+	// Wait for reply to be processed
+	time.Sleep(50 * time.Millisecond)
+
+	cnt := atomic.LoadInt64(&counter)
+	if cnt != 0 {
+		t.Errorf("Expecting no requests for bad upstream, got %d", cnt)
+	}
+}
+
+func TestIsAllowedDomain(t *testing.T) {
+	f := Forward{from: ".", ignored: []string{"example.net."}}
+
+	if x := f.isAllowedDomain("."); x != true {
+		t.Errorf("Expected true, got %t for .", x)
+	}
+	if x := f.isAllowedDomain("www.example.org."); x != true {
+		t.Errorf("Expected true, got %t for www.example.org.", x)
+	}
+	if x := f.isAllowedDomain("example.net."); x != false {
+		t.Errorf("Expected false, got %t for example.net.", x)
+	}
+	if x := f.isAllowedDomain("www.example.net."); x != false {
+		t.Errorf("Expected false, got %t for www.example.net.", x)
+	}
+}

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -1,0 +1,62 @@
+package forward
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// For HC we send to . IN NS +norec message to the upstream. Dial timeouts and empty
+// replies are considered fails, basically anything else constitutes a healthy upstream.
+
+func (h *host) Check() {
+	h.Lock()
+
+	if h.checking {
+		h.Unlock()
+		return
+	}
+
+	h.checking = true
+	h.Unlock()
+
+	err := h.send()
+	if err != nil {
+		atomic.AddUint32(&h.fails, 1)
+	} else {
+		atomic.StoreUint32(&h.fails, 0)
+	}
+
+	h.Lock()
+	h.checking = false
+	h.Unlock()
+
+	return
+}
+
+func (h *host) send() error {
+	hcping := new(dns.Msg)
+	hcping.SetQuestion(".", dns.TypeNS)
+	hcping.RecursionDesired = false
+
+	_, _, err := hcclient.Exchange(hcping, h.addr)
+	return err
+}
+
+func (h *host) down(maxfails uint32) bool {
+	if maxfails == 0 {
+		return false
+	}
+
+	fails := atomic.LoadUint32(&h.fails)
+	return fails > maxfails
+}
+
+var hcclient = func() *dns.Client {
+	c := new(dns.Client)
+	c.Net = "tcp"
+	c.ReadTimeout = 2 * time.Second
+	c.WriteTimeout = 2 * time.Second
+	return c
+}()

--- a/plugin/forward/host.go
+++ b/plugin/forward/host.go
@@ -1,0 +1,15 @@
+package forward
+
+import "sync"
+
+type host struct {
+	addr string
+
+	fails uint32
+	sync.RWMutex
+	checking bool
+}
+
+func newHost(addr string) *host { return &host{addr: addr} }
+
+func (h *host) String() string { return h.addr }

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -1,0 +1,56 @@
+package forward
+
+import (
+	"sync"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Variables declared for monitoring
+var (
+	RequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "request_count_total",
+		Help:      "Counter of requests made per protocol, family and upstream.",
+	}, []string{"proto", "family", "to"})
+	SocketCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "socket_count_total",
+		Help:      "Counter of open socket per upstream.",
+	}, []string{"to"})
+	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "request_duration_milliseconds",
+		Buckets:   append(prometheus.DefBuckets, []float64{15, 20, 25, 30, 40, 50, 100, 200, 500, 1000, 2000, 3000, 4000, 5000, 10000}...),
+		Help:      "Histogram of the time (in milliseconds) each request took.",
+	}, []string{"proto", "family", "to"})
+)
+
+// OnStartupMetrics sets up the metrics on startup.
+func OnStartupMetrics() error {
+	metricsOnce.Do(func() {
+		prometheus.MustRegister(RequestCount)
+		prometheus.MustRegister(SocketCount)
+		prometheus.MustRegister(RequestDuration)
+	})
+	return nil
+}
+
+// familyToString returns the string form of either 1, or 2. Returns
+// empty string is not a known family
+func familyToString(f int) string {
+	if f == 1 {
+		return "1"
+	}
+	if f == 2 {
+		return "2"
+	}
+	return ""
+}
+
+var metricsOnce sync.Once

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Variables declared for monitoring
+// Variables declared for monitoring.
 var (
 	RequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -215,6 +215,6 @@ func clientID(w dns.ResponseWriter) (id, proto string) {
 
 const (
 	dialTimeout = 1 * time.Second
-	connTimeout = 2 * time.Second
+	connTimeout = 3500 * time.Millisecond
 	hcDuration  = 500 * time.Millisecond
 )

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2016 Felipe Cavalcanti <fjfcavalcanti@gmail.com>
+ * Author: Felipe Cavalcanti <fjfcavalcanti@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* General idea kept, but completely rewritten for use in CoreDNS */
+
+package forward
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+type conn struct {
+	c    *dns.Conn
+	w    dns.ResponseWriter
+	used time.Time
+}
+
+type proxy struct {
+	host        *host
+	connTimeout time.Duration
+	conns       map[string]conn
+	sync.RWMutex
+	clientChan   chan request.Request
+	upstreamChan chan request.Request
+
+	// copied from Forward.
+	hcInterval time.Duration
+	forceTCP   bool
+
+	cl   bool
+	clMu sync.RWMutex
+}
+
+func newProxy(addr string) *proxy {
+	proxy := &proxy{
+		host:         newHost(addr),
+		connTimeout:  connTimeout,
+		cl:           false,
+		conns:        make(map[string]conn),
+		clientChan:   make(chan request.Request),
+		upstreamChan: make(chan request.Request),
+		hcInterval:   hcDuration,
+	}
+
+	return proxy
+}
+
+func (p *proxy) closed() bool {
+	p.clMu.RLock()
+	b := p.cl
+	p.clMu.RUnlock()
+	return b
+}
+
+func (p *proxy) setClosed(b bool) {
+	p.clMu.Lock()
+	p.cl = b
+	p.clMu.Unlock()
+}
+
+func (p *proxy) setUsed(clientID string) {
+	p.Lock()
+	if _, found := p.conns[clientID]; found {
+		connWrapper := p.conns[clientID]
+		connWrapper.used = time.Now()
+		p.conns[clientID] = connWrapper
+	}
+	p.Unlock()
+}
+
+// clientRead reads from upstream and send it to upstreamChan for writing it
+// back to the original client.
+func (p *proxy) clientRead(upstreamConn *dns.Conn, w dns.ResponseWriter) {
+	clientID, _ := clientID(w)
+	for {
+		start := time.Now()
+		ret, err := upstreamConn.ReadMsg()
+		if err != nil {
+			p.Lock()
+			upstreamConn.Close()
+			delete(p.conns, clientID)
+			p.Unlock()
+			return
+		}
+
+		p.setUsed(clientID)
+		state := request.Request{Req: ret, W: w}
+		p.upstreamChan <- state
+
+		RequestDuration.WithLabelValues(state.Proto(), familyToString(state.Family()), p.host.String()).Observe(float64(time.Since(start) / time.Millisecond))
+	}
+}
+
+func (p *proxy) upstreamPackets() {
+	for pa := range p.upstreamChan {
+		pa.W.WriteMsg(pa.Req)
+	}
+}
+
+func (p *proxy) clientPackets() {
+	for pa := range p.clientChan {
+		clientID, proto := clientID(pa.W)
+
+		p.RLock()
+		c, found := p.conns[clientID]
+		p.RUnlock()
+
+		if !found {
+			if p.forceTCP {
+				proto = "tcp"
+			}
+			c, err := dns.DialTimeout(proto, p.host.addr, dialTimeout)
+			if err != nil {
+				// try another nameserver?
+				continue
+			}
+
+			p.Lock()
+			p.conns[clientID] = conn{
+				c:    c,
+				w:    pa.W,
+				used: time.Now(),
+			}
+			p.Unlock()
+
+			c.WriteMsg(pa.Req)
+
+			go p.clientRead(c, pa.W)
+			continue
+		}
+
+		c.c.WriteMsg(pa.Req)
+
+		p.RLock()
+		if _, ok := p.conns[clientID]; ok {
+			if p.conns[clientID].used.Before(
+				time.Now().Add(-p.connTimeout / 4)) {
+				p.setUsed(clientID)
+			}
+		}
+		p.RUnlock()
+	}
+}
+
+func (p *proxy) free() {
+	for !p.closed() {
+		time.Sleep(p.connTimeout)
+
+		p.Lock()
+		for client, conn := range p.conns {
+			if conn.used.Before(time.Now().Add(-p.connTimeout)) {
+				delete(p.conns, client)
+			}
+		}
+		p.Unlock()
+	}
+}
+
+func (p *proxy) healthCheck() {
+	for !p.closed() {
+		time.Sleep(p.hcInterval)
+
+		go p.host.Check()
+	}
+}
+
+// knownClient returns true when this particular client has been seen by this proxy.
+func (p *proxy) knownClient(id string) bool {
+	p.RLock()
+	_, ok := p.conns[id]
+	p.RUnlock()
+	return ok
+}
+
+// Len returns the number of known connection for this proxy.
+func (p *proxy) Len() int {
+	p.RLock()
+	l := len(p.conns)
+	p.RUnlock()
+	return l
+}
+
+// clientID returns a string that identifies this particular client's 3-tuple.
+func clientID(w dns.ResponseWriter) (id, proto string) {
+	if _, ok := w.RemoteAddr().(*net.UDPAddr); ok {
+		return w.RemoteAddr().String() + "udp", "udp"
+	}
+	return w.RemoteAddr().String() + "tcp", "tcp"
+}
+
+const (
+	udpBufSize  = 4096
+	dialTimeout = 1 * time.Second
+	connTimeout = 2 * time.Second
+	hcDuration  = 500 * time.Millisecond
+)

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -93,7 +93,7 @@ func (p *proxy) setUsed(clientID string) {
 	p.Unlock()
 }
 
-// clientRead reads from upstream and send it to upstreamChan for writing it
+// clientRead reads from upstream and sends it to upstreamChan for writing it
 // back to the original client.
 func (p *proxy) clientRead(upstreamConn *dns.Conn, w dns.ResponseWriter) {
 	clientID, _ := clientID(w)

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -214,7 +214,6 @@ func clientID(w dns.ResponseWriter) (id, proto string) {
 }
 
 const (
-	udpBufSize  = 4096
 	dialTimeout = 1 * time.Second
 	connTimeout = 2 * time.Second
 	hcDuration  = 500 * time.Millisecond

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -1,0 +1,145 @@
+package forward
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+
+	"github.com/mholt/caddy"
+)
+
+func init() {
+	caddy.RegisterPlugin("forward", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	f, err := parseForward(c)
+	if err != nil {
+		return err
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		f.Next = next
+		return f
+	})
+
+	c.OnStartup(func() error {
+		OnStartupMetrics()
+		return f.OnStartup()
+	})
+	c.OnShutdown(func() error {
+		return f.OnShutdown()
+	})
+
+	return nil
+}
+
+// OnStartup starts a goroutines for all proxies.
+func (f *Forward) OnStartup() (err error) {
+	for _, p := range f.proxies {
+		if p.connTimeout.Nanoseconds() > 0 {
+			go p.free()
+		}
+
+		go p.upstreamPackets()
+		go p.clientPackets()
+		go p.healthCheck()
+	}
+	return nil
+}
+
+// OnShutdown stops all configures proxies.
+func (f *Forward) OnShutdown() error {
+	for _, p := range f.proxies {
+		p.setClosed(true)
+
+		p.Lock()
+		for _, conn := range p.conns {
+			conn.c.Close()
+		}
+		p.Unlock()
+	}
+	return nil
+}
+
+func parseForward(c *caddy.Controller) (Forward, error) {
+	f := Forward{maxfails: 2}
+	for c.Next() {
+		if !c.Args(&f.from) {
+			return f, c.ArgErr()
+		}
+		f.from = plugin.Host(f.from).Normalize()
+
+		to := c.RemainingArgs()
+		if len(to) == 0 {
+			return f, c.ArgErr()
+		}
+		toHosts, err := dnsutil.ParseHostPortOrFile(to...)
+		if err != nil {
+			return f, err
+		}
+		for _, h := range toHosts {
+			p := newProxy(h)
+			f.proxies = append(f.proxies, p)
+
+		}
+
+		for c.NextBlock() {
+			if err := parseBlock(c, &f); err != nil {
+				return f, err
+			}
+		}
+	}
+	return f, nil
+}
+
+func parseBlock(c *caddy.Controller, f *Forward) error {
+	switch c.Val() {
+	case "except":
+		ignore := c.RemainingArgs()
+		if len(ignore) == 0 {
+			return c.ArgErr()
+		}
+		for i := 0; i < len(ignore); i++ {
+			ignore[i] = plugin.Host(ignore[i]).Normalize()
+		}
+		f.ignored = ignore
+	case "max_fails":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.Atoi(c.Val())
+		if err != nil {
+			return err
+		}
+		f.maxfails = uint32(n)
+	case "health_check":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		dur, err := time.ParseDuration(c.Val())
+		if err != nil {
+			return err
+		}
+		for i := range f.proxies {
+			f.proxies[i].hcInterval = dur
+		}
+	case "force_tcp":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.forceTCP = true
+		for i := range f.proxies {
+			f.proxies[i].forceTCP = true
+		}
+	default:
+		return c.Errf("unknown property '%s'", c.Val())
+	}
+	return nil
+}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -1,0 +1,61 @@
+package forward
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestSetupForward(t *testing.T) {
+	tests := []struct {
+		input            string
+		shouldErr        bool
+		expectedFrom     string
+		expectedIgnored  []string
+		expectedFails    uint32
+		expectedForceTCP bool
+		expectedErr      string
+	}{
+		// positive
+		{"forward . 127.0.0.1", false, ".", nil, 2, false, ""},
+		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, false, ""},
+		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, false, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, true, ""},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		f, err := parseForward(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: expected no error but found one for input %s. Error was: %v", i, test.input, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
+			}
+		}
+
+		if !test.shouldErr && f.from != test.expectedFrom {
+			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedFrom, f.from)
+		}
+		if !test.shouldErr && test.expectedIgnored != nil {
+			if !reflect.DeepEqual(f.ignored, test.expectedIgnored) {
+				t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedIgnored, f.ignored)
+			}
+		}
+		if !test.shouldErr && f.maxfails != test.expectedFails {
+			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedFails, f.maxfails)
+		}
+		if !test.shouldErr && f.forceTCP != test.expectedForceTCP {
+			t.Errorf("Test %d: expected: %t, got: %t", i, test.expectedForceTCP, f.forceTCP)
+		}
+	}
+}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -23,6 +23,9 @@ func TestSetupForward(t *testing.T) {
 		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, false, ""},
 		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, false, ""},
 		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, true, ""},
+		// negative
+		{"forward . a27.0.0.1", true, "", nil, 0, false, "not an IP"},
+		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, false, "unknown property"},
 	}
 
 	for i, test := range tests {
@@ -35,7 +38,7 @@ func TestSetupForward(t *testing.T) {
 
 		if err != nil {
 			if !test.shouldErr {
-				t.Errorf("Test %d: expected no error but found one for input %s. Error was: %v", i, test.input, err)
+				t.Errorf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
 			}
 
 			if !strings.Contains(err.Error(), test.expectedErr) {


### PR DESCRIPTION
This is a new proxy implementation that caches upstream connections. It
works with udp and tcp. The healthchecks are inband doing a ". IN NS"
+norec query against the upstream.

See the README.md for the implemented features.
