### PR TITLE
Don't use standard lib context package

### DIFF
--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -3,7 +3,6 @@
 package etcd
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 func init() {

--- a/plugin/proxy/dns.go
+++ b/plugin/proxy/dns.go
@@ -1,13 +1,13 @@
 package proxy
 
 import (
-	"context"
 	"net"
 	"time"
 
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 type dnsEx struct {

--- a/plugin/proxy/exchanger.go
+++ b/plugin/proxy/exchanger.go
@@ -1,10 +1,10 @@
 package proxy
 
 import (
-	"context"
-
 	"github.com/coredns/coredns/request"
+
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 // Exchanger is an interface that specifies a type implementing a DNS resolver that

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -16,6 +15,7 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 type google struct {

--- a/plugin/proxy/grpc.go
+++ b/plugin/proxy/grpc.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/tls"
 	"log"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
 	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/plugin/proxy/lookup.go
+++ b/plugin/proxy/lookup.go
@@ -3,7 +3,6 @@ package proxy
 // functions other plugin might want to use to do lookup in the same style as the proxy.
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"sync/atomic"
@@ -13,6 +12,7 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 // NewLookup create a new proxy with the hosts in host and a Random policy.

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"bytes"
-	"context"
 	"regexp"
 	"strconv"
 	gotmpl "text/template"
@@ -12,6 +11,7 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 // Handler is a plugin handler that takes a query and templates a response.

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 func TestHandler(t *testing.T) {


### PR DESCRIPTION
With Go 1.9 you *can* include the std lib's context package and nothing
breaks. However we never officially made the move (and grpc also doesn't
ues the std lib's one).

Standardize all plugins on using the external context package.

Fixes #1466