### PR TITLE
Instead of hardcoding plugin lists in autopath/health, use interfaces.

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -167,6 +167,21 @@ func (c *Config) Handler(name string) plugin.Handler {
 	return nil
 }
 
+// Handlers returns a slice of plugins that have been registered. This can be used to
+// inspect and interact with registered plugins but cannot be used to remove or add plugins.
+// Note that this is order dependent and the order is defined in directives.go, i.e. if your plugin
+// comes before the plugin you are checking; it will not be there (yet).
+func (c *Config) Handlers() []plugin.Handler {
+	if c.registry == nil {
+		return nil
+	}
+	hs := make([]plugin.Handler, 0, len(c.registry))
+	for k := range c.registry {
+		hs = append(hs, c.registry[k])
+	}
+	return hs
+}
+
 // groupSiteConfigsByListenAddr groups site configs by their listen
 // (bind) address, so sites that use the same listener can be served
 // on the same server instance. The return value maps the listen

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -1,0 +1,31 @@
+package dnsserver
+
+import (
+	"testing"
+)
+
+func TestHandler(t *testing.T) {
+	tp := testPlugin{}
+	c := testConfig("dns", tp)
+	if _, err := NewServer("127.0.0.1:53", []*Config{c}); err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	if h := c.Handler("testplugin"); h != tp {
+		t.Errorf("Expected testPlugin from Handler, got %T", h)
+	}
+	if h := c.Handler("nothing"); h != nil {
+		t.Errorf("Expected nil from Handler, got %T", h)
+	}
+}
+
+func TestHandlers(t *testing.T) {
+	tp := testPlugin{}
+	c := testConfig("dns", tp)
+	if _, err := NewServer("127.0.0.1:53", []*Config{c}); err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	hs := c.Handlers()
+	if len(hs) != 1 || hs[0] != tp {
+		t.Errorf("Expected [testPlugin] from Handlers, got %v", hs)
+	}
+}

--- a/plugin/autopath/README.md
+++ b/plugin/autopath/README.md
@@ -19,15 +19,12 @@ autopath [ZONE...] RESOLV-CONF
   plugin. For instance `@kubernetes`, will call out to the kubernetes plugin (for each
   query) to retrieve the search list it should use.
 
-Currently the following set of plugin has implemented *autopath*:
-
-* *kubernetes*
-* *erratic*
+If a plugin implements the `AutoPather` interface then it can be used.
 
 ## Metrics
- 
+
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
- 
+
 * `coredns_autopath_success_count_total{}` - counter of successfully autopath-ed queries.
 
 ## Examples

--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -46,6 +46,12 @@ import (
 // If Func returns a nil slice, no autopathing will be done.
 type Func func(request.Request) []string
 
+// AutoPather defines the interface that a plugin should implement in order to be
+// used by AutoPath.
+type AutoPather interface {
+	AutoPath(request.Request) []string
+}
+
 // AutoPath perform autopath: service side search path completion.
 type AutoPath struct {
 	Next  plugin.Handler

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/erratic"
-	"github.com/coredns/coredns/plugin/kubernetes"
 
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
@@ -34,11 +32,10 @@ func setup(c *caddy.Controller) error {
 		if m == nil {
 			return nil
 		}
-		if x, ok := m.(*kubernetes.Kubernetes); ok {
+		if x, ok := m.(AutoPather); ok {
 			ap.searchFunc = x.AutoPath
-		}
-		if x, ok := m.(*erratic.Erratic); ok {
-			ap.searchFunc = x.AutoPath
+		} else {
+			return plugin.Error("autopath", fmt.Errorf("%s does not implement the AutoPather interface", mw))
 		}
 		return nil
 	})
@@ -49,12 +46,6 @@ func setup(c *caddy.Controller) error {
 	})
 
 	return nil
-}
-
-// allowedPlugins has a list of plugin that can be used by autopath.
-var allowedPlugins = map[string]bool{
-	"@kubernetes": true,
-	"@erratic":    true,
 }
 
 func autoPathParse(c *caddy.Controller) (*AutoPath, string, error) {
@@ -68,10 +59,7 @@ func autoPathParse(c *caddy.Controller) (*AutoPath, string, error) {
 		}
 		resolv := zoneAndresolv[len(zoneAndresolv)-1]
 		if resolv[0] == '@' {
-			_, ok := allowedPlugins[resolv]
-			if ok {
-				mw = resolv[1:]
-			}
+			mw = resolv[1:]
 		} else {
 			// assume file on disk
 			rc, err := dns.ClientConfigFromFile(resolv)

--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -18,10 +18,7 @@ supports health checks has a section "Health" in their README.
 
 ## Plugins
 
-The following plugins report health to the health plugin:
-
-* erratic
-* kubernetes
+Any plugin that implements the Healther interface will be used to report health.
 
 ## Examples
 

--- a/plugin/health/healther.go
+++ b/plugin/health/healther.go
@@ -36,9 +36,3 @@ func (h *health) poll() {
 	}
 	h.SetOk(true)
 }
-
-// Plugins that implements the Healther interface.
-var healthers = map[string]bool{
-	"erratic":    true,
-	"kubernetes": true,
-}

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -26,9 +26,9 @@ func setup(c *caddy.Controller) error {
 	h := &health{Addr: addr}
 
 	c.OnStartup(func() error {
-		for he := range healthers {
-			m := dnsserver.GetConfig(c).Handler(he)
-			if x, ok := m.(Healther); ok {
+		plugins := dnsserver.GetConfig(c).Handlers()
+		for _, p := range plugins {
+			if x, ok := p.(Healther); ok {
 				h.h = append(h.h, x)
 			}
 		}


### PR DESCRIPTION
Switched health and autopath plugin to allow any plugins to be used instead
of a hardcoded list. I did not switch federation over since it wasn't
obvious that anything other than kubernetes could be used with it.

Fixes #1291