### PR TITLE
Enable goimports check, and fixes several imports format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gen:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --deadline=1m --disable-all --enable=gofmt --enable=golint --enable=vet --exclude=^vendor/ --exclude=^pb/ ./...
+	gometalinter --deadline=2m --disable-all --enable=gofmt --enable=golint --enable=vet --enable=goimports --exclude=^vendor/ --exclude=^pb/ ./...
 
 .PHONY: clean
 clean:

--- a/plugin/dnstap/setup_test.go
+++ b/plugin/dnstap/setup_test.go
@@ -1,8 +1,9 @@
 package dnstap
 
 import (
-	"github.com/mholt/caddy"
 	"testing"
+
+	"github.com/mholt/caddy"
 )
 
 func TestConfig(t *testing.T) {

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -2,11 +2,12 @@ package rewrite
 
 import (
 	"fmt"
-	"github.com/coredns/coredns/plugin"
-	"github.com/miekg/dns"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
 )
 
 type nameRule struct {

--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -1,10 +1,11 @@
 package rewrite
 
 import (
-	"github.com/miekg/dns"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/miekg/dns"
 )
 
 // ResponseRule contains a rule to rewrite a response with.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

This fix enables goimports check and fixes several imports format
so that the import sections are prettier, e.g.:
```diff
 import (
-       "github.com/miekg/dns"
        "regexp"
        "strconv"
        "strings"
+
+       "github.com/miekg/dns"
 )
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>