### PR TITLE
Up version to 1.0.4

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 const (
 	coreName    = "CoreDNS"
-	coreVersion = "1.0.3"
+	coreVersion = "1.0.4"
 
 	serverType = "dns"
 )


### PR DESCRIPTION
Due to the one-off nature of releases 1.0.4 we need to manually bump
the version in master.

