### PR TITLE
plugin/metrics: convience MustRegister function

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -35,19 +35,22 @@ func New(addr string) *Metrics {
 		zoneMap: make(map[string]bool),
 	}
 	// Add the default collectors
-	met.Reg.MustRegister(prometheus.NewGoCollector())
-	met.Reg.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+	met.MustRegister(prometheus.NewGoCollector())
+	met.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
 
 	// Add all of our collectors
-	met.Reg.MustRegister(vars.RequestCount)
-	met.Reg.MustRegister(vars.RequestDuration)
-	met.Reg.MustRegister(vars.RequestSize)
-	met.Reg.MustRegister(vars.RequestDo)
-	met.Reg.MustRegister(vars.RequestType)
-	met.Reg.MustRegister(vars.ResponseSize)
-	met.Reg.MustRegister(vars.ResponseRcode)
+	met.MustRegister(vars.RequestCount)
+	met.MustRegister(vars.RequestDuration)
+	met.MustRegister(vars.RequestSize)
+	met.MustRegister(vars.RequestDo)
+	met.MustRegister(vars.RequestType)
+	met.MustRegister(vars.ResponseSize)
+	met.MustRegister(vars.ResponseRcode)
 	return met
 }
+
+// MustRegister wraps m.Reg.MustRegister.
+func (m *Metrics) MustRegister(c prometheus.Collector) { m.Reg.MustRegister(c) }
 
 // AddZone adds zone z to m.
 func (m *Metrics) AddZone(z string) {


### PR DESCRIPTION
This leave most of the code intact, but we need to stop vendoring
prometheus, because, again, plugins may want to use it. vendoring types clash with non-vendoring types.

Not vendoring prometheus makes my forward metrics show up again. Code looks bit convoluted, but works:

~~~
	c.OnStartup(func() error {
		once.Do(func() {
			m := dnsserver.GetConfig(c).Handler("prometheus")
			if m == nil {
				return
			}
			if x, ok := m.(*metrics.Metrics); ok {
				x.MustRegister(RequestCount)
				x.MustRegister(RcodeCount)
				x.MustRegister(RequestDuration)
				x.MustRegister(HealthcheckFailureCount)
				x.MustRegister(SocketGauge)
			}
		})
	})
~~~