### PR TITLE
Increase performance of Dnstap plugin

### DIFF
--- a/plugin/dnstap/dnstapio/dnstap_encoder.go
+++ b/plugin/dnstap/dnstapio/dnstap_encoder.go
@@ -1,0 +1,92 @@
+package dnstapio
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	tap "github.com/dnstap/golang-dnstap"
+	fs "github.com/farsightsec/golang-framestream"
+	"github.com/golang/protobuf/proto"
+)
+
+const (
+	frameLenSize = 4
+	protobufSize = 1024 * 1024
+)
+
+type dnstapEncoder struct {
+	fse    *fs.Encoder
+	opts   *fs.EncoderOptions
+	writer io.Writer
+	buffer *proto.Buffer
+}
+
+func newDnstapEncoder(o *fs.EncoderOptions) *dnstapEncoder {
+	return &dnstapEncoder{
+		opts:   o,
+		buffer: proto.NewBuffer(make([]byte, 0, protobufSize)),
+	}
+}
+
+func (enc *dnstapEncoder) resetWriter(w io.Writer) error {
+	fse, err := fs.NewEncoder(w, enc.opts)
+	if err != nil {
+		return err
+	}
+	if err = fse.Flush(); err != nil {
+		return err
+	}
+	enc.fse = fse
+	enc.writer = w
+	return nil
+}
+
+func (enc *dnstapEncoder) writeMsg(msg *tap.Dnstap) error {
+	if len(enc.buffer.Bytes()) >= protobufSize {
+		if err := enc.flushBuffer(); err != nil {
+			return err
+		}
+	}
+	bufLen := len(enc.buffer.Bytes())
+	// add placeholder for frame length
+	if err := enc.buffer.EncodeFixed32(0); err != nil {
+		enc.buffer.SetBuf(enc.buffer.Bytes()[:bufLen])
+		return err
+	}
+	if err := enc.buffer.Marshal(msg); err != nil {
+		enc.buffer.SetBuf(enc.buffer.Bytes()[:bufLen])
+		return err
+	}
+	enc.encodeFrameLen(enc.buffer.Bytes()[bufLen:])
+	return nil
+}
+
+func (enc *dnstapEncoder) flushBuffer() error {
+	if enc.fse == nil || enc.writer == nil {
+		return fmt.Errorf("no writer")
+	}
+
+	buf := enc.buffer.Bytes()
+	written := 0
+	for written < len(buf) {
+		n, err := enc.writer.Write(buf[written:])
+		written += n
+		if err != nil {
+			return err
+		}
+	}
+	enc.buffer.Reset()
+	return nil
+}
+
+func (enc *dnstapEncoder) encodeFrameLen(buf []byte) {
+	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
+}
+
+func (enc *dnstapEncoder) close() error {
+	if enc.fse != nil {
+		return enc.fse.Close()
+	}
+	return nil
+}

--- a/plugin/dnstap/dnstapio/dnstap_encoder_test.go
+++ b/plugin/dnstap/dnstapio/dnstap_encoder_test.go
@@ -1,0 +1,53 @@
+package dnstapio
+
+import (
+	"bytes"
+	"testing"
+
+	tap "github.com/dnstap/golang-dnstap"
+	fs "github.com/farsightsec/golang-framestream"
+	"github.com/golang/protobuf/proto"
+)
+
+func dnstapMsg() *tap.Dnstap {
+	t := tap.Dnstap_MESSAGE
+	mt := tap.Message_CLIENT_RESPONSE
+	msg := &tap.Message{Type: &mt}
+	return &tap.Dnstap{Type: &t, Message: msg}
+}
+
+func TestEncoderCompatibility(t *testing.T) {
+	opts := &fs.EncoderOptions{
+		ContentType:   []byte("protobuf:dnstap.DnstapTest"),
+		Bidirectional: false,
+	}
+	msg := dnstapMsg()
+
+	//framestream encoder
+	fsW := new(bytes.Buffer)
+	fsEnc, err := fs.NewEncoder(fsW, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fsEnc.Write(data)
+	fsEnc.Close()
+
+	//dnstap encoder
+	dnstapW := new(bytes.Buffer)
+	dnstapEnc := newDnstapEncoder(opts)
+	if err := dnstapEnc.resetWriter(dnstapW); err != nil {
+		t.Fatal(err)
+	}
+	dnstapEnc.writeMsg(msg)
+	dnstapEnc.flushBuffer()
+	dnstapEnc.close()
+
+	//compare results
+	if !bytes.Equal(fsW.Bytes(), dnstapW.Bytes()) {
+		t.Fatal("dnstapEncoder is not compatible with framestream Encoder")
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
 - added dnstapEncoder object which incapsulates marshalling of dnstap
   messages to protobuf and writing data to connection

 - dnstapEncoder writes data directly to connection object. It doesn't
   use the framestream's "write" method, because it writes data to
   intermediate buffer (bufio.Writer) which leads to unnecessary
   data copying and drops the performance

 - dnstapEncoder reuses a preallocated buffer for marshalling dnstap
   messages. Many messages are added to the same buffer. They are
   separated with a "frame length" 4-byte values, so the buffer content
   is writen to connection object in the format compatible with
   framestream library

 - added test which guarantees that dnstapEncoder output is the same
   as framestream Encoder output

 - the performance increase is about 50% in (dio *dnstapIO) serve() method
   of dnstap plugin. The overall coredns performance increase is about 10%
   in the following configuration:

   .:1053 {
       erratic {
           drop 0
           truncate 0
           delay 0
       }
       dnstap tcp://127.0.0.1:6000 full
       errors stdout
   }

   tested with dnsperf tool



### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none
