### PR TITLE
Allow graceful restart when using TLS listener

### DIFF
--- a/core/dnsserver/server-tls.go
+++ b/core/dnsserver/server-tls.go
@@ -12,6 +12,7 @@ import (
 // ServerTLS represents an instance of a TLS-over-DNS-server.
 type ServerTLS struct {
 	*Server
+	tlsConfig *tls.Config
 }
 
 // NewServerTLS returns a new CoreDNS TLS server and compiles all plugin in to it.
@@ -20,13 +21,24 @@ func NewServerTLS(addr string, group []*Config) (*ServerTLS, error) {
 	if err != nil {
 		return nil, err
 	}
+	// The *tls* plugin must make sure that multiple conflicting
+	// TLS configuration return an error: it can only be specified once.
+	var tlsConfig *tls.Config
+	for _, conf := range s.zones {
+		// Should we error if some configs *don't* have TLS?
+		tlsConfig = conf.TLSConfig
+	}
 
-	return &ServerTLS{Server: s}, nil
+	return &ServerTLS{Server: s, tlsConfig: tlsConfig}, nil
 }
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerTLS) Serve(l net.Listener) error {
 	s.m.Lock()
+
+	if s.tlsConfig != nil {
+		l = tls.NewListener(l, s.tlsConfig)
+	}
 
 	// Only fill out the TCP server for this one.
 	s.server[tcp] = &dns.Server{Listener: l, Net: "tcp-tls", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
@@ -43,25 +55,7 @@ func (s *ServerTLS) ServePacket(p net.PacketConn) error { return nil }
 
 // Listen implements caddy.TCPServer interface.
 func (s *ServerTLS) Listen() (net.Listener, error) {
-	// The *tls* plugin must make sure that multiple conflicting
-	// TLS configuration return an error: it can only be specified once.
-	tlsConfig := new(tls.Config)
-	for _, conf := range s.zones {
-		// Should we error if some configs *don't* have TLS?
-		tlsConfig = conf.TLSConfig
-	}
-
-	var (
-		l   net.Listener
-		err error
-	)
-
-	if tlsConfig == nil {
-		l, err = net.Listen("tcp", s.Addr[len(TransportTLS+"://"):])
-	} else {
-		l, err = tls.Listen("tcp", s.Addr[len(TransportTLS+"://"):], tlsConfig)
-	}
-
+	l, err := net.Listen("tcp", s.Addr[len(TransportTLS+"://"):])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The original ServergRPC.Listen() method returns a tls.Listener
when tls protocol is specified. Unfortunate, tls.Listener
does not implement the caddy.Listener interface that is
needed for graceful restart to work.

The change is to have the ServergRPC.Listen() method returns the
inner net.Listener instead. The creation of the tls.Listener
is deferred to the ServergRPC.Serve() method.

Fixes issue: #1244 
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
(please see commit msg)
This PR supersedes #1254 .
#1254 depends on caddy PR https://github.com/mholt/caddy/pull/1963
This PR does not require any caddy changes.

### 2. Which issues (if any) are related?
Fixes issue: #1244 

### 3. Which documentation changes (if any) need to be made?