### PR TITLE
core: Fix no handler crash

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -255,7 +255,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		}
 	}
 
-	if r.Question[0].Qtype == dns.TypeDS && dshandler != nil {
+	if r.Question[0].Qtype == dns.TypeDS && dshandler != nil && dshandler.pluginChain != nil {
 		// DS request, and we found a zone, use the handler for the query.
 		rcode, _ := dshandler.pluginChain.ServeDNS(ctx, w, r)
 		if !plugin.ClientWrite(rcode) {
@@ -265,7 +265,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 
 	// Wildcard match, if we have found nothing try the root zone as a last resort.
-	if h, ok := s.zones["."]; ok {
+	if h, ok := s.zones["."]; ok && h.pluginChain != nil {
 		rcode, _ := h.pluginChain.ServeDNS(ctx, w, r)
 		if !plugin.ClientWrite(rcode) {
 			DefaultErrorFunc(w, r, rcode)


### PR DESCRIPTION
If you have no handlers for any zone CoreDNS would crash, this is very
*uncommon*, because it makes your server a unusable. Example config:
~~~
. {
    #forward . tls://9.9.9.9 8.8.8.8 {
    #    health_check 5s
    #    tls_servername dns.quad9.net
    #}
    pprof
    debug
}
~~~
It this does nothing and doesn't setup you plugin chain because pprof and
debug don't handle queries