### PR TITLE
plugin/rewrite: don't set or use ecs.DraftOption

### DIFF
--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -368,7 +368,6 @@ func (rule *edns0SubnetRule) fillEcsData(w dns.ResponseWriter, r *dns.Msg,
 		return fmt.Errorf("unable to fill data for EDNS0 subnet due to invalid IP family")
 	}
 
-	ecs.DraftOption = false
 	ecs.Family = uint16(family)
 	ecs.SourceScope = 0
 

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -364,8 +364,9 @@ func optsEqual(a, b []dns.EDNS0) bool {
 				if !bytes.Equal(aa.Address, bb.Address) {
 					return false
 				}
+			} else {
+				return false
 			}
-			return false
 
 		default:
 			return false

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -364,12 +364,8 @@ func optsEqual(a, b []dns.EDNS0) bool {
 				if !bytes.Equal(aa.Address, bb.Address) {
 					return false
 				}
-				if aa.DraftOption != bb.DraftOption {
-					return false
-				}
-			} else {
-				return false
 			}
+			return false
 
 		default:
 			return false
@@ -479,7 +475,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceNetmask: 0x18,
 				SourceScope:   0x0,
 				Address:       []byte{0x0A, 0xF0, 0x00, 0x00},
-				DraftOption:   false}},
+			}},
 		},
 		{
 			&test.ResponseWriter{},
@@ -490,7 +486,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceNetmask: 0x20,
 				SourceScope:   0x0,
 				Address:       []byte{0x0A, 0xF0, 0x00, 0x01},
-				DraftOption:   false}},
+			}},
 		},
 		{
 			&test.ResponseWriter{},
@@ -501,7 +497,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceNetmask: 0x0,
 				SourceScope:   0x0,
 				Address:       []byte{0x00, 0x00, 0x00, 0x00},
-				DraftOption:   false}},
+			}},
 		},
 		{
 			&test.ResponseWriter6{},
@@ -513,7 +509,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceScope:   0x0,
 				Address: []byte{0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-				DraftOption: false}},
+			}},
 		},
 		{
 			&test.ResponseWriter6{},
@@ -525,7 +521,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceScope:   0x0,
 				Address: []byte{0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					0x00, 0x42, 0x00, 0xff, 0xfe, 0xca, 0x4c, 0x65},
-				DraftOption: false}},
+			}},
 		},
 		{
 			&test.ResponseWriter6{},
@@ -537,7 +533,7 @@ func TestRewriteEDNS0Subnet(t *testing.T) {
 				SourceScope:   0x0,
 				Address: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-				DraftOption: false}},
+			}},
 		},
 	}
 


### PR DESCRIPTION
Don't know why we are accessing this and explicitally setting it to
False (the default).
Any kill with fire - makes the build, build again.