### PR TITLE
plugin/log: remove need to specify stdout

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -10,14 +10,10 @@ log
 
 * With no arguments, a query log entry is written to *stdout* in the common log format for all requests
 
-~~~ txt
-log [stdout]
-~~~
-
 Or if you want/need slightly more control:
 
 ~~~ txt
-log [NAME] stdout [FORMAT]
+log [NAME] [FORMAT]
 ~~~
 
 * `NAME` is the name to match in order to be logged
@@ -26,7 +22,7 @@ log [NAME] stdout [FORMAT]
 You can further specify the class of responses that get logged:
 
 ~~~ txt
-log [NAME] stdout [FORMAT] {
+log [NAME] [FORMAT] {
     class [success|denial|error|all]
 }
 ~~~
@@ -88,7 +84,7 @@ Custom log format, for all zones (`.`)
 
 ~~~ corefile
 . {
-    log . stdout "{proto} Request: {name} {type} {>id}"
+    log . "{proto} Request: {name} {type} {>id}"
 }
 ~~~
 
@@ -96,7 +92,7 @@ Only log denials for example.org (and below to a file)
 
 ~~~ corefile
 . {
-    log example.org stdout {
+    log example.org {
         class denial
     }
 }

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -77,8 +77,6 @@ type Rule struct {
 }
 
 const (
-	// DefaultLogFilename is the default output name. This is the only supported value.
-	DefaultLogFilename = "stdout"
 	// CommonLogFormat is the common log format.
 	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + ` [{when}] "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
 	// CommonLogEmptyValue is the common empty log value.

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -1,7 +1,6 @@
 package log
 
 import (
-	"fmt"
 	"log"
 	"os"
 
@@ -55,32 +54,21 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 				Format:    DefaultLogFormat,
 			})
 		} else if len(args) == 1 {
-			// Only an output file specified, can only be *stdout*
-			if args[0] != "stdout" {
-				return nil, fmt.Errorf("only stdout is allowed: %s", args[0])
-			}
 			rules = append(rules, Rule{
-				NameScope: ".",
+				NameScope: dns.Fqdn(args[0]),
 				Format:    DefaultLogFormat,
 			})
 		} else {
-			// Name scope, output file (stdout), and maybe a format specified
-
+			// Name scope, and maybe a format specified
 			format := DefaultLogFormat
 
-			if len(args) > 2 {
-				switch args[2] {
-				case "{common}":
-					format = CommonLogFormat
-				case "{combined}":
-					format = CombinedLogFormat
-				default:
-					format = args[2]
-				}
-			}
-
-			if args[1] != "stdout" {
-				return nil, fmt.Errorf("only stdout is allowed: %s", args[1])
+			switch args[1] {
+			case "{common}":
+				format = CommonLogFormat
+			case "{combined}":
+				format = CombinedLogFormat
+			default:
+				format = args[1]
 			}
 
 			rules = append(rules, Rule{

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -18,32 +18,28 @@ func TestLogParse(t *testing.T) {
 			NameScope: ".",
 			Format:    DefaultLogFormat,
 		}}},
-		{`log example.org stdout`, false, []Rule{{
+		{`log example.org.`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    DefaultLogFormat,
 		}}},
-		{`log example.org. stdout`, false, []Rule{{
-			NameScope: "example.org.",
-			Format:    DefaultLogFormat,
-		}}},
-		{`log example.org stdout {common}`, false, []Rule{{
+		{`log example.org. {common}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
 		}}},
-		{`log example.org stdout {combined}`, false, []Rule{{
+		{`log example.org. {combined}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CombinedLogFormat,
 		}}},
-		{`log example.org. stdout
-		log example.net stdout {combined}`, false, []Rule{{
+		{`log example.org.
+		log example.net {combined}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    DefaultLogFormat,
 		}, {
 			NameScope: "example.net.",
 			Format:    CombinedLogFormat,
 		}}},
-		{`log example.org stdout {host}
-			  log example.org stdout {when}`, false, []Rule{{
+		{`log example.org {host}
+			  log example.org {when}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    "{host}",
 		}, {
@@ -51,14 +47,14 @@ func TestLogParse(t *testing.T) {
 			Format:    "{when}",
 		}}},
 
-		{`log example.org stdout {
+		{`log example.org. {
 				class all
 			}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
 			Class:     response.All,
 		}}},
-		{`log example.org stdout {
+		{`log example.org {
 			class denial
 		}`, false, []Rule{{
 			NameScope: "example.org.",
@@ -72,17 +68,16 @@ func TestLogParse(t *testing.T) {
 			Format:    CommonLogFormat,
 			Class:     response.Denial,
 		}}},
-
-		{`log log.txt`, true, nil},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputLogRules)
 		actualLogRules, err := logParse(c)
 
 		if err == nil && test.shouldErr {
-			t.Errorf("Test %d didn't error, but it should have", i)
+			t.Errorf("Test %d with input '%s' didn't error, but it should have", i, test.inputLogRules)
 		} else if err != nil && !test.shouldErr {
-			t.Errorf("Test %d errored, but it shouldn't have; got '%v'", i, err)
+			t.Errorf("Test %d with input '%s' errored, but it shouldn't have; got '%v'",
+				i, test.inputLogRules, err)
 		}
 		if len(actualLogRules) != len(test.expectedLogRules) {
 			t.Fatalf("Test %d expected %d no of Log rules, but got %d ",
@@ -91,13 +86,13 @@ func TestLogParse(t *testing.T) {
 		for j, actualLogRule := range actualLogRules {
 
 			if actualLogRule.NameScope != test.expectedLogRules[j].NameScope {
-				t.Errorf("Test %d expected %dth LogRule NameScope to be  %s  , but got %s",
-					i, j, test.expectedLogRules[j].NameScope, actualLogRule.NameScope)
+				t.Errorf("Test %d expected %dth LogRule NameScope for '%s' to be  %s  , but got %s",
+					i, j, test.inputLogRules, test.expectedLogRules[j].NameScope, actualLogRule.NameScope)
 			}
 
 			if actualLogRule.Format != test.expectedLogRules[j].Format {
-				t.Errorf("Test %d expected %dth LogRule Format to be  %s  , but got %s",
-					i, j, test.expectedLogRules[j].Format, actualLogRule.Format)
+				t.Errorf("Test %d expected %dth LogRule Format for '%s' to be  %s  , but got %s",
+					i, j, test.inputLogRules, test.expectedLogRules[j].Format, actualLogRule.Format)
 			}
 
 			if actualLogRule.Class != test.expectedLogRules[j].Class {

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -18,7 +18,7 @@ func TestLogParse(t *testing.T) {
 			NameScope: ".",
 			Format:    DefaultLogFormat,
 		}}},
-		{`log example.org.`, false, []Rule{{
+		{`log example.org`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    DefaultLogFormat,
 		}}},
@@ -26,7 +26,7 @@ func TestLogParse(t *testing.T) {
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
 		}}},
-		{`log example.org. {combined}`, false, []Rule{{
+		{`log example.org {combined}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CombinedLogFormat,
 		}}},
@@ -47,7 +47,7 @@ func TestLogParse(t *testing.T) {
 			Format:    "{when}",
 		}}},
 
-		{`log example.org. {
+		{`log example.org {
 				class all
 			}`, false, []Rule{{
 			NameScope: "example.org.",


### PR DESCRIPTION
### 1. What does this pull request do?
Clean up of log plugin to remove need to specify stdout in Corefile

### 2. Which issues (if any) are related?
#1218

### 3. Which documentation changes (if any) need to be made?
README.md of log plugin has been changed to match new format
