### PR TITLE
Added note to README about golang version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ dependencies:
 
 (You can do the checkout and dependency resolution as a single step with: `go get github.com/coredns/coredns`.)
 
+Some of the dependencies require Go version 1.8 or later.
+
 And then `go build` as you would normally do:
 
     go build


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. Adds a note to README about golang versions (needed for "dns")


### 2. No issue here, but I had opened an issue in "dns" that was closed because I had an old version of golang


### 3. No doc other than the README.

