### PR TITLE
plugin/{kubernetes/etcd}: dynamic SOA

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -26,6 +26,17 @@ type ServiceBackend interface {
 
 	// IsNameError return true if err indicated a record not found condition
 	IsNameError(err error) bool
+
+	Transferer
+}
+
+// Transferer defines an interface for backends that provide AXFR of all records.
+type Transferer interface {
+	// Serial returns a SOA serial number to construct a SOA record.
+	Serial(state request.Request) uint32
+
+	// MinTTL returns the minimum TTL to be used in the SOA record.
+	MinTTL(state request.Request) uint32
 }
 
 // Options are extra options that can be specified for a lookup.

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"net"
-	"time"
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
@@ -371,11 +370,11 @@ func SOA(b ServiceBackend, zone string, state request.Request, opt Options) ([]d
 	soa := &dns.SOA{Hdr: header,
 		Mbox:    Mbox,
 		Ns:      Ns,
-		Serial:  uint32(time.Now().Unix()),
+		Serial:  b.Serial(state),
 		Refresh: 7200,
 		Retry:   1800,
 		Expire:  86400,
-		Minttl:  minTTL,
+		Minttl:  b.MinTTL(state),
 	}
 	return []dns.RR{soa}, nil
 }
@@ -404,7 +403,4 @@ func newAddress(s msg.Service, name string, ip net.IP, what uint16) dns.RR {
 	return &dns.AAAA{Hdr: hdr, AAAA: ip}
 }
 
-const (
-	minTTL     = 60
-	hostmaster = "hostmaster"
-)
+const hostmaster = "hostmaster"

--- a/plugin/etcd/xfr.go
+++ b/plugin/etcd/xfr.go
@@ -1,0 +1,17 @@
+package etcd
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/request"
+)
+
+// Serial implements the Transferer interface.
+func (e *Etcd) Serial(state request.Request) uint32 {
+	return uint32(time.Now().Unix())
+}
+
+// MinTTL implements the Transferer interface.
+func (e *Etcd) MinTTL(state request.Request) uint32 {
+	return 30
+}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -1,0 +1,17 @@
+package kubernetes
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/request"
+)
+
+// Serial implements the Transferer interface.
+func (e *Kubernetes) Serial(state request.Request) uint32 {
+	return uint32(time.Now().Unix())
+}
+
+// MinTTL implements the Transferer interface.
+func (e *Kubernetes) MinTTL(state request.Request) uint32 {
+	return 30
+}


### PR DESCRIPTION
Add a dynamic SOA record (at least the serial and minttl). This create
another interface that should be implemented by the backends.

For now default to returning epoch in as a uint32 (no change from before).

Lower the minTTL returned to 30s (from 60s)

### 1. What does this pull request do?


### 2. Which issues (if any) are related?
#994

### 3. Which documentation changes (if any) need to be made?
Possibly the minTTL change.
