### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+core/*
+coremain/*
+hooks/*
+man/*
+pb/*
+plugin/*
+request/*
+test/*
+vendor/*


### PR DESCRIPTION
Ignore most of the source code - this should lead to smaller docker
images.
