### PR TITLE
Fix truncation of messages longer than permitted by the client

### DIFF
--- a/plugin/etcd/other_test.go
+++ b/plugin/etcd/other_test.go
@@ -131,16 +131,12 @@ var dnsTestCasesOther = []test.Case{
 	// Large txt greater than 512 (UDP)
 	{
 		Qname: "large600.skydns.test.", Qtype: dns.TypeTXT,
-		Answer: []dns.RR{
-			test.TXT(fmt.Sprintf("large600.skydns.test. 300 IN TXT \"%s\"", strings.Repeat("0", 600))),
-		},
+		Answer: []dns.RR{},
 	},
 	// Large txt greater than 1500 (typical Ethernet)
 	{
 		Qname: "large2000.skydns.test.", Qtype: dns.TypeTXT,
-		Answer: []dns.RR{
-			test.TXT(fmt.Sprintf("large2000.skydns.test. 300 IN TXT \"%s\"", strings.Repeat("0", 2000))),
-		},
+		Answer: []dns.RR{},
 	},
 	// Duplicate IP address test
 	{

--- a/request/request.go
+++ b/request/request.go
@@ -180,11 +180,11 @@ const (
 	ScrubDone
 )
 
-// Scrub scrubs the reply message so that it will fit the client's buffer. If even after dropping
-// the additional section, it still does not fit the TC bit will be set on the message. Note,
-// the TC bit will be set regardless of protocol, even TCP message will get the bit, the client
-// should then retry with pigeons.
-// TODO(referral).
+// Scrub scrubs the reply message so that it will fit the client's buffer. If
+// even after dropping the additional section it does not fit, the answer will
+// be cleared and the TC bit will be set on the message. Note, the TC bit will
+// be set regardless of protocol, even TCP message will get the bit, the client
+// should then retry with pigeons. TODO(referral).
 func (r *Request) Scrub(reply *dns.Msg) (*dns.Msg, Result) {
 	size := r.Size()
 	l := reply.Len()
@@ -200,8 +200,9 @@ func (r *Request) Scrub(reply *dns.Msg) (*dns.Msg, Result) {
 	if size >= l {
 		return reply, ScrubDone
 	}
-	// Still?!! does not fit.
+
 	reply.Truncated = true
+	reply.Answer = nil
 	return reply, ScrubDone
 }
 


### PR DESCRIPTION
### 1. What does this pull request do?

CoreDNS currently doesn't respect the maximum response size advertised
by the client and returns the full answer on a message with the TC bit
set. This breaks client implementations which rely on DNS servers
respecting the advertised size limit, for example the Ruby stdlib
client. It also has negative network performance implications, as large
messages will be split up into multiple UDP packets, even though the
client will discard the truncated response anyway.

While RFC 2181 permits the response of partial RRSets, finding the
correct number of records fitting into the advertised response size is
non-trivial. As clients should ignore truncated messages, this change
simply removes the full RRSet on truncated messages.

### 2. Which issues (if any) are related?

#1416, but all plugins using `request.Scrub()` are affected by the incorrect truncation handling.

### 3. Which documentation changes (if any) need to be made?

n/a