### PR TITLE
Add OWNERS file

### DIFF
--- a/plugin/auto/OWNERS
+++ b/plugin/auto/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - miekg
+  - stp-ip
+approvers:
+  - miekg

--- a/plugin/autopath/OWNERS
+++ b/plugin/autopath/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - chrisohaver
+  - miekg
+approvers:
+  - chrisohaver
+  - miekg

--- a/plugin/bind/OWNERS
+++ b/plugin/bind/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - miekg
+  - fturib
+approvers:
+  - miekg
+  - fturib

--- a/plugin/cache/OWNERS
+++ b/plugin/cache/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - grobie
+  - miekg
+approvers:
+  - grobie
+  - miekg

--- a/plugin/chaos/OWNERS
+++ b/plugin/chaos/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/dnssec/OWNERS
+++ b/plugin/dnssec/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - isolus
+  - miekg
+approvers:
+  - isolus
+  - miekg

--- a/plugin/dnstap/OWNERS
+++ b/plugin/dnstap/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - varyoo
+  - yongtang
+approvers:
+  - varyoo
+  - yongtang

--- a/plugin/erratic/OWNERS
+++ b/plugin/erratic/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/errors/OWNERS
+++ b/plugin/errors/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/etcd/OWNERS
+++ b/plugin/etcd/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/federation/OWNERS
+++ b/plugin/federation/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - chrisohaver
+  - miekg
+approvers:
+  - chrisohaver
+  - miekg

--- a/plugin/file/OWNERS
+++ b/plugin/file/OWNERS
@@ -1,0 +1,7 @@
+reviewers:
+  - miekg
+  - yongtang
+  - stp-ip
+approvers:
+  - miekg
+  - yongtang

--- a/plugin/health/OWNERS
+++ b/plugin/health/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - fastest963
+  - miekg
+approvers:
+  - fastest963
+  - miekg

--- a/plugin/hosts/OWNERS
+++ b/plugin/hosts/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - johnbelamaric
+  - pmoroney
+approvers:
+  - johnbelamaric
+  - pmoroney

--- a/plugin/kubernetes/OWNERS
+++ b/plugin/kubernetes/OWNERS
@@ -1,21 +1,16 @@
 reviewers:
   - bradbeam
   - chrisohaver
-  - fastest963
   - fturib
-  - greenpau
-  - grobie
-  - isolus
   - johnbelamaric
   - miekg
-  - pmoroney
   - rajansandeep
-  - stp-ip
-  - superq
-  - varyoo
   - yongtang
 approvers:
+  - bradbeam
   - chrisohaver
+  - fturib
   - johnbelamaric
   - miekg
+  - rajansandeep
   - yongtang

--- a/plugin/loadbalance/OWNERS
+++ b/plugin/loadbalance/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/log/OWNERS
+++ b/plugin/log/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/metrics/OWNERS
+++ b/plugin/metrics/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - fastest963
+  - miekg
+  - superq
+  - greenpau
+approvers:
+  - fastest963
+  - miekg
+  - superq

--- a/plugin/nsid/OWNERS
+++ b/plugin/nsid/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - yongtang
+approvers:
+  - yongtang

--- a/plugin/pprof/OWNERS
+++ b/plugin/pprof/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/proxy/OWNERS
+++ b/plugin/proxy/OWNERS
@@ -1,0 +1,10 @@
+reviewers:
+  - fturib
+  - grobie
+  - johnbelamaric
+  - miekg
+approvers:
+  - fturib
+  - grobie
+  - johnbelamaric
+  - miekg

--- a/plugin/reload/OWNERS
+++ b/plugin/reload/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - johnbelamaric
+approvers:
+  - johnbelamaric

--- a/plugin/reverse/OWNERS
+++ b/plugin/reverse/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+approvers:

--- a/plugin/rewrite/OWNERS
+++ b/plugin/rewrite/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - greenpau
+  - johnbelamaric
+approvers:
+  - greenpau
+  - johnbelamaric

--- a/plugin/root/OWNERS
+++ b/plugin/root/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg

--- a/plugin/route53/OWNERS
+++ b/plugin/route53/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - yongtang
+approvers:
+  - yongtang

--- a/plugin/secondary/OWNERS
+++ b/plugin/secondary/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - bradbeam
+  - miekg
+approvers:
+  - bradbeam
+  - miekg

--- a/plugin/template/OWNERS
+++ b/plugin/template/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - rtreffer
+approvers:
+  - rtreffer

--- a/plugin/tls/OWNERS
+++ b/plugin/tls/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - johnbelamaric
+approvers:
+  - johnbelamaric

--- a/plugin/trace/OWNERS
+++ b/plugin/trace/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - johnbelamaric
+approvers:
+  - johnbelamaric

--- a/plugin/whoami/OWNERS
+++ b/plugin/whoami/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - miekg
+approvers:
+  - miekg


### PR DESCRIPTION
This should have everyone, but the process was quite manual. The rename
from middleware -> plugin also meant I had to do some extra digging on
who actually submitted the PR. I also double checked the current list of
people with commit access.