### PR TITLE
plugin/dnssec: check validityperiod of RRSIGs

### DIFF
--- a/plugin/dnssec/cache_test.go
+++ b/plugin/dnssec/cache_test.go
@@ -77,6 +77,6 @@ func TestCacheNotValidYet(t *testing.T) {
 
 	_, ok := d.get(k)
 	if ok {
-		t.Errorf("signature was added to the cache even though not valid")
+		t.Errorf("signature was added to the cache even though not valid yet")
 	}
 }

--- a/plugin/dnssec/cache_test.go
+++ b/plugin/dnssec/cache_test.go
@@ -32,3 +32,51 @@ func TestCacheSet(t *testing.T) {
 		t.Errorf("signature was not added to the cache")
 	}
 }
+
+func TestCacheNotValidExpired(t *testing.T) {
+	fPriv, rmPriv, _ := test.TempFile(".", privKey)
+	fPub, rmPub, _ := test.TempFile(".", pubKey)
+	defer rmPriv()
+	defer rmPub()
+
+	dnskey, err := ParseKeyFile(fPub, fPriv)
+	if err != nil {
+		t.Fatalf("failed to parse key: %v\n", err)
+	}
+
+	c := cache.New(defaultCap)
+	m := testMsg()
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	k := hash(m.Answer) // calculate *before* we add the sig
+	d := New([]string{"miek.nl."}, []*DNSKEY{dnskey}, nil, c)
+	d.Sign(state, time.Now().UTC().AddDate(0, 0, -9))
+
+	_, ok := d.get(k)
+	if ok {
+		t.Errorf("signature was added to the cache even though not valid")
+	}
+}
+
+func TestCacheNotValidYet(t *testing.T) {
+	fPriv, rmPriv, _ := test.TempFile(".", privKey)
+	fPub, rmPub, _ := test.TempFile(".", pubKey)
+	defer rmPriv()
+	defer rmPub()
+
+	dnskey, err := ParseKeyFile(fPub, fPriv)
+	if err != nil {
+		t.Fatalf("failed to parse key: %v\n", err)
+	}
+
+	c := cache.New(defaultCap)
+	m := testMsg()
+	state := request.Request{Req: m, Zone: "miek.nl."}
+	k := hash(m.Answer) // calculate *before* we add the sig
+	d := New([]string{"miek.nl."}, []*DNSKEY{dnskey}, nil, c)
+	d.Sign(state, time.Now().UTC().AddDate(0, 0, +9))
+
+	_, ok := d.get(k)
+	if ok {
+		t.Errorf("signature was added to the cache even though not valid")
+	}
+}

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -155,6 +155,6 @@ func incepExpir(now time.Time) (uint32, uint32) {
 
 const (
 	eightDays  = 8 * 24 * time.Hour
-	sixDays    = 8 * 24 * time.Hour
+	sixDays    = 6 * 24 * time.Hour
 	defaultCap = 10000 // default capacity of the cache.
 )

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -131,6 +131,14 @@ func (d Dnssec) set(key uint32, sigs []dns.RR) {
 
 func (d Dnssec) get(key uint32) ([]dns.RR, bool) {
 	if s, ok := d.cache.Get(key); ok {
+		now := time.Now().UTC()
+		for _, rr := range s.([]dns.RR) {
+			if !rr.(*dns.RRSIG).ValidityPeriod(now) {
+				cacheMisses.Inc()
+				return nil, false
+			}
+		}
+
 		cacheHits.Inc()
 		return s.([]dns.RR), true
 	}

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -131,9 +131,10 @@ func (d Dnssec) set(key uint32, sigs []dns.RR) {
 
 func (d Dnssec) get(key uint32) ([]dns.RR, bool) {
 	if s, ok := d.cache.Get(key); ok {
-		now := time.Now().UTC()
+		// we sign for 8 days, check if a signature in the cache reached 3/4 of that
+		is75 := time.Now().UTC().Add(sixDays)
 		for _, rr := range s.([]dns.RR) {
-			if !rr.(*dns.RRSIG).ValidityPeriod(now) {
+			if !rr.(*dns.RRSIG).ValidityPeriod(is75) {
 				cacheMisses.Inc()
 				return nil, false
 			}
@@ -154,5 +155,6 @@ func incepExpir(now time.Time) (uint32, uint32) {
 
 const (
 	eightDays  = 8 * 24 * time.Hour
+	sixDays    = 8 * 24 * time.Hour
 	defaultCap = 10000 // default capacity of the cache.
 )


### PR DESCRIPTION
Somehow we missed implementing this. If a sig a retrieved from the
cache, but not valid anymore, regenerate it instead of server invalid
signatures.

Fixes #1378