### PR TITLE
Emit InstanceStartupEvent after starting server

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -98,6 +98,9 @@ func Run() {
 		showVersion()
 	}
 
+	// Execute instantiation events
+	caddy.EmitEvent(caddy.InstanceStartupEvent, instance)
+
 	// Twiddle your thumbs
 	instance.Wait()
 }


### PR DESCRIPTION
### 1. What does this pull request do?
Add emitting InstanceStartupEvent after starting server instance. The similar piece of code exists in caddy project, see
https://github.com/mholt/caddy/blob/master/caddy/caddymain/run.go#L144
This allows coredns to run extra scripts after start or communicate about its readiness to parent process with "startup" plugin (github.com/mholt/caddy/startupshutdown) or it's modern replacement - "on" plugin (github.com/mholt/caddy/onevent).

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none
