### PR TITLE
WIP: plugin/kubernetes: axfr

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -37,6 +37,10 @@ type Transferer interface {
 
 	// MinTTL returns the minimum TTL to be used in the SOA record.
 	MinTTL(state request.Request) uint32
+
+	// Transfer returns a channel that returns all services for this backend.
+	// The channel is closed when all records are sent.
+	Transfer(state request.Request) <-chan msg.Service
 }
 
 // Options are extra options that can be specified for a lookup.

--- a/plugin/etcd/xfr.go
+++ b/plugin/etcd/xfr.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"time"
 
+	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/request"
 )
 
@@ -14,4 +15,11 @@ func (e *Etcd) Serial(state request.Request) uint32 {
 // MinTTL implements the Transferer interface.
 func (e *Etcd) MinTTL(state request.Request) uint32 {
 	return 30
+}
+
+// Transfer implements the Transferer interface.
+func (e *Etcd) Transfer(state request.Request) <-chan msg.Service {
+	c := make(chan msg.Service)
+
+	return c
 }

--- a/plugin/federation/kubernetes_api_test.go
+++ b/plugin/federation/kubernetes_api_test.go
@@ -14,6 +14,7 @@ func (APIConnFederationTest) Run()                                   { return }
 func (APIConnFederationTest) Stop() error                            { return nil }
 func (APIConnFederationTest) SvcIndexReverse(string) []*api.Service  { return nil }
 func (APIConnFederationTest) EpIndexReverse(string) []*api.Endpoints { return nil }
+func (APIConnFederationTest) Modified() int64                        { return 0 }
 
 func (APIConnFederationTest) PodIndex(string) []*api.Pod {
 	a := []*api.Pod{{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -196,6 +196,7 @@ func (APIConnServeTest) Run()                                   { return }
 func (APIConnServeTest) Stop() error                            { return nil }
 func (APIConnServeTest) EpIndexReverse(string) []*api.Endpoints { return nil }
 func (APIConnServeTest) SvcIndexReverse(string) []*api.Service  { return nil }
+func (APIConnServeTest) Modified() int64                        { return 0 }
 
 func (APIConnServeTest) PodIndex(string) []*api.Pod {
 	a := []*api.Pod{{

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -57,6 +57,7 @@ func (APIConnServiceTest) Stop() error                            { return nil }
 func (APIConnServiceTest) PodIndex(string) []*api.Pod             { return nil }
 func (APIConnServiceTest) SvcIndexReverse(string) []*api.Service  { return nil }
 func (APIConnServiceTest) EpIndexReverse(string) []*api.Endpoints { return nil }
+func (APIConnServiceTest) Modified() int64                        { return 0 }
 
 func (APIConnServiceTest) SvcIndex(string) []*api.Service {
 	svcs := []*api.Service{

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -17,6 +17,7 @@ func (APIConnTest) SvcIndex(string) []*api.Service        { return nil }
 func (APIConnTest) SvcIndexReverse(string) []*api.Service { return nil }
 func (APIConnTest) EpIndex(string) []*api.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*api.Endpoints       { return nil }
+func (APIConnTest) Modified() int64                       { return 0 }
 
 func (APIConnTest) ServiceList() []*api.Service {
 	svcs := []*api.Service{

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -22,6 +22,7 @@ func (APIConnReverseTest) SvcIndex(string) []*api.Service        { return nil }
 func (APIConnReverseTest) SvcIndexReverse(string) []*api.Service { return nil }
 func (APIConnReverseTest) EpIndex(string) []*api.Endpoints       { return nil }
 func (APIConnReverseTest) EndpointsList() []*api.Endpoints       { return nil }
+func (APIConnReverseTest) Modified() int64                       { return 0 }
 
 func (APIConnReverseTest) ServiceList() []*api.Service {
 	svcs := []*api.Service{

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Serial implements the Transferer interface.
-func (k *Kubernetes) Serial(state request.Request) uint32 { return k.APIConn.Modified() }
+func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIConn.Modified()) }
 
 // MinTTL implements the Transferer interface.
 func (k *Kubernetes) MinTTL(state request.Request) uint32 { return 30 }

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -1,17 +1,81 @@
 package kubernetes
 
 import (
-	"time"
+	"strings"
 
+	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	api "k8s.io/client-go/pkg/api/v1"
 )
 
 // Serial implements the Transferer interface.
-func (e *Kubernetes) Serial(state request.Request) uint32 {
-	return uint32(time.Now().Unix())
-}
+func (k *Kubernetes) Serial(state request.Request) uint32 { return k.APIConn.Modified() }
 
 // MinTTL implements the Transferer interface.
-func (e *Kubernetes) MinTTL(state request.Request) uint32 {
-	return 30
+func (k *Kubernetes) MinTTL(state request.Request) uint32 { return 30 }
+
+// Transfer implements the Transferer interface.
+func (k *Kubernetes) Transfer(state request.Request) <-chan msg.Service {
+	c := make(chan msg.Service)
+
+	go k.transfer(c, state.Zone)
+
+	return c
+}
+
+func (k *Kubernetes) transfer(c chan msg.Service, zone string) {
+
+	defer close(c)
+
+	zonePath := msg.Path(zone, "coredns")
+	serviceList := k.APIConn.ServiceList()
+	endpointsList := k.APIConn.EndpointsList()
+	for _, svc := range serviceList {
+		// Endpoint query or headless service
+		if svc.Spec.ClusterIP == api.ClusterIPNone {
+			for _, ep := range endpointsList {
+				if ep.ObjectMeta.Name != svc.Name || ep.ObjectMeta.Namespace != svc.Namespace {
+					continue
+				}
+
+				for _, eps := range ep.Subsets {
+					for _, addr := range eps.Addresses {
+						for _, p := range eps.Ports {
+
+							s := msg.Service{Host: addr.IP, Port: int(p.Port), TTL: k.ttl}
+							s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name, endpointHostname(addr)}, "/")
+
+							c <- s
+						}
+					}
+				}
+			}
+
+			continue
+		}
+
+		// External service
+		if svc.Spec.ExternalName != "" {
+			s := msg.Service{Key: strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/"), Host: svc.Spec.ExternalName, TTL: k.ttl}
+			if t, _ := s.HostType(); t == dns.TypeCNAME {
+				s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
+
+				c <- s
+
+				continue
+			}
+		}
+
+		// ClusterIP service
+		for _, p := range svc.Spec.Ports {
+
+			s := msg.Service{Host: svc.Spec.ClusterIP, Port: int(p.Port), TTL: k.ttl}
+			s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
+
+			c <- s
+		}
+	}
+	return
 }

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -1,0 +1,20 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestTransfer(t *testing.T) {
+	k := New([]string{"cluster.local."})
+	k.APIConn = &APIConnServeTest{}
+
+	state := request.Request{Zone: "cluster.local.", Req: new(dns.Msg)}
+
+	for msg := range k.Transfer(state) {
+		t.Logf("%v", msg)
+	}
+}


### PR DESCRIPTION
### 1. What does this pull request do?

Hook up dynamic SOA serial by setting ResourceEventHandlerFuncs in
dnsController.

Add prototype of returns msg.Services via the Transfer function. Leave
expanding this to RRs out of scope for a bit.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

This needs to be documented in the README and requires extension of the setup to allow `transfer to` syntax to be added.

