### PR TITLE
Add coredns_build_info metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: coredns
 
 .PHONY: coredns
 coredns: $(CHECKS)
-	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.gitCommit=$(GITCOMMIT)" -o $(BINARY)
+	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
 check: linter core/zplugin.go core/dnsserver/zdirectives.go godeps

--- a/Makefile.release
+++ b/Makefile.release
@@ -53,7 +53,7 @@ endif
 
 DOCKER:=
 NAME:=coredns
-VERSION:=$(shell grep 'coreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
+VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
 GITCOMMIT:=$(shell git describe --dirty --always)

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -49,7 +49,7 @@ func init() {
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
 
 	caddy.AppName = coreName
-	caddy.AppVersion = coreVersion
+	caddy.AppVersion = CoreVersion
 }
 
 // Run is CoreDNS's main() function.
@@ -180,7 +180,7 @@ func versionString() string {
 // e.g.,
 // linux/amd64, go1.8.3, a6d2d7b5
 func releaseString() string {
-	return fmt.Sprintf("%s/%s, %s, %s\n", runtime.GOOS, runtime.GOARCH, runtime.Version(), gitCommit)
+	return fmt.Sprintf("%s/%s, %s, %s\n", runtime.GOOS, runtime.GOARCH, runtime.Version(), GitCommit)
 }
 
 // setVersion figures out the version information
@@ -193,7 +193,7 @@ func setVersion() {
 	if gitNearestTag != "" || gitTag != "" {
 		if devBuild && gitNearestTag != "" {
 			appVersion = fmt.Sprintf("%s (+%s %s)",
-				strings.TrimPrefix(gitNearestTag, "v"), gitCommit, buildDate)
+				strings.TrimPrefix(gitNearestTag, "v"), GitCommit, buildDate)
 		} else if gitTag != "" {
 			appVersion = strings.TrimPrefix(gitTag, "v")
 		}
@@ -252,7 +252,7 @@ var (
 	buildDate        string // date -u
 	gitTag           string // git describe --exact-match HEAD 2> /dev/null
 	gitNearestTag    string // git describe --abbrev=0 --tags HEAD
-	gitCommit        string // git rev-parse HEAD
+	GitCommit        string // git rev-parse HEAD
 	gitShortStat     string // git diff-index --shortstat
 	gitFilesModified string // git diff-index --name-only HEAD
 )

--- a/coremain/version.go
+++ b/coremain/version.go
@@ -1,8 +1,9 @@
 package coremain
 
 const (
-	coreName    = "CoreDNS"
-	coreVersion = "1.0.4"
+	coreName = "CoreDNS"
+	// CoreVersion is the current version of CoreDNS.
+	CoreVersion = "1.0.4"
 
 	serverType = "dns"
 )

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -10,6 +10,7 @@ With *prometheus* you export metrics from CoreDNS and any plugin that has them.
 The default location for the metrics is `localhost:9153`. The metrics path is fixed to `/metrics`.
 The following metrics are exported:
 
+* `coredns_build_info{version, revision, goversion}` - info about CoreDNS itself.
 * `coredns_dns_request_count_total{zone, proto, family}` - total query count.
 * `coredns_dns_request_duration_seconds{zone}` - duration to process each query.
 * `coredns_dns_request_size_bytes{zone, proto}` - size of the request in bytes.


### PR DESCRIPTION
### 1. What does this pull request do?

In order to track the rollout status of CoreDNS versions, add the common
build_info metric.

```
$ curl -s localhost:1853/metrics | grep build_info
# HELP coredns_build_info A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.
# TYPE coredns_build_info gauge
coredns_build_info{goversion="go1.9.2",revision="f9c03c2e-dirty",version="1.0.4"} 1
```

### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?

n/a