### PR TITLE
plugin/metrics: Added NewMetrics func

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -36,6 +36,11 @@ type Metrics struct {
 	zoneMu    sync.RWMutex
 }
 
+// New returns a new instance of Metrics with the given address
+func New(addr string) *Metrics {
+	return &Metrics{Addr: addr, zoneMap: make(map[string]bool)}
+}
+
 // AddZone adds zone z to m.
 func (m *Metrics) AddZone(z string) {
 	m.zoneMu.Lock()

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMetrics(t *testing.T) {
-	met := &Metrics{Addr: "localhost:0", zoneMap: make(map[string]bool)}
+	met := New("localhost:0")
 	if err := met.OnStartup(); err != nil {
 		t.Fatalf("Failed to start metrics handler: %s", err)
 	}

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -42,10 +42,7 @@ func setup(c *caddy.Controller) error {
 }
 
 func prometheusParse(c *caddy.Controller) (*Metrics, error) {
-	var (
-		met = &Metrics{Addr: addr, zoneMap: make(map[string]bool)}
-		err error
-	)
+	var met = New(defaultAddr)
 
 	defer func() {
 		uniqAddr.SetAddress(met.Addr)
@@ -73,7 +70,7 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 			return met, c.ArgErr()
 		}
 	}
-	return met, err
+	return met, nil
 }
 
 var uniqAddr addrs
@@ -91,8 +88,8 @@ func (a *addrs) SetAddress(addr string) {
 	a.a[addr] = todo
 }
 
-// Addr is the address the where the metrics are exported by default.
-const addr = "localhost:9153"
+// defaultAddr is the address the where the metrics are exported by default.
+const defaultAddr = "localhost:9153"
 
 const (
 	todo = 1


### PR DESCRIPTION
If external plugins wanted to extend metrics there was no way since
zoneNames couldn't be initialized. Now plugins can call NewMetrics to
get an instance of Metrics that they can extend.

We need to extend the metrics plugin to integrate it with our default metrics and to include automatic metrics that our other plugins generate. As in the commit message, there's no way to do this since zoneNames is private. By making a `NewMetrics` method, we can call that and then use the `*Metrics` instance.