### PR TITLE
plugin/proxy: add note about HC and google_https

### DIFF
--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -188,3 +188,8 @@ example.org {
     proxy . 8.8.8.8:53
 }
 ~~~
+
+# Bugs
+
+When using the `google_https` protocol the health checking will health check the wrong endpoint.
+See <https://github.com/coredns/coredns/issues/1202> for some background.

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -117,8 +117,6 @@ func (g *google) OnStartup(p *Proxy) error {
 
 	oldUpstream := (*p.Upstreams)[0]
 
-	log.Printf("[INFO] Bootstrapping A records %q", g.endpoint)
-
 	new, err := g.bootstrapProxy.Lookup(state, g.endpoint, dns.TypeA)
 	if err != nil {
 		log.Printf("[WARNING] Failed to bootstrap A records %q: %s", g.endpoint, err)


### PR DESCRIPTION
HC for google_https does not work because it does not HC the correct
set of IPs. Hard to solve in the current code - rather use forward as
the new impl. and leave this as legacy.

Remove superfluous println that we are refreshing the dns.google.com IP
address.


### 2. Which issues (if any) are related?
#1202 

### 3. Which documentation changes (if any) need to be made?
plugin/proxy/README
