### PR TITLE
plugin/log: remove OutputFile

### DIFF
--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -70,11 +70,10 @@ func (l Logger) Name() string { return "log" }
 
 // Rule configures the logging plugin.
 type Rule struct {
-	NameScope  string
-	Class      response.Class
-	OutputFile string
-	Format     string
-	Log        *log.Logger
+	NameScope string
+	Class     response.Class
+	Format    string
+	Log       *log.Logger
 }
 
 const (

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -29,13 +29,7 @@ func setup(c *caddy.Controller) error {
 	// Open the log files for writing when the server starts
 	c.OnStartup(func() error {
 		for i := 0; i < len(rules); i++ {
-			// We only support stdout
-			writer := os.Stdout
-			if rules[i].OutputFile != "stdout" {
-				return plugin.Error("log", fmt.Errorf("invalid log file: %s", rules[i].OutputFile))
-			}
-
-			rules[i].Log = log.New(writer, "", 0)
+			rules[i].Log = log.New(os.Stdout, "", 0)
 		}
 
 		return nil
@@ -57,19 +51,20 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 		if len(args) == 0 {
 			// Nothing specified; use defaults
 			rules = append(rules, Rule{
-				NameScope:  ".",
-				OutputFile: DefaultLogFilename,
-				Format:     DefaultLogFormat,
+				NameScope: ".",
+				Format:    DefaultLogFormat,
 			})
 		} else if len(args) == 1 {
-			// Only an output file specified.
+			// Only an output file specified, can only be *stdout*
+			if args[0] != "stdout" {
+				return nil, fmt.Errorf("invalid log file: %s, only %s is allowed", args[0], "stdout")
+			}
 			rules = append(rules, Rule{
-				NameScope:  ".",
-				OutputFile: args[0],
-				Format:     DefaultLogFormat,
+				NameScope: ".",
+				Format:    DefaultLogFormat,
 			})
 		} else {
-			// Name scope, output file, and maybe a format specified
+			// Name scope, output file (stdout), and maybe a format specified
 
 			format := DefaultLogFormat
 
@@ -84,10 +79,13 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 				}
 			}
 
+			if args[1] != "stdout" {
+				return nil, fmt.Errorf("invalid log file: %s, only %s is allowed", args[1], "stdout")
+			}
+
 			rules = append(rules, Rule{
-				NameScope:  dns.Fqdn(args[0]),
-				OutputFile: args[1],
-				Format:     format,
+				NameScope: dns.Fqdn(args[0]),
+				Format:    format,
 			})
 		}
 

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -57,7 +57,7 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 		} else if len(args) == 1 {
 			// Only an output file specified, can only be *stdout*
 			if args[0] != "stdout" {
-				return nil, fmt.Errorf("invalid log file: %s, only %s is allowed", args[0], "stdout")
+				return nil, fmt.Errorf("only stdout is allowed: %s", args[0])
 			}
 			rules = append(rules, Rule{
 				NameScope: ".",
@@ -80,7 +80,7 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			}
 
 			if args[1] != "stdout" {
-				return nil, fmt.Errorf("invalid log file: %s, only %s is allowed", args[1], "stdout")
+				return nil, fmt.Errorf("only stdout is allowed: %s", args[1])
 			}
 
 			rules = append(rules, Rule{

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -15,80 +15,65 @@ func TestLogParse(t *testing.T) {
 		expectedLogRules []Rule
 	}{
 		{`log`, false, []Rule{{
-			NameScope:  ".",
-			OutputFile: DefaultLogFilename,
-			Format:     DefaultLogFormat,
+			NameScope: ".",
+			Format:    DefaultLogFormat,
 		}}},
-		{`log log.txt`, false, []Rule{{
-			NameScope:  ".",
-			OutputFile: "log.txt",
-			Format:     DefaultLogFormat,
-		}}},
-		{`log example.org log.txt`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     DefaultLogFormat,
+		{`log example.org stdout`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    DefaultLogFormat,
 		}}},
 		{`log example.org. stdout`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "stdout",
-			Format:     DefaultLogFormat,
+			NameScope: "example.org.",
+			Format:    DefaultLogFormat,
 		}}},
-		{`log example.org log.txt {common}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     CommonLogFormat,
+		{`log example.org stdout {common}`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    CommonLogFormat,
 		}}},
-		{`log example.org accesslog.txt {combined}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "accesslog.txt",
-			Format:     CombinedLogFormat,
+		{`log example.org stdout {combined}`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    CombinedLogFormat,
 		}}},
-		{`log example.org. log.txt
-		log example.net accesslog.txt {combined}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     DefaultLogFormat,
+		{`log example.org. stdout
+		log example.net stdout {combined}`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    DefaultLogFormat,
 		}, {
-			NameScope:  "example.net.",
-			OutputFile: "accesslog.txt",
-			Format:     CombinedLogFormat,
+			NameScope: "example.net.",
+			Format:    CombinedLogFormat,
 		}}},
 		{`log example.org stdout {host}
-			  log example.org log.txt {when}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "stdout",
-			Format:     "{host}",
+			  log example.org stdout {when}`, false, []Rule{{
+			NameScope: "example.org.",
+			Format:    "{host}",
 		}, {
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     "{when}",
+			NameScope: "example.org.",
+			Format:    "{when}",
 		}}},
 
-		{`log example.org log.txt {
+		{`log example.org stdout {
 				class all
 			}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     CommonLogFormat,
-			Class:      response.All,
+			NameScope: "example.org.",
+			Format:    CommonLogFormat,
+			Class:     response.All,
 		}}},
-		{`log example.org log.txt {
+		{`log example.org stdout {
 			class denial
 		}`, false, []Rule{{
-			NameScope:  "example.org.",
-			OutputFile: "log.txt",
-			Format:     CommonLogFormat,
-			Class:      response.Denial,
+			NameScope: "example.org.",
+			Format:    CommonLogFormat,
+			Class:     response.Denial,
 		}}},
 		{`log {
 			class denial
 		}`, false, []Rule{{
-			NameScope:  ".",
-			OutputFile: DefaultLogFilename,
-			Format:     CommonLogFormat,
-			Class:      response.Denial,
+			NameScope: ".",
+			Format:    CommonLogFormat,
+			Class:     response.Denial,
 		}}},
+
+		{`log log.txt`, true, nil},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputLogRules)
@@ -108,11 +93,6 @@ func TestLogParse(t *testing.T) {
 			if actualLogRule.NameScope != test.expectedLogRules[j].NameScope {
 				t.Errorf("Test %d expected %dth LogRule NameScope to be  %s  , but got %s",
 					i, j, test.expectedLogRules[j].NameScope, actualLogRule.NameScope)
-			}
-
-			if actualLogRule.OutputFile != test.expectedLogRules[j].OutputFile {
-				t.Errorf("Test %d expected %dth LogRule OutputFile to be  %s  , but got %s",
-					i, j, test.expectedLogRules[j].OutputFile, actualLogRule.OutputFile)
 			}
 
 			if actualLogRule.Format != test.expectedLogRules[j].Format {


### PR DESCRIPTION
We use stdout for everything, remove OutputFile as it isn't used and
causes confusion.

Fixes #1216