### PR TITLE
fix computation of reverse zone based on Ipv6 CIDRs

### DIFF
--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -34,9 +34,9 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		expected  string
 		shouldErr bool
 	}{
-		{"2003::1/64", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
+		{"2003::1/64", "dns://0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
 		{"2003::1/64.", "dns://2003::1/64.:53", false}, // OK, with closing dot the parse will fail.
-		{"2003::1/64:53", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
+		{"2003::1/64:53", "dns://0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
 		{"2003::1/64.:53", "dns://2003::1/64.:53", false},
 
 		{"10.0.0.0/24", "dns://0.0.10.in-addr.arpa.:53", false},
@@ -45,9 +45,10 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		{"10.0.0.0/24.:53", "dns://10.0.0.0/24.:53", false},
 
 		// non %8==0 netmasks
-		{"2003::53/67", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
+		{"2003::53/67", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.:53", false},
 		{"10.0.0.0/25.", "dns://10.0.0.0/25.:53", false}, // has dot
 		{"10.0.0.0/25", "dns://0.0.10.in-addr.arpa.:53", false},
+		{"fd00:77:30::0/110", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.:53", false},
 	} {
 		addr, err := normalizeZone(test.input)
 		actual := addr.String()

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -50,6 +50,8 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 	switch ip {
 	case "10.0.0.100":
 	case "1234:abcd::1":
+	case "fd00:77:30::a":
+	case "fd00:77:30::2:9ba6":
 	default:
 		return nil
 	}
@@ -65,6 +67,14 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 						{
 							IP:       "1234:abcd::1",
 							Hostname: "ep1b",
+						},
+						{
+							IP:       "fd00:77:30::a",
+							Hostname: "ip6svc1ex",
+						},
+						{
+							IP:       "fd00:77:30::2:9ba6",
+							Hostname: "ip6svc1in",
 						},
 					},
 					Ports: []api.EndpointPort{
@@ -103,7 +113,7 @@ func (APIConnReverseTest) GetNamespaceByName(name string) (*api.Namespace, error
 
 func TestReverse(t *testing.T) {
 
-	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa."})
+	k := New([]string{"cluster.local.", "0.10.in-addr.arpa.", "168.192.in-addr.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa."})
 	k.APIConn = &APIConnReverseTest{}
 
 	tests := []test.Case{
@@ -126,6 +136,20 @@ func TestReverse(t *testing.T) {
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
 				test.PTR("1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.d.c.b.a.4.3.2.1.ip6.arpa. 5 IN PTR ep1b.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa. 5 IN PTR ip6svc1ex.svc1.testns.svc.cluster.local."),
+			},
+		},
+		{ // A PTR record query for an existing ipv6 endpoint should return a record
+			Qname: "6.a.b.9.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.", Qtype: dns.TypePTR,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.PTR("6.a.b.9.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa. 5 IN PTR ip6svc1in.svc1.testns.svc.cluster.local."),
 			},
 		},
 		{

--- a/plugin/kubernetes/setup_reverse_test.go
+++ b/plugin/kubernetes/setup_reverse_test.go
@@ -13,6 +13,7 @@ func TestKubernetesParseReverseZone(t *testing.T) {
 	}{
 		{`kubernetes coredns.local 10.0.0.0/16`, []string{"coredns.local.", "0.10.in-addr.arpa."}},
 		{`kubernetes coredns.local 10.0.0.0/17`, []string{"coredns.local.", "0.10.in-addr.arpa."}},
+		{`kubernetes coredns.local fd00:77:30::0/110`, []string{"coredns.local.", "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa."}},
 	}
 
 	for i, tc := range tests {

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -115,11 +115,16 @@ func SplitHostPort(s string) (host, port string, ipnet *net.IPNet, err error) {
 	if err == nil {
 		if rev, e := dns.ReverseAddr(ip.String()); e == nil {
 			ones, bits = n.Mask.Size()
+			// get the size, in bits, of each portion of hostname defined in the reverse address. (8 for IPv4, 4 for IPv6)
+			sizeDigit := 8
+			if len(n.IP) == net.IPv6len {
+				sizeDigit = 4
+			}
 			// Get the first lower octet boundary to see what encompassing zone we should be authoritative for.
-			mod := (bits - ones) % 8
+			mod := (bits - ones) % sizeDigit
 			nearest := (bits - ones) + mod
 			offset, end := 0, false
-			for i := 0; i < nearest/8; i++ {
+			for i := 0; i < nearest/sizeDigit; i++ {
 				offset, end = dns.NextLabel(rev, offset)
 				if end {
 					break


### PR DESCRIPTION
### 1. What does this pull request do?

Fix computation of ipv6 reverse zone : for Ipv6 the value of one digit in the zone is 4 bit as for ipv4 it is 8 bits.

### 2. Which issues (if any) are related?
I did not opened an issue

### 3. Which documentation changes (if any) need to be made?
no need to change.
I updated the UT, but did not run all of them .. we will see with Travis :)
