### PR TITLE
plugin/metrics: fix duration reporting

### DIFF
--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -20,7 +20,7 @@ func Report(req request.Request, zone, rcode string, size int, start time.Time) 
 	typ := req.QType()
 
 	RequestCount.WithLabelValues(zone, net, fam).Inc()
-	RequestDuration.WithLabelValues(zone).Observe(float64(time.Since(start) / time.Millisecond))
+	RequestDuration.WithLabelValues(zone).Observe(float64(time.Since(start)) / float64(time.Millisecond))
 
 	if req.Do() {
 		RequestDo.WithLabelValues(zone).Inc()


### PR DESCRIPTION
The calculation was done wrong resulting in the a large value being
written all the time.

### 2. Which issues (if any) are related?
Fixes #1251 

### 3. Which documentation changes (if any) need to be made?
None
