### PR TITLE
core: don't always include all plugins

### DIFF
--- a/core/coredns.go
+++ b/core/coredns.go
@@ -4,29 +4,4 @@ package core
 import (
 	// plug in the server
 	_ "github.com/coredns/coredns/core/dnsserver"
-
-	// plug in the standard directives (sorted)
-	_ "github.com/coredns/coredns/plugin/auto"
-	_ "github.com/coredns/coredns/plugin/bind"
-	_ "github.com/coredns/coredns/plugin/cache"
-	_ "github.com/coredns/coredns/plugin/chaos"
-	_ "github.com/coredns/coredns/plugin/dnssec"
-	_ "github.com/coredns/coredns/plugin/dnstap"
-	_ "github.com/coredns/coredns/plugin/erratic"
-	_ "github.com/coredns/coredns/plugin/errors"
-	_ "github.com/coredns/coredns/plugin/etcd"
-	_ "github.com/coredns/coredns/plugin/file"
-	_ "github.com/coredns/coredns/plugin/health"
-	_ "github.com/coredns/coredns/plugin/kubernetes"
-	_ "github.com/coredns/coredns/plugin/loadbalance"
-	_ "github.com/coredns/coredns/plugin/log"
-	_ "github.com/coredns/coredns/plugin/metrics"
-	_ "github.com/coredns/coredns/plugin/pprof"
-	_ "github.com/coredns/coredns/plugin/proxy"
-	_ "github.com/coredns/coredns/plugin/reverse"
-	_ "github.com/coredns/coredns/plugin/rewrite"
-	_ "github.com/coredns/coredns/plugin/root"
-	_ "github.com/coredns/coredns/plugin/secondary"
-	_ "github.com/coredns/coredns/plugin/trace"
-	_ "github.com/coredns/coredns/plugin/whoami"
 )

--- a/core/zplugin.go
+++ b/core/zplugin.go
@@ -3,7 +3,7 @@
 package core
 
 import (
-	// Include all plugin.
+	// Include all plugins.
 	_ "github.com/coredns/coredns/plugin/auto"
 	_ "github.com/coredns/coredns/plugin/autopath"
 	_ "github.com/coredns/coredns/plugin/bind"

--- a/directives_generate.go
+++ b/directives_generate.go
@@ -59,7 +59,7 @@ func genImports(file, pack string, mi map[string]string) {
 		outs += "\n"
 	}
 
-	outs += "// Include all plugin.\n"
+	outs += "// Include all plugins.\n"
 	for _, v := range mi {
 		outs += `_ "` + v + `"` + "\n"
 	}


### PR DESCRIPTION
Clean out the imports in coredns.go and just leave the server import.

Fixes #1119

