### PR TITLE
metrics: correctly register all metrics

### DIFF
--- a/plugin/autopath/metrics.go
+++ b/plugin/autopath/metrics.go
@@ -18,12 +18,4 @@ var (
 	}, []string{})
 )
 
-// OnStartupMetrics sets up the metrics on startup.
-func OnStartupMetrics() error {
-	metricsOnce.Do(func() {
-		prometheus.MustRegister(AutoPathCount)
-	})
-	return nil
-}
-
-var metricsOnce sync.Once
+var once sync.Once

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"sync"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -84,38 +85,31 @@ func (c *Cache) get(now time.Time, qname string, qtype uint16, do bool) (*item, 
 var (
 	cacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "cache",
 		Name:      "size",
 		Help:      "The number of elements in the cache.",
 	}, []string{"type"})
 
 	cacheCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "cache",
 		Name:      "capacity",
 		Help:      "The cache's capacity.",
 	}, []string{"type"})
 
 	cacheHits = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "cache",
 		Name:      "hits_total",
 		Help:      "The count of cache hits.",
 	}, []string{"type"})
 
 	cacheMisses = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "cache",
 		Name:      "misses_total",
 		Help:      "The count of cache misses.",
 	})
 )
 
-const subsystem = "cache"
-
-func init() {
-	prometheus.MustRegister(cacheSize)
-	prometheus.MustRegister(cacheCapacity)
-	prometheus.MustRegister(cacheHits)
-	prometheus.MustRegister(cacheMisses)
-}
+var once sync.Once

--- a/plugin/dnssec/handler.go
+++ b/plugin/dnssec/handler.go
@@ -1,6 +1,8 @@
 package dnssec
 
 import (
+	"sync"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
@@ -42,28 +44,28 @@ func (d Dnssec) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 var (
 	cacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "dnssec",
 		Name:      "cache_size",
 		Help:      "The number of elements in the dnssec cache.",
 	}, []string{"type"})
 
 	cacheCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "dnssec",
 		Name:      "cache_capacity",
 		Help:      "The dnssec cache's capacity.",
 	}, []string{"type"})
 
 	cacheHits = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "dnssec",
 		Name:      "cache_hits_total",
 		Help:      "The count of cache hits.",
 	})
 
 	cacheMisses = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: "dnssec",
 		Name:      "cache_misses_total",
 		Help:      "The count of cache misses.",
 	})
@@ -72,11 +74,4 @@ var (
 // Name implements the Handler interface.
 func (d Dnssec) Name() string { return "dnssec" }
 
-const subsystem = "dnssec"
-
-func init() {
-	prometheus.MustRegister(cacheSize)
-	prometheus.MustRegister(cacheCapacity)
-	prometheus.MustRegister(cacheHits)
-	prometheus.MustRegister(cacheMisses)
-}
+var once sync.Once

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/pkg/cache"
 
 	"github.com/mholt/caddy"
@@ -28,6 +29,22 @@ func setup(c *caddy.Controller) error {
 	ca := cache.New(capacity)
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		return New(zones, keys, next, ca)
+	})
+
+	c.OnStartup(func() error {
+		once.Do(func() {
+			m := dnsserver.GetConfig(c).Handler("prometheus")
+			if m == nil {
+				return
+			}
+			if x, ok := m.(*metrics.Metrics); ok {
+				x.MustRegister(cacheSize)
+				x.MustRegister(cacheCapacity)
+				x.MustRegister(cacheHits)
+				x.MustRegister(cacheMisses)
+			}
+		})
+		return nil
 	})
 
 	// Export the capacity for the metrics. This only happens once, because this is a re-load change only.

--- a/plugin/proxy/metrics.go
+++ b/plugin/proxy/metrics.go
@@ -25,15 +25,6 @@ var (
 	}, []string{"proto", "proxy_proto", "family", "to"})
 )
 
-// OnStartupMetrics sets up the metrics on startup. This is done for all proxy protocols.
-func OnStartupMetrics() error {
-	metricsOnce.Do(func() {
-		prometheus.MustRegister(RequestCount)
-		prometheus.MustRegister(RequestDuration)
-	})
-	return nil
-}
-
 // familyToString returns the string form of either 1, or 2. Returns
 // empty string is not a known family
 func familyToString(f int) string {
@@ -46,4 +37,4 @@ func familyToString(f int) string {
 	return ""
 }
 
-var metricsOnce sync.Once
+var once sync.Once


### PR DESCRIPTION
After initial startup, see if prometheus is loaded and if so, register
our metrics with it.
Stop doing the init() func and just use the sync.Once so we don't double
registrer our metrics.