### PR TITLE
plugin/kubernetes: Allow only one k8s section

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -74,7 +74,10 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, dnsControlOpts, error) {
 		resyncPeriod: defaultResyncPeriod,
 	}
 
-	for c.Next() {
+	for i := 1; c.Next(); i++ {
+		if i > 1 {
+			return nil, opts, fmt.Errorf("only one kubernetes section allowed per server block")
+		}
 		zones := c.RemainingArgs()
 
 		if len(zones) != 0 {

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -382,6 +382,20 @@ func TestKubernetesParse(t *testing.T) {
 			fall.Zero,
 			nil,
 		},
+		// More than one Kubernetes not allowed
+		{
+			`kubernetes coredns.local
+kubernetes cluster.local`,
+			true,
+			"only one kubernetes section allowed per server block",
+			-1,
+			0,
+			defaultResyncPeriod,
+			"",
+			podModeDisabled,
+			fall.Zero,
+			nil,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. What does this pull request do?

Errors during setup if more than one kubernetes is specified in the same server block.

### 2. Which issues (if any) are related?

Currently we allow more than one, but the results are counterintuitive.

### 3. Which documentation changes (if any) need to be made?
