### PR TITLE
Fix time bucketing of response time

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -103,4 +103,4 @@ func ClientWrite(rcode int) bool {
 const Namespace = "coredns"
 
 // TimeBuckets is based on Prometheus client_golang prometheus.DefBuckets
-var TimeBuckets = prometheus.ExponentialBuckets(0.25, 2, 16) // from 0.25ms to 8 seconds
+var TimeBuckets = prometheus.ExponentialBuckets(0.00025, 2, 16) // from 0.25ms to 8 seconds


### PR DESCRIPTION
### 1. What does this pull request do?

Fix the time bucketing. The comment says "0.25ms to 8s" but the base unit is seconds, so 0.25 means 250ms instead of 0.25ms.

### 2. Which issues (if any) are related?

Relates to #1253 (use timing histogram, added correct timing) and #1261 (broke buckets)

### 3. Which documentation changes (if any) need to be made?

Changes to the bucketing and metric names can break existing dashboards and might be noteworthy on releases.