### PR TITLE
pl/kubernetes: drop the comma parsing

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -30,7 +30,7 @@ all the zones the plugin should be authoritative for.
 ```
 kubernetes [ZONES...] {
     resyncperiod DURATION
-    endpoint URL
+    endpoint URL [URL...]
     tls CERT KEY CACERT
     namespaces NAMESPACE...
     labels EXPRESSION
@@ -45,8 +45,8 @@ kubernetes [ZONES...] {
 * `resyncperiod` specifies the Kubernetes data API **DURATION** period.
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
-   Multiple k8s API endpoints could be specified, separated by `,`s, e.g.
-   `endpoint http://k8s-endpoint1:8080,http://k8s-endpoint2:8080`. CoreDNS
+   Multiple k8s API endpoints could be specified:
+   `endpoint http://k8s-endpoint1:8080 http://k8s-endpoint2:8080`. CoreDNS
    will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -135,9 +135,7 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, dnsControlOpts, error) {
 			case "endpoint":
 				args := c.RemainingArgs()
 				if len(args) > 0 {
-					for _, endpoint := range strings.Split(args[0], ",") {
-						k8s.APIServerList = append(k8s.APIServerList, strings.TrimSpace(endpoint))
-					}
+					k8s.APIServerList = args
 					continue
 				}
 				return nil, opts, c.ArgErr()

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -64,7 +64,7 @@ func TestKubernetesParse(t *testing.T) {
 		},
 		{
 			`kubernetes coredns.local {
-	endpoint http://localhost:9090
+	endpoint http://localhost:9090 http://localhost:9091
 }`,
 			false,
 			"",


### PR DESCRIPTION
Let caddyfile parser give us the token, the comma sep thing also didn't
work.

Fixes #1446

