### PR TITLE
Remove TTL ceiling at 5s in plugin/cache

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -47,8 +47,6 @@ cache [TTL] [ZONES...] {
   which defaults to `10%`. Values should be in the range `[10%, 90%]`. Note the percent sign is
   mandatory. **PERCENTAGE** is treated as an `int`.
 
-The minimum TTL allowed on resource records is 5 seconds.
-
 ## Metrics
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -168,8 +168,6 @@ const (
 	maxTTL  = 1 * time.Hour
 	maxNTTL = 30 * time.Minute
 
-	minTTL = 5 // seconds
-
 	defaultCap = 10000 // default capacity of the cache.
 
 	// Success is the class for caching positive caching.

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -68,10 +68,6 @@ func (i *item) toMsg(m *dns.Msg) *dns.Msg {
 	m1.Extra = make([]dns.RR, len(i.Extra))
 
 	ttl := uint32(i.ttl(time.Now()))
-	if ttl < minTTL {
-		ttl = minTTL
-	}
-
 	for j, r := range i.Answer {
 		m1.Answer[j] = dns.Copy(r)
 		m1.Answer[j].Header().Ttl = ttl


### PR DESCRIPTION
### 1. What does this pull request do?

The cache plugin always returned a minimum TTL of 5 seconds, regardless
of the actual TTL of the records. A cache is not authoritative for the
record TTL and should not extend it.