### PR TITLE
WIP: new plugin/allow, to block certain incoming requests

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -22,6 +22,7 @@ var directives = []string{
 	"prometheus",
 	"errors",
 	"log",
+	"allow",
 	"dnstap",
 	"chaos",
 	"cache",

--- a/core/zplugin.go
+++ b/core/zplugin.go
@@ -4,6 +4,7 @@ package core
 
 import (
 	// Include all plugins.
+	_ "github.com/coredns/coredns/plugin/allow"
 	_ "github.com/coredns/coredns/plugin/auto"
 	_ "github.com/coredns/coredns/plugin/autopath"
 	_ "github.com/coredns/coredns/plugin/bind"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -50,3 +50,4 @@ erratic:erratic
 whoami:whoami
 startup:github.com/mholt/caddy/startupshutdown
 shutdown:github.com/mholt/caddy/startupshutdown
+allow:allow

--- a/plugin/allow/allow.go
+++ b/plugin/allow/allow.go
@@ -1,0 +1,40 @@
+package allow
+
+import (
+    "net"
+
+    "github.com/coredns/coredns/plugin"
+    "github.com/coredns/coredns/request"
+
+    "github.com/miekg/dns"
+    "golang.org/x/net/context"
+)
+
+type Allow struct {
+    Next     plugin.Handler
+    Cidrs  []string
+}
+
+func (rw Allow) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+    state := request.Request{W: w, Req: r}
+    ip := state.IP()
+
+    for _, it := range rw.Cidrs {
+        _, cidr, err := net.ParseCIDR(it)
+        if err != nil {
+            return 0, err
+        }
+        if cidr.Contains(net.ParseIP(ip)) {
+            return plugin.NextOrFailure(rw.Name(), rw.Next, ctx, w, r)
+        }
+    }
+
+    m := new(dns.Msg)
+    m.SetRcode(r, dns.RcodeRefused)
+    state.SizeAndDo(m)
+    w.WriteMsg(m)
+
+    return 0, nil
+}
+
+func (rw Allow) Name() string { return "allow" }

--- a/plugin/allow/setup.go
+++ b/plugin/allow/setup.go
@@ -1,0 +1,43 @@
+package allow
+
+import (
+    "strings"
+
+    "github.com/coredns/coredns/core/dnsserver"
+    "github.com/coredns/coredns/plugin"
+
+    "github.com/mholt/caddy"
+)
+
+func init() {
+    caddy.RegisterPlugin("allow", caddy.Plugin{
+        ServerType: "dns",
+        Action: setup,
+    })
+}
+
+func setup(c *caddy.Controller) error {
+    cidrs, err := argsParse(c)
+    if err != nil {
+        return plugin.Error("allow", err)
+    }
+
+    dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+	    return Allow{Next: next, Cidrs: cidrs}
+    })
+
+    return nil
+}
+
+func argsParse(c *caddy.Controller) ([]string, error) {
+	var cidrs []string
+
+	for c.Next() {
+		args := c.RemainingArgs()
+		for _, arg := range args {
+			cidrs = append(cidrs, strings.ToLower(arg))
+		}
+	}
+
+	return cidrs, nil
+}


### PR DESCRIPTION
This is a proposal to introduce a new plugin that can filter incoming requests. It returns the error code: `REFUSED` if the client's IP address isn't in one of the configured CIDR.

A use case would be to run CoreDNS into a Kubernetes cluster. If exposing the DNS service to the outside (to serve a domain's zone), it can be used to prevent public IPs to do requests to say: the Kubernetes plugin (and thus retrieve the internal IPs of the cluster's containers).

If it is interesting enough to be included into mainline, I will ensure to follow with documentation and test code.