### PR TITLE
plugin/kubernetes: check err in getClientConfig

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -222,6 +222,9 @@ func (k *Kubernetes) getClientConfig() (*rest.Config, error) {
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
 
 	cc, err := clientConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
 	cc.ContentType = "application/vnd.kubernetes.protobuf"
 	return cc, err
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Check the error returned by clientConfig.ClientConfig() before trying to set cc.ContentType. Otherwise, you can get an ugly nil pointer exception.


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?
