### PR TITLE
plugin/kubernetes: re-add sleep(3)

### DIFF
--- a/test/kubernetes_test.go
+++ b/test/kubernetes_test.go
@@ -279,7 +279,7 @@ func doIntegrationTests(t *testing.T, corefile string, testCases []test.Case) {
 	}
 	defer server.Stop()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	for _, tc := range testCases {
 


### PR DESCRIPTION
This flakyness is driving me crazy. Add the sleep(3s) back.