### PR TITLE
release: add more build targets

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -70,19 +70,30 @@ commit:
 
 .PHONY: build
 build:
+	@echo Cleaning old builds
+	rm -rf build
 	@echo Building: linux  $(VERSION)
-	mkdir -p build/Linux      && $(MAKE) coredns BINARY=build/Linux/$(NAME) SYSTEM="GOOS=linux"
+	mkdir -p build/linux/$(ARCH)      && $(MAKE) coredns BINARY=build/linux/$(ARCH)/$(NAME) SYSTEM="GOOS=linux"
 	@echo Building: darwin $(VERSION)
-	mkdir -p build/Darwin     && $(MAKE) coredns BINARY=build/Darwin/$(NAME) SYSTEM="GOOS=darwin"
+	mkdir -p build/darwin/$(ARCH)     && $(MAKE) coredns BINARY=build/darwin/$(ARCH)/$(NAME) SYSTEM="GOOS=darwin"
 	@echo Building: arm    $(VERSION)
-	mkdir -p build/Linux/Arm  && $(MAKE) coredns BINARY=build/Linux/Arm/$(NAME) SYSTEM="GOOS=linux GOARCH=arm"
+	mkdir -p build/linux/arm  && $(MAKE) coredns BINARY=build/linux/arm/$(NAME) SYSTEM="GOOS=linux GOARCH=arm"
+	@echo Building: arm64  $(VERSION)
+	mkdir -p build/linux/arm64 && $(MAKE) coredns BINARY=build/linux/arm64/$(NAME) SYSTEM="GOOS=linux GOARCH=arm64"
+	@echo Building: ppc64  $(VERSION)
+	mkdir -p build/linux/ppc64 && $(MAKE) coredns BINARY=build/linux/ppc64/$(NAME) SYSTEM="GOOS=linux GOARCH=ppc64le"
+	@echo Building: s390x  $(VERSION)
+	mkdir -p build/linux/ppc64 && $(MAKE) coredns BINARY=build/linux/s390/$(NAME) SYSTEM="GOOS=linux GOARCH=s390x"
 
 .PHONY: tar
 tar:
 	rm -rf release && mkdir release
-	tar -zcf release/$(NAME)_$(VERSION)_linux_$(ARCH).tgz -C build/Linux $(NAME)
-	tar -zcf release/$(NAME)_$(VERSION)_linux_armv6l.tgz -C build/Linux/Arm $(NAME)
-	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(ARCH).tgz -C build/Darwin $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_linux_$(ARCH).tgz -C build/linux/$(ARCH) $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_darwin_$(ARCH).tgz -C build/darwin/$(ARCH) $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_linux_armv6l.tgz -C build/linux/arm $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_linux_armv8l.tgz -C build/linux/arm64 $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_linux_ppc64le.tgz -C build/linux/ppc64 $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_linux_s390x.tgz -C build/linux/s390 $(NAME)
 
 .PHONY: upload
 upload:

--- a/Makefile.release
+++ b/Makefile.release
@@ -83,7 +83,7 @@ build:
 	@echo Building: ppc64  $(VERSION)
 	mkdir -p build/linux/ppc64 && $(MAKE) coredns BINARY=build/linux/ppc64/$(NAME) SYSTEM="GOOS=linux GOARCH=ppc64le"
 	@echo Building: s390x  $(VERSION)
-	mkdir -p build/linux/ppc64 && $(MAKE) coredns BINARY=build/linux/s390/$(NAME) SYSTEM="GOOS=linux GOARCH=s390x"
+	mkdir -p build/linux/s390 && $(MAKE) coredns BINARY=build/linux/s390/$(NAME) SYSTEM="GOOS=linux GOARCH=s390x"
 
 .PHONY: tar
 tar:


### PR DESCRIPTION
This adds amd64, ppc and s390. Rework some other builds/directories.

This builds:
% find build
build
build/darwin
build/darwin/x86_64
build/darwin/x86_64/coredns
build/linux
build/linux/ppc64
build/linux/ppc64/coredns
build/linux/x86_64
build/linux/x86_64/coredns
build/linux/arm64
build/linux/arm64/coredns
build/linux/s390
build/linux/s390/coredns
build/linux/arm
build/linux/arm/coredns

% make -f Makefile.release tar
rm -rf release && mkdir release
tar -zcf release/coredns_0.9.9_linux_x86_64.tgz -C build/linux/x86_64 coredns
tar -zcf release/coredns_0.9.9_darwin_x86_64.tgz -C build/darwin/x86_64 coredns
tar -zcf release/coredns_0.9.9_linux_armv6l.tgz -C build/linux/arm coredns
tar -zcf release/coredns_0.9.9_linux_armv8l.tgz -C build/linux/arm64 coredns
tar -zcf release/coredns_0.9.9_linux_ppc64le.tgz -C build/linux/ppc64 coredns
tar -zcf release/coredns_0.9.9_linux_s390x.tgz -C build/linux/s390 coredns

Checking:
% for i in $(find build -type f); do file $i; done
build/darwin/x86_64/coredns: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
build/linux/ppc64/coredns: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, stripped
build/linux/x86_64/coredns: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
build/linux/arm64/coredns: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
build/linux/s390/coredns: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, stripped
build/linux/arm/coredns: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped


### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/1177

### 3. Which documentation changes (if any) need to be made?
Release notes may mention this.
