### PR TITLE
Add fallback plugin (DNS endpoints only)

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -301,7 +301,7 @@ func (s *Server) Tracer() ot.Tracer {
 }
 
 // DefaultErrorFunc responds to an DNS request with an error.
-func DefaultErrorFunc(w dns.ResponseWriter, r *dns.Msg, rc int) {
+var DefaultErrorFunc = func(w dns.ResponseWriter, r *dns.Msg, rc int) {
 	state := request.Request{W: w, Req: r}
 
 	answer := new(dns.Msg)

--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -39,6 +39,7 @@ var Directives = []string{
 	"secondary",
 	"etcd",
 	"proxy",
+	"fallback",
 	"erratic",
 	"whoami",
 	"startup",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/erratic"
 	_ "github.com/coredns/coredns/plugin/errors"
 	_ "github.com/coredns/coredns/plugin/etcd"
+	_ "github.com/coredns/coredns/plugin/fallback"
 	_ "github.com/coredns/coredns/plugin/federation"
 	_ "github.com/coredns/coredns/plugin/file"
 	_ "github.com/coredns/coredns/plugin/health"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -48,6 +48,7 @@ auto:auto
 secondary:secondary
 etcd:etcd
 proxy:proxy
+fallback:fallback
 erratic:erratic
 whoami:whoami
 startup:github.com/mholt/caddy/startupshutdown

--- a/plugin/fallback/README.md
+++ b/plugin/fallback/README.md
@@ -1,0 +1,32 @@
+# fallback
+
+## Name
+
+*fallback* - send failed DNS queries to fallback endpoints.
+
+## Description
+
+This plugin sends failed DNS quieres (e.g., NXDOMAIN, SERVFAIL, etc)
+to fallback endpoints.
+
+## Syntax
+
+~~~ txt
+fallback [ZONE] {
+  on [FAILURE] [ENDPOINTS...]
+}
+~~~
+
+* **ZONE** the name of the domain to be accessed.
+* **FAILURE** the failure code of the DNS queries (NXDOMAIN, SERVFAIL, etc.).
+* **ENDPOINTS** the fallback endpoints to send to.
+
+## Examples
+
+~~~ corefile
+. {
+    fallback example.org {
+      on NXDOMAIN 10.10.10.10:53
+    }
+}
+~~~

--- a/plugin/fallback/fallback.go
+++ b/plugin/fallback/fallback.go
@@ -1,0 +1,42 @@
+package fallback
+
+import (
+	"log"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+	"golang.org/x/net/context"
+)
+
+type processor struct {
+	rcode    int
+	endpoint string
+}
+
+func (p *processor) ErrorFunc(w dns.ResponseWriter, r *dns.Msg, rc int) error {
+	if rc == p.rcode {
+		state := request.Request{W: w, Req: r}
+		qname := state.Name()
+		log.Printf("[INFO] Send fallback %q to %q", qname, p.endpoint)
+		_, err := dns.Exchange(r, p.endpoint)
+		return err
+	}
+	return nil
+}
+
+// Fallback is a plugin that provide fallback in case of error
+type Fallback struct {
+	Next  plugin.Handler
+	zones []string
+	funcs []processor
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (f Fallback) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
+}
+
+// Name implements the Handler interface.
+func (f Fallback) Name() string { return "fallback" }

--- a/plugin/fallback/setup.go
+++ b/plugin/fallback/setup.go
@@ -1,0 +1,86 @@
+package fallback
+
+import (
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/request"
+
+	"github.com/mholt/caddy"
+	"github.com/miekg/dns"
+)
+
+func init() {
+	caddy.RegisterPlugin("fallback", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	f := Fallback{}
+
+	for c.Next() {
+		f.zones = c.RemainingArgs()
+		if len(f.zones) == 0 {
+			f.zones = make([]string, len(c.ServerBlockKeys))
+			copy(f.zones, c.ServerBlockKeys)
+		}
+		plugin.Zones(f.zones).Normalize()
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "on":
+				args := c.RemainingArgs()
+				if len(args) < 2 {
+					return c.Errf("unknown property '%v'", args)
+				}
+				rcode := 0
+				switch args[0] {
+				case "SERVFAIL":
+					rcode = dns.RcodeServerFailure
+				case "NXDOMAIN":
+					rcode = dns.RcodeNameError
+				case "REFUSED":
+					rcode = dns.RcodeRefused
+				default:
+					return c.Errf("unknown property '%v'", args)
+				}
+				for _, arg := range args[1:] {
+					f.funcs = append(f.funcs, processor{
+						rcode:    rcode,
+						endpoint: arg,
+					})
+				}
+
+			default:
+				return c.Errf("unknown property '%s'", c.Val())
+			}
+		}
+	}
+
+	c.OnStartup(func() error {
+		defaultErrorFunc := dnsserver.DefaultErrorFunc
+		dnsserver.DefaultErrorFunc = func(w dns.ResponseWriter, r *dns.Msg, rc int) {
+			state := request.Request{W: w, Req: r}
+			qname := state.Name()
+
+			zone := plugin.Zones(f.zones).Matches(qname)
+			if zone != "" {
+				for i := range f.funcs {
+					if err := f.funcs[i].ErrorFunc(w, r, rc); err == nil {
+						break
+					}
+				}
+			}
+			defaultErrorFunc(w, r, rc)
+		}
+		return nil
+	})
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		f.Next = next
+		return f
+	})
+
+	return nil
+}

--- a/plugin/fallback/setup_test.go
+++ b/plugin/fallback/setup_test.go
@@ -1,0 +1,21 @@
+package fallback
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestSetupFallback(t *testing.T) {
+	c := caddy.NewTestController("dns", `fallback`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `fallback example.org {
+    on NXDOMAIN 10.10.10.10:100 8.8.8.8:53
+}`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+}

--- a/test/fallback_test.go
+++ b/test/fallback_test.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+func TestFallbackLookup(t *testing.T) {
+	corefile := `fallback.org:0 {
+                       fallback fallback.org {
+                         on SERVFAIL 127.0.0.1:999
+                      }	
+                    }`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	var b bytes.Buffer
+	log.SetOutput(&b)
+
+	p := proxy.NewLookup([]string{udp})
+	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
+
+	resp, err := p.Lookup(state, "nop.fallback.org.", dns.TypeA)
+	if err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	// expect no answer section
+	if len(resp.Answer) != 0 {
+		t.Fatalf("Expected no RR in the answer section, got %d", len(resp.Answer))
+	}
+	if !strings.Contains(b.String(), `[INFO] Send fallback "nop.fallback.org." to "127.0.0.1:999"`) {
+		t.Fatal("Expected to receive log but didn't")
+	}
+}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

This fix adds a preliminary fallback plugin so that failed DNS queries could be sent to other endpoints.

This fix only accept DNS endpoints at the moment.


### 2. Which issues (if any) are related?

This fix is part of the #1382.

### 3. Which documentation changes (if any) need to be made?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>