### PR TITLE
Tolerate go get failures for coredns/forward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ testk8s: check
 
 .PHONY: godeps
 godeps:
-	-git checkout master
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
@@ -37,14 +36,13 @@ godeps:
 	go get -u github.com/prometheus/client_golang/prometheus
 	go get -u golang.org/x/net/context
 	go get -u golang.org/x/text
-	go get -u github.com/coredns/forward
+	-go get -f -u github.com/coredns/forward
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.10)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.4)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
 	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q v0.0.2)
-	-git checkout -
 
 .PHONY: travis
 travis: check

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ testk8s: check
 
 .PHONY: godeps
 godeps:
-	(git checkout master)
+	-git checkout master
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
@@ -44,7 +44,7 @@ godeps:
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
 	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q v0.0.2)
-	(git checkout -)
+	-git checkout -
 
 .PHONY: travis
 travis: check

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ testk8s: check
 
 .PHONY: godeps
 godeps:
+	(git checkout master)
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
@@ -43,6 +44,7 @@ godeps:
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
 	(cd $(GOPATH)/src/github.com/coredns/forward          && git checkout -q v0.0.2)
+	(git checkout -)
 
 .PHONY: travis
 travis: check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-TEST
 [![CoreDNS](https://coredns.io/images/CoreDNS_Colour_Horizontal.png)](https://coredns.io)
 
 [![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/coredns/coredns)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+TEST
 [![CoreDNS](https://coredns.io/images/CoreDNS_Colour_Horizontal.png)](https://coredns.io)
 
 [![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/coredns/coredns)


### PR DESCRIPTION
### 1. What does this pull request do?

Make will tolerate failures when go-getting coredns/forward. Specifically, the failure to get coredns/coredns, when coredns/coredns is the current project.

This fix is a hack. But its IMO a workable one until we identify a better fix.

### 2. Which issues (if any) are related?
Fixes #1442

### 3. Which documentation changes (if any) need to be made?
n/a
