### PR TITLE
plugin/etcd: drop inflight

### DIFF
--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
-	"github.com/coredns/coredns/plugin/pkg/singleflight"
 	"github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/plugin/test"
@@ -232,7 +231,6 @@ func newEtcdPlugin() *Etcd {
 		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53"}),
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
-		Inflight:   &singleflight.Group{},
 		Zones:      []string{"skydns.test.", "skydns_extra.test.", "in-addr.arpa."},
 		Client:     client,
 	}

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -6,7 +6,6 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
-	"github.com/coredns/coredns/plugin/pkg/singleflight"
 	mwtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/proxy"
 
@@ -50,7 +49,6 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 		//		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53", "8.8.4.4:53"}),
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
-		Inflight:   &singleflight.Group{},
 		Stubmap:    &stub,
 	}
 	var (


### PR DESCRIPTION
Use caching, just ask etcd for every query. This also improves
throughput because the single lock in inflght is bypassed.

This makes *etcd* behave as *kubernetes*

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None
