### PR TITLE
Plugin/RELOAD - Tune usage of var global, add limit to options

### DIFF
--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -35,6 +35,7 @@ reload [INTERVAL] [JITTER]
 * The plugin will check for changes every **INTERVAL**, subject to +/- the **JITTER** duration
 * **INTERVAL** and **JITTER** are Golang (durations)[https://golang.org/pkg/time/#ParseDuration]
 * Default **INTERVAL** is 30s, default **JITTER** is 15s
+* Minimal value for **INTERVAL** is 2s, and for **JITTER** is 1s
 * If **JITTER** is more than half of **INTERVAL**, it will be set to half of **INTERVAL**
 
 ## Examples

--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -36,6 +36,7 @@ func hook(event caddy.EventName, info interface{}) error {
 	// this should be an instance. ok to panic if not
 	instance := info.(*caddy.Instance)
 	md5sum := md5.Sum(instance.Caddyfile().Body())
+	log.Printf("[INFO] Running configuration MD5 = %x\n", md5sum)
 
 	go func() {
 		tick := time.NewTicker(r.interval)

--- a/plugin/reload/reload.go
+++ b/plugin/reload/reload.go
@@ -11,9 +11,7 @@ import (
 // reload periodically checks if the Corefile has changed, and reloads if so
 
 type reload struct {
-	instance *caddy.Instance
 	interval time.Duration
-	sum      [md5.Size]byte
 	stopped  bool
 	quit     chan bool
 }
@@ -31,8 +29,8 @@ func hook(event caddy.EventName, info interface{}) error {
 	}
 
 	// this should be an instance. ok to panic if not
-	r.instance = info.(*caddy.Instance)
-	r.sum = md5.Sum(r.instance.Caddyfile().Body())
+	instance := info.(*caddy.Instance)
+	md5sum := md5.Sum(instance.Caddyfile().Body())
 
 	go func() {
 		tick := time.NewTicker(r.interval)
@@ -40,19 +38,23 @@ func hook(event caddy.EventName, info interface{}) error {
 		for {
 			select {
 			case <-tick.C:
-				corefile, err := caddy.LoadCaddyfile(r.instance.Caddyfile().ServerType())
+				corefile, err := caddy.LoadCaddyfile(instance.Caddyfile().ServerType())
 				if err != nil {
 					continue
 				}
 				s := md5.Sum(corefile.Body())
-				if s != r.sum {
-					_, err := r.instance.Restart(corefile)
+				if s != md5sum {
+					// Let not try to restart with the same file, even though it is wrong.
+					md5sum = s
+					// now lets consider that plugin will not be reload, unless appear in next config file
+					// r.stopped will be reset in setup if the plugin appears in config file
+					r.stopped = true
+					_, err := instance.Restart(corefile)
 					if err != nil {
 						log.Printf("[ERROR] Corefile changed but reload failed: %s\n", err)
 						continue
 					}
 					// we are done, this hook gets called again with new instance
-					r.stopped = true
 					return
 				}
 			case <-r.quit:

--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -1,6 +1,7 @@
 package reload
 
 import (
+	"errors"
 	"math/rand"
 	"sync"
 	"time"
@@ -17,7 +18,11 @@ func init() {
 	})
 }
 
-var r *reload
+// the info reload is global to all application, whatever number of reloads.
+// it is used to transmit data between Setup and start of the hook called 'onInstanceStartup'
+// channel for QUIT is never changed in purpose.
+// WARNING: this data may be unsync after an invalid attempt of reload Corefile.
+var r = reload{interval: defaultInterval, stopped: true, quit: make(chan bool)}
 var once sync.Once
 
 func setup(c *caddy.Controller) error {
@@ -32,18 +37,24 @@ func setup(c *caddy.Controller) error {
 	if len(args) > 0 {
 		d, err := time.ParseDuration(args[0])
 		if err != nil {
-			return err
+			return plugin.Error("reload", err)
 		}
 		i = d
+	}
+	if i < minInterval {
+		return plugin.Error("reload", errors.New("interval value must be greater or equal to 2 sec"))
 	}
 
 	j := defaultJitter
 	if len(args) > 1 {
 		d, err := time.ParseDuration(args[1])
 		if err != nil {
-			return err
+			return plugin.Error("reload", err)
 		}
 		j = d
+	}
+	if j < minJitter {
+		return plugin.Error("reload", errors.New("jitter value must be greater or equal to 1 sec"))
 	}
 
 	if j > i/2 {
@@ -53,20 +64,25 @@ func setup(c *caddy.Controller) error {
 	jitter := time.Duration(rand.Int63n(j.Nanoseconds()) - (j.Nanoseconds() / 2))
 	i = i + jitter
 
-	r = &reload{interval: i, quit: make(chan bool)}
+	// prepare info for next onInstanceStartup event
+	r.interval = i
+	r.stopped = false
+
 	once.Do(func() {
 		caddy.RegisterEventHook("reload", hook)
 	})
 
+	// re-register on finalShutDown as the instance most-likely will be changed.
 	c.OnFinalShutdown(func() error {
 		r.quit <- true
 		return nil
 	})
-
 	return nil
 }
 
 const (
+	minJitter       = 1 * time.Second
+	minInterval     = 2 * time.Second
 	defaultInterval = 30 * time.Second
 	defaultJitter   = 15 * time.Second
 )

--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -72,7 +72,7 @@ func setup(c *caddy.Controller) error {
 		caddy.RegisterEventHook("reload", hook)
 	})
 
-	// re-register on finalShutDown as the instance most-likely will be changed.
+	// re-register on finalShutDown as the instance most-likely will be changed
 	c.OnFinalShutdown(func() error {
 		r.quit <- true
 		return nil

--- a/plugin/reload/setup_test.go
+++ b/plugin/reload/setup_test.go
@@ -36,4 +36,16 @@ func TestSetupReload(t *testing.T) {
 	if err := setup(c); err == nil {
 		t.Fatalf("Expected errors, but got: %v", err)
 	}
+	c = caddy.NewTestController("dns", `reload 1s`)
+	if err := setup(c); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+	c = caddy.NewTestController("dns", `reload 0s`)
+	if err := setup(c); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+	c = caddy.NewTestController("dns", `reload 3s 0.5s`)
+	if err := setup(c); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Tune the plugin RELOAD
- found that the RELOAD was going inactive after load of invalid corefile. That may depend where is the error on the corefile (I mean if the setup for RELOAD was fully completed or not)
- add limits to the parameter to avoid issues with 0.

### 2. Which issues (if any) are related?
fix partially #1455 

### 3. Which documentation changes (if any) need to be made?
modified the README for minimal values. 

**IMPORTANT**: There is still an issue at shutdown: with no RELOAD, the server stop nicely, with several reload (and thus restart), the server does not stop nicely. I guess it needs to revisit the go function that runs in background and that should stop. Maybe link to #1456 