### PR TITLE
Align plugin/template usage and syntax with other plugins

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -9,29 +9,34 @@ The *template* plugin allows you to dynamically repond to queries by just writin
 ## Syntax
 
 ~~~
-template CLASS TYPE [REGEX...] {
+template CLASS TYPE [ZONE...] {
+    [match REGEX...]
     [answer RR]
     [additional RR]
     [authority RR]
     [...]
-    [rcode CODE]
+    [rcode responsecode]
+    [fallthrough]
 }
 ~~~
 
-* **CLASS** the query class (usually IN or ANY)
-* **TYPE** the query type (A, PTR, ...)
+* **CLASS** the query class (usually IN or ANY).
+* **TYPE** the query type (A, PTR, ... can be ANY to match all types).
+* **ZONE** the zone scope(s) for this template. Defaults to '.' (everything).
 * **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   build by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
+* `fallthrough` Continue with the next plugin if the zone matched but no regex did not match.
 
-At least one answer section or rcode is needed.
+At least one `answer` or `rcode` directive is needed (e.g. `rcode NXDOMAIN`).
 
 [Also see](#also-see) contains an additional reading list.
 
 ## Templates
 
 Each resource record is a full-featured [Go template](https://golang.org/pkg/text/template/) with the following predefined data
+* `.Zone` the matched zone string (e.g. `example.`).
 * `.Name` the query name, as a string (lowercased).
 * `.Class` the query class (usually `IN`).
 * `.Type` the RR type requested (e.g. `PTR`).
@@ -57,6 +62,22 @@ Both failure cases indicate a problem with the template configuration.
 
 ## Examples
 
+### Resolve everything to NXDOMAIN
+
+The most simplistic template is
+
+~~~ corefile
+. {
+    template ANY ANY {
+      rcode NXDOMAIN
+    }
+}
+~~~
+
+1. This template uses the default zone (`.` or all queries)
+2. All queries will be answered (no `fallthrough`)
+3. The answer is always NXDOMAIN
+
 ### Resolve .invalid as NXDOMAIN
 
 The `.invalid` domain is a reserved TLD (see [RFC-2606 Reserved Top Level DNS Names](https://tools.ietf.org/html/rfc2606#section-2)) to indicate invalid domains.
@@ -65,7 +86,7 @@ The `.invalid` domain is a reserved TLD (see [RFC-2606 Reserved Top Level DNS Na
 . {
     proxy . 8.8.8.8
 
-    template ANY ANY "[.]invalid[.]$" {
+    template ANY ANY invalid. {
       rcode NXDOMAIN
       answer "invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"
     }
@@ -75,6 +96,7 @@ The `.invalid` domain is a reserved TLD (see [RFC-2606 Reserved Top Level DNS Na
 1. A query to .invalid will result in NXDOMAIN (rcode)
 2. A dummy SOA record is send to hand out a TTL of 60s for caching
 3. Querying `.invalid` of `CH` will also cause a NXDOMAIN/SOA response
+4. The default regex is `.*`
 
 ### Block invalid search domain completions
 
@@ -88,14 +110,33 @@ path (`dc1.example.com`) added.
 . {
     proxy . 8.8.8.8
 
-    template IN ANY "[.](example[.]com[.]dc1[.]example[.]com[.])$" {
+    template IN ANY example.com.dc1.example.com. {
       rcode NXDOMAIN
-      answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+      answer "{{ .Zone }} 60 IN SOA a.{{ .Zone }} b.{{ .Zone }} (1 60 60 60 60)"
     }
 }
 ~~~
 
+A more verbose regex based equivalent would be
+
+~~~ corefile
+. {
+    proxy . 8.8.8.8
+
+    template IN ANY example.com. {
+      match "(example.com.dc1.example.com)$"
+      rcode NXDOMAIN
+      answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+      fallthrough
+    }
+}
+~~~
+
+<<<<<<< HEAD
 Using numbered matches works well if there are a few groups (1-4).
+=======
+The regex based version can do more complex matching/templating while zone based templating is easier to read and use.
+>>>>>>> 60626052... Align plugin/template usage and syntax with other plugins
 
 ### Resolve A/PTR for .example
 
@@ -105,13 +146,16 @@ Using numbered matches works well if there are a few groups (1-4).
 
     # ip-a-b-c-d.example.com A a.b.c.d
 
-    template IN A (^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+    template IN A example. {
+      match (^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      fallthrough
     }
 
     # d.c.b.a.in-addr.arpa PTR ip-a-b-c-d.example
 
-    template IN PTR ^(?P<d>[0-9]*)[.](?P<c>[0-9]*)[.](?P<b>[0-9]*)[.]10[.]in-addr[.]arpa[.]$ {
+    template IN PTR 10.in-addr.arpa. {
+      match ^(?P<d>[0-9]*)[.](?P<c>[0-9]*)[.](?P<b>[0-9]*)[.]10[.]in-addr[.]arpa[.]$
       answer "{{ .Name }} 60 IN PTR ip-10-{{ .Group.b }}-{{ .Group.c }}-{{ .Group.d }}.example.com."
     }
 }
@@ -124,14 +168,19 @@ Note that the A record is actually a wildcard, any subdomain of the ip will reso
 
 Having templates to map certain PTR/A pairs is a common pattern.
 
+Fallthrough is needed for mixed domains where only some responses are templated.
+
 ### Resolve multiple ip patterns
 
 ~~~ corefile
 . {
     proxy . 8.8.8.8
 
-    template IN A "^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$" "^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$" {
+    template IN A example. {
+      match "^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$"
+      match "^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$"
       answer "{{ .Name }} 60 IN A {{ .Group.a}}.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      fallthrough
     }
 }
 ~~~
@@ -144,12 +193,16 @@ Named capture groups can be used to template one response for multiple patterns.
 . {
     proxy . 8.8.8.8
 
-    template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+    template IN A example. {
+      match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      fallthrough
     }
-    template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+    template IN MX example. {
+      match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
       additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+      fallthrough
     }
 }
 ~~~

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -87,7 +87,7 @@ The `.invalid` domain is a reserved TLD (see [RFC-2606 Reserved Top Level DNS Na
 . {
     proxy . 8.8.8.8
 
-    template ANY ANY invalid. {
+    template ANY ANY invalid {
       rcode NXDOMAIN
       answer "invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"
     }
@@ -111,7 +111,7 @@ path (`dc1.example.com`) added.
 . {
     proxy . 8.8.8.8
 
-    template IN ANY example.com.dc1.example.com. {
+    template IN ANY example.com.dc1.example.com {
       rcode NXDOMAIN
       answer "{{ .Zone }} 60 IN SOA a.{{ .Zone }} b.{{ .Zone }} (1 60 60 60 60)"
     }
@@ -124,7 +124,7 @@ A more verbose regex based equivalent would be
 . {
     proxy . 8.8.8.8
 
-    template IN ANY example.com. {
+    template IN ANY example.com {
       match "(example.com.dc1.example.com)$"
       rcode NXDOMAIN
       answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
@@ -143,7 +143,7 @@ The regex based version can do more complex matching/templating while zone based
 
     # ip-a-b-c-d.example.com A a.b.c.d
 
-    template IN A example. {
+    template IN A example {
       match (^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
       fallthrough
@@ -173,7 +173,7 @@ Fallthrough is needed for mixed domains where only some responses are templated.
 . {
     proxy . 8.8.8.8
 
-    template IN A example. {
+    template IN A example {
       match "^ip-(?P<a>10)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]dc[.]example[.]$"
       match "^(?P<a>[0-9]*)[.](?P<b>[0-9]*)[.](?P<c>[0-9]*)[.](?P<d>[0-9]*)[.]ext[.]example[.]$"
       answer "{{ .Name }} 60 IN A {{ .Group.a}}.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
@@ -190,12 +190,12 @@ Named capture groups can be used to template one response for multiple patterns.
 . {
     proxy . 8.8.8.8
 
-    template IN A example. {
+    template IN A example {
       match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
       fallthrough
     }
-    template IN MX example. {
+    template IN MX example {
       match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
       additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
@@ -210,20 +210,24 @@ Named capture groups can be used to template one response for multiple patterns.
 . {
     proxy . 8.8.8.8
 
-    template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+    template IN A example {
+      match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
       authority  "example. 60 IN NS ns0.example."
       authority  "example. 60 IN NS ns1.example."
       additional "ns0.example. 60 IN A 203.0.113.8"
       additional "ns1.example. 60 IN A 198.51.100.8"
+      fallthrough
     }
-    template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+    template IN MX example {
+      match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
       answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
       additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
       authority  "example. 60 IN NS ns0.example."
       authority  "example. 60 IN NS ns1.example."
       additional "ns0.example. 60 IN A 203.0.113.8"
       additional "ns1.example. 60 IN A 198.51.100.8"
+      fallthrough
     }
 }
 ~~~

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -16,18 +16,19 @@ template CLASS TYPE [ZONE...] {
     [authority RR]
     [...]
     [rcode responsecode]
-    [fallthrough]
+    [fallthrough [fallthrough zone...]]
 }
 ~~~
 
 * **CLASS** the query class (usually IN or ANY).
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
-* **ZONE** the zone scope(s) for this template. Defaults to '.' (everything).
+* **ZONE** the zone scope(s) for this template. Defaults to the server zones.
 * **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   build by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex did not match.
+* `fallthrough zone` One or more zones that may fall through to other plugins. Defaults to all zones of the template.
 
 At least one `answer` or `rcode` directive is needed (e.g. `rcode NXDOMAIN`).
 
@@ -132,11 +133,7 @@ A more verbose regex based equivalent would be
 }
 ~~~
 
-<<<<<<< HEAD
-Using numbered matches works well if there are a few groups (1-4).
-=======
 The regex based version can do more complex matching/templating while zone based templating is easier to read and use.
->>>>>>> 60626052... Align plugin/template usage and syntax with other plugins
 
 ### Resolve A/PTR for .example
 

--- a/plugin/template/metrics.go
+++ b/plugin/template/metrics.go
@@ -3,7 +3,10 @@ package template
 import (
 	"sync"
 
+	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
+	"github.com/mholt/caddy"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -15,28 +18,38 @@ var (
 		Subsystem: "template",
 		Name:      "matches_total",
 		Help:      "Counter of template regex matches.",
-	}, []string{"regex"})
+	}, []string{"zone", "class", "type"})
 	TemplateFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "template",
 		Name:      "template_failures_total",
 		Help:      "Counter of go template failures.",
-	}, []string{"regex", "section", "template"})
+	}, []string{"zone", "class", "type", "section", "template"})
 	TemplateRRFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "template",
 		Name:      "rr_failures_total",
 		Help:      "Counter of mis-templated RRs.",
-	}, []string{"regex", "section", "template"})
+	}, []string{"zone", "class", "type", "section", "template"})
 )
 
 // OnStartupMetrics sets up the metrics on startup.
-func OnStartupMetrics() error {
-	metricsOnce.Do(func() {
-		prometheus.MustRegister(TemplateMatchesCount)
-		prometheus.MustRegister(TemplateFailureCount)
-		prometheus.MustRegister(TemplateRRFailureCount)
+func setupMetrics(c *caddy.Controller) error {
+	c.OnStartup(func() error {
+		metricsOnce.Do(func() {
+			m := dnsserver.GetConfig(c).Handler("prometheus")
+			if m == nil {
+				return
+			}
+			if x, ok := m.(*metrics.Metrics); ok {
+				x.MustRegister(TemplateMatchesCount)
+				x.MustRegister(TemplateFailureCount)
+				x.MustRegister(TemplateRRFailureCount)
+			}
+		})
+		return nil
 	})
+
 	return nil
 }
 

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -134,6 +134,9 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 				}
 				t.rcode = rcode
 
+			case "fallthrough":
+				handler.Fall.SetZonesFromArgs(c.RemainingArgs())
+
 			default:
 				return handler, c.ArgErr()
 			}

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -24,7 +24,9 @@ func setupTemplate(c *caddy.Controller) error {
 		return plugin.Error("template", err)
 	}
 
-	c.OnStartup(OnStartupMetrics)
+	if err := setupMetrics(c); err != nil {
+		return plugin.Error("template", err)
+	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		handler.Next = next

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -59,7 +59,11 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 
 		handler.Zones = c.RemainingArgs()
 		if len(handler.Zones) == 0 {
-			handler.Zones = []string{"."}
+			handler.Zones = make([]string, len(c.ServerBlockKeys))
+			copy(handler.Zones, c.ServerBlockKeys)
+		}
+		for i, str := range handler.Zones {
+			handler.Zones[i] = plugin.Host(str).Normalize()
 		}
 
 		t := template{}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -93,30 +93,35 @@ func TestSetupParse(t *testing.T) {
 		},
 		// examples
 		{
-			`template ANY A ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com {
+			`template ANY A example.com. {
+				match ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com
 				answer "{{ .Name }} A {{ .Group.a }}.{{ .Group.b }}.{{ .Group.c }}.{{ .Grup.d }}."
 			}`,
 			false,
 		},
 		{
-			`template IN ANY "[.](example[.]com[.]dc1[.]example[.]com[.])$" {
+			`template IN ANY example.com. {
+				match "[.](example[.]com[.]dc1[.]example[.]com[.])$"
 				rcode NXDOMAIN
 				answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
 			}`,
 			false,
 		},
 		{
-			`template IN A ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+			`template IN A example. {
+				match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 				answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 			}
-			template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+			template IN MX example. {
+				match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 				answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
 				additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 			}`,
 			false,
 		},
 		{
-			`template IN MX ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$ {
+			`template IN MX example. {
+					match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 					answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
 					additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 					authority  "example. 60 IN NS ns0.example."

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -93,7 +93,7 @@ func TestSetupParse(t *testing.T) {
 		},
 		// examples
 		{
-			`template ANY A example.com. {
+			`template ANY A example.com {
 				match ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com
 				answer "{{ .Name }} A {{ .Group.a }}.{{ .Group.b }}.{{ .Group.c }}.{{ .Grup.d }}."
 				fallthrough
@@ -101,16 +101,16 @@ func TestSetupParse(t *testing.T) {
 			false,
 		},
 		{
-			`template IN ANY example.com. {
+			`template IN ANY example.com {
 				match "[.](example[.]com[.]dc1[.]example[.]com[.])$"
 				rcode NXDOMAIN
 				answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
-				fallthrough example.com.
+				fallthrough example.com
 			}`,
 			false,
 		},
 		{
-			`template IN A example. {
+			`template IN A example {
 				match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 				answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 			}
@@ -122,7 +122,7 @@ func TestSetupParse(t *testing.T) {
 			false,
 		},
 		{
-			`template IN MX example. {
+			`template IN MX example {
 					match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 					answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
 					additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -96,6 +96,7 @@ func TestSetupParse(t *testing.T) {
 			`template ANY A example.com. {
 				match ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com
 				answer "{{ .Name }} A {{ .Group.a }}.{{ .Group.b }}.{{ .Group.c }}.{{ .Grup.d }}."
+				fallthrough
 			}`,
 			false,
 		},
@@ -104,6 +105,7 @@ func TestSetupParse(t *testing.T) {
 				match "[.](example[.]com[.]dc1[.]example[.]com[.])$"
 				rcode NXDOMAIN
 				answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+				fallthrough example.com.
 			}`,
 			false,
 		},

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -8,6 +8,7 @@ import (
 	gotmpl "text/template"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -15,10 +16,10 @@ import (
 
 // Handler is a plugin handler that takes a query and templates a response.
 type Handler struct {
-	Zones       []string
-	Fallthrough bool
-	Class       uint16
-	Qtype       uint16
+	Zones []string
+	Class uint16
+	Qtype uint16
+	Fall  fall.F
 
 	Next      plugin.Handler
 	Templates []template
@@ -106,7 +107,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		return template.rcode, nil
 	}
 
-	if h.Fallthrough {
+	if h.Fall.Through(state.Name()) {
 		return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 	}
 

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -226,13 +226,13 @@ func TestHandler(t *testing.T) {
 
 	for _, tr := range tests {
 		handler := Handler{
-			Next:        test.NextHandler(rcodeFallthrough, nil),
-			Class:       tr.qclass,
-			Qtype:       tr.qtype,
-			Zones:       []string{"."},
-			Fallthrough: true,
-			Templates:   []template{tr.tmpl},
+			Next:      test.NextHandler(rcodeFallthrough, nil),
+			Class:     tr.qclass,
+			Qtype:     tr.qtype,
+			Zones:     []string{"."},
+			Templates: []template{tr.tmpl},
 		}
+		handler.Fall.SetZonesFromArgs([]string{})
 		req := &dns.Msg{
 			Question: []dns.Question{{
 				Name:   tr.qname,

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -7,62 +7,100 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/mholt/caddy"
 
 	gotmpl "text/template"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/miekg/dns"
 )
 
 func TestHandler(t *testing.T) {
 	rcodeFallthrough := 3841 // reserved for private use, used to indicate a fallthrough
 	exampleDomainATemplate := template{
-		regex:  []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
-		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
+		regex:    []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
+		answer:   []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
+		qclass:   dns.ClassANY,
+		qtype:    dns.TypeANY,
+		fthrough: fall.F{Zones: []string{"."}},
+		zones:    []string{"."},
 	}
 	exampleDomainANSTemplate := template{
 		regex:      []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
 		answer:     []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
 		additional: []*gotmpl.Template{gotmpl.Must(gotmpl.New("additional").Parse("ns0.example. IN A 203.0.113.8"))},
 		authority:  []*gotmpl.Template{gotmpl.Must(gotmpl.New("authority").Parse("example. IN NS ns0.example.com."))},
+		qclass:     dns.ClassANY,
+		qtype:      dns.TypeANY,
+		fthrough:   fall.F{Zones: []string{"."}},
+		zones:      []string{"."},
 	}
 	exampleDomainMXTemplate := template{
 		regex:      []*regexp.Regexp{regexp.MustCompile("(^|[.])ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$")},
 		answer:     []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 MX 10 {{ .Name }}"))},
 		additional: []*gotmpl.Template{gotmpl.Must(gotmpl.New("additional").Parse("{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"))},
+		qclass:     dns.ClassANY,
+		qtype:      dns.TypeANY,
+		fthrough:   fall.F{Zones: []string{"."}},
+		zones:      []string{"."},
 	}
 	invalidDomainTemplate := template{
-		regex:  []*regexp.Regexp{regexp.MustCompile("[.]invalid[.]$")},
-		rcode:  dns.RcodeNameError,
-		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"))},
+		regex:    []*regexp.Regexp{regexp.MustCompile("[.]invalid[.]$")},
+		rcode:    dns.RcodeNameError,
+		answer:   []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("invalid. 60 {{ .Class }} SOA a.invalid. b.invalid. (1 60 60 60 60)"))},
+		qclass:   dns.ClassANY,
+		qtype:    dns.TypeANY,
+		fthrough: fall.F{Zones: []string{"."}},
+		zones:    []string{"."},
 	}
 	rcodeServfailTemplate := template{
-		regex: []*regexp.Regexp{regexp.MustCompile(".*")},
-		rcode: dns.RcodeServerFailure,
+		regex:    []*regexp.Regexp{regexp.MustCompile(".*")},
+		rcode:    dns.RcodeServerFailure,
+		qclass:   dns.ClassANY,
+		qtype:    dns.TypeANY,
+		fthrough: fall.F{Zones: []string{"."}},
+		zones:    []string{"."},
 	}
 	brokenTemplate := template{
-		regex:  []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
-		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN TXT \"{{ index .Match 2 }}\""))},
+		regex:    []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
+		answer:   []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }} 60 IN TXT \"{{ index .Match 2 }}\""))},
+		qclass:   dns.ClassANY,
+		qtype:    dns.TypeANY,
+		fthrough: fall.F{Zones: []string{"."}},
+		zones:    []string{"."},
 	}
 	nonRRTemplate := template{
-		regex:  []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
-		answer: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }}"))},
+		regex:    []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
+		answer:   []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }}"))},
+		qclass:   dns.ClassANY,
+		qtype:    dns.TypeANY,
+		fthrough: fall.F{Zones: []string{"."}},
+		zones:    []string{"."},
 	}
 	nonRRAdditionalTemplate := template{
 		regex:      []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
 		additional: []*gotmpl.Template{gotmpl.Must(gotmpl.New("answer").Parse("{{ .Name }}"))},
+		qclass:     dns.ClassANY,
+		qtype:      dns.TypeANY,
+		fthrough:   fall.F{Zones: []string{"."}},
+		zones:      []string{"."},
 	}
 	nonRRAuthoritativeTemplate := template{
 		regex:     []*regexp.Regexp{regexp.MustCompile("[.]example[.]$")},
 		authority: []*gotmpl.Template{gotmpl.Must(gotmpl.New("authority").Parse("{{ .Name }}"))},
+		qclass:    dns.ClassANY,
+		qtype:     dns.TypeANY,
+		fthrough:  fall.F{Zones: []string{"."}},
+		zones:     []string{"."},
 	}
 
 	tests := []struct {
 		tmpl           template
 		qname          string
+		name           string
 		qclass         uint16
 		qtype          uint16
-		name           string
 		expectedCode   int
 		expectedErr    string
 		verifyResponse func(*dns.Msg) error
@@ -70,8 +108,6 @@ func TestHandler(t *testing.T) {
 		{
 			name:         "RcodeServFail",
 			tmpl:         rcodeServfailTemplate,
-			qclass:       dns.ClassANY,
-			qtype:        dns.TypeANY,
 			qname:        "test.invalid.",
 			expectedCode: dns.RcodeServerFailure,
 			verifyResponse: func(r *dns.Msg) error {
@@ -227,12 +263,9 @@ func TestHandler(t *testing.T) {
 	for _, tr := range tests {
 		handler := Handler{
 			Next:      test.NextHandler(rcodeFallthrough, nil),
-			Class:     tr.qclass,
-			Qtype:     tr.qtype,
 			Zones:     []string{"."},
 			Templates: []template{tr.tmpl},
 		}
-		handler.Fall.SetZonesFromArgs([]string{})
 		req := &dns.Msg{
 			Question: []dns.Question{{
 				Name:   tr.qname,
@@ -261,4 +294,150 @@ func TestHandler(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestMultiSection verfies that a corefile with mutliple but different template sections works
+func TestMultiSection(t *testing.T) {
+	rcodeFallthrough := 3841 // reserved for private use, used to indicate a fallthrough
+	ctx := context.TODO()
+
+	multisectionConfig := `
+		# Implicit section (see c.ServerBlockKeys)
+		# test.:8053 {
+
+	  # REFUSE IN A for the server zone (test.)
+		template IN A {
+			rcode REFUSED
+		}
+		# Fallthrough everyting IN TXT for test.
+		template IN TXT {
+			match "$^"
+			rcode SERVFAIL
+			fallthrough
+		}
+		# Answer CH TXT *.coredns.invalid. / coredns.invalid.
+		template CH TXT coredns.invalid. {
+			answer "{{ .Name }} 60 CH TXT \"test\""
+		}
+		# Anwser example. ip templates and fallthrough otherwise
+		template IN A example. {
+			match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
+			answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+			fallthrough
+		}
+		# Answer MX record requests for ip templates in example. and never fall through
+		template IN MX example. {
+			match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
+			answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
+			additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
+		}
+		`
+	c := caddy.NewTestController("dns", multisectionConfig)
+	c.ServerBlockKeys = []string{"test.:8053"}
+
+	handler, err := templateParse(c)
+	if err != nil {
+		t.Fatalf("TestMultiSection could not parse config: %v", err)
+	}
+
+	handler.Next = test.NextHandler(rcodeFallthrough, nil)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	// Asking for test. IN A -> REFUSED
+
+	req := &dns.Msg{Question: []dns.Question{{Name: "some.test.", Qclass: dns.ClassINET, Qtype: dns.TypeA}}}
+	code, err := handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving some.test. A, got: %v", err)
+	}
+	if code != dns.RcodeRefused {
+		t.Fatalf("TestMultiSection expected response code REFUSED got: %v", code)
+	}
+
+	// Asking for test. IN TXT -> fallthrough
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "some.test.", Qclass: dns.ClassINET, Qtype: dns.TypeTXT}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving some.test. TXT, got: %v", err)
+	}
+	if code != rcodeFallthrough {
+		t.Fatalf("TestMultiSection expected response code fallthrough got: %v", code)
+	}
+
+	// Asking for coredns.invalid. CH TXT -> TXT "test"
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "coredns.invalid.", Qclass: dns.ClassCHAOS, Qtype: dns.TypeTXT}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving coredns.invalid. TXT, got: %v", err)
+	}
+	if code != dns.RcodeSuccess {
+		t.Fatalf("TestMultiSection expected success response for coredns.invalid. TXT got: %v", code)
+	}
+	if len(rec.Msg.Answer) != 1 {
+		t.Fatalf("TestMultiSection expected one answer for coredns.invalid. TXT got: %v", rec.Msg.Answer)
+	}
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeTXT || rec.Msg.Answer[0].(*dns.TXT).Txt[0] != "test" {
+		t.Fatalf("TestMultiSection a \"test\" answer for coredns.invalid. TXT got: %v", rec.Msg.Answer[0])
+	}
+
+	// Asking for an ip template in example
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "ip-10-11-12-13.example.", Qclass: dns.ClassINET, Qtype: dns.TypeA}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving ip-10-11-12-13.example. IN A, got: %v", err)
+	}
+	if code != dns.RcodeSuccess {
+		t.Fatalf("TestMultiSection expected success response ip-10-11-12-13.example. IN A got: %v, %v", code, dns.RcodeToString[code])
+	}
+	if len(rec.Msg.Answer) != 1 {
+		t.Fatalf("TestMultiSection expected one answer for ip-10-11-12-13.example. IN A got: %v", rec.Msg.Answer)
+	}
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Fatalf("TestMultiSection an A RR answer for ip-10-11-12-13.example. IN A got: %v", rec.Msg.Answer[0])
+	}
+
+	// Asking for an MX ip template in example
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "ip-10-11-12-13.example.", Qclass: dns.ClassINET, Qtype: dns.TypeMX}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving ip-10-11-12-13.example. IN MX, got: %v", err)
+	}
+	if code != dns.RcodeSuccess {
+		t.Fatalf("TestMultiSection expected success response ip-10-11-12-13.example. IN MX got: %v, %v", code, dns.RcodeToString[code])
+	}
+	if len(rec.Msg.Answer) != 1 {
+		t.Fatalf("TestMultiSection expected one answer for ip-10-11-12-13.example. IN MX got: %v", rec.Msg.Answer)
+	}
+	if rec.Msg.Answer[0].Header().Rrtype != dns.TypeMX {
+		t.Fatalf("TestMultiSection an A RR answer for ip-10-11-12-13.example. IN MX got: %v", rec.Msg.Answer[0])
+	}
+
+	// Test that something.example. A does fall through but something.example. MX does not
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "something.example.", Qclass: dns.ClassINET, Qtype: dns.TypeA}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving something.example. IN A, got: %v", err)
+	}
+	if code != rcodeFallthrough {
+		t.Fatalf("TestMultiSection expected a fall through resolving something.example. IN A, got: %v, %v", code, dns.RcodeToString[code])
+	}
+
+	req = &dns.Msg{Question: []dns.Question{{Name: "something.example.", Qclass: dns.ClassINET, Qtype: dns.TypeMX}}}
+	code, err = handler.ServeDNS(ctx, rec, req)
+	if err != nil {
+		t.Fatalf("TestMultiSection expected no error resolving something.example. IN MX, got: %v", err)
+	}
+	if code == rcodeFallthrough {
+		t.Fatalf("TestMultiSection expected no fall through resolving something.example. IN MX")
+	}
+	if code != dns.RcodeNameError {
+		t.Fatalf("TestMultiSection expected NXDOMAIN resolving something.example. IN MX, got %v, %v", code, dns.RcodeToString[code])
+	}
+
 }

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -316,17 +316,17 @@ func TestMultiSection(t *testing.T) {
 			fallthrough
 		}
 		# Answer CH TXT *.coredns.invalid. / coredns.invalid.
-		template CH TXT coredns.invalid. {
+		template CH TXT coredns.invalid {
 			answer "{{ .Name }} 60 CH TXT \"test\""
 		}
 		# Anwser example. ip templates and fallthrough otherwise
-		template IN A example. {
+		template IN A example {
 			match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 			answer "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"
 			fallthrough
 		}
 		# Answer MX record requests for ip templates in example. and never fall through
-		template IN MX example. {
+		template IN MX example {
 			match ^ip-10-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]$
 			answer "{{ .Name }} 60 IN MX 10 {{ .Name }}"
 			additional "{{ .Name }} 60 IN A 10.{{ .Group.b }}.{{ .Group.c }}.{{ .Group.d }}"


### PR DESCRIPTION
### 1. What does this pull request do?

The plugin/template is currently scoped by regex with a fallthrough default.

This patch changes the config to be zone scoped and makes fallthrough an option instead of a default.

### 2. Which issues (if any) are related?

This change was discussed in #1298

### 3. Which documentation changes (if any) need to be made?

README change is included, plugin/template wasn't shipped yet.