### PR TITLE
Add Qunar to ADOPTORS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,4 +2,5 @@
 * [Sky Betting & Gaming](http://engineering.skybettingandgaming.com) uses CoreDNS for Kubernetes cluster DNS.
 * [Kismia](https://kismia.com) uses CoreDNS for Kubernetes cluster DNS.
 * [Admiral](https://getadmiral.com) uses CoreDNS to handle geographic DNS requests for our public-facing microservices.
+* [Qunar](https://qunar.com) uses CoreDNS for service discovery of its GPU machine learning cloud with TensorFlow and Kubernetes.
 * [seansean2](https://web.mit.edu) uses coreDNS in production at MIT for DNS.


### PR DESCRIPTION
Qunar (https://qunar.com) is the leading travel booking service in China. They use CoreDNS for service discovery of the GPU machine learning cloud they build with TensorFlow and Kubernetes.

There is a very nice talk in KubeCon 2017, presented by Ye Lu (👍 ):
https://kccncna17.sched.com/event/CU61/all-you-need-to-know-to-build-your-gpu-machine-learning-cloud-b-ye-lu-qunar

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

