### PR TITLE
plugin/k8s: ipv6 UT for endpoint

### DIFF
--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -47,7 +47,10 @@ func (APIConnReverseTest) SvcIndexReverse(ip string) []*api.Service {
 }
 
 func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
-	if ip != "10.0.0.100" {
+	switch ip {
+	case "10.0.0.100":
+	case "1234:abcd::1":
+	default:
 		return nil
 	}
 	eps := []*api.Endpoints{
@@ -57,6 +60,10 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 					Addresses: []api.EndpointAddress{
 						{
 							IP:       "10.0.0.100",
+							Hostname: "ep1a",
+						},
+						{
+							IP:       "1234:abcd::1",
 							Hostname: "ep1a",
 						},
 					},
@@ -96,7 +103,7 @@ func (APIConnReverseTest) GetNamespaceByName(name string) (*api.Namespace, error
 
 func TestReverse(t *testing.T) {
 
-	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa."})
+	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa."})
 	k.APIConn = &APIConnReverseTest{}
 
 	tests := []test.Case{
@@ -112,6 +119,13 @@ func TestReverse(t *testing.T) {
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.PTR("100.1.168.192.in-addr.arpa.     5     IN      PTR       svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 5 IN PTR ep1a.svc1.testns.svc.cluster.local."),
 			},
 		},
 		{

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -64,7 +64,7 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 						},
 						{
 							IP:       "1234:abcd::1",
-							Hostname: "ep1a",
+							Hostname: "ep1b",
 						},
 					},
 					Ports: []api.EndpointPort{
@@ -125,7 +125,7 @@ func TestReverse(t *testing.T) {
 			Qname: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", Qtype: dns.TypePTR,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 5 IN PTR ep1a.svc1.testns.svc.cluster.local."),
+				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 5 IN PTR ep1b.svc1.testns.svc.cluster.local."),
 			},
 		},
 		{


### PR DESCRIPTION
### 1. What does this pull request do?

Add unit test for IPv6 endpoint reverse lookup

### 2. Which issues (if any) are related?

#1236

### 3. Which documentation changes (if any) need to be made?

