### PR TITLE
plugin/reload: disable for now

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -11,7 +11,6 @@ package dnsserver
 // care what plugin above them are doing.
 var Directives = []string{
 	"tls",
-	"reload",
 	"nsid",
 	"root",
 	"bind",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -27,7 +27,6 @@ import (
 	_ "github.com/coredns/coredns/plugin/nsid"
 	_ "github.com/coredns/coredns/plugin/pprof"
 	_ "github.com/coredns/coredns/plugin/proxy"
-	_ "github.com/coredns/coredns/plugin/reload"
 	_ "github.com/coredns/coredns/plugin/reverse"
 	_ "github.com/coredns/coredns/plugin/rewrite"
 	_ "github.com/coredns/coredns/plugin/root"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -20,7 +20,7 @@
 # log:log
 
 tls:tls
-reload:reload
+#reload:reload # enable by reverting #1511
 nsid:nsid
 root:root
 bind:bind

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -42,7 +42,7 @@ reload [INTERVAL] [JITTER]
 
 Check with the default intervals:
 
-~~~ corefile
+~~~ txt
 . {
     reload
     erratic
@@ -51,7 +51,7 @@ Check with the default intervals:
 
 Check every 10 seconds (jitter is automatically set to 10 / 2 = 5 in this case):
 
-~~~ corefile
+~~~ txt
 . {
     reload 10s
     erratic


### PR DESCRIPTION
Reloading should work (kill -TERM reload the coredns process), but a lot
of plugins can't handle it proper. Disable to reload plugin until we fix
(most) of the plugins.