### PR TITLE
plugin/k8s: clean up and add some ipv6 tests

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -176,6 +176,14 @@ var dnsTestCases = []test.Case{
 			test.AAAA("hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::2"),
 		},
 	},
+	// AAAA Endpoint
+	{
+		Qname: "5678-abcd--1.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::1"),
+		},
+	},
 }
 
 func TestServeDNS(t *testing.T) {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -100,7 +100,6 @@ var dnsTestCases = []test.Case{
 			test.A("172-0-0-3.hdls1.testns.svc.cluster.local.	303	IN	A	172.0.0.3"),
 			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::1"),
 			test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::2"),
-
 		},
 	},
 	// CNAME External
@@ -345,7 +344,6 @@ var epsIndex = map[string][]*api.Endpoints{
 					{
 						IP: "5678:abcd::2",
 					},
-
 				},
 				Ports: []api.EndpointPort{
 					{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -90,12 +90,17 @@ var dnsTestCases = []test.Case{
 		Qname: "_http._tcp.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 50 80 172-0-0-2.hdls1.testns.svc.cluster.local."),
-			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 50 80 172-0-0-3.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 25 80 172-0-0-2.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 25 80 172-0-0-3.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 25 80 5678-abcd--1.hdls1.testns.svc.cluster.local."),
+			test.SRV("_http._tcp.hdls1.testns.svc.cluster.local.	303	IN	SRV	0 25 80 5678-abcd--2.hdls1.testns.svc.cluster.local."),
 		},
 		Extra: []dns.RR{
 			test.A("172-0-0-2.hdls1.testns.svc.cluster.local.	303	IN	A	172.0.0.2"),
 			test.A("172-0-0-3.hdls1.testns.svc.cluster.local.	303	IN	A	172.0.0.3"),
+			test.AAAA("5678-abcd--1.hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::1"),
+			test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::2"),
+
 		},
 	},
 	// CNAME External
@@ -106,7 +111,7 @@ var dnsTestCases = []test.Case{
 			test.CNAME("external.testns.svc.cluster.local.	303	IN	CNAME	ext.interwebs.test."),
 		},
 	},
-	// AAAA Service (existing service)
+	// AAAA Service (with an existing A record, but no AAAA record)
 	{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
 		Rcode: dns.RcodeSuccess,
@@ -152,6 +157,23 @@ var dnsTestCases = []test.Case{
 		Rcode: dns.RcodeNameError,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// AAAA Service
+	{
+		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("svc6.testns.svc.cluster.local.	5	IN	AAAA	1234:abcd::1"),
+		},
+	},
+	// AAAA Service (Headless)
+	{
+		Qname: "hdls1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::1"),
+			test.AAAA("hdls1.testns.svc.cluster.local.	303	IN	AAAA	5678:abcd::2"),
 		},
 	},
 }
@@ -209,264 +231,141 @@ func (APIConnServeTest) PodIndex(string) []*api.Pod {
 	return a
 }
 
-func (APIConnServeTest) SvcIndex(string) []*api.Service {
-	svcs := []*api.Service{
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: "10.0.0.1",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
+var svcIndex = map[string][]*api.Service{
+	"svc1.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "testns",
 		},
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: api.ClusterIPNone,
-			},
+		Spec: api.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
 		},
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "external",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ExternalName: "ext.interwebs.test",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
+	}},
+	"svc6.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc6",
+			Namespace: "testns",
 		},
-	}
-	return svcs
+		Spec: api.ServiceSpec{
+			ClusterIP: "1234:abcd::1",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+		},
+	}},
+	"hdls1.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ClusterIP: api.ClusterIPNone,
+		},
+	}},
+	"external.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "external",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ExternalName: "ext.interwebs.test",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+		},
+	}},
+}
+
+func (APIConnServeTest) SvcIndex(s string) []*api.Service {
+	return svcIndex[s]
 }
 
 func (APIConnServeTest) ServiceList() []*api.Service {
-	svcs := []*api.Service{
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: "10.0.0.1",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
-		},
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: api.ClusterIPNone,
-			},
-		},
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "external",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ExternalName: "ext.interwebs.test",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
-		},
+	var svcs []*api.Service
+	for _, svc := range svcIndex {
+		svcs = append(svcs, svc...)
 	}
 	return svcs
 }
 
-func (APIConnServeTest) EpIndex(string) []*api.Endpoints {
-	n := "test.node.foo.bar"
+var epsIndex = map[string][]*api.Endpoints{
+	"svc1.testns": {{
+		Subsets: []api.EndpointSubset{
+			{
+				Addresses: []api.EndpointAddress{
+					{
+						IP:       "172.0.0.1",
+						Hostname: "ep1a",
+					},
+				},
+				Ports: []api.EndpointPort{
+					{
+						Port:     80,
+						Protocol: "tcp",
+						Name:     "http",
+					},
+				},
+			},
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "testns",
+		},
+	}},
+	"hdls1.testns": {{
+		Subsets: []api.EndpointSubset{
+			{
+				Addresses: []api.EndpointAddress{
+					{
+						IP: "172.0.0.2",
+					},
+					{
+						IP: "172.0.0.3",
+					},
+					{
+						IP: "5678:abcd::1",
+					},
+					{
+						IP: "5678:abcd::2",
+					},
 
-	eps := []*api.Endpoints{
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP:       "172.0.0.1",
-							Hostname: "ep1a",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
 				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP: "172.0.0.2",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
-				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP: "172.0.0.3",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
-				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP:       "10.9.8.7",
-							NodeName: &n,
-						},
+				Ports: []api.EndpointPort{
+					{
+						Port:     80,
+						Protocol: "tcp",
+						Name:     "http",
 					},
 				},
 			},
 		},
-	}
-	return eps
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "hdls1",
+			Namespace: "testns",
+		},
+	}},
+}
+
+func (APIConnServeTest) EpIndex(s string) []*api.Endpoints {
+	return epsIndex[s]
 }
 
 func (APIConnServeTest) EndpointsList() []*api.Endpoints {
-	n := "test.node.foo.bar"
-
-	eps := []*api.Endpoints{
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP:       "172.0.0.1",
-							Hostname: "ep1a",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
-				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP: "172.0.0.2",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
-				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP: "172.0.0.3",
-						},
-					},
-					Ports: []api.EndpointPort{
-						{
-							Port:     80,
-							Protocol: "tcp",
-							Name:     "http",
-						},
-					},
-				},
-			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
-				Namespace: "testns",
-			},
-		},
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP:       "10.9.8.7",
-							NodeName: &n,
-						},
-					},
-				},
-			},
-		},
+	var eps []*api.Endpoints
+	for _, ep := range epsIndex {
+		eps = append(eps, ep...)
 	}
 	return eps
+
 }
 
 func (APIConnServeTest) GetNodeByName(name string) (*api.Node, error) {


### PR DESCRIPTION
### 1. What does this pull request do?

Add following unit test cases for IPv6:
* AAAA record for cluster ip service
* AAAA record for headless service
* AAAA record for endpoint
* SRV record for headless service with mixed ipv4/ipv6 endpoints

These tests pass with the code as-is! :tada:

These changes also...
* Consolidate some redundant data in the test (copy-pasted List vs Index data sets)
* Fix the behavior of the handler_test.go index function implementations.
* Fix mocked Endpoint structure (for > 1 endpoint in a service)

### 2. Which issues (if any) are related?

#1236

### 3. Which documentation changes (if any) need to be made?
