### PR TITLE
kubernetes: Tweak federation example in kubernetes README

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -167,10 +167,8 @@ feature enables serving federated domains from the kubernetes clusters.
 
     cluster.local {
         federation {
-            fallthrough
             prod prod.example.org
             staging staging.example.org
-
         }
         kubernetes
     }


### PR DESCRIPTION
### 1. What does this pull request do?

Removes `fallthrough` from the federation example in the kubernetes README.  `fallthrough` isn't needed here and has no meaningful effect (federation already has an implicit fallthrough for non-federated queries).  Its inclusion is confusing.

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?
