### PR TITLE
plugin/template

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -38,6 +38,7 @@ loadbalance:loadbalance
 dnssec:dnssec
 autopath:autopath
 reverse:reverse
+template:template
 hosts:hosts
 federation:federation
 kubernetes:kubernetes

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -39,6 +39,15 @@ The output of the template must be a [RFC 1035](https://tools.ietf.org/html/rfc1
 
 **WARNING** there is a syntactical problem with Go templates and caddy config files. Expressions like `{{$var}}` will be interpreted as a reference to an environment variable by caddy/coredns while `{{ $var }}` will work. Try to avoid template variables. See [Bugs](#bugs)
 
+## Metrics
+
+If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
+- `coredns_template_matches_total` the total number of matched requests.
+- `coredns_template_template_failures_total` the number of times the Go templating failed.
+- `coredns_template_rr_failures_total` the number of times the templated resource record was invalid and could not be parsed.
+
+Both failure cases indicate a problem with the template configuration.
+
 ## Examples
 
 ### Resolve .invalid as NXDOMAIN

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -41,7 +41,7 @@ Each resource record is a full-featured [Go template](https://golang.org/pkg/tex
 
 The output of the template must be a [RFC 1035](https://tools.ietf.org/html/rfc1035) style resource record line (commonly refered to as a "zone file").
 
-**WARNING** there is a syntactical problem with Go templates and caddy config files. Expressions like `{{$var}}` will be interpreted as a reference to an environment variable by caddy/coredns while `{{ $var }}` will work. Try to avoid template variables. See [Bugs](#bugs)
+**WARNING** there is a syntactical problem with Go templates and caddy config files. Expressions like `{{$var}}` will be interpreted as a reference to an environment variable by caddy/coredns while `{{ $var }}` will work. Try to avoid template variables. See [Bugs](#bugs).
 
 ## Metrics
 

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -31,7 +31,7 @@ Each resource record is a full-featured [Go template](https://golang.org/pkg/tex
 * `.Class` the query class (usually `IN`)
 * `.Type` the RR type requested (e.g. `PTR`)
 * `.Match` an array of all matches. `index .Match 0` refers to the whole match.
-* `.Group` a map fo the named capture groups.
+* `.Group` a map of the named capture groups.
 * `.Message` the incoming DNS query message.
 * `.Question` the matched question section.
 

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -13,6 +13,7 @@ template CLASS TYPE [REGEX...] {
     [answer RR]
     [answer RR]
     [additional RR]
+    [authority RR]
     [...]
     [rcode responsecode]
 }

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -1,6 +1,10 @@
 # template
 
-*template* allows for dynamic responses based on the incoming query.
+*template* - allows for dynamic responses based on the incoming query.
+
+## Description
+
+The *template* plugin allows you to dynamically repond to queries by just writing a (Go) template.
 
 ## Syntax
 

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -47,9 +47,9 @@ The output of the template must be a [RFC 1035](https://tools.ietf.org/html/rfc1
 ## Metrics
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
-- `coredns_template_matches_total` the total number of matched requests.
-- `coredns_template_template_failures_total` the number of times the Go templating failed.
-- `coredns_template_rr_failures_total` the number of times the templated resource record was invalid and could not be parsed.
+- `coredns_template_matches_total{regex}` the total number of matched requests by regex.
+- `coredns_template_template_failures_total{regex,section,template}` the number of times the Go templating failed. Regex, section and template label values can be used to map the error back to the config file.
+- `coredns_template_rr_failures_total{regex,section,template}` the number of times the templated resource record was invalid and could not be parsed. Regex, section and template label values can be used to map the error back to the config file.
 
 Both failure cases indicate a problem with the template configuration.
 

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -110,9 +110,7 @@ Having templates to map certain PTR/A pairs is a common pattern.
 . {
     proxy 8.8.8.8
 
-    template IN A
-        ^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$
-        ^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$ {
+    template IN A "^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$" "^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$" {
       answer "{{ .Name }} 60 IN A {{ .Group.a}}.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
     }
 }

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -20,7 +20,7 @@ template CLASS TYPE [REGEX...] {
 
 * **CLASS** the query class (usually IN or ANY)
 * **TYPE** the query type (A, PTR, ...)
-* **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming query. Specifying no regex matches everything (default: `.*`). First matching regex wins.
+* **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `RR` A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style `<rr>` fragment build by a [Go template](https://golang.org/pkg/text/template/) that contains the answer.
 * `responsecode` A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
 

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -108,7 +108,7 @@ Having templates to map certain PTR/A pairs is a common pattern.
 
 ~~~ corefile
 . {
-    proxy 8.8.8.8
+    proxy . 8.8.8.8
 
     template IN A "^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$" "^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$" {
       answer "{{ .Name }} 60 IN A {{ .Group.a}}.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -138,15 +138,39 @@ Named capture groups can be used to template one response for multiple patterns.
 ### Resolve A and MX records for ip templates in .example
 
 ~~~ corefile
-. { 
+. {
     proxy . 8.8.8.8
-    
+
     template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
     }
     template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
       answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
       additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    }
+}
+~~~
+
+### Adding authoritative nameservers to the response
+
+~~~ corefile
+. {
+    proxy . 8.8.8.8
+
+    template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+      answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      authority  "example. 60 IN NS ns0.example."
+      authority  "example. 60 IN NS ns1.example."
+      additional "ns0.example. 60 IN A 203.0.113.8"
+      additional "ns1.example. 60 IN A 198.51.100.8"
+    }
+    template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+      answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
+      additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      authority  "example. 60 IN NS ns0.example."
+      authority  "example. 60 IN NS ns1.example."
+      additional "ns0.example. 60 IN A 203.0.113.8"
+      additional "ns1.example. 60 IN A 198.51.100.8"
     }
 }
 ~~~

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -1,0 +1,137 @@
+# template
+
+*template* allows for dynamic responses base on the incoming query.
+
+## Syntax
+
+~~~
+template CLASS TYPE [REGEX...] {
+    [answer section]
+    [answer section]
+    [additional section]
+    [...]
+    [rcode  responsecode]
+}
+~~~
+
+* **CLASS** the query class (usually IN or ANY)
+* **TYPE** the query type (A, PTR, ...)
+* **REGEX** regex that are matched against the incoming query. Specifying no regex matches everything.
+* `section` A RFC 1035 style fragment build by a go template that contains the answer.
+* `resplonsecode` A response code (NXDOMAIN, SERVFAIL, ...)
+
+At least one answer section or rcode is needed.
+
+## Templates
+
+Each answer section is a full-featured go templated with the following predefined data
+* `.Name` the query name, as a string
+* `.Class` the query class (usually `IN`)
+* `.Type` the RR type requested (e.g. `PTR`)
+* `.Match` an array of all matches. `index .Match 0` refers to the whole match.
+* `.Group` a map fo the named capture groups.
+* `.Message` the incoming DNS query message.
+* `.Question` the matched question section.
+
+The output of the template must be a RFC 1035 style RR line (commonly refered to as a "zone file").
+
+**WARNING** there is a syntactical problem with go templates and caddy config files. Expressions like `{{$var}}` will be interpreted as a reference to an envorionment variable while `{{ $var }}` will work. Try to avoid template variables.
+
+## Examples
+
+### Resolve .invalid as NXDOMAIN
+
+The `.invalid` domain is a reserved TLD to indicate non-existing domains.
+
+~~~ corefile
+. {
+    proxy . 8.8.8.8
+
+    template ANY ANY "[.]invalid[.]$" {
+      rcode NXDOMAIN
+      answer "invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"
+    }
+}
+~~~
+
+1. A query to .invalid will result in NXDOMAIN (rcode)
+2. A dummy SOA record is send to hand out a TTL of 60s for caching
+3. Querying `.invalid` of `CH` will also cause a NXDOMAIN/SOA response
+
+### Block invalid search domain completions
+
+Imagine you run `example.com` with a datacenter `dc1.example.com`. The datacenter domain
+is part of the DNS search domain.
+However `something.example.com.dc1.example.com` would usually indicate a wrong autocomplete.
+
+~~~ corefile
+. {
+    proxy . 8.8.8.8
+
+    template IN ANY "[.](example[.]com[.]dc1[.]example[.]com[.])$" {
+      rcode NXDOMAIN
+      answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+    }
+}
+~~~
+
+1. Using numbered matches works well if there are very few groups (1-4)
+
+### Resolve A/PTR for .example
+
+~~~ corefile
+. {
+    proxy . 8.8.8.8
+
+    # ip-a-b-c-d.example.com A a.b.c.d
+
+    template IN A (^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+      answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    }
+
+    # d.c.b.a.in-addr.arpa PTR ip-a-b-c-d.example
+
+    template IN PTR ^(?P<d>[0-9]*)[.](?P<c>[0-9]*)[.](?P<b>[0-9]*)[.]10[.]in-addr[.]arpa[.]$ {
+      answer "{{ .Name }} 60 IN PTR ip-10-{{ .Group.b }}-{{ .Group.c }}-{{ .Group.d }}.example.com."
+    }
+}
+~~~
+
+An IP consists of 4 bytes, `a.b.c.d`. Named groups make it less error prone to reverse the
+ip in the PTR case. Try to use named groups to explain what your regex and template are doing.
+
+Note that the A record is actually a wildcard, any subdomain of the ip will resolve to the ip.
+
+Having templates to map certain PTR/A pairs is a common pattern.
+
+### Resolve multiple ip patterns
+
+~~~ corefile
+. {
+    proxy 8.8.8.8
+
+    template IN A
+        ^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$
+        ^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$ {
+      answer "{{ .Name }} 60 IN A {{ .Group.a}}.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    }
+}
+~~~
+
+Named capture groups can be used to template one response for multiple patterns.
+
+### Resolve A and MX records for ip templates in .example
+
+~~~ corefile
+. { 
+    proxy . 8.8.8.8
+    
+    template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+      answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    }
+    template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+      answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
+      additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    }
+}
+~~~

--- a/plugin/template/metrics.go
+++ b/plugin/template/metrics.go
@@ -1,0 +1,43 @@
+package template
+
+import (
+	"sync"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics for template.
+var (
+	TemplateMatchesCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "template",
+		Name:      "matches_total",
+		Help:      "Counter of template regex matches.",
+	}, []string{"regex"})
+	TemplateFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "template",
+		Name:      "template_failures_total",
+		Help:      "Counter of go template failures.",
+	}, []string{"regex"})
+	TemplateRRFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "template",
+		Name:      "rr_failures_total",
+		Help:      "Counter of mis-templated RRs.",
+	}, []string{"regex"})
+)
+
+// OnStartupMetrics sets up the metrics on startup.
+func OnStartupMetrics() error {
+	metricsOnce.Do(func() {
+		prometheus.MustRegister(TemplateMatchesCount)
+		prometheus.MustRegister(TemplateFailureCount)
+		prometheus.MustRegister(TemplateRRFailureCount)
+	})
+	return nil
+}
+
+var metricsOnce sync.Once

--- a/plugin/template/metrics.go
+++ b/plugin/template/metrics.go
@@ -21,13 +21,13 @@ var (
 		Subsystem: "template",
 		Name:      "template_failures_total",
 		Help:      "Counter of go template failures.",
-	}, []string{"regex"})
+	}, []string{"regex", "section", "template"})
 	TemplateRRFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "template",
 		Name:      "rr_failures_total",
 		Help:      "Counter of mis-templated RRs.",
-	}, []string{"regex"})
+	}, []string{"regex", "section", "template"})
 )
 
 // OnStartupMetrics sets up the metrics on startup.

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -104,6 +104,19 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 					t.additional = append(t.additional, tmpl)
 				}
 
