### PR TITLE
Don't number the plugins

### DIFF
--- a/directives_generate.go
+++ b/directives_generate.go
@@ -8,17 +8,17 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sort"
-	"strconv"
 	"strings"
 )
 
 func main() {
 	mi := make(map[string]string, 0)
-	md := make(map[int]string, 0)
+	md := []string{}
 
 	file, err := os.Open(pluginFile)
-	fatalIfErr(err)
+	if err != nil {
+		log.Fatalf("Failed to open %s: %q", pluginFile, err)
+	}
 
 	defer file.Close()
 
@@ -30,21 +30,21 @@ func main() {
 		}
 
 		items := strings.Split(line, ":")
-		if len(items) != 3 {
-			// ignore
+		if len(items) != 2 {
+			// ignore empty lines
 			continue
 		}
-		priority, err := strconv.Atoi(items[0])
-		fatalIfErr(err)
+		name := items[0]
 
-		if v, ok := md[priority]; ok {
-			log.Fatalf("Duplicate priority '%d', slot already taken by %q", priority, v)
+		if _, ok := mi[name]; ok {
+			log.Fatalf("Duplicate entry %q", name)
 		}
-		md[priority] = items[1]
-		mi[items[1]] = pluginPath + items[2] // Default, unless overridden by 3rd arg
 
-		if _, err := os.Stat(pluginFSPath + items[2]); err != nil { // External package has been given
-			mi[items[1]] = items[2]
+		md = append(md, items[0])
+		mi[items[0]] = pluginPath + items[1] // Default, unless overridden by 3rd arg
+
+		if _, err := os.Stat(pluginFSPath + items[1]); err != nil { // External package has been given
+			mi[items[0]] = items[1]
 		}
 	}
 
@@ -65,14 +65,12 @@ func genImports(file, pack string, mi map[string]string) {
 	}
 	outs += ")\n"
 
-	res, err := format.Source([]byte(outs))
-	fatalIfErr(err)
-
-	err = ioutil.WriteFile(file, res, 0644)
-	fatalIfErr(err)
+	if err := formatAndWrite(file, outs); err != nil {
+		log.Fatalf("Failed to format and write: %q", err)
+	}
 }
 
-func genDirectives(file, pack string, md map[int]string) {
+func genDirectives(file, pack string, md []string) {
 
 	outs := header + "package " + pack + "\n\n"
 	outs += `
@@ -87,29 +85,27 @@ func genDirectives(file, pack string, md map[int]string) {
 var directives = []string{
 `
 
-	var orders []int
-	for k := range md {
-		orders = append(orders, k)
-	}
-	sort.Ints(orders)
-
-	for _, k := range orders {
-		outs += `"` + md[k] + `",` + "\n"
+	for i := range md {
+		outs += `"` + md[i] + `",` + "\n"
 	}
 
 	outs += "}\n"
 
-	res, err := format.Source([]byte(outs))
-	fatalIfErr(err)
-
-	err = ioutil.WriteFile(file, res, 0644)
-	fatalIfErr(err)
+	if err := formatAndWrite(file, outs); err != nil {
+		log.Fatalf("Failed to format and write: %q", err)
+	}
 }
 
-func fatalIfErr(err error) {
+func formatAndWrite(file string, data string) error {
+	res, err := format.Source([]byte(data))
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
+	if err = ioutil.WriteFile(file, res, 0644); err != nil {
+		return err
+	}
+	return nil
 }
 
 const (

--- a/directives_generate.go
+++ b/directives_generate.go
@@ -34,17 +34,17 @@ func main() {
 			// ignore empty lines
 			continue
 		}
-		name := items[0]
+		name, repo := items[0], items[1]
 
 		if _, ok := mi[name]; ok {
 			log.Fatalf("Duplicate entry %q", name)
 		}
 
-		md = append(md, items[0])
-		mi[items[0]] = pluginPath + items[1] // Default, unless overridden by 3rd arg
+		md = append(md, name)
+		mi[name] = pluginPath + repo // Default, unless overridden by 3rd arg
 
-		if _, err := os.Stat(pluginFSPath + items[1]); err != nil { // External package has been given
-			mi[items[0]] = items[1]
+		if _, err := os.Stat(pluginFSPath + repo); err != nil { // External package has been given
+			mi[name] = repo
 		}
 	}
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -10,42 +10,42 @@
 # Modify the list below and run `go gen && go build`
 
 # The parser takes the input format of
-#     <order>:<plugin-name>:<package-name>
+#     <plugin-name>:<package-name>
 # Or
-#     <order>:<plugin-name>:<fully-qualified-package-name>
+#     <plugin-name>:<fully-qualified-package-name>
 #
 # External plugin example:
-# 80:log:github.com/coredns/coredns/plugin/log
+# log:github.com/coredns/coredns/plugin/log
 # Local plugin example:
-# 80:log:log
+# log:log
 
-1:tls:tls
-10:root:root
-20:bind:bind
-30:debug:debug
-40:trace:trace
-50:health:health
-60:pprof:pprof
-70:prometheus:metrics
-80:errors:errors
-90:log:log
-100:autopath:autopath
-110:dnstap:dnstap
-120:chaos:chaos
-130:cache:cache
-140:rewrite:rewrite
-150:loadbalance:loadbalance
-160:dnssec:dnssec
-170:reverse:reverse
-180:hosts:hosts
-190:federation:federation
-200:kubernetes:kubernetes
-210:file:file
-220:auto:auto
-230:secondary:secondary
-240:etcd:etcd
-250:proxy:proxy
-260:erratic:erratic
-270:whoami:whoami
-500:startup:github.com/mholt/caddy/startupshutdown
-510:shutdown:github.com/mholt/caddy/startupshutdown
+tls:tls
+root:root
+bind:bind
+debug:debug
+trace:trace
+health:health
+pprof:pprof
+prometheus:metrics
+errors:errors
+log:log
+autopath:autopath
+dnstap:dnstap
+chaos:chaos
+cache:cache
+rewrite:rewrite
+loadbalance:loadbalance
+dnssec:dnssec
+reverse:reverse
+hosts:hosts
+federation:federation
+kubernetes:kubernetes
+file:file
+auto:auto
+secondary:secondary
+etcd:etcd
+proxy:proxy
+erratic:erratic
+whoami:whoami
+startup:github.com/mholt/caddy/startupshutdown
+shutdown:github.com/mholt/caddy/startupshutdown


### PR DESCRIPTION
The number is not needed, because the ordering is already specified.
It's also annoying when you move plugins, because you need to renumber
them. Remove this.

'go gen' shows no changes in the generated files, meaning this just
works.