### PR TITLE
plugin/reload: enable proper coredns instance shutdown

### DIFF
--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -24,6 +24,7 @@ func init() {
 // WARNING: this data may be unsync after an invalid attempt of reload Corefile.
 var r = reload{interval: defaultInterval, usage: unused, quit: make(chan bool)}
 var once sync.Once
+var shutOnce sync.Once
 
 func setup(c *caddy.Controller) error {
 	c.Next() // 'reload'
@@ -73,9 +74,11 @@ func setup(c *caddy.Controller) error {
 	})
 
 	// re-register on finalShutDown as the instance most-likely will be changed
-	c.OnFinalShutdown(func() error {
-		r.quit <- true
-		return nil
+	shutOnce.Do(func() {
+		c.OnFinalShutdown(func() error {
+			r.quit <- true
+			return nil
+		})
 	})
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This PR enables proper shutdown of CoreDNS instance when using reload plugin more than once.

Example scenario:
```
.:5356 {
    reload 3s
    log
    errors
}
.:5358 {
    reload 3s
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
}
```
Before Fix (Need to give SIGINT twice):
```
$ ./coredns
.:5356
.:5358
2018/02/08 10:47:50 [INFO] CoreDNS-1.0.5
2018/02/08 10:47:50 [INFO] darwin/amd64, go1.9.3, 
CoreDNS-1.0.5
darwin/amd64, go1.9.3, 
2018/02/08 10:47:50 [INFO] Running configuration MD5 = 8ee3104d51143cb2311f17075628eb5c
^C2018/02/08 10:47:50 [INFO] SIGINT: Shutting down
^C2018/02/08 10:47:52 [INFO] SIGINT: Force quit
$
```

After fix: 
```
$ ./coredns
.:5356
.:5358
2018/02/08 10:48:11 [INFO] CoreDNS-1.0.5
2018/02/08 10:48:11 [INFO] darwin/amd64, go1.9.3, 
CoreDNS-1.0.5
darwin/amd64, go1.9.3, 
2018/02/08 10:48:11 [INFO] Running configuration MD5 = 8ee3104d51143cb2311f17075628eb5c
^C2018/02/08 10:48:12 [INFO] SIGINT: Shutting down
$
```
### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None
