### PR TITLE
plugin/proxy: when HC fails increase fails

### DIFF
--- a/plugin/pkg/healthcheck/healthcheck.go
+++ b/plugin/pkg/healthcheck/healthcheck.go
@@ -123,6 +123,7 @@ func (uh *UpstreamHost) HealthCheckURL() {
 
 	if err != nil {
 		log.Printf("[WARNING] Host %s health check probe failed: %v", uh.Name, err)
+		atomic.AddInt32(&uh.Fails, 1)
 		return
 	}
 
@@ -132,6 +133,7 @@ func (uh *UpstreamHost) HealthCheckURL() {
 
 		if r.StatusCode < 200 || r.StatusCode >= 400 {
 			log.Printf("[WARNING] Host %s health check returned HTTP code %d", uh.Name, r.StatusCode)
+			atomic.AddInt32(&uh.Fails, 1)
 			return
 		}
 


### PR DESCRIPTION
When we failing the healthcheck we should increate the fails for this
host; which is the *bleeping* point of doing the HC in the first place.

Add the missing atomic.Adds.

Fixes #1247