### PR TITLE
plugin/Proxy - WIP implement Healther interface

### DIFF
--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -39,33 +39,42 @@ func (h *health) OnStartup() error {
 		h.Addr = defAddr
 	}
 
-	once.Do(func() {
-		ln, err := net.Listen("tcp", h.Addr)
-		if err != nil {
-			log.Printf("[ERROR] Failed to start health handler: %s", err)
+	ln, err := net.Listen("tcp", h.Addr)
+	if err != nil {
+		log.Printf("[ERROR] Failed to start health handler: %s", err)
+		return err
+	}
+
+	h.ln = ln
+
+	h.mux = http.NewServeMux()
+
+	h.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if h.Ok() {
+			w.WriteHeader(http.StatusOK)
+			io.WriteString(w, ok)
 			return
 		}
-
-		h.ln = ln
-
-		h.mux = http.NewServeMux()
-
-		h.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-			if h.Ok() {
-				w.WriteHeader(http.StatusOK)
-				io.WriteString(w, ok)
-				return
-			}
-			w.WriteHeader(http.StatusServiceUnavailable)
-		})
-
-		go func() {
-			http.Serve(h.ln, h.mux)
-		}()
-		go func() {
-			h.overloaded()
-		}()
+		w.WriteHeader(http.StatusServiceUnavailable)
 	})
+
+	go func() {
+		http.Serve(h.ln, h.mux)
+	}()
+	go func() {
+		h.overloaded()
+	}()
+	return nil
+}
+
+func (h *health) OnShutdownBeforeRestart() error {
+	// Stop polling plugins
+	h.pollstop <- true
+	if h.ln != nil {
+		return h.ln.Close()
+	}
+
+	h.stop <- true
 	return nil
 }
 

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -68,10 +68,10 @@ func setup(c *caddy.Controller) error {
 	})
 
 	// NOTE: if the restart endup failing, then the Healthcheck will be unavailable until next config is reloaded
-	c.OnRestart(h.OnShutdownBeforeRestart)
+	c.OnRestart(h.OnShutdown)
+	// Shutdown happen after the Restart, but is used sometimes directly.
 	// final shutdown is a bit different as we process the lameduck delay
 	c.OnFinalShutdown(h.OnShutdown)
-
 	// start listener for each stat of the server, including the restarts for reload
 	c.OnStartup(h.OnStartup)
 

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -67,8 +67,13 @@ func setup(c *caddy.Controller) error {
 		return nil
 	})
 
-	c.OnStartup(h.OnStartup)
+	// NOTE: if the restart endup failing, then the Healthcheck will be unavailable until next config is reloaded
+	c.OnRestart(h.OnShutdownBeforeRestart)
+	// final shutdown is a bit different as we process the lameduck delay
 	c.OnFinalShutdown(h.OnShutdown)
