### PR TITLE
plugin/k8s: fix pods disabled behavior

### DIFF
--- a/plugin/kubernetes/handler_pod_disabled_test.go
+++ b/plugin/kubernetes/handler_pod_disabled_test.go
@@ -14,7 +14,6 @@ var podModeDisabledCases = []test.Case{
 	{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
-		Error: errPodsDisabled,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -22,7 +21,6 @@ var podModeDisabledCases = []test.Case{
 	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
-		Error: errPodsDisabled,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
@@ -44,7 +42,7 @@ func TestServeDNSModeDisabled(t *testing.T) {
 
 		_, err := k.ServeDNS(ctx, w, r)
 		if err != tc.Error {
-			t.Errorf("Test %d expected no error, got %v", i, err)
+			t.Errorf("Test %d got unexpected error %v", i, err)
 			return
 		}
 		if tc.Error != nil {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -143,7 +143,7 @@ func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dn
 
 // IsNameError implements the ServiceBackend interface.
 func (k *Kubernetes) IsNameError(err error) bool {
-	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest
+	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest || err == errPodsDisabled
 }
 
 func (k *Kubernetes) getClientConfig() (*rest.Config, error) {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -77,7 +77,6 @@ var (
 	errNoItems        = errors.New("no items found")
 	errNsNotExposed   = errors.New("namespace is not exposed")
 	errInvalidRequest = errors.New("invalid query name")
-	errPodsDisabled   = errors.New("pod records disabled")
 )
 
 // Services implements the ServiceBackend interface.
@@ -143,7 +142,7 @@ func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dn
 
 // IsNameError implements the ServiceBackend interface.
 func (k *Kubernetes) IsNameError(err error) bool {
-	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest || err == errPodsDisabled
+	return err == errNoItems || err == errNsNotExposed || err == errInvalidRequest
 }
 
 func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
@@ -295,7 +294,7 @@ func endpointHostname(addr api.EndpointAddress, endpointNameMode bool) string {
 
 func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service, err error) {
 	if k.podMode == podModeDisabled {
-		return nil, errPodsDisabled
+		return nil, errNoItems
 	}
 
 	namespace := r.namespace


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Fix return code for pods queries when pods are disabled - per docs, should be `NXDOMAIN`, not `SERVFAIL`...  Unit tests also expect `NXDOMAIN` (but the return code not actually checked in the tests due the the "expected" error returned)


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?