### PR TITLE
Pass net.TCPAddr type as remote address to gRPCresponse writer

### DIFF
--- a/core/dnsserver/server-grpc.go
+++ b/core/dnsserver/server-grpc.go
@@ -133,8 +133,7 @@ func (s *ServergRPC) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket
 		return nil, fmt.Errorf("no TCP peer in gRPC context: %v", p.Addr)
 	}
 
-	r := &net.IPAddr{IP: a.IP}
-	w := &gRPCresponse{localAddr: s.listenAddr, remoteAddr: r, Msg: msg}
+	w := &gRPCresponse{localAddr: s.listenAddr, remoteAddr: a, Msg: msg}
 
 	s.ServeDNS(ctx, w, msg)
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Dnstap requires the "protocol", "address" and "port" info about peer. Dnstap plugin expects that the address is of type net.TCPAddr or net.UDPAddr. So, I removed the conversion of TCPAddr to IPAddr in 
func (s *ServergRPC) Query(...)
Please let me know if there were some reasons for address conversion

### 2. Which issues (if any) are related?
Fixes #1245 

### 3. Which documentation changes (if any) need to be made?
none
