### PR TITLE
core: add ServeDNS benchmark

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -280,7 +280,7 @@ func (s *Server) OnStartupComplete() {
 	}
 }
 
-// Tracer ... TODO: Add comment
+// Tracer returns the tracer in the server if defined.
 func (s *Server) Tracer() ot.Tracer {
 	if s.trace == nil {
 		return nil
@@ -308,7 +308,5 @@ const (
 	udp = 1
 )
 
-var (
-	// Quiet mode will not show any informative output on initialization.
-	Quiet bool
-)
+// Quiet mode will not show any informative output on initialization.
+var Quiet bool

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -48,7 +48,7 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
-func BenchmarkServeDns(b *testing.B) {
+func BenchmarkCoreServeDNS(b *testing.B) {
 	s, err := NewServer("127.0.0.1:53", []*Config{testConfig("dns")})
 	if err != nil {
 		b.Errorf("Expected no error for NewServer, got %s.", err)

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -2,25 +2,66 @@ package dnsserver
 
 import (
 	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
-func makeConfig(transport string) *Config {
-	return &Config{Zone: "example.com", Transport: transport, ListenHost: "127.0.0.1", Port: "53"}
+type testPlugin struct{}
+
+func (tp testPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return 0, nil
+}
+
+func (tp testPlugin) Name() string { return "testplugin" }
+
+func testConfig(transport string) *Config {
+	c := &Config{
+		Zone:       "example.com.",
+		Transport:  transport,
+		ListenHost: "127.0.0.1",
+		Port:       "53",
+		Debug:      false,
+	}
+
+	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return testPlugin{} })
+	return c
 }
 
 func TestNewServer(t *testing.T) {
-	_, err := NewServer("127.0.0.1:53", []*Config{makeConfig("dns")})
+	_, err := NewServer("127.0.0.1:53", []*Config{testConfig("dns")})
 	if err != nil {
 		t.Errorf("Expected no error for NewServer, got %s.", err)
 	}
 
-	_, err = NewServergRPC("127.0.0.1:53", []*Config{makeConfig("grpc")})
+	_, err = NewServergRPC("127.0.0.1:53", []*Config{testConfig("grpc")})
 	if err != nil {
 		t.Errorf("Expected no error for NewServergRPC, got %s.", err)
 	}
 
-	_, err = NewServerTLS("127.0.0.1:53", []*Config{makeConfig("tls")})
+	_, err = NewServerTLS("127.0.0.1:53", []*Config{testConfig("tls")})
 	if err != nil {
 		t.Errorf("Expected no error for NewServerTLS, got %s.", err)
+	}
+}
+
+func BenchmarkServeDns(b *testing.B) {
+	s, err := NewServer("127.0.0.1:53", []*Config{testConfig("dns")})
+	if err != nil {
+		b.Errorf("Expected no error for NewServer, got %s.", err)
+	}
+
+	ctx := context.TODO()
+	w := &test.ResponseWriter{}
+	m := new(dns.Msg)
+	m.SetQuestion("aaa.example.com.", dns.TypeTXT)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.ServeDNS(ctx, w, m)
 	}
 }


### PR DESCRIPTION
Add benchmark function so we can perf test future additions to the
servers' ServeDNS function.