### PR TITLE
plugin/k8s: Use service IP index in reverse lookups

### DIFF
--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -25,14 +25,12 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 // If a service cluster ip does not match, it checks all endpoints
 func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 	// First check services with cluster ips
-	for _, service := range k.APIConn.ServiceList() {
+	for _, service := range k.APIConn.SvcIndexReverse(ip) {
 		if (len(k.Namespaces) > 0) && !k.namespaceExposed(service.Namespace) {
 			continue
 		}
-		if service.Spec.ClusterIP == ip {
-			domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
-			return []msg.Service{{Host: domain}}
-		}
+		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
+		return []msg.Service{{Host: domain}}
 	}
 	// If no cluster ips match, search endpoints
 	for _, ep := range k.APIConn.EpIndexReverse(ip) {

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -25,12 +25,14 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 // If a service cluster ip does not match, it checks all endpoints
 func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 	// First check services with cluster ips
-	for _, service := range k.APIConn.SvcIndexReverse(ip) {
+	for _, service := range k.APIConn.ServiceList() {
 		if (len(k.Namespaces) > 0) && !k.namespaceExposed(service.Namespace) {
 			continue
 		}
-		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
-		return []msg.Service{{Host: domain}}
+		if service.Spec.ClusterIP == ip {
+			domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
+			return []msg.Service{{Host: domain}}
+		}
 	}
 	// If no cluster ips match, search endpoints
 	for _, ep := range k.APIConn.EpIndexReverse(ip) {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -14,19 +14,16 @@ import (
 
 type APIConnReverseTest struct{}
 
-func (APIConnReverseTest) HasSynced() bool                 { return true }
-func (APIConnReverseTest) Run()                            { return }
-func (APIConnReverseTest) Stop() error                     { return nil }
-func (APIConnReverseTest) PodIndex(string) []*api.Pod      { return nil }
-func (APIConnReverseTest) SvcIndex(string) []*api.Service  { return nil }
-func (APIConnReverseTest) EpIndex(string) []*api.Endpoints { return nil }
-func (APIConnReverseTest) EndpointsList() []*api.Endpoints { return nil }
-func (APIConnReverseTest) ServiceList() []*api.Service     { return nil }
+func (APIConnReverseTest) HasSynced() bool                       { return true }
+func (APIConnReverseTest) Run()                                  { return }
+func (APIConnReverseTest) Stop() error                           { return nil }
+func (APIConnReverseTest) PodIndex(string) []*api.Pod            { return nil }
+func (APIConnReverseTest) SvcIndex(string) []*api.Service        { return nil }
+func (APIConnReverseTest) SvcIndexReverse(string) []*api.Service { return nil }
+func (APIConnReverseTest) EpIndex(string) []*api.Endpoints       { return nil }
+func (APIConnReverseTest) EndpointsList() []*api.Endpoints       { return nil }
 
-func (APIConnReverseTest) SvcIndexReverse(ip string) []*api.Service {
-	if ip != "192.168.1.100" {
-		return nil
-	}
+func (APIConnReverseTest) ServiceList() []*api.Service {
 	svcs := []*api.Service{
 		{
 			ObjectMeta: meta.ObjectMeta{
@@ -46,10 +43,7 @@ func (APIConnReverseTest) SvcIndexReverse(ip string) []*api.Service {
 	return svcs
 }
 
-func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
-	if ip != "10.0.0.100" {
-		return nil
-	}
+func (APIConnReverseTest) EpIndexReverse(string) []*api.Endpoints {
 	eps := []*api.Endpoints{
 		{
 			Subsets: []api.EndpointSubset{
@@ -88,7 +82,7 @@ func (APIConnReverseTest) GetNodeByName(name string) (*api.Node, error) {
 
 func TestReverse(t *testing.T) {
 
-	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa."})
+	k := New([]string{"cluster.local.", "0.10.in-addr.arpa."})
 	k.APIConn = &APIConnReverseTest{}
 
 	tests := []test.Case{
@@ -97,13 +91,6 @@ func TestReverse(t *testing.T) {
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.PTR("100.0.0.10.in-addr.arpa.      303    IN      PTR       ep1a.svc1.testns.svc.cluster.local."),
-			},
-		},
-		{
-			Qname: "100.1.168.192.in-addr.arpa.", Qtype: dns.TypePTR,
-			Rcode: dns.RcodeSuccess,
-			Answer: []dns.RR{
-				test.PTR("100.1.168.192.in-addr.arpa.      303    IN      PTR       svc1.testns.svc.cluster.local."),
 			},
 		},
 		{


### PR DESCRIPTION
### 1. What does this pull request do?

Uses the service IP index (instead of service list) for reverse lookups in kubernetes.

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

