### PR TITLE
feature: plugin/rewrite: rewrite ANSWER SECTION

### DIFF
--- a/plugin/rewrite/class.go
+++ b/plugin/rewrite/class.go
@@ -41,3 +41,8 @@ func (rule *classRule) Rewrite(w dns.ResponseWriter, r *dns.Msg) Result {
 func (rule *classRule) Mode() string {
 	return rule.NextAction
 }
+
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *classRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
+}

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -78,6 +78,11 @@ func (rule *edns0NsidRule) Mode() string {
 	return rule.mode
 }
 
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *edns0NsidRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
+}
+
 // Rewrite will alter the request EDNS0 local options
 func (rule *edns0LocalRule) Rewrite(w dns.ResponseWriter, r *dns.Msg) Result {
 	result := RewriteIgnored
@@ -113,6 +118,11 @@ func (rule *edns0LocalRule) Rewrite(w dns.ResponseWriter, r *dns.Msg) Result {
 // Mode returns the processing mode
 func (rule *edns0LocalRule) Mode() string {
 	return rule.mode
+}
+
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *edns0LocalRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
 }
 
 // newEdns0Rule creates an EDNS0 rule of the appropriate type based on the args
@@ -312,6 +322,11 @@ func (rule *edns0VariableRule) Mode() string {
 	return rule.mode
 }
 
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *edns0VariableRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
+}
+
 func isValidVariable(variable string) bool {
 	switch variable {
 	case
@@ -421,6 +436,11 @@ func (rule *edns0SubnetRule) Rewrite(w dns.ResponseWriter, r *dns.Msg) Result {
 // Mode returns the processing mode
 func (rule *edns0SubnetRule) Mode() string {
 	return rule.mode
+}
+
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *edns0SubnetRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
 }
 
 // These are all defined actions.

--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -1,27 +1,61 @@
 package rewrite
 
-import "github.com/miekg/dns"
+import (
+	"github.com/miekg/dns"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ResponseRule contains a rule to rewrite a response with.
+type ResponseRule struct {
+	Active      bool
+	Pattern     *regexp.Regexp
+	Replacement string
+}
 
 // ResponseReverter reverses the operations done on the question section of a packet.
 // This is need because the client will otherwise disregards the response, i.e.
 // dig will complain with ';; Question section mismatch: got miek.nl/HINFO/IN'
 type ResponseReverter struct {
 	dns.ResponseWriter
-	original dns.Question
+	originalQuestion dns.Question
+	ResponseRewrite  bool
+	ResponseRules    []ResponseRule
 }
 
 // NewResponseReverter returns a pointer to a new ResponseReverter.
 func NewResponseReverter(w dns.ResponseWriter, r *dns.Msg) *ResponseReverter {
 	return &ResponseReverter{
-		ResponseWriter: w,
-		original:       r.Question[0],
+		ResponseWriter:   w,
+		originalQuestion: r.Question[0],
 	}
 }
 
 // WriteMsg records the status code and calls the
 // underlying ResponseWriter's WriteMsg method.
 func (r *ResponseReverter) WriteMsg(res *dns.Msg) error {
-	res.Question[0] = r.original
+	res.Question[0] = r.originalQuestion
+	if r.ResponseRewrite {
+		for _, rr := range res.Answer {
+			name := rr.(*dns.A).Hdr.Name
+			for _, rule := range r.ResponseRules {
+				regexGroups := rule.Pattern.FindStringSubmatch(name)
+				if len(regexGroups) == 0 {
+					continue
+				}
+				s := rule.Replacement
+				for groupIndex, groupValue := range regexGroups {
+					groupIndexStr := "{" + strconv.Itoa(groupIndex) + "}"
+					if strings.Contains(s, groupIndexStr) {
+						s = strings.Replace(s, groupIndexStr, groupValue, -1)
+					}
+				}
+				name = s
+			}
+			rr.(*dns.A).Hdr.Name = name
+		}
+	}
 	return r.ResponseWriter.WriteMsg(res)
 }
 

--- a/plugin/rewrite/setup.go
+++ b/plugin/rewrite/setup.go
@@ -3,7 +3,6 @@ package rewrite
 import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-
 	"github.com/mholt/caddy"
 )
 
@@ -32,6 +31,12 @@ func rewriteParse(c *caddy.Controller) ([]Rule, error) {
 
 	for c.Next() {
 		args := c.RemainingArgs()
+		if len(args) < 2 {
+			// Handles rules out of nested instructions, i.e. the ones enclosed in curly brackets
+			for c.NextBlock() {
+				args = append(args, c.Val())
+			}
+		}
 		rule, err := newRule(args...)
 		if err != nil {
 			return nil, err

--- a/plugin/rewrite/type.go
+++ b/plugin/rewrite/type.go
@@ -42,3 +42,8 @@ func (rule *typeRule) Rewrite(w dns.ResponseWriter, r *dns.Msg) Result {
 func (rule *typeRule) Mode() string {
 	return rule.nextAction
 }
+
+// GetResponseRule return a rule to rewrite the response with. Currently not implemented.
+func (rule *typeRule) GetResponseRule() ResponseRule {
+	return ResponseRule{}
+}


### PR DESCRIPTION
Resolves: #1313

### 1. What does this pull request do?

The change allows rewriting a DNS response when the response was matched by `name regex` rule.

```
.:5353 {
    rewrite stop name regex xxx.(google.com) www.{1}
    rewrite stop {
        name regex yyy.(google.com) www.{1}
        answer name www.(google.com) xxx.{1}
    }
    proxy . 8.8.8.8
    log
    errors
}
``` 

When a user queries `yyy.google.com`, the response that the user would see is `xxx.google.com`. However, the answer itself is based of `www.google.com`.

In a nutshell, the rule syntax is:

```
rewrite {
    name regex STRING STRING
    answer [name] STRING STRING
}
```

### 2. Which issues (if any) are related?

#1313

### 3. Which documentation changes (if any) need to be made?

Amend documentation of `plugin/rewrite`.