### PR TITLE
Plugin/BIND - extend the syntax to allow multiple addresses

### DIFF
--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -1,6 +1,7 @@
 package dnsserver
 
 import (
+	"fmt"
 	"net"
 	"strings"
 
@@ -70,6 +71,21 @@ func normalizeZone(str string) (zoneAddr, error) {
 	}
 
 	return zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
+}
+
+// SplitProtocolHostPort - split a full formed address like "dns://[::1}:53" into parts
+func SplitProtocolHostPort(address string) (protocol string, ip string, port string, err error) {
+	parts := strings.Split(address, "://")
+	switch len(parts) {
+	case 1:
+		ip, port, err := net.SplitHostPort(parts[0])
+		return "", ip, port, err
+	case 2:
+		ip, port, err := net.SplitHostPort(parts[1])
+		return parts[0], ip, port, err
+	default:
+		return "", "", "", fmt.Errorf("provided value is not in an address format : %s", address)
+	}
 }
 
 // Supported transports.

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -63,3 +63,48 @@ func TestNormalizeZoneReverse(t *testing.T) {
 		}
 	}
 }
+
+func TestSplitProtocolHostPort(t *testing.T) {
+	for i, test := range []struct {
+		input     string
+		proto     string
+		ip        string
+		port      string
+		shouldErr bool
+	}{
+		{"dns://:53", "dns", "", "53", false},
+		{"dns://127.0.0.1:4005", "dns", "127.0.0.1", "4005", false},
+		{"[ffe0:34ab:1]:4005", "", "ffe0:34ab:1", "4005", false},
+
+		// port part is mandatory
+		{"dns://", "dns", "", "", true},
+		{"dns://127.0.0.1", "dns", "127.0.0.1", "", true},
+		// cannot be empty
+		{"", "", "", "", true},
+		// invalid format with twice ://
+		{"dns://127.0.0.1://53", "", "", "", true},
+	} {
+		proto, ip, port, err := SplitProtocolHostPort(test.input)
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: (address = %s) expected error, but there wasn't any", i, test.input)
+			continue
+		}
+		if !test.shouldErr && err != nil {
+			t.Errorf("Test %d: (address = %s) expected no error, but there was one: %v", i, test.input, err)
+			continue
+		}
+		if err == nil || test.shouldErr {
+			continue
+		}
+		if proto != test.proto {
+			t.Errorf("Test %d: (address = %s) expected protocol with value %s but got %s", i, test.input, test.proto, proto)
+		}
+		if ip != test.ip {
+			t.Errorf("Test %d: (address = %s) expected ip with value %s but got %s", i, test.input, test.ip, ip)
+		}
+		if port != test.port {
+			t.Errorf("Test %d: (address = %s) expected port with value %s but got %s", i, test.input, test.port, port)
+		}
+
+	}
+}

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -2,6 +2,7 @@ package dnsserver
 
 import (
 	"crypto/tls"
+	"net"
 
 	"github.com/coredns/coredns/plugin"
 
@@ -13,7 +14,8 @@ type Config struct {
 	// The zone of the site.
 	Zone string
 
-	// The hostname to bind listener to, defaults to the wildcard address
+	// one or several hostnames to bind the server to.
+	// defaults to a single empty string that denote the wildcard address
 	ListenHosts []string
 
 	// The port to listen on.
@@ -50,6 +52,22 @@ type Config struct {
 	registry map[string]plugin.Handler
 }
 
+//HostAddresses builds a representation of the addresses of this Config
+//after server is started ONLY, can be used as a Key for identifing that config
+// :53 or 127.0.0.1:53 or 127.0.0.1:53/::1:53
+func (c *Config) HostAddresses() string {
+	hosts := ""
+	for _, h := range c.ListenHosts {
+		host := net.JoinHostPort(h, c.Port)
+		if hosts == "" {
+			hosts = host
+			continue
+		}
+		hosts = hosts + "/" + host
+	}
+	return hosts
+}
+
 // GetConfig gets the Config that corresponds to c.
 // If none exist nil is returned.
 func GetConfig(c *caddy.Controller) *Config {
@@ -60,6 +78,6 @@ func GetConfig(c *caddy.Controller) *Config {
 	// we should only get here during tests because directive
 	// actions typically skip the server blocks where we make
 	// the configs.
-	ctx.saveConfig(c.Key, &Config{})
+	ctx.saveConfig(c.Key, &Config{ListenHosts: []string{""}})
 	return GetConfig(c)
 }

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	Zone string
 
 	// The hostname to bind listener to, defaults to the wildcard address
-	ListenHost string
+	ListenHosts []string
 
 	// The port to listen on.
 	Port string

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -56,16 +56,16 @@ type Config struct {
 //after server is started ONLY, can be used as a Key for identifing that config
 // :53 or 127.0.0.1:53 or 127.0.0.1:53/::1:53
 func (c *Config) HostAddresses() string {
-	hosts := ""
+	all := ""
 	for _, h := range c.ListenHosts {
-		host := net.JoinHostPort(h, c.Port)
-		if hosts == "" {
-			hosts = host
+		addr := net.JoinHostPort(h, c.Port)
+		if all == "" {
+			all = addr
 			continue
 		}
-		hosts = hosts + "/" + host
+		all = all + "/" + addr
 	}
-	return hosts
+	return all
 }
 
 // GetConfig gets the Config that corresponds to c.

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -70,9 +70,10 @@ func (h *dnsContext) InspectServerBlocks(sourceFile string, serverBlocks []caddy
 
 			// Save the config to our master list, and key it for lookups.
 			cfg := &Config{
-				Zone:      za.Zone,
-				Port:      za.Port,
-				Transport: za.Transport,
+				Zone:        za.Zone,
+				Port:        za.Port,
+				Transport:   za.Transport,
+				ListenHosts: []string{""},
 			}
 			if za.IPNet == nil {
 				h.saveConfig(za.String(), cfg)
@@ -191,13 +192,7 @@ func groupConfigsByListenAddr(configs []*Config) (map[string][]*Config, error) {
 	groups := make(map[string][]*Config)
 
 	for _, conf := range configs {
-		hosts := []string{}
-		if conf.ListenHosts == nil {
-			hosts = append(hosts, "")
-		} else {
-			hosts = append(hosts, conf.ListenHosts...)
-		}
-		for _, h := range hosts {
+		for _, h := range conf.ListenHosts {
 			addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(h, conf.Port))
 			if err != nil {
 				return nil, err

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -191,14 +191,21 @@ func groupConfigsByListenAddr(configs []*Config) (map[string][]*Config, error) {
 	groups := make(map[string][]*Config)
 
 	for _, conf := range configs {
-		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(conf.ListenHost, conf.Port))
-		if err != nil {
-			return nil, err
+		hosts := []string{}
+		if conf.ListenHosts == nil {
+			hosts = append(hosts, "")
+		} else {
+			hosts = append(hosts, conf.ListenHosts...)
 		}
-		addrstr := conf.Transport + "://" + addr.String()
-		groups[addrstr] = append(groups[addrstr], conf)
+		for _, h := range hosts {
+			addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(h, conf.Port))
+			if err != nil {
+				return nil, err
+			}
+			addrstr := conf.Transport + "://" + addr.String()
+			groups[addrstr] = append(groups[addrstr], conf)
+		}
 	}
-
 	return groups, nil
 }
 

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -32,57 +32,70 @@ func TestHandlers(t *testing.T) {
 
 func TestGroupingServers(t *testing.T) {
 	for i, test := range []struct {
-		configs []*Config
-		gpes    []string
-		failing bool
+		configs        []*Config
+		expectedGroups []string
+		failing        bool
 	}{
+		// single config -> one group
 		{configs: []*Config{
-			{Transport: "dns", Zone: ".", Port: "53"},
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{""}},
 		},
-			gpes:    []string{"dns://:53"},
-			failing: false},
+			expectedGroups: []string{"dns://:53"},
+			failing:        false},
+
+		// 2 configs on different port -> 2 groups
 		{configs: []*Config{
-			{Transport: "dns", Zone: ".", Port: "53"},
-			{Transport: "dns", Zone: ".", Port: "54"},
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{""}},
+			{Transport: "dns", Zone: ".", Port: "54", ListenHosts: []string{""}},
 		},
-			gpes:    []string{"dns://:53", "dns://:54"},
-			failing: false},
+			expectedGroups: []string{"dns://:53", "dns://:54"},
+			failing:        false},
+
+		// 2 configs on same port, same broadcast address, diff zones -> 1 group
 		{configs: []*Config{
-			{Transport: "dns", Zone: ".", Port: "53"},
-			{Transport: "dns", Zone: "com.", Port: "53"},
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{""}},
+			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{""}},
 		},
-			gpes:    []string{"dns://:53"},
-			failing: false},
+			expectedGroups: []string{"dns://:53"},
+			failing:        false},
+
+		// 2 configs on same port, same address, diff zones -> 1 group
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1"}},
-			{Transport: "dns", Zone: ".", Port: "54"},
+			{Transport: "dns", Zone: ".", Port: "54", ListenHosts: []string{""}},
 		},
-			gpes:    []string{"dns://127.0.0.1:53", "dns://:54"},
-			failing: false},
+			expectedGroups: []string{"dns://127.0.0.1:53", "dns://:54"},
+			failing:        false},
+
+		// 2 configs on diff ports, 3 different address, diff zones -> 3 group
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
-			{Transport: "dns", Zone: ".", Port: "54"}},
-			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:54"},
-			failing: false},
+			{Transport: "dns", Zone: ".", Port: "54", ListenHosts: []string{""}}},
+			expectedGroups: []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:54"},
+			failing:        false},
+
+		// 2 configs on same port, same unicast address, diff zones -> 1 group
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
 			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
 		},
