### PR TITLE
plugin/proxy: max the number of upstreams

### DIFF
--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -53,6 +53,10 @@ func NewStaticUpstreams(c *caddyfile.Dispenser) ([]Upstream, error) {
 			return upstreams, err
 		}
 
+		if len(toHosts) > max {
+			return upstreams, fmt.Errorf("more than %d TOs configured: %d", max, len(toHosts))
+		}
+
 		for c.NextBlock() {
 			if err := parseBlock(c, upstream); err != nil {
 				return upstreams, err
@@ -192,3 +196,5 @@ func (u *staticUpstream) IsAllowedDomain(name string) bool {
 
 func (u *staticUpstream) Exchanger() Exchanger { return u.ex }
 func (u *staticUpstream) From() string         { return u.from }
+
+const max = 15

--- a/plugin/proxy/upstream_test.go
+++ b/plugin/proxy/upstream_test.go
@@ -303,6 +303,16 @@ junky resolv.conf
 	}
 }
 
+func TestMaxTo(t *testing.T) {
+	// Has 16 IP addresses.
+	config := `proxy . 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1 1.1.1.1`
+	c := caddy.NewTestController("dns", config)
+	_, err := NewStaticUpstreams(&c.Dispenser)
+	if err == nil {
+		t.Error("Expected to many TOs configured, but nil")
+	}
+}
+
 func getPEMFiles(t *testing.T) (rmFunc func(), cert, key, ca string) {
 	tempDir, rmFunc, err := test.WritePEMFiles("")
 	if err != nil {

--- a/plugin/proxy/upstream_test.go
+++ b/plugin/proxy/upstream_test.go
@@ -259,7 +259,7 @@ proxy . FILE
 proxy example.org 2.2.2.2:1234
 `,
 			`
-junky resolve.conf
+junky resolv.conf
 `,
 			false,
 			[]string{"1.1.1.1:5000", "2.2.2.2:1234"},


### PR DESCRIPTION
Put a max of 15 on the number of upstreams.

Fixes #1339