### PR TITLE
[WIP] CoreDNS distributed plugin with NSID

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -39,6 +39,7 @@ var directives = []string{
 	"etcd",
 	"proxy",
 	"erratic",
+	"distributed",
 	"whoami",
 	"startup",
 	"shutdown",

--- a/core/zplugin.go
+++ b/core/zplugin.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/cache"
 	_ "github.com/coredns/coredns/plugin/chaos"
 	_ "github.com/coredns/coredns/plugin/debug"
+	_ "github.com/coredns/coredns/plugin/distributed"
 	_ "github.com/coredns/coredns/plugin/dnssec"
 	_ "github.com/coredns/coredns/plugin/dnstap"
 	_ "github.com/coredns/coredns/plugin/erratic"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -47,6 +47,7 @@ secondary:secondary
 etcd:etcd
 proxy:proxy
 erratic:erratic
+distributed:distributed
 whoami:whoami
 startup:github.com/mholt/caddy/startupshutdown
 shutdown:github.com/mholt/caddy/startupshutdown

--- a/plugin/distributed/distributed.go
+++ b/plugin/distributed/distributed.go
@@ -1,0 +1,218 @@
+// Package distributed implements a distributed CoreDNS with NSID
+package distributed
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+type endpoint struct {
+	addr string
+	port string
+	quit chan struct{}
+}
+
+type entries struct {
+	sync.RWMutex
+	byAddr map[string]string
+	byName map[string][]net.IP
+}
+
+// Distributed plugin
+type Distributed struct {
+	Next      plugin.Handler
+	Origin    string
+	Endpoints *[]endpoint
+	Entries   *entries
+}
+
+func (e *endpoint) update(d *Distributed) error {
+	name, _ := e.query(d)
+
+	d.Entries.Lock()
+	defer d.Entries.Unlock()
+
+	// Only update when data is dirty
+	dirty := false
+	if name == "" {
+		if v, ok := d.Entries.byAddr[e.addr]; ok {
+			delete(d.Entries.byAddr, e.addr)
+			dirty = true
+			log.Printf("[INFO] Record %q:%q has been removed from the lookup table", e.addr, v)
+		}
+	} else {
+		if v, ok := d.Entries.byAddr[e.addr]; !ok || v != name {
+			d.Entries.byAddr[e.addr] = name
+			dirty = true
+			log.Printf("[INFO] Record %q:%q has been inserted to the lookup table", e.addr, name)
+		}
+	}
+
+	if dirty {
+		d.Entries.byName = make(map[string][]net.IP)
+		for k, v := range d.Entries.byAddr {
+			d.Entries.byName[v] = append(d.Entries.byName[v], net.ParseIP(k))
+		}
+	}
+	return nil
+}
+
+func (e *endpoint) query(d *Distributed) (string, error) {
+	addr := net.JoinHostPort(e.addr, e.port)
+	conn, err := net.DialTimeout("udp", addr, defaultTimeout)
+	if err != nil {
+		return "", err
+	}
+
+	req := dns.Msg{}
+	req.SetQuestion(dns.Fqdn(d.Origin), dns.TypeSRV)
+	req.Question[0].Qclass = dns.ClassINET
+
+	req.SetEdns0(4096, false)
+	option := req.Extra[0].(*dns.OPT)
+	option.Option = append(option.Option, &dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""})
+
+	udpsize := option.UDPSize
+
+	dnsconn := &dns.Conn{Conn: conn, UDPSize: udpsize()}
+
+	writeDeadline := time.Now().Add(defaultTimeout)
+	dnsconn.SetWriteDeadline(writeDeadline)
+	dnsconn.WriteMsg(&req)
+
+	readDeadline := time.Now().Add(defaultTimeout)
+	conn.SetReadDeadline(readDeadline)
+	res, err := dnsconn.ReadMsg()
+
+	dnsconn.Close()
+	conn.Close()
+
+	if res == nil {
+		return "", err
+	}
+
+	option = res.IsEdns0()
+	for _, s := range option.Option {
+		switch e := s.(type) {
+		case *dns.EDNS0_NSID:
+			nsid, err := hex.DecodeString(e.Nsid)
+			if err != nil {
+				return "", err
+			}
+			return string(nsid), nil
+		}
+	}
+
+	return "", fmt.Errorf("no nsid returned for %q", addr)
+}
+
+func (d Distributed) lookup(ctx context.Context, qname string) []net.IP {
+	// Perform table lookup
+	d.Entries.RLock()
+	defer d.Entries.RUnlock()
+	if len(d.Entries.byName) != 0 {
+		if ips, ok := d.Entries.byName[qname]; ok {
+			entries := make([]net.IP, len(ips))
+			copy(entries, ips)
+			return entries
+		}
+	}
+	return nil
+}
+
+// OnShutdown is the shutdown handle
+func (e *endpoint) OnShutdown(d *Distributed) error {
+	close(e.quit)
+	return nil
+}
+
+// OnStartup is the startup handle
+func (e *endpoint) OnStartup(d *Distributed) error {
+	go func() {
+		// Update record at the startup time
+		e.update(d)
+
+		tick := time.NewTicker(defaultInterval)
+
+		for {
+			select {
+			case <-tick.C:
+				if err := e.update(d); err != nil {
+					continue
+				}
+			case <-e.quit:
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (d Distributed) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	state := request.Request{W: w, Req: r}
+	qname := plugin.Name(state.Name()).Normalize()
+
+	answers := []dns.RR{}
+
+	if !plugin.Name(d.Origin).Matches(qname) {
+		return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
+	}
+
+	switch state.QType() {
+	case dns.TypeA:
+		// A record response to client
+		for _, ip := range d.lookup(ctx, qname) {
+			a := new(dns.A)
+			a.Hdr = dns.RR_Header{Name: qname, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: defaultTTL}
+			a.A = ip
+			answers = append(answers, a)
+		}
+	case dns.TypeSRV:
+		// SRV record response so that peers could obtain information (with NSID)
+		srv := new(dns.SRV)
+		srv.Hdr = dns.RR_Header{Name: "_" + state.Proto() + "." + state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass()}
+		if state.QName() == "." {
+			srv.Hdr.Name = "_" + state.Proto() + state.QName()
+		}
+		port, _ := strconv.Atoi(state.Port())
+		srv.Port = uint16(port)
+		srv.Target = "."
+
+		answers = append(answers, srv)
+	}
+
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative, m.RecursionAvailable, m.Compress = true, true, true
+	m.Answer = answers
+	if len(answers) == 0 {
+		m.Rcode = dns.RcodeNameError
+	}
+
+	state.SizeAndDo(m)
+	m, _ = state.Scrub(m)
+	w.WriteMsg(m)
+	return dns.RcodeSuccess, nil
+}
+
+// Name implements the Handler interface.
+func (d Distributed) Name() string { return "distributed" }
+
+const (
+	defaultTTL      = 15
+	defaultTimeout  = 5 * time.Second
+	defaultInterval = 15 * time.Second
+)

--- a/plugin/distributed/setup.go
+++ b/plugin/distributed/setup.go
@@ -1,0 +1,158 @@
+package distributed
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/mholt/caddy"
+)
+
+func init() {
+	caddy.RegisterPlugin("distributed", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	origin, endpoints, err := distributedParse(c)
+	if err != nil {
+		return plugin.Error("distributed", err)
+	}
+
+	d := &Distributed{
+		Entries: &entries{
+			byName: map[string][]net.IP{},
+			byAddr: map[string]string{},
+		},
+	}
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		d.Next = next
+		d.Origin = origin
+		d.Endpoints = &endpoints
+		return d
+	})
+
+	for i := range endpoints {
+		u := endpoints[i]
+		c.OnStartup(func() error {
+			return u.OnStartup(d)
+		})
+		c.OnShutdown(func() error {
+			return u.OnShutdown(d)
+		})
+	}
+
+	return nil
+}
+
+func distributedParse(c *caddy.Controller) (string, []endpoint, error) {
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) != 2 {
+			return "", nil, c.Dispenser.ArgErr()
+		}
+
+		origin := plugin.Host(args[1]).Normalize()
+
+		endpoints, err := parseEndpoint(args[0])
+		if err != nil {
+			return "", nil, err
+		}
+
+		if origin == "" || len(endpoints) == 0 {
+			return "", nil, c.Dispenser.ArgErr()
+		}
+		return origin, endpoints, nil
+	}
+	return "", nil, c.Dispenser.ArgErr()
+}
+
+func parseEndpoint(arg string) ([]endpoint, error) {
+	var endpoints []endpoint
+
+	entries := map[string]struct{}{}
+	for _, s := range strings.Split(arg, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+
+		host := s
+		port := "53"
+		colon := strings.LastIndex(s, ":")
+		if colon == len(s)-1 {
+			return nil, fmt.Errorf("expecting data after last colon: %q", s)
+		}
+		if colon != -1 {
+			if p, err := strconv.Atoi(s[colon+1:]); err == nil {
+				if p < 0 || p >= 65536 {
+					return nil, fmt.Errorf("invalid port number: %q", s[colon+1:])
+				}
+				port = strconv.Itoa(p)
+				host = s[:colon]
+			}
+		}
+
+		slash := strings.LastIndex(host, "/")
+		if slash == len(host)-1 {
+			return nil, fmt.Errorf("expecting data after last slash: %q", host)
+		}
+		if slash != -1 {
+			ip, ipnet, err := net.ParseCIDR(host)
+			if err != nil {
+				return nil, fmt.Errorf("invalid cidr block %q: %s", host, err)
+			}
+			for _, ip = range listIPAddr(ip, ipnet) {
+				if _, ok := entries[ip.String()]; !ok {
+					entries[ip.String()] = struct{}{}
+					endpoints = append(endpoints, endpoint{
+						addr: ip.String(),
+						port: port,
+						quit: make(chan struct{}),
+					})
+				}
+			}
+
+			continue
+		}
+		ip := net.ParseIP(host)
+		if ip == nil {
+			return nil, fmt.Errorf("invalid ip address: %q", host)
+		}
+		if _, ok := entries[ip.String()]; !ok {
+			entries[ip.String()] = struct{}{}
+			endpoints = append(endpoints, endpoint{
+				addr: ip.String(),
+				port: port,
+				quit: make(chan struct{}),
+			})
+		}
+	}
+	return endpoints, nil
+}
+
+func listIPAddr(ip net.IP, ipnet *net.IPNet) []net.IP {
+	inc := func(ip net.IP) {
+		for j := len(ip) - 1; j >= 0; j-- {
+			ip[j]++
+			if ip[j] > 0 {
+				break
+			}
+		}
+	}
+
+	var entries []net.IP
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		entry := make(net.IP, len(ip))
+		copy(entry, ip)
+		entries = append(entries, entry)
+	}
+	// remove network address and broadcast address
+	return entries[1 : len(entries)-1]
+}


### PR DESCRIPTION
### 1. What does this pull request do?
This fix tries to implement a CoreDNS distributed in a cluster, and each CoreDNS node could return the domain names specified by its peers (through NSID).

The basic idea is that each node will use NSID to publish its domain name. The cluster is specified through the list of IPs or the list of subnets. When every node is up, it will send NSID queries to every IP in the list, and receive the domain names by response. If the domain name is within the specified domain, then each node will expose to the outside. This is more of an attempt to assign each node within a cluster a unique name in a distributed fashion, without relying on external storages or K-V stores.


### 2. Which issues (if any) are related?

This fix fixes #1295

### 3. Which documentation changes (if any) need to be made?

To be updated.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>