### PR TITLE
Expose directives in dnsserver to help external plugin developers

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -22,7 +22,7 @@ func init() {
 	flag.StringVar(&Port, serverType+".port", DefaultPort, "Default port")
 
 	caddy.RegisterServerType(serverType, caddy.ServerType{
-		Directives: func() []string { return directives },
+		Directives: func() []string { return Directives },
 		DefaultInput: func() caddy.Input {
 			return caddy.CaddyfileInput{
 				Filepath:       "Corefile",

--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -9,8 +9,7 @@ package dnsserver
 // feel the effects of all other plugin below
 // (after) them during a request, but they must not
 // care what plugin above them are doing.
-
-var directives = []string{
+var Directives = []string{
 	"tls",
 	"nsid",
 	"root",

--- a/directives_generate.go
+++ b/directives_generate.go
@@ -81,8 +81,7 @@ func genDirectives(file, pack string, md []string) {
 // feel the effects of all other plugin below
 // (after) them during a request, but they must not
 // care what plugin above them are doing.
-
-var directives = []string{
+var Directives = []string{
 `
 
 	for i := range md {


### PR DESCRIPTION
### 1. What does this pull request do?

This fix expose directives in dnsserver package, so that external
plugin developers could easily build customerized coredns+plugin
without changing the code base tree of coredns.

The following is an example that could bundle coredns+example,
in one simple file without modifying coredns codebase.
With changes in this PR, an external plugin developer
could just import the plugin it want (like `_ "github.com/coredns/example"`), 
and update the `dnsserver.Directives`,
then invoking `go build -v sample.go` below will be enough

```
package main

import (
        _ "github.com/coredns/example"

        "github.com/coredns/coredns/coremain"
        "github.com/coredns/coredns/core/dnsserver"
)

var directives = []string{
        "example",
        "log",
        "errors",
        ...
        ...
        ...
        "whoami",
        "startup",
        "shutdown",
}

func init() {
        dnsserver.Directives = directives
}

func main() {
        coremain.Run()
}
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
