### PR TITLE
Fix version of go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ godeps:
 	go get github.com/prometheus/client_golang/prometheus
 	go get golang.org/x/net/context
 	go get golang.org/x/text
+	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.10)
+	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.3)
+	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
+	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
+	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
 
 .PHONY: travis
 travis: check


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix fixes version fetched from `go get` so that versions are guarded.

```
github.com/mholt/caddy              v0.10.10
github.com/miekg/dns                v1.0.3
github.com/prometheus/client_golang v0.8.0
golang.org/x/net                    release-branch.go1.9 (branch)
golang.org/x/text                   e19ae1496984b1c655b8044a65c0300a3c878dd3
```

### 2. Which issues (if any) are related?

This fix is related #1368.

### 3. Which documentation changes (if any) need to be made?

N/A

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
