### PR TITLE
Remove MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,0 @@
-Chris O'Haver <chris@coredns.io>
-John Belamaric <john@coredns.io>
-Manuel Alejandro de Brito Fontes <aledbf@gmail.com>
-Miek Gieben <miek@coredns.io>
-Yong Tang <yong.tang@coredns.io>


### PR DESCRIPTION
We have OWNERS file throughout the repo. The top level OWNERS file
replaces the MAINTAINERS file (sans email addresses that is).
