### PR TITLE
Add version check for github.com/miekg/dns

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -2,10 +2,12 @@ package dnsserver
 
 import (
 	"crypto/tls"
+	"log"
 
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
 )
 
 // Config configuration for a single server.
@@ -62,4 +64,10 @@ func GetConfig(c *caddy.Controller) *Config {
 	// the configs.
 	ctx.saveConfig(c.Key, &Config{})
 	return GetConfig(c)
+}
+
+func init() {
+	if dns.Version.Major != 1 {
+		log.Fatalf("[PANIC]: coredns is built with an incompatible version (v%s) of github.com/miekg/dns", dns.Version)
+	}
 }


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

This fix adds version check for github.com/miekg/dns in runtime so that only `v1.x.x` is supported.


### 2. Which issues (if any) are related?

This is related to #1368.

### 3. Which documentation changes (if any) need to be made?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>