### PR TITLE
Add docker to make for local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINARY:=coredns
 SYSTEM:=
 CHECKS:=check godeps
 VERBOSE:=-v
+DOCKER_IMAGE_NAME:=coredns/coredns
 
 all: coredns
 
@@ -72,3 +73,9 @@ linter:
 clean:
 	go clean
 	rm -f coredns
+
+.PHONY: docker
+docker:
+	$(MAKE) coredns SYSTEM="GOOS=linux" CHECKS="" ;\
+	docker build -t coredns . ;\
+	docker tag coredns $(DOCKER_IMAGE_NAME):latest


### PR DESCRIPTION
### 1. What does this pull request do?

Adds `make docker` to build locally a dockerized coredns for local dev testing.  This is not associated with the release, just convenience for developer docker/k8s testing on a local system.

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?
