### PR TITLE
plugin/metrcs: add env variable example

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -48,6 +48,15 @@ Use an alternative address:
 }
 ~~~
 
+Or via an enviroment variable (this is supported throughout the Corefile): `export PORT=9253`, and
+then:
+
+~~~ corefile
+. {
+    prometheus localhost:{$PORT}
+}
+~~~
+
 # Bugs
 
 When reloading, we keep the handler running, meaning that any changes to the handler's address

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -14,15 +14,14 @@ import (
 	"github.com/mholt/caddy"
 )
 
-// Pasrse all README.md's of the plugin and check if every example Corefile
-// actually works. Each corefile is only used if the language is set to 'corefile':
+// TestReadme parses all README.md's of the plugins and checks if every example Corefile
+// actually works. Each corefile snippet is only used if the language is set to 'corefile':
 //
 // ~~~ corefile
 // . {
 //	# check-this-please
 // }
 // ~~~
-
 func TestReadme(t *testing.T) {
 	port := 30053
 	caddy.Quiet = true


### PR DESCRIPTION
We support ENV variables in config files, add an example in the one for
metric, note that `localhost:` is a valid host (in Go), so the
TestReadme will parse this correctly.

Fixes #1150

