### PR TITLE
WIP - Allow BIND plugin to accept multiple addresses for listening incoming DNS requests

### DIFF
--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -2,59 +2,112 @@ package dnsserver
 
 import (
 	"net"
+	"strconv"
 	"strings"
 
+	"fmt"
 	"github.com/coredns/coredns/plugin"
-
 	"github.com/miekg/dns"
+	"sort"
 )
 
-type zoneAddr struct {
-	Zone      string
-	Port      string
-	Transport string     // dns, tls or grpc
-	IPNet     *net.IPNet // if reverse zone this hold the IPNet
+//ZoneAddr is the memory structure representation of Keys for ServerBlocs
+// use String() to get a print representation
+// use asKey() if you need to use this ZoneAddr in a map
+// use ParseZoneAddr() if you need to retrieve the initial ZoneAddr from the key format
+type ZoneAddr struct {
+	// first 4 are part of the key
+	Transport     string // dns, tls or grpc
+	Zone          string
+	Port          string
+	ListeningAddr string
+	IPNet         *net.IPNet // if reverse zone this hold the IPNet
+	Options       map[string]string
 }
 
-// String return the string representation of z.
-func (z zoneAddr) String() string { return z.Transport + "://" + z.Zone + ":" + z.Port }
+const (
+	separateProtocol  = "://"
+	separatePortAndIP = ":"
+	separateCIDR      = "##"
+	separateOptions   = "#$#"
+	startOption       = "["
+	endOption         = "]"
+	partsSep          = "="
+)
 
-// Transport returns the protocol of the string s
-func Transport(s string) string {
-	switch {
-	case strings.HasPrefix(s, TransportTLS+"://"):
-		return TransportTLS
-	case strings.HasPrefix(s, TransportDNS+"://"):
-		return TransportDNS
-	case strings.HasPrefix(s, TransportGRPC+"://"):
-		return TransportGRPC
+var transports map[int]string
+
+// Copy : provide a duplicate of this ZoneAddr
+func (z *ZoneAddr) Copy() ZoneAddr {
+	za := ZoneAddr{Transport: z.Transport, Zone: z.Zone, Port: z.Port, ListeningAddr: z.ListeningAddr, IPNet: z.IPNet}
+	for k, v := range z.Options {
+		za.Options[k] = v
 	}
-	return TransportDNS
+	return za
+}
+
+func (z ZoneAddr) copyAsMulticast() ZoneAddr {
+	return ZoneAddr{Zone: z.Zone, ListeningAddr: "", Port: z.Port, Transport: z.Transport, IPNet: z.IPNet}
+
+}
+
+// CompleteAddress : update ListeningAddr if not already set
+func (z *ZoneAddr) CompleteAddress(address string) {
+	if (z.ListeningAddr == "") && (address != "") {
+		z.ListeningAddr = address
+	}
+}
+
+// String return the string representation of this ZoneAddr - for print
+func (z ZoneAddr) String() string {
+	if z.ListeningAddr == "" {
+		return z.Transport + separateProtocol + z.Zone + separatePortAndIP + z.Port
+	}
+	return z.Transport + separateProtocol + z.Zone + separatePortAndIP + z.ListeningAddr + separatePortAndIP + z.Port
+}
+
+// return a string representation that is usable for  of this ZoneAddr - for print
+func (z ZoneAddr) keyForListener() string {
+	if z.ListeningAddr == "" {
+		return z.Transport + separateProtocol + z.Zone + separatePortAndIP + z.Port
+	}
+	return z.Transport + separateProtocol + z.Zone + separatePortAndIP + z.ListeningAddr + separatePortAndIP + z.Port
+}
+
+func (z ZoneAddr) isMulticast() bool {
+	return z.ListeningAddr == ""
+}
+
+func (z ZoneAddr) serverAddr() string {
+	if len(z.ListeningAddr) > 0 && z.ListeningAddr[0] == '[' {
+		return z.ListeningAddr[1 : len(z.ListeningAddr)-1]
+	}
+	return z.ListeningAddr
 }
 
 // normalizeZone parses an zone string into a structured format with separate
 // host, and port portions, as well as the original input string.
-func normalizeZone(str string) (zoneAddr, error) {
+func normalizeZone(str string) (*ZoneAddr, error) {
 	var err error
 
 	// Default to DNS if there isn't a transport protocol prefix.
 	trans := TransportDNS
 
 	switch {
-	case strings.HasPrefix(str, TransportTLS+"://"):
+	case strings.HasPrefix(str, TransportTLS+separateProtocol):
 		trans = TransportTLS
-		str = str[len(TransportTLS+"://"):]
-	case strings.HasPrefix(str, TransportDNS+"://"):
+		str = str[len(TransportTLS+separateProtocol):]
+	case strings.HasPrefix(str, TransportDNS+separateProtocol):
 		trans = TransportDNS
-		str = str[len(TransportDNS+"://"):]
-	case strings.HasPrefix(str, TransportGRPC+"://"):
+		str = str[len(TransportDNS+separateProtocol):]
+	case strings.HasPrefix(str, TransportGRPC+separateProtocol):
 		trans = TransportGRPC
-		str = str[len(TransportGRPC+"://"):]
+		str = str[len(TransportGRPC+separateProtocol):]
 	}
 
 	host, port, ipnet, err := plugin.SplitHostPort(str)
 	if err != nil {
-		return zoneAddr{}, err
+		return nil, err
 	}
 
 	if port == "" {
@@ -69,7 +122,25 @@ func normalizeZone(str string) (zoneAddr, error) {
 		}
 	}
 
-	return zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
+	// at the end we should verify that the host is a real dns domain
+	if _, ok := dns.IsDomainName(host); !ok {
+		return nil, fmt.Errorf("invalid format for zone, it is not considered as a dns domain : '%v'", host)
+	}
+
+	return &ZoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
+}
+
+// Transport returns the protocol of the string s
+func Transport(s string) string {
+	switch {
+	case strings.HasPrefix(s, TransportTLS+separateProtocol):
+		return TransportTLS
+	case strings.HasPrefix(s, TransportDNS+separateProtocol):
+		return TransportDNS
+	case strings.HasPrefix(s, TransportGRPC+separateProtocol):
+		return TransportGRPC
+	}
+	return TransportDNS
 }
 
 // Supported transports.
@@ -78,3 +149,168 @@ const (
 	TransportTLS  = "tls"
 	TransportGRPC = "grpc"
 )
+
+// test if the addr is either ipv4 or ipv6 enclosed in [], return the non enclosed version
+func isIP(addr string) (bool, string) {
+	shouldIpv6 := false
+	if addr[0] == '[' && addr[len(addr)-1] == ']' {
+		addr = addr[1 : len(addr)-1]
+		shouldIpv6 = true
+	}
+	if ip := net.ParseIP(addr); ip != nil {
+		isIpv4 := ip.To4() != nil
+		return (isIpv4 && !shouldIpv6) || (!isIpv4 && shouldIpv6), addr
+	}
+	return false, addr
+}
+
+// split the string on sep, but avoid to split if that sep is in a zomment zone
+func splitWithComment(s string, sep int32, commentStart int32, commentEnd int32) []string {
+	// need a split where the string between [] is not splitted
+	a := make([]string, 0)
+	comment := 0
+	initPos := 0
+	for i, car := range s {
+		if car == commentStart {
+			comment++
+		}
+		if car == commentEnd && comment > 0 {
+			comment--
+		}
+		if car == sep && comment == 0 {
+			a = append(a, s[initPos:i])
+			initPos = i + 1
+		}
+	}
+	a = append(a, s[initPos:])
+	return a
+}
+
+//parseFromKey build a ZoneAddr from standard format that includes all options
+func parseFromKey(value string) (*ZoneAddr, error) {
+	// value is a an output of the ZoneAddr produced by asKey()
+	// including all parts : protocol, domain, optional IP, port, option set of options
+
+	v := strings.Split(value, separateOptions)
+	// left part is limited to rotocol, domain, optional IP, port
+
+	// right parts are the options
+	if len(v[0]) == 0 {
+		return nil, fmt.Errorf("invalid format for a ZoneAddress, it should not contains ony options : '%v'", value)
+	}
+
+	// extract the protocol
+	head := strings.Split(v[0], "://")
+	if len(head) != 2 {
+		return nil, fmt.Errorf("invalid format for a ZoneAddress, it should start with a listening protocol : '%v'", head)
+	}
+	proto := head[0]
+	tail := strings.Split(head[1], separateCIDR)
+	corp := tail[0]
+	zone, ip, port := "", "", ""
+	// extract Zone, maybe IP, and port
+	zoneAddr := splitWithComment(corp, ':', '[', ']')
+	switch len(zoneAddr) {
+	case 2:
+		zone, ip, port = zoneAddr[0], "", zoneAddr[1]
+	case 3:
+		zone, ip, port = zoneAddr[0], zoneAddr[1], zoneAddr[2]
+	default:
+		return nil, fmt.Errorf("invalid format for a ZoneAddress, it should contains host, IP and port : '%v'", corp)
+	}
+	if zone == "" {
+		return nil, fmt.Errorf("invalid format for zone, it should not be empwty : '%v'", corp)
+	}
+	if _, ok := dns.IsDomainName(zone); !ok {
+		return nil, fmt.Errorf("invalid format for zone, it is not considered as a dns domain : '%v'", zone)
+	}
+	if ip != "" {
+		if ok, _ := isIP(ip); !ok {
+			return nil, fmt.Errorf("invalid format for ip, it is not an Ipv4 or Ipv6 format : '%v'", ip)
+		}
+	}
+	_, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, fmt.Errorf("invalid format for port, it is not an integer : '%v', error is %v ", value, err)
+	}
+
+	options := make(map[string]string)
+	for _, ov := range v[:1] {
+		if strings.Index(ov, startOption) == 0 && strings.LastIndex(ov, endOption) == len(ov)-len(endOption) {
+			opt := ov[len(startOption) : len(ov)-len(endOption)]
+			parts := strings.Split(opt, partsSep)
+			if len(parts[0]) == 0 {
+				return nil, fmt.Errorf("invalid option with no name : %v", opt)
+			}
+			if len(parts) > 2 {
+				return nil, fmt.Errorf("invalid option with too much values : %v", opt)
+			}
+			options[parts[0]] = parts[1]
+		}
+	}
+	za := ZoneAddr{proto, zone, port, ip, nil, options}
+	if len(tail) > 1 {
+		sipnet := tail[1]
+		_, ipnet, err := net.ParseCIDR(sipnet)
+		if err != nil {
+			return nil, fmt.Errorf("invalid format for a ZoneAddress, cannot parse the network CIDR provided : '%v' - %v", sipnet, err)
+		}
+		za.IPNet = ipnet
+	}
+
+	return &za, nil
+}
+
+func (z ZoneAddr) asKey() string {
+	head := z.String()
+	if z.IPNet != nil {
+		head = head + separateCIDR + z.IPNet.String()
+	}
+	if len(z.Options) > 0 {
+		// Need to order the map to get the same key on each print
+		oNames := make([]string, len(z.Options))
+		i := 0
+		for k := range z.Options {
+			oNames[i] = k
+			i++
+		}
+		sort.Strings(oNames)
+		for _, k := range oNames {
+			head += separateOptions + startOption + k + partsSep + z.Options[k] + endOption
+		}
+	}
+	return head
+}
+
+// Build a Validator that rise error if the bound addresses for listeners are overlapping
+type zoneAddrOverlapValidator struct {
+	registeredAddr   map[string]string
+	multicastOverlap map[string]string
+}
+
+func newZoneAddrOverlapValidator() *zoneAddrOverlapValidator {
+	return &zoneAddrOverlapValidator{registeredAddr: make(map[string]string), multicastOverlap: make(map[string]string)}
+}
+
+func (c *zoneAddrOverlapValidator) registerAndCheck(z ZoneAddr) (same bool, overlap bool, overlapKey string) {
+	key := z.asKey()
+	if _, ok := c.registeredAddr[key]; ok {
+		// exact same zone already registered
+		return true, false, ""
+	}
+	mkey := z.copyAsMulticast().asKey()
+	if already, ok := c.multicastOverlap[mkey]; ok {
+		if z.isMulticast() {
+			// there is already a unicast registered
+			return false, true, already
+		}
+		if _, ok := c.registeredAddr[mkey]; ok {
+			// the overlapping multicast is already registered
+			return false, true, mkey
+		}
+	} else {
+		c.multicastOverlap[mkey] = key
+	}
+	c.registeredAddr[key] = key
+	return false, false, ""
+}

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -1,6 +1,9 @@
 package dnsserver
 
-import "testing"
+import (
+	"net"
+	"testing"
+)
 
 func TestNormalizeZone(t *testing.T) {
 	for i, test := range []struct {
@@ -15,6 +18,9 @@ func TestNormalizeZone(t *testing.T) {
 		{".:", "://:", true},
 	} {
 		addr, err := normalizeZone(test.input)
+		if addr == nil {
+			addr = &ZoneAddr{}
+		}
 		actual := addr.String()
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error, but there wasn't any", i)
@@ -51,6 +57,9 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		{"fd00:77:30::0/110", "dns://0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.7.7.0.0.0.0.d.f.ip6.arpa.:53", false},
 	} {
 		addr, err := normalizeZone(test.input)
+		if addr == nil {
+			addr = &ZoneAddr{}
+		}
 		actual := addr.String()
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error, but there wasn't any", i)
@@ -60,6 +69,93 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		}
 		if actual != test.expected {
 			t.Errorf("Test %d: Expected %s but got %s", i, test.expected, actual)
+		}
+	}
+}
+
+type checkCall struct {
+	zone       string
+	same       bool
+	overlap    bool
+	overlapKey string
+}
+
+type checkTest struct {
+	sequence []checkCall
+}
+
+func TestOverlapAddressChecker(t *testing.T) {
+	for i, test := range []checkTest{
+		{sequence: []checkCall{
+			{"dns://.:53", false, false, ""},
+			{"dns://.:53", true, false, ""},
+		},
+		},
+		{sequence: []checkCall{
+			{"dns://.:53", false, false, ""},
+			{"dns://.:54", false, false, ""},
+			{"dns://.:127.0.0.1:53", false, true, "dns://.:53"},
+		},
+		},
+		{sequence: []checkCall{
+			{"dns://.:127.0.0.1:53", false, false, ""},
+			{"dns://.:54", false, false, ""},
+			{"dns://.:127.0.0.1:53", true, false, ""},
+		},
+		},
+		{sequence: []checkCall{
+			{"dns://.:127.0.0.1:53", false, false, ""},
+			{"dns://.:54", false, false, ""},
+			{"dns://.:128.0.0.1:53", false, false, ""},
+			{"dns://.:129.0.0.1:53", false, false, ""},
+			{"dns://.:53", false, true, "dns://.:127.0.0.1:53"},
+		},
+		},
+	} {
+
+		checker := newZoneAddrOverlapValidator()
+		for _, call := range test.sequence {
+			za, err := parseFromKey(call.zone)
+			if err != nil {
+				t.Errorf("Test %d: error at normalizing zone %s, err = %v", i, call.zone, err)
+			}
+			same, overlap, overkey := checker.registerAndCheck(*za)
+			if same != call.same {
+				t.Errorf("Test %d: error, for zone %s, 'same' (%v) has not the expected value (%v)", i, call.zone, same, call.same)
+			}
+			if !same {
+				if overlap != call.overlap {
+					t.Errorf("Test %d: error, for zone %s, 'overlap' (%v) has not the expected value (%v)", i, call.zone, overlap, call.overlap)
+				}
+				if overlap {
+					if overkey != call.overlapKey {
+						t.Errorf("Test %d: error, for zone %s, 'overlap Key' (%v) has not the expected value (%v)", i, call.zone, overkey, call.overlapKey)
+					}
+
+				}
+			}
+
+		}
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	_, ipnet1, _ := net.ParseCIDR("2003::53/67")
+	for i, test := range []ZoneAddr{
+		{TransportDNS, ".", "52", "127.0.0.1", nil, map[string]string{}},
+		{TransportDNS, ".", "53", "127.0.0.1", nil, map[string]string{}},
+		{TransportDNS, "local.com.", "54", "127.0.0.1", nil, map[string]string{}},
+		{TransportDNS, "local.com.", "54", "[::1]", nil, map[string]string{}},
+		{TransportDNS, "0.0.0.0.0.0.0.0.0.0.0.0.0.3.0.0.2.ip6.arpa.", "53", "[::1]", ipnet1, map[string]string{}},
+	} {
+		zonePrinted := test.asKey()
+		addr, err := parseFromKey(zonePrinted)
+		if err != nil {
+			t.Errorf("Test %d: Expected no error, but there was one: %v", i, err)
+		}
+		secondPrint := addr.asKey()
+		if zonePrinted != secondPrint {
+			t.Errorf("Test %d: Second print does not match after parsing : 1 = '%v', 2 = '%v'", i, zonePrinted, secondPrint)
 		}
 	}
 }

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -287,7 +287,13 @@ func (s *Server) OnStartupComplete() {
 	}
 
 	for zone, config := range s.zones {
-		fmt.Println(zone + ":" + config.Port)
+		// if the server is listening on a specific address let's make it visible in the log,
+		// so one can differentiate between all active listeners
+		boundAddr := ""
+		if config.ListenHost != "" {
+			boundAddr = " (->" + config.ListenHost + ")"
+		}
+		fmt.Println(zone + ":" + config.Port + boundAddr)
 	}
 }
 

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -6,16 +6,17 @@
 
 ## Description
 
-Normally, the listener binds to the wildcard host. However, you may force the listener to bind to
-another IP instead. This directive accepts only an address, not a port.
+Normally, the listener binds to the wildcard host. However, you may want the listener to bind to
+another IP instead. If several addresses are provided, the listener will be duplicated such as each address is listened. 
+This directive accepts several addresses, no ports.
 
 ## Syntax
 
 ~~~ txt
-bind ADDRESS
+bind ADDRESS [ADDRESS] ...
 ~~~
 
-**ADDRESS** is the IP address to bind to.
+**ADDRESS** is the IP address or list of IP addresses to bind to.
 
 ## Examples
 
@@ -26,3 +27,12 @@ To make your socket accessible only to that machine, bind to IP 127.0.0.1 (local
     bind 127.0.0.1
 }
 ~~~
+
+To duplicate the server and open on a second socket for the Ipv6 localhost counterpart:
+
+~~~
+. {
+    bind 127.0.0.1 ::1
+}
+~~~
+

--- a/plugin/bind/bind.go
+++ b/plugin/bind/bind.go
@@ -1,11 +1,39 @@
 // Package bind allows binding to a specific interface instead of bind to all of them.
 package bind
 
-import "github.com/mholt/caddy"
+import (
+	"fmt"
+	"net"
+
+	"github.com/coredns/coredns/core/dnsserver"
+)
+
+const bindName = "bind"
 
 func init() {
-	caddy.RegisterPlugin("bind", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setupBind,
-	})
+	// add options to the KeyEnhancermanager
+	dnsserver.Register(bindName, setupEnhancerBind)
+}
+
+type bindKeyEnhancer struct {
+	addresses []string
+}
+
+func (bke *bindKeyEnhancer) EnhanceKey(key dnsserver.ZoneAddr) []dnsserver.ZoneAddr {
+	// create all needed keys
+	newKeys := make([]dnsserver.ZoneAddr, len(bke.addresses))
+	for i, addr := range bke.addresses {
+		nk := key.Copy()
+		nk.CompleteAddress(addr)
+		newKeys[i] = nk
+	}
+	return newKeys
+}
+func (bke *bindKeyEnhancer) addEnhancement(data string) error {
+	ip := net.ParseIP(data)
+	if ip == nil {
+		return fmt.Errorf("bind : ip value provided is invalid : '%v', it should be an either IPv4 or Ipv6 format", data)
+	}
+	bke.addresses = append(bke.addresses, data)
+	return nil
 }

--- a/plugin/bind/bind_test.go
+++ b/plugin/bind/bind_test.go
@@ -1,30 +1,33 @@
 package bind
 
 import (
-	"testing"
-
 	"github.com/coredns/coredns/core/dnsserver"
-
 	"github.com/mholt/caddy"
+	"testing"
 )
 
 func TestSetupBind(t *testing.T) {
-	c := caddy.NewTestController("dns", `bind 1.2.3.4`)
-	err := setupBind(c)
-	if err != nil {
-		t.Fatalf("Expected no errors, but got: %v", err)
-	}
-
-	cfg := dnsserver.GetConfig(c)
-	if got, want := cfg.ListenHost, "1.2.3.4"; got != want {
-		t.Errorf("Expected the config's ListenHost to be %s, was %s", want, got)
-	}
-}
-
-func TestBindAddress(t *testing.T) {
-	c := caddy.NewTestController("dns", `bind 1.2.3.bla`)
-	err := setupBind(c)
-	if err == nil {
-		t.Fatalf("Expected errors, but got none")
+	for i, test := range []struct {
+		bindToken string
+		addresses []string
+	}{
+		{`bind 1.2.3.4`, []string{"1.2.3.4"}},
+		{`bind 1.2.3.4 ::1`, []string{"1.2.3.4", "::1"}},
+	} {
+		c := caddy.NewTestController("dns", test.bindToken)
+		enh, err := setupEnhancerBind(&c.Dispenser)
+		if err != nil {
+			t.Fatalf("test %d expected no errors, but got: %v", i, err)
+		}
+		za := dnsserver.ZoneAddr{Transport: "dns", Zone: ".", Port: "53", Options: map[string]string{}}
+		zas := enh(za)
+		if len(zas) != len(test.addresses) {
+			t.Fatalf("test %d: too much ZoneAddr returns, expected %v, got %v", i, len(test.addresses), len(zas))
+		}
+		for i, addr := range test.addresses {
+			if zas[i].ListeningAddr != addr {
+				t.Fatalf("test %d: invalid address injected, expected %v, got %v", i, addr, zas[i].ListeningAddr)
+			}
+		}
 	}
 }

--- a/plugin/normalize_test.go
+++ b/plugin/normalize_test.go
@@ -96,7 +96,7 @@ func TestSplitHostPortReverse(t *testing.T) {
 		"2003::1/65":   128 - 65,
 	}
 	for in, expect := range tests {
-		_, _, n, err := SplitHostPort(in)
+		_, _, _, n, err := SplitHostPort(in)
 		if err != nil {
 			t.Errorf("Expected no error, got %q for %s", in, err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Allow BIND to accept multiple addresses, therefore the ServerBloc that includes this BIND directive will be duplicated to allow listening the incoming requests on each addresses provided.

1- The "duplication" part is compatible with the caddy process of the BlocServer and directives.
2- BIND 'looks like' a regular plugin, but now register as a "KeyEnhancer" instead as a Plugin.
 
## Synopsis

Caddy delegate to the ServerType (in our case "dns" of CoreDNS) the responsibility to validate the ServerBlocs and Directives generated by the parsing of the corefile. in CoreDNS languages, it is the place we can reviews and modify the Zones and the Plugins involved, for each ServerBloc.

It is done in the function **InspectServerBlocks** that must be implemented by caddy ServerType's Context. That function, called after the parsing of the corefile - and before any instantiation of listening Servers or setup of Plugin, allow the ServerType to transform as needed these ServerBlocs.
This function is meant to customize the list of Zones, and for each, the list of Plugin to call. it is time to add or remove elements. Nothing is created yet.

This function, for CoreDNS, is implemented in the file dnserver/register.go.

I added a pre-processor to recompute the Zones based on the Plugins declared in the ServerBloc. For instance, BIND is binding the Zone with the address, and if any extra address, BIND will bind a duplicate of the Zone to those extra addresses.

- All Zones, including the duplicates are processed through the usual loop, with an enhanced validator for checking the overlapping zone (multicast address is not compatible with unicast address).

I had to focus on the KeyAddr.String() that define the key that is used to save the Config for each ServerBloc : the duplicate Zones need to have a dedicated key. And the Normalise() functions used by all plugin to extract the host from the ServerBlockKey have to understand that format.

### Choice of implementation

**Code change is in dnsserver (address, register) and plugin/bind** + Unit Tests. Integration tests to come.

Some of the choice can be re-arranged depending this review:

As BIND was already a plugin and there was a comment about 'future extensions' .. I implemented that pre-processor for Zones as kind of "mini-plugin" processor. It is dedicated to transform the Zones:
- I introduced the concepts of KeyEnhancers .. similar to Plugin (but simpler)
=> BIND is registering as keyEnhancer, instead of registering as Plugin. It is invoked for parsing and for computing Zones, but no more for serveDNS.
- each Plugin directive that is acting as 'KeyEnhancer' is removed of the Plugin list before running all Setups. BIND is invoked only as KeyEnhancer. (it is not incompatible to implement both interface for a plugin, though)

_That "mini-plugin" implementation allow several other BIND-like plugins. If we do not expect to have other directive similar to BIND, we may directly include the code of BIND into address.go and remove completely the  plugin, keeping only the README (because it looks like a plugin)._

- I extended ZoneAddr, which is the structured format of a Zone (adding ListeningAddr). 
_Here I also added an Options map for future extension. But it is not really useful for now. If we do not expect to have other mini-plugin like BIND, I maybe can revert_

- I made the ZoneAddrOverlapValidator a dedicated object, as it was a little more complex to compute the overlap than before, and I moved it to address.go. We need it.

- I modified slightly the log for listening servers, so we can understand which one is listening what zone on what address. 
_Here the format of logs can be adapted to wished .._

Example of stanza:

```
.:5354 {
    bind 127.0.0.1 ::1
    log
    errors
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
}

example.com:5357 sample.com:5358 {
    log
    errors
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
}
my.domain.com:5356 {
    bind ::1
    log
    errors
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
    reload 3s
}
```

Corresponding logs ... 

```
.:5354 (->127.0.0.1)
.:5354 (->::1)
example.com.:5357
sample.com.:5358
my.domain.com.:5356 (->::1)
CoreDNS-1.0.5
darwin/amd64, go1.9.2, 

2018/02/07 17:16:43 [INFO] CoreDNS-1.0.5
2018/02/07 17:16:43 [INFO] darwin/amd64, go1.9.2, 
2018/02/07 17:16:43 [INFO] Running configuration MD5 = add2385596aa244249a5319083b3b4ec

```


### 2. Which issues (if any) are related?
#1478 and #1208 

### 3. Which documentation changes (if any) need to be made?
BIND documentation was changed to show acceptance of multiple addresses.


