### PR TITLE
Fix a couple of typos

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -80,7 +80,7 @@ func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 			}
 
 			ones, bits := za.IPNet.Mask.Size()
-			if (bits-ones)%8 != 0 { // only do this for non-octet bounderies
+			if (bits-ones)%8 != 0 { // only do this for non-octet boundaries
 				cfg.FilterFunc = func(s string) bool {
 					// TODO(miek): strings.ToLower! Slow and allocates new string.
 					addr := dnsutil.ExtractAddressFromReverse(strings.ToLower(s))

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -417,7 +417,7 @@ func (APIConnServeTest) GetNodeByName(name string) (*api.Node, error) {
 }
 
 func (APIConnServeTest) GetNamespaceByName(name string) (*api.Namespace, error) {
-	if name == "pod-nons" { // hanlder_pod_verified_test.go uses this for non-existent namespace.
+	if name == "pod-nons" { // handler_pod_verified_test.go uses this for non-existent namespace.
 		return &api.Namespace{}, nil
 	}
 	return &api.Namespace{


### PR DESCRIPTION
`hanlder` -> `handler`

`bounderies` -> `boundaries`

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
