### PR TITLE
plugin/kubernetes: implement HasSynced() 

### DIFF
--- a/plugin/federation/kubernetes_api_test.go
+++ b/plugin/federation/kubernetes_api_test.go
@@ -9,6 +9,7 @@ import (
 
 type APIConnFederationTest struct{}
 
+func (APIConnFederationTest) HasSynced() bool                        { return true }
 func (APIConnFederationTest) Run()                                   { return }
 func (APIConnFederationTest) Stop() error                            { return nil }
 func (APIConnFederationTest) SvcIndexReverse(string) []*api.Service  { return nil }

--- a/plugin/kubernetes/apiproxy.go
+++ b/plugin/kubernetes/apiproxy.go
@@ -65,7 +65,9 @@ func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func (p *apiProxy) Run() {
 	p.handler.Start()
-	p.Serve(p.listener)
+	go func() {
+		p.Serve(p.listener)
+	}()
 }
 
 func (p *apiProxy) Stop() {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -191,6 +191,7 @@ func TestServeDNS(t *testing.T) {
 
 type APIConnServeTest struct{}
 
+func (APIConnServeTest) HasSynced() bool                        { return true }
 func (APIConnServeTest) Run()                                   { return }
 func (APIConnServeTest) Stop() error                            { return nil }
 func (APIConnServeTest) EpIndexReverse(string) []*api.Endpoints { return nil }

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -338,10 +338,13 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 	)
 	if wildcard(r.service) || wildcard(r.namespace) {
 		serviceList = k.APIConn.ServiceList()
+		endpointsList = k.APIConn.EndpointsList()
 	} else {
 		idx = r.service + "." + r.namespace
 		serviceList = k.APIConn.SvcIndex(idx)
+		endpointsList = k.APIConn.EpIndex(idx)
 	}
+
 	for _, svc := range serviceList {
 
 		if !(match(r.namespace, svc.Namespace) && match(r.service, svc.Name)) {
@@ -356,12 +359,6 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 		// Endpoint query or headless service
 		if svc.Spec.ClusterIP == api.ClusterIPNone || r.endpoint != "" {
-			if wildcard(r.service) || wildcard(r.namespace) {
-				endpointsList = k.APIConn.EndpointsList()
-			} else {
-				idx = r.service + "." + r.namespace
-				endpointsList = k.APIConn.EpIndex(idx)
-			}
 			for _, ep := range endpointsList {
 				if ep.ObjectMeta.Name != svc.Name || ep.ObjectMeta.Namespace != svc.Namespace {
 					continue

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -51,6 +51,7 @@ func TestEndpointHostname(t *testing.T) {
 
 type APIConnServiceTest struct{}
 
+func (APIConnServiceTest) HasSynced() bool                        { return true }
 func (APIConnServiceTest) Run()                                   { return }
 func (APIConnServiceTest) Stop() error                            { return nil }
 func (APIConnServiceTest) PodIndex(string) []*api.Pod             { return nil }

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -9,6 +9,7 @@ import (
 
 type APIConnTest struct{}
 
+func (APIConnTest) HasSynced() bool                       { return true }
 func (APIConnTest) Run()                                  { return }
 func (APIConnTest) Stop() error                           { return nil }
 func (APIConnTest) PodIndex(string) []*api.Pod            { return nil }

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -14,6 +14,7 @@ import (
 
 type APIConnReverseTest struct{}
 
+func (APIConnReverseTest) HasSynced() bool                       { return true }
 func (APIConnReverseTest) Run()                                  { return }
 func (APIConnReverseTest) Stop() error                           { return nil }
 func (APIConnReverseTest) PodIndex(string) []*api.Pod            { return nil }

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -39,8 +39,14 @@ func setup(c *caddy.Controller) error {
 	c.OnStartup(func() error {
 		go kubernetes.APIConn.Run()
 		if kubernetes.APIProxy != nil {
-			go kubernetes.APIProxy.Run()
+			kubernetes.APIProxy.Run()
 		}
+		synced := false
+		for synced == false {
+			synced = kubernetes.APIConn.HasSynced()
+			time.Sleep(100 * time.Millisecond)
+		}
+
 		return nil
 	})
 

--- a/test/kubernetes_api_fallthrough_test.go
+++ b/test/kubernetes_api_fallthrough_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -35,9 +34,6 @@ func TestKubernetesAPIFallthrough(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range tests {
 

--- a/test/kubernetes_nsexposed_test.go
+++ b/test/kubernetes_nsexposed_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -41,9 +40,6 @@ func TestKubernetesNSExposed(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesAllNSExposed {
 

--- a/test/kubernetes_pods_test.go
+++ b/test/kubernetes_pods_test.go
@@ -4,7 +4,6 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -30,11 +29,11 @@ var dnsTestCasesPodsInsecure = []test.Case{
 
 func TestKubernetesPodsInsecure(t *testing.T) {
 	corefile := `.:0 {
-    kubernetes cluster.local 0.0.10.in-addr.arpa {
-                endpoint http://localhost:8080
-                namespaces test-1
-                pods insecure
-    }
+kubernetes cluster.local 0.0.10.in-addr.arpa {
+	endpoint http://localhost:8080
+	namespaces test-1
+	pods insecure
+}
 `
 
 	server, udp, _, err := CoreDNSServerAndPorts(corefile)
@@ -42,9 +41,6 @@ func TestKubernetesPodsInsecure(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesPodsInsecure {
 
@@ -91,9 +87,6 @@ func TestKubernetesPodsVerified(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range dnsTestCasesPodsVerified {
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -278,9 +277,6 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
-
-	// Work-around for timing condition that results in no-data being returned in test environment.
-	time.Sleep(3 * time.Second)
 
 	for _, tc := range testCases {
 

--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -277,6 +278,8 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer server.Stop()
+
+	time.Sleep(1 * time.Second)
 
 	for _, tc := range testCases {
 


### PR DESCRIPTION
### 1. What does this pull request do?

Implements HasSynced() that holds startup until the API has fully synced. Removing the race in the startup we now have.

Fixes #1006 