### PR TITLE
plugin/file: Fix response for qtype=DS

### DIFF
--- a/plugin/file/delegation_test.go
+++ b/plugin/file/delegation_test.go
@@ -121,7 +121,7 @@ var secureDelegationTestCases = []test.Case{
 		},
 	},
 	{
-		Qname: "foo.delegated.example.org.", Qtype: dns.TypeTXT,
+		Qname: "foo.delegated.example.org.", Qtype: dns.TypeDS,
 		Do: true,
 		Ns: []dns.RR{
 			test.DS("delegated.example.org.	1800	IN	DS	10056 5 1 EE72CABD1927759CDDA92A10DBF431504B9E1F13"),
@@ -134,6 +134,23 @@ var secureDelegationTestCases = []test.Case{
 			test.OPT(4096, true),
 			test.A("a.delegated.example.org. 1800 IN A 139.162.196.78"),
 			test.AAAA("a.delegated.example.org. 1800 IN AAAA 2a01:7e00::f03c:91ff:fef1:6735"),
+		},
+	},
+	{
+		Qname: "delegated.example.org.", Qtype: dns.TypeDS,
+		Do: true,
+		Answer: []dns.RR{
+			test.DS("delegated.example.org.	1800	IN	DS	10056 5 1 EE72CABD1927759CDDA92A10DBF431504B9E1F13"),
+			test.DS("delegated.example.org.	1800	IN	DS	10056 5 2 E4B05F87725FA86D9A64F1E53C3D0E6250946599DFE639C45955B0ED416CDDFA"),
+			test.RRSIG("delegated.example.org.	1800	IN	RRSIG	DS 13 3 1800 20161129153240 20161030153240 49035 example.org. rlNNzcUmtbjLSl02ZzQGUbWX75yCUx0Mug1jHtKVqRq1hpPE2S3863tIWSlz+W9wz4o19OI4jbznKKqk+DGKog=="),
+		},
+		Ns: []dns.RR{
+			test.NS("example.org.	1800	IN	NS	a.iana-servers.net."),
+			test.NS("example.org.	1800	IN	NS	b.iana-servers.net."),
+			test.RRSIG("example.org.	1800	IN	RRSIG	NS 13 2 1800 20161129153240 20161030153240 49035 example.org. llrHoIuw="),
+		},
+		Extra: []dns.RR{
+			test.OPT(4096, true),
 		},
 	},
 }

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -127,6 +127,15 @@ func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, 
 
 		// If we see NS records, it means the name as been delegated, and we should return the delegation.
 		if nsrrs := elem.Types(dns.TypeNS); nsrrs != nil {
+
+			// If the query is specifically for DS and the qname matches the delegated name, we should
+			// return the DS in the answer section and leave the rest empty, i.e. just continue the loop
+			// and continue searching.
+			if qtype == dns.TypeDS && elem.Name() == qname {
+				i++
+				continue
+			}
+
 			glue := z.Glue(nsrrs, do)
 			if do {
 				dss := z.typeFromElem(elem, dns.TypeDS, do)


### PR DESCRIPTION
DS is peculiar and needs some special cases to do the right things.
For a direct query return the DS, but if we're hitting below the
delegation return the NS+DS in a delegation response.
