### PR TITLE
plugin/kubernetes: set TTL on pod responses

### DIFF
--- a/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/plugin/kubernetes/handler_pod_insecure_test.go
@@ -15,14 +15,14 @@ var podModeInsecureCases = []test.Case{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
+			test.A("10-240-0-1.podns.pod.cluster.local.	5	IN	A	10.240.0.1"),
 		},
 	},
 	{
 		Qname: "172-0-0-2.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("172-0-0-2.podns.pod.cluster.local.	0	IN	A	172.0.0.2"),
+			test.A("172-0-0-2.podns.pod.cluster.local.	5	IN	A	172.0.0.2"),
 		},
 	},
 }

--- a/plugin/kubernetes/handler_pod_verified_test.go
+++ b/plugin/kubernetes/handler_pod_verified_test.go
@@ -15,7 +15,7 @@ var podModeVerifiedCases = []test.Case{
 		Qname: "10-240-0-1.podns.pod.cluster.local.", Qtype: dns.TypeA,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("10-240-0-1.podns.pod.cluster.local.	0	IN	A	10.240.0.1"),
+			test.A("10-240-0-1.podns.pod.cluster.local.	5	IN	A	10.240.0.1"),
 		},
 	},
 	{

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -320,7 +320,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 	}
 
 	if k.podMode == podModeInsecure {
-		return []msg.Service{{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip}}, nil
+		return []msg.Service{{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}}, nil
 	}
 
 	// PodModeVerified
@@ -331,7 +331,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 		}
 		// check for matching ip and namespace
 		if ip == p.Status.PodIP && match(namespace, p.Namespace) {
-			s := msg.Service{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip}
+			s := msg.Service{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}
 			pods = append(pods, s)
 
 			err = nil


### PR DESCRIPTION
The TTL was still zero, instead it should adhere to the k.ttl setting.
Change this and update tests to match.

