### PR TITLE
Golint: make golint happy

### DIFF
--- a/coremain/version.go
+++ b/coremain/version.go
@@ -1,7 +1,8 @@
 package coremain
 
+// Various CoreDNS constants.
 const (
-	coreName    = "CoreDNS"
 	CoreVersion = "1.0.5"
+	coreName    = "CoreDNS"
 	serverType  = "dns"
 )


### PR DESCRIPTION
CoreVersion needs to be documented for golint, but we can't use too much
text because we grep this file for the coredns version.
