### PR TITLE
plugin/cache: Don't cache completely empty messages

### DIFF
--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -95,6 +95,10 @@ func minMsgTTL(m *dns.Msg, mt response.Type) time.Duration {
 		return 0
 	}
 
+	if len(m.Answer) == 0 && len(m.Ns) == 0 {
+		return 0
+	}
+
 	minTTL := maxTTL
 	for _, r := range append(m.Answer, m.Ns...) {
 		switch mt {

--- a/plugin/cache/minttl_test.go
+++ b/plugin/cache/minttl_test.go
@@ -25,9 +25,8 @@ func TestMinMsgTTL(t *testing.T) {
 	if mt != response.NoData {
 		t.Fatalf("Expected type to be response.NoData, got %s", mt)
 	}
-	dur := minMsgTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
-	if dur != time.Duration(3600*time.Second) {
-		t.Fatalf("Expected minttl duration to be %d, got %d", 3600, dur)
+	if want, got := 3600*time.Second, minMsgTTL(m, mt); want != got {
+		t.Fatalf("Expected minttl duration to be %s, got %s", want, got)
 	}
 
 	m.Rcode = dns.RcodeNameError
@@ -35,8 +34,12 @@ func TestMinMsgTTL(t *testing.T) {
 	if mt != response.NameError {
 		t.Fatalf("Expected type to be response.NameError, got %s", mt)
 	}
-	dur = minMsgTTL(m, mt) // minTTL on msg is 3600 (neg. ttl on SOA)
-	if dur != time.Duration(3600*time.Second) {
-		t.Fatalf("Expected minttl duration to be %d, got %d", 3600, dur)
+	if want, got := 3600*time.Second, minMsgTTL(m, mt); want != got {
+		t.Fatalf("Expected minttl duration to be %s, got %s", want, got)
+	}
+
+	m.Ns = nil
+	if want, got := 0*time.Second, minMsgTTL(m, mt); want != got {
+		t.Fatalf("Expected minttl duration to be %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
While a well-behaving server should always include a SOA record in the
Authority section for NXDOMAIN/no data responses, CoreDNS should err on
the side of caution and not cache responses for the configured maximum
TTL from such misbehaving servers.

For more information, see Section 3 of [RFC2308](https://tools.ietf.org/html/rfc2308).

@miekg 