### PR TITLE
Makefile: add Windows target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,23 +3,24 @@ GITCOMMIT:=$(shell git describe --dirty --always)
 BINARY:=coredns
 SYSTEM:=
 CHECKS:=check godeps
+VERBOSE:=-v
 
 all: coredns
 
 .PHONY: coredns
 coredns: $(CHECKS)
-	CGO_ENABLED=0 $(SYSTEM) go build -v -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o $(BINARY)
+	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
 check: linter core/zplugin.go core/dnsserver/zdirectives.go godeps
 
 .PHONY: test
 test: check
-	go test -race -v ./test ./plugin/...
+	go test -race $(VERBOSE) ./test ./plugin/...
 
 .PHONY: testk8s
 testk8s: check
-	go test -race -v -tags=k8s -run 'TestKubernetes' ./test ./plugin/kubernetes/...
+	go test -race $(VERBOSE) -tags=k8s -run 'TestKubernetes' ./test ./plugin/kubernetes/...
 
 .PHONY: godeps
 godeps:

--- a/Makefile.release
+++ b/Makefile.release
@@ -15,7 +15,7 @@
 #
 # git log --pretty=format:'%an' v001..master | sort -u (where v001 is the
 # previous release, obviously you'll need to adjust this)
-# 
+#
 # Steps:
 #
 # * Get an access token: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
@@ -38,11 +38,11 @@
 # Github.
 
 ifeq (, $(shell which gh-release))
-     $(error "No gh-release in $$PATH, install with `go get github.com/progrium/gh-release`")
+    $(error "No gh-release in $$PATH, install with: go get github.com/progrium/gh-release")
 endif
 
 ifeq (, $(shell which manifest-tool))
-     $(error "No manifest-tool in $$PATH, install with `go get github.com/estesp/manifest-tool")
+    $(error "No manifest-tool in $$PATH, install with: go get github.com/estesp/manifest-tool")
 endif
 
 NAME:=coredns
@@ -73,19 +73,22 @@ commit:
 .PHONY: build
 build:
 	@echo Cleaning old builds
-	rm -rf build && mkdir build
+	@rm -rf build && mkdir build
 	@echo Building: darwin $(VERSION)
-	mkdir -p build/darwin/amd64 && $(MAKE) coredns BINARY=build/darwin/amd64/$(NAME) SYSTEM="GOOS=darwin GOARCH=amd64" CHECKS=""
+	mkdir -p build/darwin/amd64 && $(MAKE) coredns BINARY=build/darwin/amd64/$(NAME) SYSTEM="GOOS=darwin GOARCH=amd64" CHECKS="" VERBOSE=""
+	@echo Building: windows $(VERSION)
+	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME) SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="" VERBOSE=""
+	@echo Building: linux/$(LINUX_ARCH)  $(VERSION) ;\
 	for arch in $(LINUX_ARCH); do \
-	    @echo Building: linux/$$arch  $(VERSION) ;\
-	    mkdir -p build/linux/amd64  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" ;\
+	    mkdir -p build/linux/amd64  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" VERBOSE="" ;\
 	done
 
 .PHONY: tar
 tar:
 	@echo Cleaning old releases
-	rm -rf release && mkdir release
+	@rm -rf release && mkdir release
 	tar -zcf release/$(NAME)_$(VERSION)_darwin_amd64.tgz -C build/darwin/amd64 $(NAME)
+	tar -zcf release/$(NAME)_$(VERSION)_windows_amd64.tgz -C build/windows/amd64 $(NAME)
 	for arch in $(LINUX_ARCH); do \
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done


### PR DESCRIPTION
While we at it, why not add a target for Windows as well.

This also introduces a VERBOSE option that defaults to -v, but it empty
when releases so that you can actually see what you're building.

Move an @echo out of shell snippet into the Makefile, as that errored
with @echo: command not found.

Sample run and resulting artifacts:

~~~
% make -f Makefile.release build
% find build -type f -exec file {} \;
build/windows/amd64/coredns: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
build/darwin/amd64/coredns: Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
build/linux/ppc64le/coredns: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, stripped
build/linux/amd64/coredns: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
build/linux/arm/coredns: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, stripped
build/linux/s390x/coredns: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, stripped
build/linux/arm64/coredns: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped

% make -f Makefile.release tar
% find release -type f | sort
release/coredns_0.9.9_darwin_amd64.tgz
release/coredns_0.9.9_linux_amd64.tgz
release/coredns_0.9.9_linux_arm64.tgz
release/coredns_0.9.9_linux_arm.tgz
release/coredns_0.9.9_linux_ppc64le.tgz
release/coredns_0.9.9_linux_s390x.tgz
release/coredns_0.9.9_windows_amd64.tgz
~~~