+			case "authority":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				for _, authority := range args {
+					tmpl, err := gotmpl.New("authority").Parse(authority)
+					if err != nil {
+						return nil, c.Errf("could not compile template: %s, %v\n", c.Val(), err)
+					}
+					t.authority = append(t.authority, tmpl)
+				}
+
 			case "rcode":
 				if !c.NextArg() {
 					return nil, c.ArgErr()

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -24,7 +24,7 @@ func setupTemplate(c *caddy.Controller) error {
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		return TemplateHandler{Next: next, Templates: templates}
+		return Handler{Next: next, Templates: templates}
 	})
 
 	return nil
@@ -38,31 +38,32 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 		if !c.NextArg() {
 			return nil, c.ArgErr()
 		}
-		if class, found := dns.StringToClass[c.Val()]; !found {
+
+		class, found := dns.StringToClass[c.Val()]
+		if !found {
 			return nil, c.Errf("Invalid query class %s", c.Val())
-		} else {
-			t.class = class
 		}
+		t.class = class
 
 		if !c.NextArg() {
 			return nil, c.ArgErr()
 		}
-		if queryType, found := dns.StringToType[c.Val()]; !found {
+		queryType, found := dns.StringToType[c.Val()]
+		if !found {
 			return nil, c.Errf("Invalid query rr type %s", c.Val())
-		} else {
-			t.qtype = queryType
 		}
+		t.qtype = queryType
 
 		t.regex = make([]*regexp.Regexp, 0)
 		templatePrefix := ""
 
 		for _, regex := range c.RemainingArgs() {
-			if r, err := regexp.Compile(regex); err != nil {
+			r, err := regexp.Compile(regex)
+			if err != nil {
 				return nil, c.Errf("Could not parse regex: %s, %v", regex, err)
-			} else {
-				templatePrefix = templatePrefix + regex + " "
-				t.regex = append(t.regex, r)
 			}
+			templatePrefix = templatePrefix + regex + " "
+			t.regex = append(t.regex, r)
 		}
 
 		if len(t.regex) == 0 {
@@ -80,11 +81,11 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 					return nil, c.ArgErr()
 				}
 				for _, answer := range args {
-					if tmpl, err := gotmpl.New("answer").Parse(answer); err != nil {
+					tmpl, err := gotmpl.New("answer").Parse(answer)
+					if err != nil {
 						return nil, c.Errf("Could not compile template: %s, %v", c.Val(), err)
-					} else {
-						t.answer = append(t.answer, tmpl)
 					}
+					t.answer = append(t.answer, tmpl)
 				}
 
 			case "additional":
@@ -93,22 +94,22 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 					return nil, c.ArgErr()
 				}
 				for _, additional := range args {
-					if tmpl, err := gotmpl.New("additional").Parse(additional); err != nil {
+					tmpl, err := gotmpl.New("additional").Parse(additional)
+					if err != nil {
 						return nil, c.Errf("Could not compile template: %s, %v\n", c.Val(), err)
-					} else {
-						t.additional = append(t.additional, tmpl)
 					}
+					t.additional = append(t.additional, tmpl)
 				}
 
 			case "rcode":
 				if !c.NextArg() {
 					return nil, c.ArgErr()
 				}
-				if rcode, found := dns.StringToRcode[c.Val()]; !found {
+				rcode, found := dns.StringToRcode[c.Val()]
+				if !found {
 					return nil, c.Errf("Unknown rcode %s", c.Val())
-				} else {
-					t.rcode = rcode
 				}
+				t.rcode = rcode
 
 			default:
 				return nil, c.ArgErr()

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
 )
@@ -39,18 +40,18 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 			return nil, c.ArgErr()
 		}
 
-		class, found := dns.StringToClass[c.Val()]
-		if !found {
-			return nil, c.Errf("Invalid query class %s", c.Val())
+		class, ok := dns.StringToClass[c.Val()]
+		if !ok {
+			return nil, c.Errf("invalid query class %s", c.Val())
 		}
 		t.class = class
 
 		if !c.NextArg() {
 			return nil, c.ArgErr()
 		}
-		queryType, found := dns.StringToType[c.Val()]
-		if !found {
-			return nil, c.Errf("Invalid query rr type %s", c.Val())
+		queryType, ok := dns.StringToType[c.Val()]
+		if !ok {
+			return nil, c.Errf("invalid RR type %s", c.Val())
 		}
 		t.qtype = queryType
 
@@ -60,7 +61,7 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 		for _, regex := range c.RemainingArgs() {
 			r, err := regexp.Compile(regex)
 			if err != nil {
-				return nil, c.Errf("Could not parse regex: %s, %v", regex, err)
+				return nil, c.Errf("could not parse regex: %s, %v", regex, err)
 			}
 			templatePrefix = templatePrefix + regex + " "
 			t.regex = append(t.regex, r)
@@ -83,7 +84,7 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 				for _, answer := range args {
 					tmpl, err := gotmpl.New("answer").Parse(answer)
 					if err != nil {
-						return nil, c.Errf("Could not compile template: %s, %v", c.Val(), err)
+						return nil, c.Errf("could not compile template: %s, %v", c.Val(), err)
 					}
 					t.answer = append(t.answer, tmpl)
 				}
@@ -96,7 +97,7 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 				for _, additional := range args {
 					tmpl, err := gotmpl.New("additional").Parse(additional)
 					if err != nil {
-						return nil, c.Errf("Could not compile template: %s, %v\n", c.Val(), err)
+						return nil, c.Errf("could not compile template: %s, %v\n", c.Val(), err)
 					}
 					t.additional = append(t.additional, tmpl)
 				}
@@ -105,9 +106,9 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 				if !c.NextArg() {
 					return nil, c.ArgErr()
 				}
-				rcode, found := dns.StringToRcode[c.Val()]
-				if !found {
-					return nil, c.Errf("Unknown rcode %s", c.Val())
+				rcode, ok := dns.StringToRcode[c.Val()]
+				if !ok {
+					return nil, c.Errf("unknown rcode %s", c.Val())
 				}
 				t.rcode = rcode
 
@@ -117,7 +118,7 @@ func templateParse(c *caddy.Controller) (templates []template, err error) {
 		}
 
 		if len(t.answer) == 0 && len(t.additional) == 0 && t.rcode == dns.RcodeSuccess {
-			return nil, c.Errf("No answer section for template %s %sfound", t.qtype, templatePrefix)
+			return nil, c.Errf("no answer section for template %s %sfound", t.qtype, templatePrefix)
 		}
 
 		templates = append(templates, t)

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -24,6 +24,8 @@ func setupTemplate(c *caddy.Controller) error {
 		return plugin.Error("template", err)
 	}
 
+	c.OnStartup(OnStartupMetrics)
+
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		return Handler{Next: next, Templates: templates}
 	})

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -1,0 +1,126 @@
+package template
+
+import (
+	"regexp"
+	gotmpl "text/template"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+)
+
+func init() {
+	caddy.RegisterPlugin("template", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setupTemplate,
+	})
+}
+
+func setupTemplate(c *caddy.Controller) error {
+	templates, err := templateParse(c)
+	if err != nil {
+		return plugin.Error("template", err)
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		return TemplateHandler{Next: next, Templates: templates}
+	})
+
+	return nil
+}
+
+func templateParse(c *caddy.Controller) (templates []template, err error) {
+	templates = make([]template, 0)
+
+	for c.Next() {
+		t := template{}
+		if !c.NextArg() {
+			return nil, c.ArgErr()
+		}
+		if class, found := dns.StringToClass[c.Val()]; !found {
+			return nil, c.Errf("Invalid query class %s", c.Val())
+		} else {
+			t.class = class
+		}
+
+		if !c.NextArg() {
+			return nil, c.ArgErr()
+		}
+		if queryType, found := dns.StringToType[c.Val()]; !found {
+			return nil, c.Errf("Invalid query rr type %s", c.Val())
+		} else {
+			t.qtype = queryType
+		}
+
+		t.regex = make([]*regexp.Regexp, 0)
+		templatePrefix := ""
+
+		for _, regex := range c.RemainingArgs() {
+			if r, err := regexp.Compile(regex); err != nil {
+				return nil, c.Errf("Could not parse regex: %s, %v", regex, err)
+			} else {
+				templatePrefix = templatePrefix + regex + " "
+				t.regex = append(t.regex, r)
+			}
+		}
+
+		if len(t.regex) == 0 {
+			t.regex = append(t.regex, regexp.MustCompile(".*"))
+			templatePrefix = ".* "
+		}
+
+		t.answer = make([]*gotmpl.Template, 0)
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "answer":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				for _, answer := range args {
+					if tmpl, err := gotmpl.New("answer").Parse(answer); err != nil {
+						return nil, c.Errf("Could not compile template: %s, %v", c.Val(), err)
+					} else {
+						t.answer = append(t.answer, tmpl)
+					}
+				}
+
+			case "additional":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return nil, c.ArgErr()
+				}
+				for _, additional := range args {
+					if tmpl, err := gotmpl.New("additional").Parse(additional); err != nil {
+						return nil, c.Errf("Could not compile template: %s, %v\n", c.Val(), err)
+					} else {
+						t.additional = append(t.additional, tmpl)
+					}
+				}
+
+			case "rcode":
+				if !c.NextArg() {
+					return nil, c.ArgErr()
+				}
+				if rcode, found := dns.StringToRcode[c.Val()]; !found {
+					return nil, c.Errf("Unknown rcode %s", c.Val())
+				} else {
+					t.rcode = rcode
+				}
+
+			default:
+				return nil, c.ArgErr()
+			}
+		}
+
+		if len(t.answer) == 0 && len(t.additional) == 0 && t.rcode == dns.RcodeSuccess {
+			return nil, c.Errf("No answer section for template %s %sfound", t.qtype, templatePrefix)
+		}
+
+		templates = append(templates, t)
+	}
+
+	return templates, nil
+}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -1,0 +1,124 @@
+package template
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestSetup(t *testing.T) {
+	c := caddy.NewTestController("dns", `template ANY ANY {
+		rcode
+	}`)
+	err := setupTemplate(c)
+	if err == nil {
+		t.Errorf("Expected setupTemplate to fail on broken template, got no error")
+	}
+	c = caddy.NewTestController("dns", `template ANY ANY {
+		rcode NXDOMAIN
+	}`)
+	err = setupTemplate(c)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
+}
+
+func TestSetupParse(t *testing.T) {
+
+	serverBlockKeys := []string{"domain.com.:8053", "dynamic.domain.com.:8053"}
+
+	tests := []struct {
+		inputFileRules string
+		shouldErr      bool
+	}{
+		// parse errors
+		{`template`, true},
+		{`template X`, true},
+		{`template ANY`, true},
+		{`template ANY X`, true},
+		{`template ANY ANY (?P<x>`, true},
+		{
+			`template ANY ANY {
+
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY .* {
+				notavailable
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				answer
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				additional
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				rcode
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				rcode UNDEFINED
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				answer	"{{"
+			}`,
+			true,
+		},
+		{
+			`template ANY ANY {
+				additional "{{"
+			}`,
+			true,
+		},
+		// examples
+		{
+			`template ANY A ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com {
+				answer "{{ .Name }} A {{ .Group.a }}.{{ .Group.b }}.{{ .Group.c }}.{{ .Grup.d }}."
+			}`,
+			false,
+		},
+		{
+			`template IN ANY "[.](example[.]com[.]dc1[.]example[.]com[.])$" {
+				rcode NXDOMAIN
+				answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+			}`,
+			false,
+		},
+		{
+			`template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+				answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+    			}
+			template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+				answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
+				additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+			}`,
+			false,
+		},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.inputFileRules)
+		c.ServerBlockKeys = serverBlockKeys
+		templates, err := templateParse(c)
+
+		if err == nil && test.shouldErr {
+			t.Fatalf("Test %d expected errors, but got no error\n---\n%s\n---\n%v", i, test.inputFileRules, templates)
+		} else if err != nil && !test.shouldErr {
+			t.Fatalf("Test %d expected no errors, but got '%v'", i, err)
+		}
+	}
+}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -85,6 +85,12 @@ func TestSetupParse(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			`template ANY ANY {
+				authority "{{"
+			}`,
+			true,
+		},
 		// examples
 		{
 			`template ANY A ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com {
@@ -102,11 +108,22 @@ func TestSetupParse(t *testing.T) {
 		{
 			`template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
 				answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
-    			}
+			}
 			template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
 				answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
 				additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 			}`,
+			false,
+		},
+		{
+			`template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+					answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
+					additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+					authority  "example. 60 IN NS ns0.example."
+					authority  "example. 60 IN NS ns1.example."
+					additional "ns0.example. 60 IN A 203.0.113.8"
+					additional "ns1.example. 60 IN A 198.51.100.8"
+				}`,
 			false,
 		},
 	}

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -1,0 +1,135 @@
+package template
+
+import (
+	"bytes"
+	"context"
+	"regexp"
+	"strconv"
+
+	gotmpl "text/template"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+type TemplateHandler struct {
+	Next      plugin.Handler
+	Templates []template
+}
+
+type template struct {
+	rcode      int
+	class      uint16
+	qtype      uint16
+	regex      []*regexp.Regexp
+	answer     []*gotmpl.Template
+	additional []*gotmpl.Template
+}
+
+type templateData struct {
+	Name     string
+	Match    []string
+	Group    map[string]string
+	Class    string
+	Type     string
+	Message  *dns.Msg
+	Question *dns.Question
+}
+
+func (h TemplateHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	for _, template := range h.Templates {
+		data, match := template.match(r)
+		if !match {
+			continue
+		}
+
+		if template.rcode == dns.RcodeServerFailure {
+			return template.rcode, nil
+		}
+
+		msg := new(dns.Msg)
+		state := request.Request{W: w, Req: r}
+		msg.SetReply(r)
+		msg.Authoritative, msg.RecursionAvailable, msg.Compress = true, true, true
+		msg.Rcode = template.rcode
+
+		for _, answer := range template.answer {
+			if rr, err := executeRRTemplate(answer, data); err != nil {
+				return dns.RcodeServerFailure, err
+			} else {
+				msg.Answer = append(msg.Answer, *rr)
+			}
+		}
+		for _, additional := range template.additional {
+			if rr, err := executeRRTemplate(additional, data); err != nil {
+				return dns.RcodeServerFailure, err
+			} else {
+				msg.Extra = append(msg.Extra, *rr)
+			}
+		}
+
+		state.SizeAndDo(msg)
+		w.WriteMsg(msg)
+		return template.rcode, nil
+	}
+	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
+}
+
+func (h TemplateHandler) Name() string {
+	return "template"
+}
+
+func executeRRTemplate(template *gotmpl.Template, data templateData) (*dns.RR, error) {
+	buffer := &bytes.Buffer{}
+	err := template.Execute(buffer, data)
+	if err != nil {
+		return nil, err
+	}
+	rrDefinition := buffer.String()
+	rr, err := dns.NewRR(rrDefinition)
+	if err != nil {
+		return nil, err
+	}
+	return &rr, nil
+}
+
+func (t template) match(r *dns.Msg) (templateData, bool) {
+	for _, q := range r.Question {
+		if t.class != dns.ClassANY && q.Qclass != dns.ClassANY && q.Qclass != t.class {
+			continue
+		}
+		if t.qtype != dns.TypeANY && q.Qtype != dns.TypeANY && q.Qtype != t.qtype {
+			continue
+		}
+		for _, regex := range t.regex {
+			if !regex.MatchString(q.Name) {
+				continue
+			}
+
+			data := templateData{}
+			data.Name = q.Name
+			data.Question = &q
+			data.Message = r
+			data.Class = dns.ClassToString[q.Qclass]
+			data.Type = dns.TypeToString[q.Qtype]
+
+			matches := regex.FindStringSubmatch(q.Name)
+			data.Match = make([]string, len(matches))
+			data.Group = make(map[string]string)
+			groupNames := regex.SubexpNames()
+			for i, m := range matches {
+				data.Match[i] = m
+				data.Group[strconv.Itoa(i)] = m
+			}
+			for i, m := range matches {
+				if len(groupNames[i]) > 0 {
+					data.Group[groupNames[i]] = m
+				}
+			}
+
+			return data, true
+		}
+	}
+	return templateData{}, false
+}

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"regexp"
 	"strconv"
-
 	gotmpl "text/template"
 
 	"github.com/coredns/coredns/plugin"

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -26,6 +26,7 @@ type template struct {
 	regex      []*regexp.Regexp
 	answer     []*gotmpl.Template
 	additional []*gotmpl.Template
+	authority  []*gotmpl.Template
 }
 
 type templateData struct {
@@ -72,6 +73,13 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 				return dns.RcodeServerFailure, err
 			}
 			msg.Extra = append(msg.Extra, rr)
+		}
+		for _, authority := range template.authority {
+			rr, err := executeRRTemplate("authority", authority, data)
+			if err != nil {
+				return dns.RcodeServerFailure, err
+			}
+			msg.Ns = append(msg.Ns, rr)
 		}
 
 		state.SizeAndDo(msg)

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -1,0 +1,240 @@
+package template
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	gotmpl "text/template"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/miekg/dns"
+)
+
+func TestTemplateHandler(t *testing.T) {
+	rcodeFallthrough := 3841 // reserved for private use, used to indicate a fallthrough
+	exampleDomainATemplate := template{
+		class:  dns.ClassINET,
+		qtype:  dns.TypeA,
+		regex:  []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
+		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
+	}
+	exampleDomainMXTemplate := template{
+		class:      dns.ClassINET,
+		qtype:      dns.TypeMX,
+		regex:      []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
+		answer:     []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 MX 10 {{ .Name }}"))},
+		additional: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
+	}
+	invalidDomainTemplate := template{
+		class:  dns.ClassANY,
+		qtype:  dns.TypeANY,
+		regex:  []*regexp.Regexp{regexp.MustCompile("[.]invalid[.]$")},
+		rcode:  dns.RcodeNameError,
+		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"))},
+	}
+	rcodeServfailTemplate := template{
+		class: dns.ClassANY,
+		qtype: dns.TypeANY,
+		regex: []*regexp.Regexp{regexp.MustCompile(".*")},
+		rcode: dns.RcodeServerFailure,
+	}
+	brokenTemplate := template{
+		class:  dns.ClassINET,
+		qtype:  dns.TypeA,
+		regex:  []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
+		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN TXT \"{{ index .Match 2 }}\""))},
+	}
+	nonRRTemplate := template{
+		class:  dns.ClassINET,
+		qtype:  dns.TypeA,
+		regex:  []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
+		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }}"))},
+	}
+	nonRRAdditionalTemplate := template{
+		class:      dns.ClassINET,
+		qtype:      dns.TypeA,
+		regex:      []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
+		additional: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }}"))},
+	}
+
+	tests := []struct {
+		tmpl           template
+		qname          string
+		qclass         uint16
+		qtype          uint16
+		name           string
+		expectedCode   int
+		expectedErr    string
+		verifyResponse func(*dns.Msg) error
+	}{
+		{
+			name:         "RcodeServFail",
+			tmpl:         rcodeServfailTemplate,
+			qclass:       dns.ClassANY,
+			qtype:        dns.TypeANY,
+			qname:        "test.invalid.",
+			expectedCode: dns.RcodeServerFailure,
+			verifyResponse: func(r *dns.Msg) error {
+				return nil
+			},
+		},
+		{
+			name:         "ExampleDomainNameMismatch",
+			tmpl:         exampleDomainATemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeA,
+			qname:        "test.invalid.",
+			expectedCode: rcodeFallthrough,
+		},
+		{
+			name:         "BrokenTemplate",
+			tmpl:         brokenTemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeANY,
+			qname:        "test.example.",
+			expectedCode: dns.RcodeServerFailure,
+			expectedErr:  `template: answer:1:26: executing "answer" at <index .Match 2>: error calling index: index out of range: 2`,
+			verifyResponse: func(r *dns.Msg) error {
+				return nil
+			},
+		},
+		{
+			name:         "NonRRTemplate",
+			tmpl:         nonRRTemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeANY,
+			qname:        "test.example.",
+			expectedCode: dns.RcodeServerFailure,
+			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
+			verifyResponse: func(r *dns.Msg) error {
+				return nil
+			},
+		},
+		{
+			name:         "NonRRAdditionalTemplate",
+			tmpl:         nonRRAdditionalTemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeANY,
+			qname:        "test.example.",
+			expectedCode: dns.RcodeServerFailure,
+			expectedErr:  `dns: not a TTL: "test.example." at line: 1:13`,
+			verifyResponse: func(r *dns.Msg) error {
+				return nil
+			},
+		},
+		{
+			name:   "ExampleDomainMatch",
+			tmpl:   exampleDomainATemplate,
+			qclass: dns.ClassINET,
+			qtype:  dns.TypeA,
+			qname:  "ip-10-95-12-8.example.",
+			verifyResponse: func(r *dns.Msg) error {
+				if len(r.Answer) != 1 {
+					return fmt.Errorf("expected 1 answer, got %v", len(r.Answer))
+				}
+				if r.Answer[0].Header().Rrtype != dns.TypeA {
+					return fmt.Errorf("expected an A record anwser, got %v", dns.TypeToString[r.Answer[0].Header().Rrtype])
+				}
+				if r.Answer[0].(*dns.A).A.String() != "10.95.12.8" {
+					return fmt.Errorf("expected an A record for 10.95.12.8, got %v", r.Answer[0].String())
+				}
+				return nil
+			},
+		},
+		{
+			name:   "ExampleDomainMXMatch",
+			tmpl:   exampleDomainMXTemplate,
+			qclass: dns.ClassINET,
+			qtype:  dns.TypeMX,
+			qname:  "ip-10-95-12-8.example.",
+			verifyResponse: func(r *dns.Msg) error {
+				if len(r.Answer) != 1 {
+					return fmt.Errorf("expected 1 answer, got %v", len(r.Answer))
+				}
+				if r.Answer[0].Header().Rrtype != dns.TypeMX {
+					return fmt.Errorf("expected an A record anwser, got %v", dns.TypeToString[r.Answer[0].Header().Rrtype])
+				}
+				if len(r.Extra) != 1 {
+					return fmt.Errorf("expected 1 extra record, got %v", len(r.Extra))
+				}
+				if r.Extra[0].Header().Rrtype != dns.TypeA {
+					return fmt.Errorf("expected an additional A record, got %v", dns.TypeToString[r.Extra[0].Header().Rrtype])
+				}
+				return nil
+			},
+		},
+		{
+			name:         "ExampleDomainMismatchType",
+			tmpl:         exampleDomainATemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeMX,
+			qname:        "ip-10-95-12-8.example.",
+			expectedCode: rcodeFallthrough,
+		},
+		{
+			name:         "ExampleDomainMismatchClass",
+			tmpl:         exampleDomainATemplate,
+			qclass:       dns.ClassCHAOS,
+			qtype:        dns.TypeA,
+			qname:        "ip-10-95-12-8.example.",
+			expectedCode: rcodeFallthrough,
+		},
+		{
+			name:         "ExampleInvalidNXDOMAIN",
+			tmpl:         invalidDomainTemplate,
+			qclass:       dns.ClassINET,
+			qtype:        dns.TypeMX,
+			qname:        "test.invalid.",
+			expectedCode: dns.RcodeNameError,
+			verifyResponse: func(r *dns.Msg) error {
+				if len(r.Answer) != 1 {
+					return fmt.Errorf("expected 1 answer, got %v", len(r.Answer))
+				}
+				if r.Answer[0].Header().Rrtype != dns.TypeSOA {
+					return fmt.Errorf("expected an SOA record anwser, got %v", dns.TypeToString[r.Answer[0].Header().Rrtype])
+				}
+				return nil
+			},
+		},
+	}
+
+	ctx := context.TODO()
+
+	for _, tr := range tests {
+		handler := TemplateHandler{
+			Next:      test.NextHandler(rcodeFallthrough, nil),
+			Templates: []template{tr.tmpl},
+		}
+		req := &dns.Msg{
+			Question: []dns.Question{dns.Question{
+				Name:   tr.qname,
+				Qclass: tr.qclass,
+				Qtype:  tr.qtype,
+			}},
+		}
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		code, err := handler.ServeDNS(ctx, rec, req)
+		if err == nil && tr.expectedErr != "" {
+			t.Errorf("Test %v expected error: %v, got nothing", tr.name, tr.expectedErr)
+		}
+		if err != nil && tr.expectedErr == "" {
+			t.Errorf("Test %v expected no error got: %v", tr.name, err)
+		}
+		if err != nil && tr.expectedErr != "" && err.Error() != tr.expectedErr {
+			t.Errorf("Test %v expected error: %v, got: %v", tr.name, tr.expectedErr, err)
+		}
+		if code != tr.expectedCode {
+			t.Errorf("Test %v expected response code %v, got %v", tr.name, tr.expectedCode, code)
+		}
+		if err == nil && code != rcodeFallthrough {
+			// only verify if we got no error and expected no error
+			if err := tr.verifyResponse(rec.Msg); err != nil {
+				t.Errorf("Test %v could not verify the response: %v", tr.name, err)
+			}
+		}
+	}
+}

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func TestTemplateHandler(t *testing.T) {
+func TestHandler(t *testing.T) {
 	rcodeFallthrough := 3841 // reserved for private use, used to indicate a fallthrough
 	exampleDomainATemplate := template{
 		class:  dns.ClassINET,
@@ -205,12 +205,12 @@ func TestTemplateHandler(t *testing.T) {
 	ctx := context.TODO()
 
 	for _, tr := range tests {
-		handler := TemplateHandler{
+		handler := Handler{
 			Next:      test.NextHandler(rcodeFallthrough, nil),
 			Templates: []template{tr.tmpl},
 		}
 		req := &dns.Msg{
-			Question: []dns.Question{dns.Question{
+			Question: []dns.Question{{
 				Name:   tr.qname,
 				Qclass: tr.qclass,
 				Qtype:  tr.qtype,


### PR DESCRIPTION
The template plugin matches the incoming query by class, type and regex and templates a response with a go templates.

As suggested in #1289

A README.md is in place. I haven't touched the root README.md.

Missing: 
1. ~~@miekg I haven't changed the rcode directive yet. Can you think of any rcode besides NXDOMAIN and ServFail that might be useful? In that case I'd go with `error|denial`.~~
2. ~~Metrics (esp. internal failures to template)~~
  
  