### PR TITLE
metrics: use exponentional buckets

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -6,7 +6,7 @@ The default location for the metrics is `localhost:9153`. The metrics path is fi
 The following metrics are exported:
 
 * `coredns_dns_request_count_total{zone, proto, family}` - total query count.
-* `coredns_dns_request_duration_milliseconds{zone}` - duration to process each query.
+* `coredns_dns_request_duration_seconds{zone}` - duration to process each query.
 * `coredns_dns_request_size_bytes{zone, proto}` - size of the request in bytes.
 * `coredns_dns_request_do_count_total{zone}` -  queries that have the DO bit set
 * `coredns_dns_request_type_count_total{zone, type}` - counter of queries per zone and type.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 )
 
@@ -102,4 +103,4 @@ func ClientWrite(rcode int) bool {
 const Namespace = "coredns"
 
 // TimeBuckets is based on Prometheus client_golang prometheus.DefBuckets
-var TimeBuckets = []float64{0.00025, 0.0005, 0.001, 0.0025, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
+var TimeBucket = prometheus.ExponentialBuckets(0.25, 2, 16) // from 0.25ms to 8 seconds

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -103,4 +103,4 @@ func ClientWrite(rcode int) bool {
 const Namespace = "coredns"
 
 // TimeBuckets is based on Prometheus client_golang prometheus.DefBuckets
-var TimeBucket = prometheus.ExponentialBuckets(0.25, 2, 16) // from 0.25ms to 8 seconds
+var TimeBuckets = prometheus.ExponentialBuckets(0.25, 2, 16) // from 0.25ms to 8 seconds

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -98,7 +98,7 @@ payload over HTTPS). Note that with `https_google` the entire transport is encry
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
 
-* `coredns_proxy_request_duration_millisecond{proto, proto_proxy, family, to}` - duration per upstream
+* `coredns_proxy_request_duration_seconds{proto, proto_proxy, family, to}` - duration per upstream
   interaction.
 * `coredns_proxy_request_count_total{proto, proto_proxy, family, to}` - query count per upstream.
 


### PR DESCRIPTION
See  https://github.com/kubernetes/dns/pull/168
