### PR TITLE
plugin/proxy: fix metrics

### DIFF
--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -98,10 +98,13 @@ payload over HTTPS). Note that with `https_google` the entire transport is encry
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
 
-* coredns_proxy_request_count_total{proto, proxy_proto, from}
+* `coredns_proxy_request_duration_millisecond{proto, proto_proxy, family, to}` - duration per upstream
+  interaction.
+* `coredns_proxy_request_count_total{proto, proto_proxy, family, to}` - query count per upstream.
 
-Where `proxy_proto` is the protocol used (`dns`, `grpc`, or `https_google`) and `from` is **FROM**
+Where `proxy_proto` is the protocol used (`dns`, `grpc`, or `https_google`) and `to` is **TO**
 specified in the config, `proto` is the protocol used by the incoming query ("tcp" or "udp").
+and family the transport family ("1" for IPv4, and "2" for IPv6).
 
 ## Examples
 

--- a/plugin/proxy/metrics.go
+++ b/plugin/proxy/metrics.go
@@ -10,21 +10,40 @@ import (
 
 // Metrics the proxy plugin exports.
 var (
+	RequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "proxy",
+		Name:      "request_count_total",
+		Help:      "Counter of requests made per protocol, proxy protocol, family and upstream.",
+	}, []string{"proto", "proxy_proto", "family", "to"})
 	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "proxy",
 		Name:      "request_duration_milliseconds",
-		Buckets:   append(prometheus.DefBuckets, []float64{50, 100, 200, 500, 1000, 2000, 3000, 4000, 5000, 10000}...),
+		Buckets:   append(prometheus.DefBuckets, []float64{15, 20, 25, 30, 40, 50, 100, 200, 500, 1000, 2000, 3000, 4000, 5000, 10000}...),
 		Help:      "Histogram of the time (in milliseconds) each request took.",
-	}, []string{"proto", "proxy_proto", "from"})
+	}, []string{"proto", "proxy_proto", "family", "to"})
 )
 
 // OnStartupMetrics sets up the metrics on startup. This is done for all proxy protocols.
 func OnStartupMetrics() error {
 	metricsOnce.Do(func() {
+		prometheus.MustRegister(RequestCount)
 		prometheus.MustRegister(RequestDuration)
 	})
 	return nil
+}
+
+// familyToString returns the string form of either 1, or 2. Returns
+// empty string is not a known family
+func familyToString(f int) string {
+	if f == 1 {
+		return "1"
+	}
+	if f == 2 {
+		return "2"
+	}
+	return ""
 }
 
 var metricsOnce sync.Once


### PR DESCRIPTION
Add Counter metrics and fix duration to use upstream name (and only use
it when we have one).

Fix the documentation to reflect this.

Fixes #1134