### PR TITLE
Added reconnect feature for dnstap plugin

### DIFF
--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -65,14 +65,11 @@ func setup(c *caddy.Controller) error {
 		return err
 	}
 
-	dio := dnstapio.New()
+	dio := dnstapio.New(conf.target, conf.socket)
 	dnstap := Dnstap{IO: dio, Pack: conf.full}
 
 	c.OnStartup(func() error {
-		err := dio.Connect(conf.target, conf.socket)
-		if err != nil {
-			return plugin.Error("dnstap", err)
-		}
+		dio.Connect()
 		return nil
 	})
 


### PR DESCRIPTION
### 1. What does this pull request do?
In case if dnstap listener endpoint fails CoreDNS tries to reconnect to - this is helps avoid error in case network fail.
### 2. Which issues (if any) are related?
Previously CoreDNS won't start if dnstap listener endpoint has not been started yet.
### 3. Which documentation changes (if any) need to be made?
none