### PR TITLE
plugin/kubernetes: add explicit non-existing ns check

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -156,6 +156,14 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
+	// A Service (non-existing namespace)
+	{
+		Qname: "svc0.svc-nons.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
 	// TXT Schema
 	{
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,


### PR DESCRIPTION
We already do the right thing here, but add a test nonetheless. 