### PR TITLE
plugin/dnstap: some cleanup

### DIFF
--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -79,7 +79,7 @@ func (h Dnstap) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	newCtx := context.WithValue(ctx, DnstapSendOption, &sendOption)
 
 	rw := &taprw.ResponseWriter{ResponseWriter: w, Tapper: &h, Query: r, Send: &sendOption}
-	rw.QueryEpoch()
+	rw.SetQueryEpoch()
 
 	code, err := plugin.NextOrFailure(h.Name(), h.Next, tapContext{newCtx, h}, rw, r)
 	if err != nil {

--- a/plugin/dnstap/msg/msg.go
+++ b/plugin/dnstap/msg/msg.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net"
 	"strconv"
-	"time"
 
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
@@ -101,16 +100,6 @@ func (d *Data) Pack(m *dns.Msg) error {
 	}
 	d.Packed = packed
 	return nil
-}
-
-// Epoch returns the epoch time in seconds.
-func Epoch() uint64 {
-	return uint64(time.Now().Unix())
-}
-
-// Epoch sets the dnstap message epoch.
-func (d *Data) Epoch() {
-	d.TimeSec = Epoch()
 }
 
 // ToClientResponse transforms Data into a client response message.

--- a/plugin/dnstap/taprw/writer.go
+++ b/plugin/dnstap/taprw/writer.go
@@ -4,6 +4,7 @@ package taprw
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 
@@ -41,9 +42,9 @@ func (w ResponseWriter) DnstapError() error {
 	return w.err
 }
 
-// QueryEpoch sets the query epoch as reported by dnstap.
-func (w *ResponseWriter) QueryEpoch() {
-	w.queryEpoch = msg.Epoch()
+// SetQueryEpoch sets the query epoch as reported by dnstap.
+func (w *ResponseWriter) SetQueryEpoch() {
+	w.queryEpoch = uint64(time.Now().Unix())
 }
 
 // WriteMsg writes back the response to the client and THEN works on logging the request
@@ -51,7 +52,7 @@ func (w *ResponseWriter) QueryEpoch() {
 // Dnstap errors are to be checked by DnstapError.
 func (w *ResponseWriter) WriteMsg(resp *dns.Msg) (writeErr error) {
 	writeErr = w.ResponseWriter.WriteMsg(resp)
-	writeEpoch := msg.Epoch()
+	writeEpoch := uint64(time.Now().Unix())
 
 	b := w.TapBuilder()
 	b.TimeSec = w.queryEpoch

--- a/plugin/proxy/dnstap.go
+++ b/plugin/proxy/dnstap.go
@@ -1,0 +1,54 @@
+package proxy
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/plugin/dnstap"
+	"github.com/coredns/coredns/request"
+
+	tap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+func toDnstap(ctx context.Context, host string, ex Exchanger, state request.Request, reply *dns.Msg, start time.Time) error {
+	tapper := dnstap.TapperFromContext(ctx)
+	if tapper == nil {
+		return nil
+	}
+
+	// Query
+	b := tapper.TapBuilder()
+	b.TimeSec = uint64(start.Unix())
+	if err := b.HostPort(host); err != nil {
+		return err
+	}
+
+	t := ex.Transport()
+	if t == "" {
+		t = state.Proto()
+	}
+	if t == "tcp" {
+		b.SocketProto = tap.SocketProtocol_TCP
+	} else {
+		b.SocketProto = tap.SocketProtocol_UDP
+	}
+
+	if err := b.Msg(state.Req); err != nil {
+		return err
+	}
+
+	if err := tapper.TapMessage(b.ToOutsideQuery(tap.Message_FORWARDER_QUERY)); err != nil {
+		return err
+	}
+
+	// Response
+	if reply != nil {
+		b.TimeSec = uint64(time.Now().Unix())
+		if err := b.Msg(reply); err != nil {
+			return err
+		}
+		return tapper.TapMessage(b.ToOutsideResponse(tap.Message_FORWARDER_RESPONSE))
+	}
+	return nil
+}

--- a/plugin/proxy/dnstap_test.go
+++ b/plugin/proxy/dnstap_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 	"github.com/coredns/coredns/plugin/dnstap/test"
@@ -18,7 +19,7 @@ func testCase(t *testing.T, ex Exchanger, q, r *dns.Msg, datq, datr *msg.Data) {
 	tapr := datr.ToOutsideResponse(tap.Message_FORWARDER_RESPONSE)
 	ctx := test.Context{}
 	err := toDnstap(&ctx, "10.240.0.1:40212", ex,
-		request.Request{W: &mwtest.ResponseWriter{}, Req: q}, r, 0, 0)
+		request.Request{W: &mwtest.ResponseWriter{}, Req: q}, r, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +51,7 @@ func TestDnstap(t *testing.T) {
 }
 
 func TestNoDnstap(t *testing.T) {
-	err := toDnstap(context.TODO(), "", nil, request.Request{}, nil, 0, 0)
+	err := toDnstap(context.TODO(), "", nil, request.Request{}, nil, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Some cleanup in proxy and dnstap:
* just use time pkg directly and side step the indirection for Epoch
* Use Set in SetQueryEpoch to be more Go like. (Looked like a reader)
* Don't maintain two sets of time, we already track start, so use that.
* Use time.Time and convert when needed
* dedent the toDnstap function and put in a separate file
