### PR TITLE
plugin/health: add lameduck mode

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -30,7 +30,7 @@ health [ADDRESS] {
 ~~~
 
 * Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
-  shuts down. If you want to explicitaly disable use `lameduck 0`.
+  shuts down.
 
 ## Plugins
 

--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -21,6 +21,17 @@ a 503. *health* periodically (1s) polls plugin that exports health information. 
 plugin signals that it is unhealthy, the server will go unhealthy too. Each plugin that
 supports health checks has a section "Health" in their README.
 
+More options can be set with this extended syntax:
+
+~~~
+health [ADDRESS] {
+    lameduck DURATION
+}
+~~~
+
+* Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
+  shuts down. If you want to explicitaly disable use `lameduck 0`.
+
 ## Plugins
 
 Any plugin that implements the Healther interface will be used to report health.
@@ -40,5 +51,15 @@ Run another health endpoint on http://localhost:8091.
 ~~~ corefile
 . {
     health localhost:8091
+}
+~~~
+
+Set a lameduck duration of 1 second:
+
+~~~ corefile
+. {
+    health localhost:8091 {
+        lameduck 1s
+    }
 }
 ~~~

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -28,6 +28,11 @@ type health struct {
 	pollstop chan bool
 }
 
+// New returns a new initialized health.
+func New(addr string) *health {
+	return &health{Addr: addr, stop: make(chan bool), pollstop: make(chan bool)}
+}
+
 func (h *health) OnStartup() error {
 	if h.Addr == "" {
 		h.Addr = defAddr

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -7,12 +7,14 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 )
 
 var once sync.Once
 
 type health struct {
-	Addr string
+	Addr     string
+	lameduck time.Duration
 
 	ln  net.Listener
 	mux *http.ServeMux
@@ -22,7 +24,8 @@ type health struct {
 	sync.RWMutex
 	ok bool // ok is the global boolean indicating an all healthy plugin stack
 
-	stop chan bool
+	stop     chan bool
+	pollstop chan bool
 }
 
 func (h *health) OnStartup() error {
@@ -61,12 +64,21 @@ func (h *health) OnStartup() error {
 }
 
 func (h *health) OnShutdown() error {
+	// Stop polling plugins
+	h.pollstop <- true
+	// NACK health
+	h.SetOk(false)
+
+	if h.lameduck > 0 {
+		log.Printf("[INFO] Going into lameduck mode for %s", h.lameduck)
+		time.Sleep(h.lameduck)
+	}
+
 	if h.ln != nil {
 		return h.ln.Close()
 	}
 
 	h.stop <- true
-
 	return nil
 }
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -12,6 +12,7 @@ import (
 
 var once sync.Once
 
+// Health implements healthchecks by polling plugins.
 type health struct {
 	Addr     string
 	lameduck time.Duration
@@ -28,8 +29,8 @@ type health struct {
 	pollstop chan bool
 }
 
-// New returns a new initialized health.
-func New(addr string) *health {
+// newHealth returns a new initialized health.
+func newHealth(addr string) *health {
 	return &health{Addr: addr, stop: make(chan bool), pollstop: make(chan bool)}
 }
 

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	h := New(":0")
+	h := newHealth(":0")
 	h.h = append(h.h, &erratic.Erratic{})
 
 	if err := h.OnStartup(); err != nil {
@@ -58,7 +58,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestHealthLameduck(t *testing.T) {
-	h := New(":0")
+	h := newHealth(":0")
 	h.lameduck = 250 * time.Millisecond
 	h.h = append(h.h, &erratic.Erratic{})
 

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	h := health{Addr: ":0", stop: make(chan bool), pollstop: make(chan bool)}
+	h := New(":0")
 	h.h = append(h.h, &erratic.Erratic{})
 
 	if err := h.OnStartup(); err != nil {

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -10,13 +10,18 @@ import (
 )
 
 func TestHealth(t *testing.T) {
-	h := health{Addr: ":0"}
+	h := health{Addr: ":0", stop: make(chan bool), pollstop: make(chan bool)}
 	h.h = append(h.h, &erratic.Erratic{})
 
 	if err := h.OnStartup(); err != nil {
 		t.Fatalf("Unable to startup the health server: %v", err)
 	}
 	defer h.OnShutdown()
+
+	go func() {
+		<-h.pollstop
+		return
+	}()
 
 	// Reconstruct the http address based on the port allocated by operating system.
 	address := fmt.Sprintf("http://%s%s", h.ln.Addr().String(), path)

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -25,7 +25,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("health", err)
 	}
 
-	h := New(addr)
+	h := newHealth(addr)
 	h.lameduck = lame
 
 	c.OnStartup(func() error {

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -19,12 +20,12 @@ func init() {
 }
 
 func setup(c *caddy.Controller) error {
-	addr, err := healthParse(c)
+	addr, lame, err := healthParse(c)
 	if err != nil {
 		return plugin.Error("health", err)
 	}
 
-	h := &health{Addr: addr, stop: make(chan bool)}
+	h := &health{Addr: addr, stop: make(chan bool), pollstop: make(chan bool), lameduck: lame}
 
 	c.OnStartup(func() error {
 		plugins := dnsserver.GetConfig(c).Handlers()
@@ -41,8 +42,12 @@ func setup(c *caddy.Controller) error {
 		h.poll()
 		go func() {
 			for {
-				<-time.After(1 * time.Second)
-				h.poll()
+				select {
+				case <-time.After(1 * time.Second):
+					h.poll()
+				case <-h.pollstop:
+					return
+				}
 			}
 		}()
 		return nil
@@ -68,8 +73,9 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func healthParse(c *caddy.Controller) (string, error) {
+func healthParse(c *caddy.Controller) (string, time.Duration, error) {
 	addr := ""
+	dur := time.Duration(0)
 	for c.Next() {
 		args := c.RemainingArgs()
 
@@ -78,11 +84,28 @@ func healthParse(c *caddy.Controller) (string, error) {
 		case 1:
 			addr = args[0]
 			if _, _, e := net.SplitHostPort(addr); e != nil {
-				return "", e
+				return "", 0, e
 			}
 		default:
-			return "", c.ArgErr()
+			return "", 0, c.ArgErr()
+		}
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "lameduck":
+				args := c.RemainingArgs()
+				if len(args) != 1 {
+					return "", 0, c.ArgErr()
+				}
+				l, err := time.ParseDuration(args[0])
+				if err != nil {
+					return "", 0, fmt.Errorf("unable to parse lameduck duration value: '%v' : %v", args[0], err)
+				}
+				dur = l
+			default:
+				return "", 0, c.ArgErr()
+			}
 		}
 	}
-	return addr, nil
+	return addr, dur, nil
 }

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -25,7 +25,8 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("health", err)
 	}
 
-	h := &health{Addr: addr, stop: make(chan bool), pollstop: make(chan bool), lameduck: lame}
+	h := New(addr)
+	h.lameduck = lame
 
 	c.OnStartup(func() error {
 		plugins := dnsserver.GetConfig(c).Handlers()

--- a/plugin/health/setup_test.go
+++ b/plugin/health/setup_test.go
@@ -13,17 +13,27 @@ func TestSetupHealth(t *testing.T) {
 	}{
 		{`health`, false},
 		{`health localhost:1234`, false},
+		{`health localhost:1234 {
+			lameduck 4s
+}`, false},
 		{`health bla:a`, false},
+
 		{`health bla`, true},
 		{`health bla bla`, true},
+		{`health localhost:1234 {
+			lameduck a
+}`, true},
+		{`health localhost:1234 {
+			lamedudk 4
+} `, true},
 	}
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		_, err := healthParse(c)
+		_, _, err := healthParse(c)
 
 		if test.shouldErr && err == nil {
-			t.Errorf("Test %d: Expected error but found %s for input %s", i, err, test.input)
+			t.Errorf("Test %d: Expected error but found none for input %s", i, test.input)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Add a way to configure lameduck more, i.e. set health to false, stop
polling plugins. Then wait for a duration before shutting down. As the
health middleware is configured early on in the plugin list, it will
hold up all other shutdowns, meaning we still answer queries.