### PR TITLE
plugin/proxy: Fix unnecessary message truncation

### DIFF
--- a/plugin/proxy/dns.go
+++ b/plugin/proxy/dns.go
@@ -63,10 +63,12 @@ func (d *dnsEx) Exchange(ctx context.Context, addr string, state request.Request
 	if err != nil {
 		return nil, err
 	}
-	// Make sure it fits in the DNS response.
-	reply, _ = state.Scrub(reply)
 	reply.Compress = true
 	reply.Id = state.Req.Id
+	// When using force_tcp the upstream can send a message that is too big for
+	// the udp buffer, hence we need to truncate the message to at least make it
+	// fit the udp buffer.
+	reply, _ = state.Scrub(reply)
 
 	return reply, nil
 }


### PR DESCRIPTION
As plugin/proxy always returns compressed messages, it's important to
set this before calling Scrub(), as some messages will be unnecessarily
truncated otherwise.

---

I plan to implement a proper Truncate() method in miekg/dns itself and use that in the server implementation. Afterwards Scrub() and all its calls can be removed.