### PR TITLE
plugin/k8s: fix endpoint index creation

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -144,12 +144,17 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
 }
 
-func epIPIndexFunc(obj interface{}) ([]string, error) {
-	ep, ok := obj.(*api.EndpointAddress)
+func epIPIndexFunc(obj interface{}) (idx []string, err error) {
+	ep, ok := obj.(*api.Endpoints)
 	if !ok {
-		return nil, errors.New("obj was not an *api.EndpointAddress")
+		return nil, errors.New("obj was not an *api.Endpoints")
 	}
-	return []string{ep.IP}, nil
+	for _, eps := range ep.Subsets {
+		for _, addr := range eps.Addresses {
+			idx = append(idx, addr.IP)
+		}
+	}
+	return idx, nil
 }
 
 func serviceListFunc(c *kubernetes.Clientset, ns string, s *labels.Selector) func(meta.ListOptions) (runtime.Object, error) {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -145,11 +145,11 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 }
 
 func epIPIndexFunc(obj interface{}) ([]string, error) {
-	var idx []string
 	ep, ok := obj.(*api.Endpoints)
 	if !ok {
 		return nil, errors.New("obj was not an *api.Endpoints")
 	}
+	var idx []string
 	for _, eps := range ep.Subsets {
 		for _, addr := range eps.Addresses {
 			idx = append(idx, addr.IP)

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -144,7 +144,8 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
 }
 
-func epIPIndexFunc(obj interface{}) (idx []string, err error) {
+func epIPIndexFunc(obj interface{}) ([]string, error) {
+	var idx []string
 	ep, ok := obj.(*api.Endpoints)
 	if !ok {
 		return nil, errors.New("obj was not an *api.Endpoints")


### PR DESCRIPTION
### 1. What does this pull request do?

Corrects the k8s endpoint ip index, which is used by reverse lookups in k8s plugin.

### 2. Which issues (if any) are related?

Sort of related: we should add (restore?) PTR tests to the CI (coredns/ci#5)

### 3. Which documentation changes (if any) need to be made?

