### PR TITLE
Fix version for apimachinery and ugorji/go in Gopkg.toml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -287,7 +287,7 @@
   branch = "master"
   name = "github.com/prometheus/common"
   packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
-  revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
+  revision = "e3fb1a1acd7605367a2b378bc2e2f893c05174b7"
 
 [[projects]]
   branch = "master"
@@ -308,7 +308,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ugorji/go"
   packages = ["codec"]
   revision = "8c0409fcbb70099c748d71f714529204975f6c3f"
@@ -323,7 +322,7 @@
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix","windows"]
-  revision = "46eaec7899b1dd945c25db17c78ba3f0c58a6613"
+  revision = "4fe5d7925040acd225bf9c7cee65e82d07f06bff"
 
 [[projects]]
   branch = "master"
@@ -340,8 +339,8 @@
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","resolver","stats","status","tap","transport"]
-  revision = "61d37c5d657a47e4404fd6823bd598341a2595de"
-  version = "v1.7.1"
+  revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
+  version = "v1.7.2"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -375,6 +374,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "916c5fe7d9ce3a19d3956068cae5daf94be1269ae86400dfed36308fbd88a539"
+  inputs-digest = "9e6593b26c8f9a3841e988e46627fa440748742be455c2523b66b01501796ca4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,3 +16,15 @@ ignored = [
 [[constraint]]
     name = "github.com/openzipkin/zipkin-go-opentracing"
     version = "v0.2.3"
+
+[[override]]
+    name = "github.com/ugorji/go"
+    revision = "8c0409fcbb70099c748d71f714529204975f6c3f"
+
+# client-go 4.0.0 uses apimachinery 1fd2e63a9a370677308a42f24fd40c86438afddf (see Godep.json)
+[[constraint]]
+  name = "k8s.io/client-go"
+  version = "v4.0.0"
+[[override]]
+    name = "k8s.io/apimachinery"
+    revision = "1fd2e63a9a370677308a42f24fd40c86438afddf"

--- a/vendor/golang.org/x/sys/unix/syscall_linux_test.go
+++ b/vendor/golang.org/x/sys/unix/syscall_linux_test.go
@@ -178,7 +178,7 @@ func TestGetrlimit(t *testing.T) {
 }
 
 func TestSelect(t *testing.T) {
-	_, err := unix.Select(0, nil, nil, nil, &unix.Timeval{0, 0})
+	_, err := unix.Select(0, nil, nil, nil, &unix.Timeval{Sec: 0, Usec: 0})
 	if err != nil {
 		t.Fatalf("Select: %v", err)
 	}

--- a/vendor/golang.org/x/sys/unix/syscall_unix_test.go
+++ b/vendor/golang.org/x/sys/unix/syscall_unix_test.go
@@ -138,6 +138,9 @@ func TestPassFD(t *testing.T) {
 		uc.Close()
 	})
 	_, oobn, _, _, err := uc.ReadMsgUnix(buf, oob)
+	if err != nil {
+		t.Fatalf("ReadMsgUnix: %v", err)
+	}
 	closeUnix.Stop()
 
 	scms, err := unix.ParseSocketControlMessage(oob[:oobn])
@@ -335,6 +338,9 @@ func TestDup(t *testing.T) {
 		t.Fatalf("Write to dup2 fd failed: %v", err)
 	}
 	_, err = unix.Seek(f, 0, 0)
+	if err != nil {
+		t.Fatalf("Seek failed: %v", err)
+	}
 	_, err = unix.Read(f, b2)
 	if err != nil {
 		t.Fatalf("Read back failed: %v", err)

--- a/vendor/google.golang.org/grpc/clientconn.go
+++ b/vendor/google.golang.org/grpc/clientconn.go
@@ -1011,6 +1011,10 @@ func (ac *addrConn) transportMonitor() {
 		default:
 		}
 		ac.mu.Lock()
+		if ac.state == connectivity.Shutdown {
+			ac.mu.Unlock()
+			return
+		}
 		// Set connectivity state to TransientFailure before calling
 		// resetTransport. Transition READY->CONNECTING is not valid.
 		ac.state = connectivity.TransientFailure

--- a/vendor/google.golang.org/grpc/rpc_util.go
+++ b/vendor/google.golang.org/grpc/rpc_util.go
@@ -567,6 +567,6 @@ const SupportPackageIsVersion3 = true
 const SupportPackageIsVersion4 = true
 
 // Version is the current grpc version.
-const Version = "1.7.1"
+const Version = "1.7.2"
 
 const grpcUA = "grpc-go/" + Version


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix is an attempt to fix the issue raised #1192.

The issue that a plain `dep -ensure update` fails is because the incompatibility of ugorji/go with the rest of packages (etcd, k8s etc) and the incompatibility of client-go vs. apimachinery.


Previously updates has to be done individually, e.g., `dep -ensure update github.com/coreos/etcd`

This fix fixed apimachinery and ugorji/go so that it is possible to use `dep -ensure update`.

### 2. Which issues (if any) are related?

This fix fixes #1192.


### 3. Which documentation changes (if any) need to be made?
N/A

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
