### PR TITLE
plugin/kubernetes: Fix reverse zone nxdomain response and tests

### DIFF
--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -18,6 +18,9 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 	}
 
 	records := k.serviceRecordForIP(ip, state.Name())
+	if len(records) == 0 {
+		return records, errNoItems
+	}
 	return records, nil
 }
 

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -155,7 +155,7 @@ func TestReverse(t *testing.T) {
 		},
 		{
 			Qname: "101.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
-			Rcode: dns.RcodeSuccess,
+			Rcode: dns.RcodeNameError,
 			Ns: []dns.RR{
 				test.SOA("0.10.in-addr.arpa.	300	IN	SOA	ns.dns.0.10.in-addr.arpa. hostmaster.0.10.in-addr.arpa. 1502782828 7200 1800 86400 60"),
 			},


### PR DESCRIPTION
### 1. What does this pull request do?

Fixes response code for PTR reverse zone queries of non-existing IPs to be NXDOMAIN.

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?
