### PR TITLE
plugin/pkg/cache: smarter locking

### DIFF
--- a/plugin/pkg/cache/cache.go
+++ b/plugin/pkg/cache/cache.go
@@ -95,19 +95,22 @@ func (s *shard) Remove(key uint32) {
 
 // Evict removes a random element from the cache.
 func (s *shard) Evict() {
-	s.Lock()
-	defer s.Unlock()
-
 	key := -1
+
+	s.RLock()
 	for k := range s.items {
 		key = int(k)
 		break
 	}
+	s.RUnlock()
+
 	if key == -1 {
 		// empty cache
 		return
 	}
-	delete(s.items, uint32(key))
+
+	// If this item is gone between the RUnlock and Lock race we don't care.
+	s.Remove(uint32(key))
 }
 
 // Get looks up the element indexed under key.

--- a/plugin/pkg/cache/cache_test.go
+++ b/plugin/pkg/cache/cache_test.go
@@ -29,3 +29,13 @@ func TestCacheLen(t *testing.T) {
 		t.Fatalf("Cache size should %d, got %d", 2, l)
 	}
 }
+
+func BenchmarkCache(b *testing.B) {
+	b.ReportAllocs()
+
+	c := New(4)
+	for n := 0; n < b.N; n++ {
+		c.Add(1, 1)
+		c.Get(1)
+	}
+}


### PR DESCRIPTION
Make the locking slightly smarter in Evict and add benchmark function.

Seems a bit faster (there was some variance while performing these
benchmarks)

Master:
BenchmarkCache-2   	 1000000	      2317 ns/op	       0 B/op	       0 allocs/op
BenchmarkCache-2   	 1000000	      2032 ns/op	       0 B/op	       0 allocs/op

This branch:
BenchmarkCache-2   	 1000000	      1806 ns/op	       0 B/op	       0 allocs/op
BenchmarkCache-2   	 1000000	      1809 ns/op	       0 B/op	       0 allocs/op

Also see #1157