### PR TITLE
Bypass predefined Rcode in proxy

### DIFF
--- a/plugin/proxy/upstream_test.go
+++ b/plugin/proxy/upstream_test.go
@@ -212,6 +212,20 @@ proxy . 8.8.8.8:53 {
 }`,
 			true,
 		},
+		{
+			`
+proxy . 8.8.8.8:53 {
+    fallthrough SERVFAIL REFUSED
+}`,
+			false,
+		},
+		{
+			`
+proxy . 8.8.8.8:53 {
+    fallthrough SERVFAIL UNKNOWN REFUSED
+}`,
+			true,
+		},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputUpstreams)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix adds `fallthrough` keyword in proxy plugin
so that predefined Rcodes are bypassed if matches the
query response. The next plugin will pick up and process.


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