-			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
-			failing: false},
-		// this group is invalid, for now. Need a checker
-		{configs: []*Config{
-			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
-			{Transport: "dns", Zone: "com.", Port: "53"}},
-			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:53"},
-			failing: false},
-		// this case is working for grouping, but is not supported as overlapping test would eliminate it
+			expectedGroups: []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
+			failing:        false},
+
+		// 2 configs on same port, total 2 diff addresses, diff zones -> 2 groups
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1"}},
 			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{"::1"}},
 		},
-			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
-			failing: false},
+			expectedGroups: []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
+			failing:        false},
+
+		// 2 configs on same port, total 3 diff addresses, diff zones -> 3 groups
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
+			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{""}}},
+			expectedGroups: []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:53"},
+			failing:        false},
 	} {
 		groups, err := groupConfigsByListenAddr(test.configs)
 		if err != nil {
@@ -94,11 +107,11 @@ func TestGroupingServers(t *testing.T) {
 		if test.failing {
 			t.Fatalf("test %d, expected to failed but did not, returned values", i)
 		}
-		if len(groups) != len(test.gpes) {
-			t.Errorf("test %d : expected the group's size to be %d, was %d", i, len(test.gpes), len(groups))
+		if len(groups) != len(test.expectedGroups) {
+			t.Errorf("test %d : expected the group's size to be %d, was %d", i, len(test.expectedGroups), len(groups))
 			continue
 		}
-		for _, v := range test.gpes {
+		for _, v := range test.expectedGroups {
 			if _, ok := groups[v]; !ok {
 				t.Errorf("test %d : expected value %v to be in the group, was not", i, v)
 

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -29,3 +29,80 @@ func TestHandlers(t *testing.T) {
 		t.Errorf("Expected [testPlugin] from Handlers, got %v", hs)
 	}
 }
+
+func TestGroupingServers(t *testing.T) {
+	for i, test := range []struct {
+		configs []*Config
+		gpes    []string
+		failing bool
+	}{
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53"},
+		},
+			gpes:    []string{"dns://:53"},
+			failing: false},
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53"},
+			{Transport: "dns", Zone: ".", Port: "54"},
+		},
+			gpes:    []string{"dns://:53", "dns://:54"},
+			failing: false},
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53"},
+			{Transport: "dns", Zone: "com.", Port: "53"},
+		},
+			gpes:    []string{"dns://:53"},
+			failing: false},
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1"}},
+			{Transport: "dns", Zone: ".", Port: "54"},
+		},
+			gpes:    []string{"dns://127.0.0.1:53", "dns://:54"},
+			failing: false},
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
+			{Transport: "dns", Zone: ".", Port: "54"}},
+			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:54"},
+			failing: false},
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
+			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
+		},
+			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
+			failing: false},
+		// this group is invalid, for now. Need a checker
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1", "::1"}},
+			{Transport: "dns", Zone: "com.", Port: "53"}},
+			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53", "dns://:53"},
+			failing: false},
+		// this case is working for grouping, but is not supported as overlapping test would eliminate it
+		{configs: []*Config{
+			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1"}},
+			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{"::1"}},
+		},
+			gpes:    []string{"dns://127.0.0.1:53", "dns://[::1]:53"},
+			failing: false},
+	} {
+		groups, err := groupConfigsByListenAddr(test.configs)
+		if err != nil {
+			if !test.failing {
+				t.Fatalf("test %d, expected no errors, but got: %v", i, err)
+			}
+			continue
+		}
+		if test.failing {
+			t.Fatalf("test %d, expected to failed but did not, returned values", i)
+		}
+		if len(groups) != len(test.gpes) {
+			t.Errorf("test %d : expected the group's size to be %d, was %d", i, len(test.gpes), len(groups))
+			continue
+		}
+		for _, v := range test.gpes {
+			if _, ok := groups[v]; !ok {
+				t.Errorf("test %d : expected value %v to be in the group, was not", i, v)
+
+			}
+		}
+	}
+}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -288,9 +288,21 @@ func (s *Server) OnStartupComplete() {
 	}
 
 	for zone := range s.zones {
+		// split addr into protocol, IP and Port
+		_, ip, port, err := SplitProtocolHostPort(s.Addr)
+
+		if err != nil {
+			// this should not happen, but we need to take care of it anyway
+			fmt.Println(zone + ":" + s.Addr)
+			return
+		}
+		if ip == "" {
+			fmt.Println(zone + ":" + port)
+			return
+		}
 		// if the server is listening on a specific address let's make it visible in the log,
 		// so one can differentiate between all active listeners
-		fmt.Println(zone + " on " + s.Addr)
+		fmt.Println(zone + ":" + port + " on " + ip)
 	}
 }
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -287,8 +287,10 @@ func (s *Server) OnStartupComplete() {
 		return
 	}
 
