### PR TITLE
Remove hooks directory

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,7 +1,0 @@
-#!/bin/sh
-echo "=> Building the CoreDNS binary"
-docker run \
-  -v $(pwd):/go/src/github.com/coredns/coredns \
-  -w /go/src/github.com/coredns/coredns \
-  golang:1.9 \
-  make


### PR DESCRIPTION
This was used for docker automation or someting?
I don't think there are uses for this, lets remove it.