### PR TITLE
Changing switch to compare on constants versus strings

### DIFF
--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -37,24 +37,25 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		records, extra []dns.RR
 		err            error
 	)
-	switch state.Type() {
-	case "A":
+
+	switch state.QType() {
+	case dns.TypeA:
 		records, err = plugin.A(e, zone, state, nil, opt)
-	case "AAAA":
+	case dns.TypeAAAA:
 		records, err = plugin.AAAA(e, zone, state, nil, opt)
-	case "TXT":
+	case dns.TypeTXT:
 		records, err = plugin.TXT(e, zone, state, opt)
-	case "CNAME":
+	case dns.TypeCNAME:
 		records, err = plugin.CNAME(e, zone, state, opt)
-	case "PTR":
+	case dns.TypePTR:
 		records, err = plugin.PTR(e, zone, state, opt)
-	case "MX":
+	case dns.TypeMX:
 		records, extra, err = plugin.MX(e, zone, state, opt)
-	case "SRV":
+	case dns.TypeSRV:
 		records, extra, err = plugin.SRV(e, zone, state, opt)
-	case "SOA":
+	case dns.TypeSOA:
 		records, err = plugin.SOA(e, zone, state, opt)
-	case "NS":
+	case dns.TypeNS:
 		if state.Name() == zone {
 			records, extra, err = plugin.NS(e, zone, state, opt)
 			break

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -30,24 +30,24 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		err     error
 	)
 
-	switch state.Type() {
-	case "A":
+	switch state.QType() {
+	case dns.TypeA:
 		records, err = plugin.A(&k, zone, state, nil, plugin.Options{})
-	case "AAAA":
+	case dns.TypeAAAA:
 		records, err = plugin.AAAA(&k, zone, state, nil, plugin.Options{})
-	case "TXT":
+	case dns.TypeTXT:
 		records, err = plugin.TXT(&k, zone, state, plugin.Options{})
-	case "CNAME":
+	case dns.TypeCNAME:
 		records, err = plugin.CNAME(&k, zone, state, plugin.Options{})
-	case "PTR":
+	case dns.TypePTR:
 		records, err = plugin.PTR(&k, zone, state, plugin.Options{})
-	case "MX":
+	case dns.TypeMX:
 		records, extra, err = plugin.MX(&k, zone, state, plugin.Options{})
-	case "SRV":
+	case dns.TypeSRV:
 		records, extra, err = plugin.SRV(&k, zone, state, plugin.Options{})
-	case "SOA":
+	case dns.TypeSOA:
 		records, err = plugin.SOA(&k, zone, state, plugin.Options{})
-	case "NS":
+	case dns.TypeNS:
 		if state.Name() == zone {
 			records, extra, err = plugin.NS(&k, zone, state, plugin.Options{})
 			break


### PR DESCRIPTION
### 1. What does this pull request do?
Minor change to kubernetes plugin to do switch comparison against constants instead of strings.

### 2. Which issues (if any) are related?
n/a

### 3. Which documentation changes (if any) need to be made?
n/a
