### PR TITLE
plugin/kubernetes: Add upstream @self and loop count

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -95,7 +95,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 func (s *Server) Serve(l net.Listener) error {
 	s.m.Lock()
 	s.server[tcp] = &dns.Server{Listener: l, Net: "tcp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.Background()
+		ctx := context.WithValue(context.Background(), Key{}, s)
 		s.ServeDNS(ctx, w, r)
 	})}
 	s.m.Unlock()
@@ -108,7 +108,7 @@ func (s *Server) Serve(l net.Listener) error {
 func (s *Server) ServePacket(p net.PacketConn) error {
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.WithValue(context.Background(), ServerKey, s)
+		ctx := context.WithValue(context.Background(), Key{}, s)
 		s.ServeDNS(ctx, w, r)
 	})}
 	s.m.Unlock()
@@ -207,7 +207,7 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		return
 	}
 
-	ctx, err := depthCheck(ctx)
+	ctx, err := incrementDepthAndCheck(ctx)
 	if err != nil {
 		DefaultErrorFunc(w, r, dns.RcodeServerFailure)
 		return
@@ -321,33 +321,35 @@ func DefaultErrorFunc(w dns.ResponseWriter, r *dns.Msg, rc int) {
 	w.WriteMsg(answer)
 }
 
-// depthCheck increments the loop counter in the context, and returns an error if
+// incrementDepthAndCheck increments the loop counter in the context, and returns an error if
 // the counter exceeds the max number of re-entries
-func depthCheck(ctx context.Context) (context.Context, error) {
+func incrementDepthAndCheck(ctx context.Context) (context.Context, error) {
 	// Loop counter for self directed lookups
-	loop := ctx.Value(loopKey)
+	loop := ctx.Value(loopKey{})
 	if loop == nil {
-		ctx = context.WithValue(ctx, loopKey, 0)
-	} else {
-		iloop := loop.(int) + 1
-		if iloop > maxreentries {
-			return ctx, fmt.Errorf("too deep")
-		}
-		ctx = context.WithValue(ctx, loopKey, iloop)
+		ctx = context.WithValue(ctx, loopKey{}, 0)
+		return ctx, nil
 	}
+
+	iloop := loop.(int) + 1
+	if iloop > maxreentries {
+		return ctx, fmt.Errorf("too deep")
+	}
+	ctx = context.WithValue(ctx, loopKey{}, iloop)
 	return ctx, nil
 }
-
-type key int
 
 const (
 	tcp          = 0
 	udp          = 1
 	maxreentries = 10
-	// ServerKey is the context key for the current server
-	ServerKey key = 0
-	loopKey   key = 1
 )
+
+// Key is the context key for the current server
+type Key struct{}
+
+// loopKey is the context key for counting self loops
+type loopKey struct{}
 
 // enableChaos is a map with plugin names for which we should open CH class queries as
 // we block these by default.

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -48,6 +48,21 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
+func TestDepthCheck(t *testing.T) {
+	ctx := context.Background()
+	var err error
+	for i := 0; i <= maxreentries; i++ {
+		ctx, err = depthCheck(ctx)
+		if err != nil {
+			t.Errorf("Expected no error for depthCheck (i=%v), got %s", i, err)
+		}
+	}
+	_, err = depthCheck(ctx)
+	if err == nil {
+		t.Errorf("Expected error for depthCheck (i=%v)", maxreentries+1)
+	}
+}
+
 func BenchmarkCoreServeDNS(b *testing.B) {
 	s, err := NewServer("127.0.0.1:53", []*Config{testConfig("dns", testPlugin{})})
 	if err != nil {

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -48,16 +48,16 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
-func TestDepthCheck(t *testing.T) {
+func TestIncrementDepthAndCheck(t *testing.T) {
 	ctx := context.Background()
 	var err error
 	for i := 0; i <= maxreentries; i++ {
-		ctx, err = depthCheck(ctx)
+		ctx, err = incrementDepthAndCheck(ctx)
 		if err != nil {
 			t.Errorf("Expected no error for depthCheck (i=%v), got %s", i, err)
 		}
 	}
-	_, err = depthCheck(ctx)
+	_, err = incrementDepthAndCheck(ctx)
 	if err == nil {
 		t.Errorf("Expected error for depthCheck (i=%v)", maxreentries+1)
 	}

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -6,6 +6,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 // ServiceBackend defines a (dynamic) backend that returns a slice of service definitions.
@@ -19,7 +20,7 @@ type ServiceBackend interface {
 	Reverse(state request.Request, exact bool, opt Options) ([]msg.Service, error)
 
 	// Lookup is used to find records else where.
-	Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error)
+	Lookup(state request.Request, name string, typ uint16, opt Options) (*dns.Msg, error)
 
 	// Returns _all_ services that matches a certain name.
 	// Note: it does not implement a specific service.
@@ -45,4 +46,6 @@ type Transferer interface {
 }
 
 // Options are extra options that can be specified for a lookup.
-type Options struct{}
+type Options struct {
+	Context context.Context
+}

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -3,9 +3,9 @@ package plugin
 import (
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/request"
-	"golang.org/x/net/context"
 
 	"github.com/miekg/dns"
+
 	"golang.org/x/net/context"
 )
 
@@ -20,7 +20,7 @@ type ServiceBackend interface {
 	Reverse(state request.Request, exact bool, opt Options) ([]msg.Service, error)
 
 	// Lookup is used to find records else where.
-	Lookup(state request.Request, name string, typ uint16, opt Options) (*dns.Msg, error)
+	Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error)
 
 	// Returns _all_ services that matches a certain name.
 	// Note: it does not implement a specific service.
@@ -47,5 +47,4 @@ type Transferer interface {
 
 // Options are extra options that can be specified for a lookup.
 type Options struct {
-	Context context.Context
 }

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -46,5 +46,4 @@ type Transferer interface {
 }
 
 // Options are extra options that can be specified for a lookup.
-type Options struct {
-}
+type Options struct{}

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -57,7 +57,7 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 				continue
 			}
 			// Lookup
-			m1, e1 := b.Lookup(state, target, state.QType())
+			m1, e1 := b.Lookup(state, target, state.QType(), opt)
 			if e1 != nil {
 				continue
 			}
@@ -121,7 +121,7 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 				// We should already have found it
 				continue
 			}
-			m1, e1 := b.Lookup(state, target, state.QType())
+			m1, e1 := b.Lookup(state, target, state.QType(), opt)
 			if e1 != nil {
 				continue
 			}
@@ -186,12 +186,12 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 			lookup[srv.Target] = true
 
 			if !dns.IsSubDomain(zone, srv.Target) {
-				m1, e1 := b.Lookup(state, srv.Target, dns.TypeA)
+				m1, e1 := b.Lookup(state, srv.Target, dns.TypeA, opt)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, srv.Target, dns.TypeAAAA)
+				m1, e1 = b.Lookup(state, srv.Target, dns.TypeAAAA, opt)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
@@ -246,12 +246,12 @@ func MX(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 			lookup[mx.Mx] = true
 
 			if !dns.IsSubDomain(zone, mx.Mx) {
-				m1, e1 := b.Lookup(state, mx.Mx, dns.TypeA)
+				m1, e1 := b.Lookup(state, mx.Mx, dns.TypeA, opt)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, mx.Mx, dns.TypeAAAA)
+				m1, e1 = b.Lookup(state, mx.Mx, dns.TypeAAAA, opt)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -57,7 +57,7 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 				continue
 			}
 			// Lookup
-			m1, e1 := b.Lookup(state, target, state.QType(), opt)
+			m1, e1 := b.Lookup(state, target, state.QType())
 			if e1 != nil {
 				continue
 			}
@@ -121,7 +121,7 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 				// We should already have found it
 				continue
 			}
-			m1, e1 := b.Lookup(state, target, state.QType(), opt)
+			m1, e1 := b.Lookup(state, target, state.QType())
 			if e1 != nil {
 				continue
 			}
@@ -186,12 +186,12 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 			lookup[srv.Target] = true
 
 			if !dns.IsSubDomain(zone, srv.Target) {
-				m1, e1 := b.Lookup(state, srv.Target, dns.TypeA, opt)
+				m1, e1 := b.Lookup(state, srv.Target, dns.TypeA)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, srv.Target, dns.TypeAAAA, opt)
+				m1, e1 = b.Lookup(state, srv.Target, dns.TypeAAAA)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
@@ -246,12 +246,12 @@ func MX(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 			lookup[mx.Mx] = true
 
 			if !dns.IsSubDomain(zone, mx.Mx) {
-				m1, e1 := b.Lookup(state, mx.Mx, dns.TypeA, opt)
+				m1, e1 := b.Lookup(state, mx.Mx, dns.TypeA)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, mx.Mx, dns.TypeAAAA, opt)
+				m1, e1 = b.Lookup(state, mx.Mx, dns.TypeAAAA)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -32,7 +32,7 @@ etcd [ZONES...] {
     fallthrough [ZONES...]
     path PATH
     endpoint ENDPOINT...
-    upstream ADDRESS...
+    upstream [ADDRESS...]
     tls CERT KEY CACERT
 }
 ~~~
@@ -47,8 +47,9 @@ etcd [ZONES...] {
 * **ENDPOINT** the etcd endpoints. Defaults to "http://localhost:2379".
 * `upstream` upstream resolvers to be used resolve external names found in etcd (think CNAMEs)
   pointing to external names. If you want CoreDNS to act as a proxy for clients, you'll need to add
-  the proxy plugin. **ADDRESS** can be an IP address, and IP:port or a string pointing to a file
-  that is structured as /etc/resolv.conf.
+  the proxy plugin. If no **ADDRESS** is given, CoreDNS will resolve CNAMEs against itself.
+  **ADDRESS** can be an IP address, and IP:port or a string pointing to a file that is structured
+  as /etc/resolv.conf.
 * `tls` followed by:
 
     * no arguments, if the server certificate is signed by a system-installed CA and no client cert is needed

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/request"
 
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
 	"golang.org/x/net/context"
@@ -24,7 +25,7 @@ type Etcd struct {
 	Fall       fall.F
 	Zones      []string
 	PathPrefix string
-	Proxy      proxy.Proxy // Proxy for looking up names during the resolution process
+	Upstream   upstream.Upstream // Proxy for looking up names during the resolution process
 	Client     etcdc.KeysAPI
 	Ctx        context.Context
 	Stubmap    *map[string]proxy.Proxy // list of proxies for stub resolving.
@@ -49,8 +50,8 @@ func (e *Etcd) Reverse(state request.Request, exact bool, opt plugin.Options) (s
 }
 
 // Lookup implements the ServiceBackend interface.
-func (e *Etcd) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
-	return e.Proxy.Lookup(state, name, typ)
+func (e *Etcd) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
+	return e.Upstream.Lookup(state, name, typ, opt)
 }
 
 // IsNameError implements the ServiceBackend interface.

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -50,8 +50,8 @@ func (e *Etcd) Reverse(state request.Request, exact bool, opt plugin.Options) (s
 }
 
 // Lookup implements the ServiceBackend interface.
-func (e *Etcd) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
-	return e.Upstream.Lookup(state, name, typ, opt)
+func (e *Etcd) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return e.Upstream.Lookup(state, name, typ)
 }
 
 // IsNameError implements the ServiceBackend interface.

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -11,8 +11,8 @@ import (
 
 // ServeDNS implements the plugin.Handler interface.
 func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	opt := plugin.Options{Context: ctx}
-	state := request.Request{W: w, Req: r}
+	opt := plugin.Options{}
+	state := request.Request{W: w, Req: r, Context: ctx}
 
 	name := state.Name()
 

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -11,7 +11,7 @@ import (
 
 // ServeDNS implements the plugin.Handler interface.
 func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	opt := plugin.Options{}
+	opt := plugin.Options{Context: ctx}
 	state := request.Request{W: w, Req: r}
 
 	name := state.Name()

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/tls"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/plugin/test"
 
@@ -227,8 +228,9 @@ func newEtcdPlugin() *Etcd {
 	tlsc, _ := tls.NewTLSConfigFromArgs()
 	client, _ := newEtcdClient(endpoints, tlsc)
 
+	p := proxy.NewLookup([]string{"8.8.8.8:53"})
 	return &Etcd{
-		Proxy:      proxy.NewLookup([]string{"8.8.8.8:53"}),
+		Upstream:   upstream.Upstream{Forward: &p},
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
 		Zones:      []string{"skydns.test.", "skydns_extra.test.", "in-addr.arpa."},

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	mwtls "github.com/coredns/coredns/plugin/pkg/tls"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/proxy"
 
 	etcdc "github.com/coreos/etcd/client"
@@ -92,11 +92,14 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 					if len(args) == 0 {
 						return &Etcd{}, false, c.ArgErr()
 					}
-					ups, err := dnsutil.ParseHostPortOrFile(args...)
-					if err != nil {
-						return &Etcd{}, false, err
+					if len(args) == 0 {
+						return nil, false, c.ArgErr()
 					}
-					etc.Proxy = proxy.NewLookup(ups)
+					u, err := upstream.NewUpstream(args)
+					if err != nil {
+						return nil, false, err
+					}
+					etc.Upstream = u
 				case "tls": // cert key cacertfile
 					args := c.RemainingArgs()
 					tlsConfig, err = mwtls.NewTLSConfigFromArgs(args...)

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -90,9 +90,6 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 				case "upstream":
 					args := c.RemainingArgs()
 					if len(args) == 0 {
-						return &Etcd{}, false, c.ArgErr()
-					}
-					if len(args) == 0 {
 						return nil, false, c.ArgErr()
 					}
 					u, err := upstream.NewUpstream(args)

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -13,8 +13,8 @@ CoreDNS running the kubernetes plugin can be used as a replacement of kube-dns i
 cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how
 to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
 
-[stubDomains](http://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html)
-are implemented via the *proxy* plugin.
+[stubDomains and upstreamNameservers](http://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html)
+are implemented via the *proxy* plugin and kubernetes *upstream*. See example below.
 
 ## Syntax
 
@@ -36,7 +36,7 @@ kubernetes [ZONES...] {
     labels EXPRESSION
     pods POD-MODE
     endpoint_pod_names
-    upstream ADDRESS...
+    upstream [ADDRESS...]
     ttl TTL
     fallthrough [ZONES...]
 }
@@ -80,8 +80,9 @@ kubernetes [ZONES...] {
    follows: Use the hostname of the endpoint, or if hostname is not set, use the
    pod name of the pod targeted by the endpoint. If there is no pod targeted by
    the endpoint, use the dashed IP address form.
-* `upstream` **ADDRESS [ADDRESS...]** defines the upstream resolvers used for resolving services
-  that point to external hosts (External Services).  **ADDRESS** can be an IP, an IP:port, or a path
+* `upstream` [**ADDRESS**...] defines the upstream resolvers used for resolving services
+  that point to external hosts (aka External Services aka CNAMEs).  If no **ADDRESS** is given, CoreDNS
+  will resolve External Services against itself. **ADDRESS** can be an IP, an IP:port, or a path
   to a file structured like resolv.conf.
 * `ttl` allows you to set a custom TTL for responses. The default (and allowed minimum) is to use
   5 seconds, the maximum is capped at 3600 seconds.
@@ -129,22 +130,31 @@ kubernetes cluster.local {
 }
 ~~~
 
-Here we use the *proxy* plugin to implement stubDomains that forwards `example.org` and
-`example.com` to another nameserver.
+
+## stubDomains and upstreamNameservers
+
+Here we use the *proxy* plugin to implement a stubDomain that forwards `example.local` to the nameserver `10.100.0.10:53`.
+The *upstream* option in kubernetes means that ExternalName services (CNAMEs) will be resolved using the respective proxy.
+Also configured is an upstreamNameserver `8.8.8.8:53` that will be used for resolving names that do not fall in `cluster.local`
+or `example.local`.
 
 ~~~ txt
-cluster.local {
-    kubernetes {
-        endpoint https://k8s-endpoint:8443
-        tls cert key cacert
+.:53 {
+    kubernetes cluster.local {
+        upstream
     }
-}
-example.org {
+    proxy example.local 10.100.0.10:53
     proxy . 8.8.8.8:53
 }
-example.com {
-    proxy . 8.8.8.8:53
-}
+~~~
+
+The configuration above represents the following Kube-DNS stubDomains and upstreamNameservers configuration.
+
+~~~ txt
+  stubDomains: |
+    {“example.local”: [“10.100.0.10:53”]}
+  upstreamNameservers: |
+    [“8.8.8.8:53”]
 ~~~
 
 ## AutoPath

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -11,6 +11,7 @@ import (
 
 // ServeDNS implements the plugin.Handler interface.
 func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	opt := plugin.Options{Context: ctx}
 	state := request.Request{W: w, Req: r}
 
 	m := new(dns.Msg)
@@ -32,24 +33,24 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	switch state.QType() {
 	case dns.TypeA:
-		records, err = plugin.A(&k, zone, state, nil, plugin.Options{})
+		records, err = plugin.A(&k, zone, state, nil, opt)
 	case dns.TypeAAAA:
-		records, err = plugin.AAAA(&k, zone, state, nil, plugin.Options{})
+		records, err = plugin.AAAA(&k, zone, state, nil, opt)
 	case dns.TypeTXT:
-		records, err = plugin.TXT(&k, zone, state, plugin.Options{})
+		records, err = plugin.TXT(&k, zone, state, opt)
 	case dns.TypeCNAME:
-		records, err = plugin.CNAME(&k, zone, state, plugin.Options{})
+		records, err = plugin.CNAME(&k, zone, state, opt)
 	case dns.TypePTR:
-		records, err = plugin.PTR(&k, zone, state, plugin.Options{})
+		records, err = plugin.PTR(&k, zone, state, opt)
 	case dns.TypeMX:
-		records, extra, err = plugin.MX(&k, zone, state, plugin.Options{})
+		records, extra, err = plugin.MX(&k, zone, state, opt)
 	case dns.TypeSRV:
-		records, extra, err = plugin.SRV(&k, zone, state, plugin.Options{})
+		records, extra, err = plugin.SRV(&k, zone, state, opt)
 	case dns.TypeSOA:
-		records, err = plugin.SOA(&k, zone, state, plugin.Options{})
+		records, err = plugin.SOA(&k, zone, state, opt)
 	case dns.TypeNS:
 		if state.Name() == zone {
-			records, extra, err = plugin.NS(&k, zone, state, plugin.Options{})
+			records, extra, err = plugin.NS(&k, zone, state, opt)
 			break
 		}
 		fallthrough
@@ -57,21 +58,21 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		k.Transfer(ctx, state)
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
-		_, err = plugin.A(&k, zone, state, nil, plugin.Options{})
+		_, err = plugin.A(&k, zone, state, nil, opt)
 	}
 
 	if k.IsNameError(err) {
 		if k.Fall.Through(state.Name()) {
 			return plugin.NextOrFailure(k.Name(), k.Next, ctx, w, r)
 		}
-		return plugin.BackendError(&k, zone, dns.RcodeNameError, state, nil /* err */, plugin.Options{})
+		return plugin.BackendError(&k, zone, dns.RcodeNameError, state, nil /* err */, opt)
 	}
 	if err != nil {
 		return dns.RcodeServerFailure, err
 	}
 
 	if len(records) == 0 {
-		return plugin.BackendError(&k, zone, dns.RcodeSuccess, state, nil, plugin.Options{})
+		return plugin.BackendError(&k, zone, dns.RcodeSuccess, state, nil, opt)
 	}
 
 	m.Answer = append(m.Answer, records...)

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -11,8 +11,8 @@ import (
 
 // ServeDNS implements the plugin.Handler interface.
 func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	opt := plugin.Options{Context: ctx}
-	state := request.Request{W: w, Req: r}
+	opt := plugin.Options{}
+	state := request.Request{W: w, Req: r, Context: ctx}
 
 	m := new(dns.Msg)
 	m.SetReply(r)

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -144,8 +144,8 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 func (k *Kubernetes) primaryZone() string { return k.Zones[k.primaryZoneIndex] }
 
 // Lookup implements the ServiceBackend interface.
-func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
-	return k.Upstream.Lookup(state, name, typ, opt)
+func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return k.Upstream.Lookup(state, name, typ)
 }
 
 // IsNameError implements the ServiceBackend interface.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/plugin/pkg/healthcheck"
-	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -31,7 +31,7 @@ import (
 type Kubernetes struct {
 	Next             plugin.Handler
 	Zones            []string
-	Proxy            proxy.Proxy // Proxy for looking up names during the resolution process
+	Upstream         upstream.Upstream
 	APIServerList    []string
 	APIProxy         *apiProxy
 	APICertAuth      string
@@ -59,7 +59,6 @@ func New(zones []string) *Kubernetes {
 	k.Namespaces = make(map[string]bool)
 	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("127.0.0.1") }
 	k.podMode = podModeDisabled
-	k.Proxy = proxy.Proxy{}
 	k.ttl = defaultTTL
 
 	return k
@@ -145,8 +144,8 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 func (k *Kubernetes) primaryZone() string { return k.Zones[k.primaryZoneIndex] }
 
 // Lookup implements the ServiceBackend interface.
-func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
-	return k.Proxy.Lookup(state, name, typ)
+func (k *Kubernetes) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
+	return k.Upstream.Lookup(state, name, typ, opt)
 }
 
 // IsNameError implements the ServiceBackend interface.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/parse"
-	"github.com/coredns/coredns/plugin/proxy"
 
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,11 +197,11 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			if len(args) == 0 {
 				return nil, c.ArgErr()
 			}
-			ups, err := dnsutil.ParseHostPortOrFile(args...)
+			u, err := upstream.NewUpstream(args)
 			if err != nil {
 				return nil, err
 			}
-			k8s.Proxy = proxy.NewLookup(ups)
+			k8s.Upstream = u
 		case "ttl":
 			args := c.RemainingArgs()
 			if len(args) == 0 {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -194,9 +194,6 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
 		case "upstream":
 			args := c.RemainingArgs()
-			if len(args) == 0 {
-				return nil, c.ArgErr()
-			}
 			u, err := upstream.NewUpstream(args)
 			if err != nil {
 				return nil, err

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/fall"
 
+	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/mholt/caddy"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -463,7 +464,10 @@ kubernetes cluster.local`,
 			t.Errorf("Test %d: Expected kubernetes controller to be initialized with fallthrough '%v'. Instead found fallthrough '%v' for input '%s'", i, test.expectedFallthrough, k8sController.Fall, test.input)
 		}
 		// upstream
-		foundUpstreams := k8sController.Proxy.Upstreams
+		var foundUpstreams *[]proxy.Upstream
+		if k8sController.Upstream.Forward != nil {
+			foundUpstreams = k8sController.Upstream.Forward.Upstreams
+		}
 		if test.expectedUpstreams == nil {
 			if foundUpstreams != nil {
 				t.Errorf("Test %d: Expected kubernetes controller to not be initialized with upstreams for input '%s'", i, test.input)

--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -3,12 +3,9 @@
 package upstream
 
 import (
-	"errors"
-
 	"github.com/miekg/dns"
 
 	"github.com/coredns/coredns/core/dnsserver"
-	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/plugin/proxy"
@@ -25,27 +22,21 @@ type Upstream struct {
 func NewUpstream(dests []string) (Upstream, error) {
 	u := Upstream{}
 	if len(dests) == 0 {
-		return u, errors.New("no upstreams")
-	}
-	if dests[0] != "@self" {
-		u.self = false
-		ups, err := dnsutil.ParseHostPortOrFile(dests...)
-		if err != nil {
-			return u, err
-		}
-		p := proxy.NewLookup(ups)
-		u.Forward = &p
+		u.self = true
 		return u, nil
 	}
-	if len(dests) > 1 {
-		return u, errors.New("upstreams found after @self")
+	u.self = false
+	ups, err := dnsutil.ParseHostPortOrFile(dests...)
+	if err != nil {
+		return u, err
 	}
-	u.self = true
+	p := proxy.NewLookup(ups)
+	u.Forward = &p
 	return u, nil
 }
 
 // Lookup routes lookups to Self or Forward
-func (u Upstream) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
+func (u Upstream) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
 	if u.self {
 		// lookup via self
 		req := new(dns.Msg)
@@ -53,8 +44,8 @@ func (u Upstream) Lookup(state request.Request, name string, typ uint16, opt plu
 		state.SizeAndDo(req)
 		nw := nonwriter.New(state.W)
 		state2 := request.Request{W: nw, Req: req}
-		server := opt.Context.Value(dnsserver.ServerKey).(*dnsserver.Server)
-		server.ServeDNS(opt.Context, state2.W, req)
+		server := state.Context.Value(dnsserver.Key{}).(*dnsserver.Server)
+		server.ServeDNS(state.Context, state2.W, req)
 		return nw.Msg, nil
 	}
 	if u.Forward != nil {

--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -1,0 +1,64 @@
+// Package upstream abstracts a upstream lookups so that plugins
+// can handle them in an unified way.
+package upstream
+
+import (
+	"errors"
+
+	"github.com/miekg/dns"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
+	"github.com/coredns/coredns/plugin/pkg/nonwriter"
+	"github.com/coredns/coredns/plugin/proxy"
+	"github.com/coredns/coredns/request"
+)
+
+// Upstream is used to resolve CNAME targets
+type Upstream struct {
+	self    bool
+	Forward *proxy.Proxy
+}
+
+// NewUpstream creates a new Upstream for given destination(s)
+func NewUpstream(dests []string) (Upstream, error) {
+	u := Upstream{}
+	if len(dests) == 0 {
+		return u, errors.New("no upstreams")
+	}
+	if dests[0] != "@self" {
+		u.self = false
+		ups, err := dnsutil.ParseHostPortOrFile(dests...)
+		if err != nil {
+			return u, err
+		}
+		p := proxy.NewLookup(ups)
+		u.Forward = &p
+		return u, nil
+	}
+	if len(dests) > 1 {
+		return u, errors.New("upstreams found after @self")
+	}
+	u.self = true
+	return u, nil
+}
+
+// Lookup routes lookups to Self or Forward
+func (u Upstream) Lookup(state request.Request, name string, typ uint16, opt plugin.Options) (*dns.Msg, error) {
+	if u.self {
+		// lookup via self
+		req := new(dns.Msg)
+		req.SetQuestion(name, typ)
+		state.SizeAndDo(req)
+		nw := nonwriter.New(state.W)
+		state2 := request.Request{W: nw, Req: req}
+		server := opt.Context.Value(dnsserver.ServerKey).(*dnsserver.Server)
+		server.ServeDNS(opt.Context, state2.W, req)
+		return nw.Msg, nil
+	}
+	if u.Forward != nil {
+		return u.Forward.Lookup(state, name, typ)
+	}
+	return &dns.Msg{}, nil
+}

--- a/request/request.go
+++ b/request/request.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
 
-	"context"
 	"github.com/miekg/dns"
+	"golang.org/x/net/context"
 )
 
 // Request contains some connection state and is useful in plugin.

--- a/request/request.go
+++ b/request/request.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
 
+	"context"
 	"github.com/miekg/dns"
 )
 
@@ -18,6 +19,8 @@ type Request struct {
 
 	// Optional lowercased zone of this query.
 	Zone string
+
+	Context context.Context
 
 	// Cache size after first call to Size or Do.
 	size int


### PR DESCRIPTION
### 1. What does this pull request do?

- Adds `@self` option to upstream for kubernetes and etcd plugins.  `upstream @self` will cause upstream `CNAME` target lookups to be processed by the current server (via recursive re-entry into dnsserver.ServeDNS()).
- Counts re-entries into ServeDNS(), and breaks loop if re-entries > limit

Still To Do:
- ~~Document `@self` option~~
- ~~Integration tests~~

### 2. Which issues (if any) are related?

coredns/deployment#55
#1427

### 3. Which documentation changes (if any) need to be made?

Document `@self` option in `upstream` directive in k8s and etcd plugin READMEs.