### PR TITLE
plugin/hosts: Change lock from a Mutex to a RWMutex

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -36,7 +36,7 @@ func absDomainName(b string) string {
 
 // Hostsfile contains known host entries.
 type Hostsfile struct {
-	sync.Mutex
+	sync.RWMutex
 
 	// list of zones we are authoritive for
 	Origins []string
@@ -139,6 +139,8 @@ func (h *Hostsfile) Parse(file io.Reader) {
 			is[addr.String()] = append(is[addr.String()], name)
 		}
 	}
+	h.Lock()
+	defer h.Unlock()
 	h.byNameV4 = hsv4
 	h.byNameV6 = hsv6
 	h.byAddr = is
@@ -159,8 +161,8 @@ func ipVersion(s string) int {
 
 // LookupStaticHostV4 looks up the IPv4 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
-	h.Lock()
-	defer h.Unlock()
+	h.RLock()
+	defer h.RUnlock()
 	h.ReadHosts()
 	if len(h.byNameV4) != 0 {
 		if ips, ok := h.byNameV4[absDomainName(host)]; ok {
@@ -174,8 +176,8 @@ func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
 
 // LookupStaticHostV6 looks up the IPv6 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
-	h.Lock()
-	defer h.Unlock()
+	h.RLock()
+	defer h.RUnlock()
 	h.ReadHosts()
 	if len(h.byNameV6) != 0 {
 		if ips, ok := h.byNameV6[absDomainName(host)]; ok {
@@ -189,8 +191,8 @@ func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
 
 // LookupStaticAddr looks up the hosts for the given address from the hosts file.
 func (h *Hostsfile) LookupStaticAddr(addr string) []string {
-	h.Lock()
-	defer h.Unlock()
+	h.RLock()
+	defer h.RUnlock()
 	h.ReadHosts()
 	addr = parseLiteralIP(addr).String()
 	if addr == "" {

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -161,9 +161,9 @@ func ipVersion(s string) int {
 
 // LookupStaticHostV4 looks up the IPv4 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
+	h.ReadHosts()
 	h.RLock()
 	defer h.RUnlock()
-	h.ReadHosts()
 	if len(h.byNameV4) != 0 {
 		if ips, ok := h.byNameV4[absDomainName(host)]; ok {
 			ipsCp := make([]net.IP, len(ips))
@@ -176,9 +176,9 @@ func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
 
 // LookupStaticHostV6 looks up the IPv6 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
+	h.ReadHosts()
 	h.RLock()
 	defer h.RUnlock()
-	h.ReadHosts()
 	if len(h.byNameV6) != 0 {
 		if ips, ok := h.byNameV6[absDomainName(host)]; ok {
 			ipsCp := make([]net.IP, len(ips))
@@ -191,9 +191,9 @@ func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
 
 // LookupStaticAddr looks up the hosts for the given address from the hosts file.
 func (h *Hostsfile) LookupStaticAddr(addr string) []string {
+	h.ReadHosts()
 	h.RLock()
 	defer h.RUnlock()
-	h.ReadHosts()
 	addr = parseLiteralIP(addr).String()
 	if addr == "" {
 		return nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Changes the lock on the hosts file data from a Mutex to a RWMutex.
This allows multiple concurrent reads from the hosts file.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
N/A
