### PR TITLE
Overloaded

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -25,6 +25,14 @@ supports health checks has a section "Health" in their README.
 
 Any plugin that implements the Healther interface will be used to report health.
 
+## Metrics
+
+If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
+
+* `coredns_health_request_duration_seconds{}` - duration to process a /health query. As this should
+  be a local operation it should be fast. A (large) increases in this duration indicates the
+  CoreDNS process is having trouble keeping up.
+
 ## Examples
 
 Run another health endpoint on http://localhost:8091.

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -13,10 +13,10 @@ func TestHealth(t *testing.T) {
 	h := health{Addr: ":0"}
 	h.h = append(h.h, &erratic.Erratic{})
 
-	if err := h.Startup(); err != nil {
+	if err := h.OnStartup(); err != nil {
 		t.Fatalf("Unable to startup the health server: %v", err)
 	}
-	defer h.Shutdown()
+	defer h.OnShutdown()
 
 	// Reconstruct the http address based on the port allocated by operating system.
 	address := fmt.Sprintf("http://%s%s", h.ln.Addr().String(), path)

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -1,0 +1,52 @@
+package health
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// overloaded queries the health end point and updates a metrics showing how long it took.
+func (h *health) overloaded() {
+	timeout := time.Duration(5 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+	url := "http://" + h.Addr
+	tick := time.NewTicker(1 * time.Second)
+
+	for {
+		select {
+		case <-tick.C:
+			start := time.Now()
+			resp, err := client.Get(url)
+			if err != nil {
+				HealthDuration.Observe(timeout.Seconds())
+				continue
+			}
+			resp.Body.Close()
+			HealthDuration.Observe(time.Since(start).Seconds())
+
+		case <-h.stop:
+			tick.Stop()
+			return
+		}
+	}
+	return
+}
+
+var (
+	HealthDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "health",
+		Name:      "request_duration_seconds",
+		Buckets:   plugin.TimeBuckets,
+		Help:      "Histogram of the time (in seconds) each request took.",
+	})
+)
+
+var onceMetric sync.Once

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -36,10 +36,10 @@ func (h *health) overloaded() {
 			return
 		}
 	}
-	return
 }
 
 var (
+	// HealthDuration is the metric used for exporting how fast we can retrieve the /health endpoint.
 	HealthDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "health",


### PR DESCRIPTION
 plugin/health: add 'I'm I overloaded metric"
   
    Query our on health endpoint and record (and export as a metric) the
    time it takes. The Get has a 5s timeout, that, when reached, will set
    the metric duration to 5s. The actually call "I'm I overloaded" is left
    to an external entity.

Fixes #1342