### PR TITLE
plugin/forward: add out of tree forward plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,17 +29,20 @@ godeps:
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/golang.org/x/net 2>/dev/null                    && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/golang.org/x/text 2>/dev/null                   && git checkout -q master 2>/dev/null || true)
+	(cd $(GOPATH)/src/github.com/coredns/forward 2>/dev/null          && git checkout -q master 2>/dev/null || true)
 	go get -u github.com/mholt/caddy
 	go get -u github.com/miekg/dns
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
 	go get -u golang.org/x/net/context
 	go get -u golang.org/x/text
+	go get -u github.com/coredns/forward
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.10)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.3)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
+	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q master)
 
 .PHONY: travis
 travis: check

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ godeps:
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
-	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q master)
+	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q v0.0.2)
 
 .PHONY: travis
 travis: check

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -47,6 +47,7 @@ file:file
 auto:auto
 secondary:secondary
 etcd:etcd
+forward:github.com/coredns/forward
 proxy:proxy
 erratic:erratic
 whoami:whoami


### PR DESCRIPTION
This is a simpler proxy than *proxy*, include by default so it is easier
to switch (i.e. no recompile). It lacks features compared to proxy (did I
say it was simpler), but does cache udp and tcp connection, so it is
faster than proxy.