### PR TITLE
plugin/k8s: fix external service type check

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -288,6 +288,7 @@ var svcIndex = map[string][]*api.Service{
 				Protocol: "tcp",
 				Port:     80,
 			}},
+			Type: api.ServiceTypeExternalName,
 		},
 	}},
 }

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -418,16 +418,15 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		}
 
 		// External service
-		if svc.Spec.ExternalName != "" {
+		if svc.Spec.Type == api.ServiceTypeExternalName {
 			s := msg.Service{Key: strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/"), Host: svc.Spec.ExternalName, TTL: k.ttl}
 			if t, _ := s.HostType(); t == dns.TypeCNAME {
 				s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
 				services = append(services, s)
 
 				err = nil
-
-				continue
 			}
+			continue
 		}
 
 		// ClusterIP service

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -101,6 +101,7 @@ func (APIConnServiceTest) SvcIndex(string) []*api.Service {
 					Protocol: "tcp",
 					Port:     80,
 				}},
+				Type: api.ServiceTypeExternalName,
 			},
 		},
 	}
@@ -144,6 +145,7 @@ func (APIConnServiceTest) ServiceList() []*api.Service {
 					Protocol: "tcp",
 					Port:     80,
 				}},
+				Type: api.ServiceTypeExternalName,
 			},
 		},
 	}


### PR DESCRIPTION
### 1. What does this pull request do?

Fixes an issue found by kubernetes end to end tests where an existing ExternalName service is converted into a ClusterIP service and results in a ClusterIP service with a (vestigial) externalName field.  This case was confusing coredns.  Fix is to identify external services by checking the service type instead of the external name field.

The failed test is the last sub test of "should provide DNS for ExternalName services" in kubernetes/test/e2e/network/dns.go

### 2. Which issues (if any) are related?

kubernetes/test-infra#5601

### 3. Which documentation changes (if any) need to be made?