+
+	// start listener for each stat of the server, including the restarts for reload
+	c.OnStartup(h.OnStartup)
 
 	// Don't do AddPlugin, as health is not *really* a plugin just a separate webserver running.
 	return nil

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -29,6 +29,7 @@ proxy FROM TO... {
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
+    report_health
     except IGNORED_NAMES...
     spray
     protocol [dns [force_tcp]|https_google [bootstrap ADDRESS...]|grpc [insecure|CACERT|KEY CERT|KEY CERT CACERT]]
@@ -49,6 +50,9 @@ proxy FROM TO... {
   200-399, then that backend is marked healthy for double the healthcheck duration.  If it doesn't,
   it is marked as unhealthy and no requests are routed to it.  If this option is not provided then
   health checks are disabled.  The default duration is 4 seconds ("4s").
+* `report_health` enable the inclusion of this proxy bloc as part of the global healh of CoreDNS 
+  reported by plugin HEALTH. The proxy bloc report OK if the connection is not in fail state and if at 
+  least one of the destination endpoint report itself as not down.    
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from proxying.
   Requests that match none of these names will be passed through.
 * `spray` when all backends are unhealthy, randomly pick one to send the traffic to. (This is

--- a/plugin/proxy/exchanger.go
+++ b/plugin/proxy/exchanger.go
@@ -11,6 +11,7 @@ import (
 // can use whatever transport it likes.
 type Exchanger interface {
 	Exchange(ctx context.Context, addr string, state request.Request) (*dns.Msg, error)
+	IsValid() bool
 	Protocol() string
 
 	// Transport returns the only transport protocol used by this Exchanger or "".

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -98,7 +98,7 @@ func (g *google) exchangeJSON(addr, json string) ([]byte, error) {
 
 func (g *google) Transport() string { return "tcp" }
 func (g *google) Protocol() string  { return "https_google" }
-
+func (g *google) IsValid() bool     { return true }
 func (g *google) OnShutdown(p *Proxy) error {
 	g.quit <- true
 	return nil

--- a/plugin/proxy/grpc.go
+++ b/plugin/proxy/grpc.go
@@ -58,6 +58,8 @@ func (g *grpcClient) Transport() string { return "tcp" }
 
 func (g *grpcClient) Protocol() string { return "grpc" }
 
+func (g *grpcClient) IsValid() bool { return len(g.conns) > 0 }
+
 func (g *grpcClient) OnShutdown(p *Proxy) error {
 	g.clients = map[string]pb.DnsServiceClient{}
 	for i, conn := range g.conns {

--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -43,8 +43,9 @@ func NewStaticUpstream(c *caddyfile.Dispenser) (Upstream, error) {
 	upstream := &staticUpstream{
 		from: ".",
 		HealthCheck: healthcheck.HealthCheck{
-			FailTimeout: 5 * time.Second,
-			MaxFails:    3,
+			FailTimeout:  5 * time.Second,
+			MaxFails:     3,
+			ReportHealth: false,
 		},
 		ex: newDNSEx(),
 	}
@@ -136,6 +137,8 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			}
 			u.HealthCheck.Interval = dur
 		}
+	case "report_health":
+		u.HealthCheck.ReportHealth = true
 	case "except":
 		ignoredDomains := c.RemainingArgs()
 		if len(ignoredDomains) == 0 {
@@ -206,5 +209,12 @@ func (u *staticUpstream) IsAllowedDomain(name string) bool {
 
 func (u *staticUpstream) Exchanger() Exchanger { return u.ex }
 func (u *staticUpstream) From() string         { return u.from }
+
+func (u *staticUpstream) ReportHealthy() bool {
+	return u.ReportHealth
+}
+func (u *staticUpstream) IsHealthy() bool {
+	return u.ex.IsValid() && !u.IsAllDown()
+}
 
 const max = 15

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -74,6 +74,9 @@ func TestReadme(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to start server with %s, for input %q:\n%s", readme, err, in.Body())
 			}
+			// Execute instantiation events
+			caddy.EmitEvent(caddy.InstanceStartupEvent, server)
+			server.ShutdownCallbacks()
 			server.Stop()
 			port++
 		}

--- a/test/server.go
+++ b/test/server.go
@@ -23,11 +23,20 @@ func CoreDNSServer(corefile string) (*caddy.Instance, error) {
 	dnsserver.Quiet = true
 	log.SetOutput(ioutil.Discard)
 
-	return caddy.Start(NewInput(corefile))
+	instance, err := caddy.Start(NewInput(corefile))
+	if err != nil {
+		return nil, err
+	}
+	// Execute instantiation events
+	caddy.EmitEvent(caddy.InstanceStartupEvent, instance)
+	return instance, nil
 }
 
 // CoreDNSServerStop stops a server.
-func CoreDNSServerStop(i *caddy.Instance) { i.Stop() }
+func CoreDNSServerStop(i *caddy.Instance) {
+	i.ShutdownCallbacks()
+	i.Stop()
+}
 
 // CoreDNSServerPorts returns the ports the instance is listening on. The integer k indicates
 // which ServerListener you want.


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
implement Healther interface for Proxy plugin.

a Proxy bloc will report its status to plugin HEALTH if:
- the option 'report_health' is set in the stanza (in order to not disrupt installations that does not report the health)
- the Exchanger report a connection valid (last use of dial was not failing)
- at least one of the Host is heathy (not down).
NOTE: the health of each host will follow usual rules (max-fails, timeout, check remote health .. )

### 2. Which issues (if any) are related?
fix #1456

### 3. Which documentation changes (if any) need to be made?
proxy.README is updated

NOTE: I needed to workaround a weird timeout usecase in proxy.go. in order to not disrupt installations I workaround only if the option 'report_health' is set.

NOTE: I modified the workflow for up and down the Health http listener for reporting. That is to be consistent with RELOAD: we need to take care of new configuration.
the drawback is that the server will be interrupted if an invalid corefile is presented, until a valid one is processed and the instance restarted.

