### PR TITLE
[WIP] Share listeners in metrics plugin.

### DIFF
--- a/corefile.cfg
+++ b/corefile.cfg
@@ -1,0 +1,22 @@
+. {
+    proxy . /etc/resolv.conf
+    prometheus :9053
+}
+
+google.com {
+    proxy . /etc/resolv.conf
+    prometheus :9053
+    cache 60
+}
+
+github.com {
+    proxy . /etc/resolv.conf
+    prometheus :9053
+    cache 60
+}
+
+segment.com {
+    proxy . /etc/resolv.conf
+    prometheus :9054
+    cache 60
+}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -31,19 +31,17 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() {
-			m := dnsserver.GetConfig(c).Handler("prometheus")
-			if m == nil {
-				return
-			}
-			if x, ok := m.(*metrics.Metrics); ok {
-				x.MustRegister(cacheSize)
-				x.MustRegister(cacheCapacity)
-				x.MustRegister(cacheHits)
-				x.MustRegister(cacheMisses)
-				x.MustRegister(cachePrefetches)
-			}
-		})
+		m := dnsserver.GetConfig(c).Handler("prometheus")
+		if m == nil {
+			return nil
+		}
+		if x, ok := m.(*metrics.Metrics); ok {
+			x.MustRegister(cacheSize)
+			x.MustRegister(cacheCapacity)
+			x.MustRegister(cacheHits)
+			x.MustRegister(cacheMisses)
+			x.MustRegister(cachePrefetches)
+		}
 		return nil
 	})
 


### PR DESCRIPTION
Hi all,

this pull request is a work in progress on the issue discussed in #1492, I'm facing a couple of bumps that I would like to gather input on before I move forward.

The changes I'm making consist of adding a shared state indirection that the `*Metrics` type uses internally to share listeners, http handlers, and prometheus registries. That way metrics of each zones can be exposed to the port they're declared on, and multiple zones can be exposed under the same port.

However there are two issues that the current design makes hard to address:
- plugins used a `sync.Once` variable to prevent registering the metrics multiple times to the same registry, but we need to remove this global synchronization in order to allow metrics to register to the registry of their zone block. This is a significant design change so I want to make sure it's OK.
- prometheus allows collectors (metrics) to be registered to multiple registries, but the use of global variables for metrics in CoreDNS means that metrics of all zones end up being exposed to all listeners, which is not the intuitive behavior (but is better than not having the metrics at all).

Overall, I feel like there's a bit of a need for a better design in how metrics are collected in CoreDNS, which doesn't involve using global variables, so we can properly scope metrics to the zone that they were generated in.

Since prometheus has been used in the project we could keep metrics as fields of the plugin values, so each plugin instantiation only reports on its own metrics to the prometheus registry that it was attached to.

Now there's a catch since two instantiations of a plugin with the same configuration would likely collide and fail to register. We can handle it by inspecting the error returned by [Register](https://godoc.org/github.com/prometheus/client_golang/prometheus#Registerer) in that case, if it's of type [AlreadyRegisteredError](https://godoc.org/github.com/prometheus/client_golang/prometheus#AlreadyRegisteredError) we get returned the collector that the operation conflicted with, so we can use that one in the plugin in place of the one we were attempting to register (since they're basically the same, it won't be wrong for two plugins to use the same metric value).

Another way to work around this problem is two require having the zones that the plugin is part of as constant labels on the metrics it registers. That way there will never be a conflict (since zone blocks are already unique). It also has the nice side effect of providing a way to visualize all metrics for a zone instead of having global ones (like the cache metrics for example).

I think we can make those changes progressively and they don't need to be part of this pull request, if we relax the use of `sync.Once` we get a non-ideal but working behavior, then we can tackle each plugin independently to have them only report metrics for the zone block that they are used in.

Let me know what you think!