-	for zone, config := range s.zones {
-		fmt.Println(zone + ":" + config.Port)
+	for zone := range s.zones {
+		// if the server is listening on a specific address let's make it visible in the log,
+		// so one can differentiate between all active listeners
+		fmt.Println(zone + " on " + s.Addr)
 	}
 }
 

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -20,11 +20,11 @@ func (tp testPlugin) Name() string { return "testplugin" }
 
 func testConfig(transport string, p plugin.Handler) *Config {
 	c := &Config{
-		Zone:       "example.com.",
-		Transport:  transport,
-		ListenHost: "127.0.0.1",
-		Port:       "53",
-		Debug:      false,
+		Zone:        "example.com.",
+		Transport:   transport,
+		ListenHosts: []string{"127.0.0.1"},
+		Port:        "53",
+		Debug:       false,
 	}
 
 	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -6,16 +6,21 @@
 
 ## Description
 
-Normally, the listener binds to the wildcard host. However, you may force the listener to bind to
-another IP instead. This directive accepts only an address, not a port.
+Normally, the listener binds to the wildcard host. However, you may want the listener to bind to
+another IP instead.      
+
+If several addresses are provided, a listener will be open on each of the IP provided.
+
+Each address has to be an IP of one of the interfaces of the host.
 
 ## Syntax
 
 ~~~ txt
-bind ADDRESS
+bind ADDRESS [ADDRESS] ...
 ~~~
 
-**ADDRESS** is the IP address to bind to.
+**ADDRESS** is an IP address to bind to.
+When several addresses are provides a listener will be opened on each of the addresses
 
 ## Examples
 
@@ -24,5 +29,13 @@ To make your socket accessible only to that machine, bind to IP 127.0.0.1 (local
 ~~~
 . {
     bind 127.0.0.1
+}
+~~~
+
+To allow processing DNS requests only local host on both Ipv4 and Ipv6 stacks, use the syntax:
+
+~~~
+. {
+    bind 127.0.0.1 ::1
 }
 ~~~

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -20,7 +20,7 @@ bind ADDRESS  ...
 ~~~
 
 **ADDRESS** is an IP address to bind to.
-When several addresses are provides a listener will be opened on each of the addresses.
+When several addresses are provided a listener will be opened on each of the addresses.
 
 ## Examples
 

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -16,11 +16,11 @@ Each address has to be an IP of one of the interfaces of the host.
 ## Syntax
 
 ~~~ txt
-bind ADDRESS [ADDRESS] ...
+bind ADDRESS  ...
 ~~~
 
 **ADDRESS** is an IP address to bind to.
-When several addresses are provides a listener will be opened on each of the addresses
+When several addresses are provides a listener will be opened on each of the addresses.
 
 ## Examples
 
@@ -32,7 +32,7 @@ To make your socket accessible only to that machine, bind to IP 127.0.0.1 (local
 }
 ~~~
 
-To allow processing DNS requests only local host on both Ipv4 and Ipv6 stacks, use the syntax:
+To allow processing DNS requests only local host on both IPv4 and IPv6 stacks, use the syntax:
 
 ~~~
 . {

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -26,7 +26,7 @@ When several addresses are provided a listener will be opened on each of the add
 
 To make your socket accessible only to that machine, bind to IP 127.0.0.1 (localhost):
 
-~~~
+~~~ corefile
 . {
     bind 127.0.0.1
 }
@@ -34,8 +34,18 @@ To make your socket accessible only to that machine, bind to IP 127.0.0.1 (local
 
 To allow processing DNS requests only local host on both IPv4 and IPv6 stacks, use the syntax:
 
-~~~
+~~~ corefile
 . {
     bind 127.0.0.1 ::1
+}
+~~~
+
+If the configuration comes up with several *bind* directives, all addresses are consolidated together:
+The following sample is equivalent to the preceding:
+ 
+~~~ corefile
+. {
+    bind 127.0.0.1 
+    bind ::1
 }
 ~~~

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -12,6 +12,9 @@ import (
 
 func setupBind(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
+
+	// addresses will be consolidated over all BIND directives available in that BlocServer
+	allAddresses := []string{}
 	for c.Next() {
 		addresses := c.RemainingArgs()
 		if len(addresses) == 0 {
@@ -22,7 +25,8 @@ func setupBind(c *caddy.Controller) error {
 				return plugin.Error("bind", fmt.Errorf("not a valid IP address: %s", addr))
 			}
 		}
-		config.ListenHosts = addresses
+		allAddresses = append(allAddresses, addresses...)
 	}
+	config.ListenHosts = allAddresses
 	return nil
 }

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -13,12 +13,16 @@ import (
 func setupBind(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
 	for c.Next() {
-		if !c.Args(&config.ListenHost) {
-			return plugin.Error("bind", c.ArgErr())
+		addresses := c.RemainingArgs()
+		if len(addresses) == 0 {
+			return plugin.Error("bind", fmt.Errorf("at least one address is expected"))
 		}
-	}
-	if net.ParseIP(config.ListenHost) == nil {
-		return plugin.Error("bind", fmt.Errorf("not a valid IP address: %s", config.ListenHost))
+		for _, addr := range addresses {
+			if net.ParseIP(addr) == nil {
+				return plugin.Error("bind", fmt.Errorf("not a valid IP address: %s", addr))
+			}
+		}
+		config.ListenHosts = addresses
 	}
 	return nil
 }

--- a/plugin/bind/setup.go
+++ b/plugin/bind/setup.go
@@ -14,19 +14,19 @@ func setupBind(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
 
 	// addresses will be consolidated over all BIND directives available in that BlocServer
-	allAddresses := []string{}
+	all := []string{}
 	for c.Next() {
-		addresses := c.RemainingArgs()
-		if len(addresses) == 0 {
+		addrs := c.RemainingArgs()
+		if len(addrs) == 0 {
 			return plugin.Error("bind", fmt.Errorf("at least one address is expected"))
 		}
-		for _, addr := range addresses {
+		for _, addr := range addrs {
 			if net.ParseIP(addr) == nil {
 				return plugin.Error("bind", fmt.Errorf("not a valid IP address: %s", addr))
 			}
 		}
-		allAddresses = append(allAddresses, addresses...)
+		all = append(all, addrs...)
 	}
-	config.ListenHosts = allAddresses
+	config.ListenHosts = all
 	return nil
 }

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -34,22 +34,6 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func endPointName(hosts []string, port string) string {
-	host := ""
-	switch len(hosts) {
-	case 0:
-	case 1:
-		host = hosts[0]
-	default:
-		host = hosts[0]
-		for _, h := range hosts[1:] {
-			host = host + "," + h
-		}
-		host = "(" + host + ")"
-	}
-	return host + ":" + port
-}
-
 func traceParse(c *caddy.Controller) (*trace, error) {
 	var (
 		tr  = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
@@ -57,7 +41,7 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	)
 
 	cfg := dnsserver.GetConfig(c)
-	tr.ServiceEndpoint = endPointName(cfg.ListenHosts, cfg.Port)
+	tr.ServiceEndpoint = cfg.HostAddresses()
 	for c.Next() { // trace
 		var err error
 		args := c.RemainingArgs()

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -34,6 +34,22 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
+func endPointName(hosts []string, port string) string {
+	host := ""
+	switch len(hosts) {
+	case 0:
+	case 1:
+		host = hosts[0]
+	default:
+		host = hosts[0]
+		for _, h := range hosts[1:] {
+			host = host + "," + h
+		}
+		host = "(" + host + ")"
+	}
+	return host + ":" + port
+}
+
 func traceParse(c *caddy.Controller) (*trace, error) {
 	var (
 		tr  = &trace{Endpoint: defEP, EndpointType: defEpType, every: 1, serviceName: defServiceName}
@@ -41,7 +57,7 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	)
 
 	cfg := dnsserver.GetConfig(c)
-	tr.ServiceEndpoint = cfg.ListenHost + ":" + cfg.Port
+	tr.ServiceEndpoint = endPointName(cfg.ListenHosts, cfg.Port)
 	for c.Next() { // trace
 		var err error
 		args := c.RemainingArgs()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Extend BIND plugin to support multiple addresses.

Config is modified : ListenHost is now an arrays of string named ListenHosts
NOTE: any external plugin that was using the former name will fail at compilation. I updated all changes for internal plugins. (only TRACE was using it to build a name of the server)

These addresses are processed in  'register', while computing the number of Server to create.

UT are provided.

We can now support configurations like:

```
.:5364 {
    reload 2s
    bind 127.0.0.1 ::1  10.84.16.153
    log
    errors
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
}

example.com:5365 {
    log
    errors
    proxy . 8.8.8.8:53 {
        protocol dns force_tcp
    }
}
```


### 2. Which issues (if any) are related?
First step to fix #1478 and #1208 

### 3. Which documentation changes (if any) need to be made?
README of BIND has been updated.
