### PR TITLE
plugin/file: fix crash

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -235,7 +235,10 @@ func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, 
 
 	ret := z.soa(do)
 	if do {
-		deny, _ := z.Tree.Prev(qname) // TODO(miek): *found* was not used here.
+		deny, found := z.Tree.Prev(qname)
+		if !found {
+			goto Out
+		}
 		nsec := z.typeFromElem(deny, dns.TypeNSEC, do)
 		ret = append(ret, nsec...)
 

--- a/test/file_serve_test.go
+++ b/test/file_serve_test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestZoneEDNS0Lookup(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", `$ORIGIN example.org.
+@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
+		2017042745 ; serial
+		7200       ; refresh (2 hours)
+		3600       ; retry (1 hour)
+		1209600    ; expire (2 weeks)
+		3600       ; minimum (1 hour)
+	)
+
+        3600 IN NS a.iana-servers.net.
+	3600 IN NS b.iana-servers.net.
+
+www     IN A 127.0.0.1
+www     IN AAAA ::1
+`)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeMX)
+	m.SetEdns0(4096, true)
+
+	r, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Could not exchange msg: %s", err)
+	}
+	if r.Rcode == dns.RcodeServerFailure {
+		t.Fatalf("Rcode should not be dns.RcodeServerFailure")
+	}
+}
+
+func TestZoneNoNS(t *testing.T) {
+	t.Parallel()
+	log.SetOutput(ioutil.Discard)
+
+	name, rm, err := TempFile(".", `$ORIGIN example.org.
+@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
+		2017042745 ; serial
+		7200       ; refresh (2 hours)
+		3600       ; retry (1 hour)
+		1209600    ; expire (2 weeks)
+		3600       ; minimum (1 hour)
+	)
+
+www     IN A 127.0.0.1
+www     IN AAAA ::1
+`)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	// Corefile with for example without proxy section.
+	corefile := `example.org:0 {
+       file ` + name + `
+}
+`
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeMX)
+	m.SetEdns0(4096, true)
+
+	r, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Could not exchange msg: %s", err)
+	}
+	if r.Rcode == dns.RcodeServerFailure {
+		t.Fatalf("Rcode should not be dns.RcodeServerFailure")
+	}
+}


### PR DESCRIPTION
When z.Tree.Prev returns zero we should break out of this loop, not
use elem as if nothing has happened.

Can be triggered by sending edns0 to unsigned zone and crash the goroutine handling it.