### PR TITLE
plugin/kubernetes: correctly set NODATA for ns

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -36,6 +36,7 @@ type dnsController interface {
 	EndpointsList() []*api.Endpoints
 
 	GetNodeByName(string) (*api.Node, error)
+	GetNamespaceByName(string) (*api.Namespace, error)
 
 	Run()
 	HasSynced() bool
@@ -394,4 +395,12 @@ func (dns *dnsControl) GetNodeByName(name string) (*api.Node, error) {
 		return &api.Node{}, err
 	}
 	return v1node, nil
+}
+
+func (dns *dnsControl) GetNamespaceByName(name string) (*api.Namespace, error) {
+	v1ns, err := dns.client.Namespaces().Get(name, meta.GetOptions{})
+	if err != nil {
+		return &api.Namespace{}, err
+	}
+	return v1ns, nil
 }

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -389,6 +389,9 @@ func (dns *dnsControl) EndpointsList() (eps []*api.Endpoints) {
 	return eps
 }
 
+// GetNodeByName return the node by name. If nothing is found an error is
+// returned. This query causes a roundtrip to the k8s API server, so use
+// sparingly. Currently this is only used for Federation.
 func (dns *dnsControl) GetNodeByName(name string) (*api.Node, error) {
 	v1node, err := dns.client.Nodes().Get(name, meta.GetOptions{})
 	if err != nil {
@@ -397,6 +400,9 @@ func (dns *dnsControl) GetNodeByName(name string) (*api.Node, error) {
 	return v1node, nil
 }
 
+// GetNamespaceByName returns the namespace by name. If nothing is found an
+// error is returned. This query causes a roundtrip to the k8s API server, so
+// use sparingly.
 func (dns *dnsControl) GetNamespaceByName(name string) (*api.Namespace, error) {
 	v1ns, err := dns.client.Namespaces().Get(name, meta.GetOptions{})
 	if err != nil {

--- a/plugin/kubernetes/handler_pod_verified_test.go
+++ b/plugin/kubernetes/handler_pod_verified_test.go
@@ -19,6 +19,27 @@ var podModeVerifiedCases = []test.Case{
 		},
 	},
 	{
+		Qname: "podns.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "svcns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	{
+		Qname: "pod-nons.pod.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -476,3 +476,14 @@ func (APIConnServeTest) GetNodeByName(name string) (*api.Node, error) {
 		},
 	}, nil
 }
+
+func (APIConnServeTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	if name == "pod-nons" { // hanlder_pod_verified_test.go uses this for non-existent namespace.
+		return &api.Namespace{}, nil
+	}
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -463,15 +463,6 @@ func wildcard(s string) bool {
 	return s == "*" || s == "any"
 }
 
-// namespaceExposed returns true when the namespace is exposed.
-func (k *Kubernetes) namespaceExposed(namespace string) bool {
-	_, ok := k.Namespaces[namespace]
-	if len(k.Namespaces) > 0 && !ok {
-		return false
-	}
-	return true
-}
-
 const (
 	// Svc is the DNS schema for kubernetes services
 	Svc = "svc"

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -332,6 +332,14 @@ func (APIConnServiceTest) GetNodeByName(name string) (*api.Node, error) {
 	}, nil
 }
 
+func (APIConnServiceTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
 func TestServices(t *testing.T) {
 
 	k := New([]string{"interwebs.test."})

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -1,0 +1,9 @@
+package kubernetes
+
+func (k *Kubernetes) namespace(n string) bool {
+	ns, err := k.APIConn.GetNamespaceByName(n)
+	if err != nil {
+		return false
+	}
+	return ns.ObjectMeta.Name == n
+}

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -1,9 +1,20 @@
 package kubernetes
 
+// namespace checks if namespace n exists in this cluster. This returns true
+// even for non exposed namespaces, see namespaceExposed.
 func (k *Kubernetes) namespace(n string) bool {
 	ns, err := k.APIConn.GetNamespaceByName(n)
 	if err != nil {
 		return false
 	}
 	return ns.ObjectMeta.Name == n
+}
+
+// namespaceExposed returns true when the namespace is exposed.
+func (k *Kubernetes) namespaceExposed(namespace string) bool {
+	_, ok := k.Namespaces[namespace]
+	if len(k.Namespaces) > 0 && !ok {
+		return false
+	}
+	return true
 }

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -55,6 +55,9 @@ func (APIConnTest) EpIndexReverse(string) []*api.Endpoints {
 }
 
 func (APIConnTest) GetNodeByName(name string) (*api.Node, error) { return &api.Node{}, nil }
+func (APIConnTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{}, nil
+}
 
 func TestNsAddr(t *testing.T) {
 

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -86,6 +86,14 @@ func (APIConnReverseTest) GetNodeByName(name string) (*api.Node, error) {
 	}, nil
 }
 
+func (APIConnReverseTest) GetNamespaceByName(name string) (*api.Namespace, error) {
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
 func TestReverse(t *testing.T) {
 
 	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa."})


### PR DESCRIPTION
A bare or wildcard query for just the namespace should return NODATA,
not NXDOMAIN, otherwise we deny the entirety of the names under the
namespace.

Add test to check for this in pod verified mode.


### 2. Which issues (if any) are related?
#1228

### 3. Which documentation changes (if any) need to be made?

