### PR TITLE
Plugin/Proxy - add new policy always_first to mimic windows dns resolvers

### DIFF
--- a/man/coredns-proxy.7
+++ b/man/coredns-proxy.7
@@ -38,7 +38,7 @@ However, advanced features including load balancing can be utilized with an expa
 .nf
 
 proxy FROM TO\.\.\. {
-    policy random|least_conn|round_robin|always_first
+    policy random|least_conn|round_robin|first
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
@@ -58,7 +58,7 @@ proxy FROM TO\.\.\. {
 \fBTO\fR is the destination endpoint to proxy to\. At least one is required, but multiple may be specified\. \fBTO\fR may be an IP:Port pair, or may reference a file in resolv\.conf format
 .
 .IP "\(bu" 4
-\fBpolicy\fR is the load balancing policy to use; applies only with multiple backends\. May be one of random, least_conn, round_robin or always_first\. Default is random\.
+\fBpolicy\fR is the load balancing policy to use; applies only with multiple backends\. May be one of random, least_conn, round_robin or first\. Default is random\.
 .
 .IP "\(bu" 4
 \fBfail_timeout\fR specifies how long to consider a backend as down after it has failed\. While it is down, requests will not be routed to that backend\. A backend is "down" if CoreDNS fails to communicate with it\. The default value is 2 seconds ("2s")\.

--- a/man/coredns-proxy.7
+++ b/man/coredns-proxy.7
@@ -38,7 +38,7 @@ However, advanced features including load balancing can be utilized with an expa
 .nf
 
 proxy FROM TO\.\.\. {
-    policy random|least_conn|round_robin
+    policy random|least_conn|round_robin|always_first
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
@@ -58,7 +58,7 @@ proxy FROM TO\.\.\. {
 \fBTO\fR is the destination endpoint to proxy to\. At least one is required, but multiple may be specified\. \fBTO\fR may be an IP:Port pair, or may reference a file in resolv\.conf format
 .
 .IP "\(bu" 4
-\fBpolicy\fR is the load balancing policy to use; applies only with multiple backends\. May be one of random, least_conn, or round_robin\. Default is random\.
+\fBpolicy\fR is the load balancing policy to use; applies only with multiple backends\. May be one of random, least_conn, round_robin or always_first\. Default is random\.
 .
 .IP "\(bu" 4
 \fBfail_timeout\fR specifies how long to consider a backend as down after it has failed\. While it is down, requests will not be routed to that backend\. A backend is "down" if CoreDNS fails to communicate with it\. The default value is 2 seconds ("2s")\.

--- a/plugin/pkg/healthcheck/policy.go
+++ b/plugin/pkg/healthcheck/policy.go
@@ -27,6 +27,7 @@ func init() {
 	RegisterPolicy("random", func() Policy { return &Random{} })
 	RegisterPolicy("least_conn", func() Policy { return &LeastConn{} })
 	RegisterPolicy("round_robin", func() Policy { return &RoundRobin{} })
+	RegisterPolicy("always_first", func() Policy { return &AlwaysFirst{} })
 }
 
 // Random is a policy that selects up hosts from a pool at random.
@@ -117,4 +118,20 @@ func (r *RoundRobin) Select(pool HostPool) *UpstreamHost {
 		host = pool[(selection+i)%poolLen]
 	}
 	return host
+}
+
+// AlwaysFirst is a policy that selects always the first healthy host in the list order.
+type AlwaysFirst struct{}
+
+// Select always the first that is not Down.
+func (r *AlwaysFirst) Select(pool HostPool) *UpstreamHost {
+	for i := 0; i < len(pool); i++ {
+		host := pool[i]
+		if host.Down() {
+			continue
+		}
+		return host
+	}
+	// return the first one, anyway none is correct
+	return nil
 }

--- a/plugin/pkg/healthcheck/policy.go
+++ b/plugin/pkg/healthcheck/policy.go
@@ -27,7 +27,7 @@ func init() {
 	RegisterPolicy("random", func() Policy { return &Random{} })
 	RegisterPolicy("least_conn", func() Policy { return &LeastConn{} })
 	RegisterPolicy("round_robin", func() Policy { return &RoundRobin{} })
-	RegisterPolicy("always_first", func() Policy { return &AlwaysFirst{} })
+	RegisterPolicy("first", func() Policy { return &First{} })
 }
 
 // Random is a policy that selects up hosts from a pool at random.
@@ -120,11 +120,11 @@ func (r *RoundRobin) Select(pool HostPool) *UpstreamHost {
 	return host
 }
 
-// AlwaysFirst is a policy that selects always the first healthy host in the list order.
-type AlwaysFirst struct{}
+// First is a policy that selects always the first healthy host in the list order.
+type First struct{}
 
 // Select always the first that is not Down.
-func (r *AlwaysFirst) Select(pool HostPool) *UpstreamHost {
+func (r *First) Select(pool HostPool) *UpstreamHost {
 	for i := 0; i < len(pool); i++ {
 		host := pool[i]
 		if host.Down() {

--- a/plugin/pkg/healthcheck/policy_test.go
+++ b/plugin/pkg/healthcheck/policy_test.go
@@ -32,8 +32,8 @@ func (r *customPolicy) Select(pool HostPool) *UpstreamHost {
 
 func testPool() HostPool {
 	pool := []*UpstreamHost{
-		{Name: workableServer.URL},         // this should resolve (healthcheck test)
-		{Name: "http://shouldnot.resolve"}, // this shouldn't
+		{Name: workableServer.URL},            // this should resolve (healthcheck test)
+		{Name: "http://shouldnot.resolve:85"}, // this shouldn't, especially on port other than 80
 		{Name: "http://C"},
 	}
 	return HostPool(pool)
@@ -114,5 +114,26 @@ func TestCustomPolicy(t *testing.T) {
 	h := customPolicy.Select(pool)
 	if h != pool[0] {
 		t.Error("Expected custom policy host to be the first host.")
+	}
+}
+
+func TestAlwaysFirstPolicy(t *testing.T) {
+	pool := testPool()
+	rrPolicy := &AlwaysFirst{}
+	h := rrPolicy.Select(pool)
+	// First selected host is 1, because counter starts at 0
+	// and increments before host is selected
+	if h != pool[0] {
+		t.Error("Expected always first to be first host in the pool.")
+	}
+	h = rrPolicy.Select(pool)
+	if h != pool[0] {
+		t.Error("Expected always first to be first host in the pool, even in second call")
+	}
+	// set this first in pool as failed
+	pool[0].Fails = 1
+	h = rrPolicy.Select(pool)
+	if h != pool[1] {
+		t.Error("Expected first to be he second in pool if the first one is down.")
 	}
 }

--- a/plugin/pkg/healthcheck/policy_test.go
+++ b/plugin/pkg/healthcheck/policy_test.go
@@ -117,9 +117,9 @@ func TestCustomPolicy(t *testing.T) {
 	}
 }
 
-func TestAlwaysFirstPolicy(t *testing.T) {
+func TestFirstPolicy(t *testing.T) {
 	pool := testPool()
-	rrPolicy := &AlwaysFirst{}
+	rrPolicy := &First{}
 	h := rrPolicy.Select(pool)
 	// First selected host is 1, because counter starts at 0
 	// and increments before host is selected

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -25,7 +25,7 @@ However, advanced features including load balancing can be utilized with an expa
 
 ~~~
 proxy FROM TO... {
-    policy random|least_conn|round_robin|always_first
+    policy random|least_conn|round_robin|first
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
@@ -39,7 +39,7 @@ proxy FROM TO... {
 * **TO** is the destination endpoint to proxy to. At least one is required, but multiple may be
   specified. **TO** may be an IP:Port pair, or may reference a file in resolv.conf format
 * `policy` is the load balancing policy to use; applies only with multiple backends. May be one of
-  random, least_conn, round_robin or always_first. Default is random.
+  random, least_conn, round_robin or first. Default is random.
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
   communicate with it. The default value is 2 seconds ("2s").

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -25,7 +25,7 @@ However, advanced features including load balancing can be utilized with an expa
 
 ~~~
 proxy FROM TO... {
-    policy random|least_conn|round_robin
+    policy random|least_conn|round_robin|always_first
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
@@ -39,7 +39,7 @@ proxy FROM TO... {
 * **TO** is the destination endpoint to proxy to. At least one is required, but multiple may be
   specified. **TO** may be an IP:Port pair, or may reference a file in resolv.conf format
 * `policy` is the load balancing policy to use; applies only with multiple backends. May be one of
-  random, least_conn, or round_robin. Default is random.
+  random, least_conn, round_robin or always_first. Default is random.
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
   communicate with it. The default value is 2 seconds ("2s").


### PR DESCRIPTION
fill documentation, add UT and cleanup fmt

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Add a new policy 'always_first' for Proxy load balancing : the upstream Host to use is always the first available in order of the list.
Purpose is to mimic basic behavior on windows laptop.


### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
updated the README for proxy, along with the man documentation.

NOTE: I had to adapt a UT for policy/health that was flaky on my installation. Reason is that I have always a reply on http port 80.
