### PR TITLE
Allow overlapping Zones if binding addresses are different

### DIFF
--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -107,11 +107,11 @@ type zoneOverlap struct {
 	unboundOverlap map[zoneAddr]zoneAddr // the "no bind" equiv ZoneAdddr is registered by its original key
 }
 
-func newZoneValidator() *zoneOverlap {
+func newOverlapZone() *zoneOverlap {
 	return &zoneOverlap{registeredAddr: make(map[zoneAddr]zoneAddr), unboundOverlap: make(map[zoneAddr]zoneAddr)}
 }
 
-// register a new zoneAddr, return information about existing or overlapping with already registered
+// registerAndCheck adds a new zoneAddr for validation, it returns information about existing or overlapping with already registered
 // we consider that an unbound address is overlapping all bound addresses for same zone, same port
 func (zo *zoneOverlap) registerAndCheck(z zoneAddr) (existingZone *zoneAddr, overlappingZone *zoneAddr) {
 

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -155,7 +155,7 @@ func TestOverlapAddressChecker(t *testing.T) {
 		},
 	} {
 
-		checker := newZoneValidator()
+		checker := newOverlapZone()
 		for _, call := range test.sequence {
 			same, overlap := checker.registerAndCheck(call.zone)
 			sZone := call.zone.String()

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -144,7 +144,7 @@ func TestOverlapAddressChecker(t *testing.T) {
 			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
 			{zoneAddr{Transport: "dns", Zone: ".", Address: "128.0.0.1", Port: "53"}, false, false, ""},
 			{zoneAddr{Transport: "dns", Zone: ".", Address: "129.0.0.1", Port: "53"}, false, false, ""},
-			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, true, "dns://.:53 on 127.0.0.1"},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, true, "dns://.:53 on 129.0.0.1"},
 		},
 		},
 		{sequence: []checkCall{
@@ -155,21 +155,20 @@ func TestOverlapAddressChecker(t *testing.T) {
 		},
 	} {
 
-		checker := newZoneAddrOverlapValidator()
+		checker := newZoneValidator()
 		for _, call := range test.sequence {
-			same, overlap, okey := checker.registerAndCheck(&call.zone)
+			same, overlap := checker.registerAndCheck(call.zone)
 			sZone := call.zone.String()
-			if same != call.same {
-				t.Errorf("Test %d: error, for zone %s, 'same' (%v) has not the expected value (%v)", i, sZone, same, call.same)
+			if (same != nil) != call.same {
+				t.Errorf("Test %d: error, for zone %s, 'same' (%v) has not the expected value (%v)", i, sZone, same != nil, call.same)
 			}
-			if !same {
-				if overlap != call.overlap {
-					t.Errorf("Test %d: error, for zone %s, 'overlap' (%v) has not the expected value (%v)", i, sZone, overlap, call.overlap)
+			if same == nil {
+				if (overlap != nil) != call.overlap {
+					t.Errorf("Test %d: error, for zone %s, 'overlap' (%v) has not the expected value (%v)", i, sZone, overlap != nil, call.overlap)
 				}
-				if overlap {
-					key := okey.String()
-					if key != call.overlapKey {
-						t.Errorf("Test %d: error, for zone %s, 'overlap Key' (%v) has not the expected value (%v)", i, sZone, key, call.overlapKey)
+				if overlap != nil {
+					if overlap.String() != call.overlapKey {
+						t.Errorf("Test %d: error, for zone %s, 'overlap Key' (%v) has not the expected value (%v)", i, sZone, overlap.String(), call.overlapKey)
 					}
 
 				}

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -110,7 +110,7 @@ func TestSplitProtocolHostPort(t *testing.T) {
 }
 
 type checkCall struct {
-	zone       addrKey
+	zone       zoneAddr
 	same       bool
 	overlap    bool
 	overlapKey string
@@ -123,41 +123,41 @@ type checkTest struct {
 func TestOverlapAddressChecker(t *testing.T) {
 	for i, test := range []checkTest{
 		{sequence: []checkCall{
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "53"}, true, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, true, false, ""},
 		},
 		},
 		{sequence: []checkCall{
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, true, "dns://.:53"},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, true, "dns://.:53"},
 		},
 		},
 		{sequence: []checkCall{
-			{addrKey{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, true, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, true, false, ""},
 		},
 		},
 		{sequence: []checkCall{
-			{addrKey{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "128.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "129.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, true, "dns://.:127.0.0.1:53"},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "54"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "128.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "129.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "", Port: "53"}, false, true, "dns://.:53 on 127.0.0.1"},
 		},
 		},
 		{sequence: []checkCall{
-			{addrKey{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: "com.", Address: "127.0.0.1", Port: "53"}, false, false, ""},
-			{addrKey{Transport: "dns", Zone: "com.", Address: "", Port: "53"}, false, true, "dns://com.:127.0.0.1:53"},
+			{zoneAddr{Transport: "dns", Zone: ".", Address: "127.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: "com.", Address: "127.0.0.1", Port: "53"}, false, false, ""},
+			{zoneAddr{Transport: "dns", Zone: "com.", Address: "", Port: "53"}, false, true, "dns://com.:53 on 127.0.0.1"},
 		},
 		},
 	} {
 
 		checker := newZoneAddrOverlapValidator()
 		for _, call := range test.sequence {
-			same, overlap, overkey := checker.registerAndCheck(&call.zone)
+			same, overlap, okey := checker.registerAndCheck(&call.zone)
 			sZone := call.zone.String()
 			if same != call.same {
 				t.Errorf("Test %d: error, for zone %s, 'same' (%v) has not the expected value (%v)", i, sZone, same, call.same)
@@ -167,10 +167,6 @@ func TestOverlapAddressChecker(t *testing.T) {
 					t.Errorf("Test %d: error, for zone %s, 'overlap' (%v) has not the expected value (%v)", i, sZone, overlap, call.overlap)
 				}
 				if overlap {
-					okey, errLoad := parseAddrKey(overkey)
-					if errLoad != nil {
-						t.Errorf("cannot parse the overla key ??? : %s - error is : %v", overkey, errLoad)
-					}
 					key := okey.String()
 					if key != call.overlapKey {
 						t.Errorf("Test %d: error, for zone %s, 'overlap Key' (%v) has not the expected value (%v)", i, sZone, key, call.overlapKey)

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -78,6 +78,6 @@ func GetConfig(c *caddy.Controller) *Config {
 	// we should only get here during tests because directive
 	// actions typically skip the server blocks where we make
 	// the configs.
-	ctx.saveConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex, &Config{})
+	ctx.saveConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex, &Config{ListenHosts: []string{""}})
 	return GetConfig(c)
 }

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -72,12 +72,12 @@ func (c *Config) HostAddresses() string {
 // If none exist nil is returned.
 func GetConfig(c *caddy.Controller) *Config {
 	ctx := c.Context().(*dnsContext)
-	if cfg, ok := ctx.keysToConfigs[c.Key]; ok {
+	if cfg, ok := ctx.getConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex); ok {
 		return cfg
 	}
 	// we should only get here during tests because directive
 	// actions typically skip the server blocks where we make
 	// the configs.
-	ctx.saveConfig(c.Key, &Config{ListenHosts: []string{""}})
+	ctx.saveConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex, &Config{})
 	return GetConfig(c)
 }

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -69,7 +69,7 @@ func (c *Config) HostAddresses() string {
 	return all
 }
 
-// build a key for identifying the configs during setup time
+// keyForConfig build a key for identifying the configs during setup time
 func keyForConfig(blocIndex int, blocKeyIndex int) string {
 	return fmt.Sprintf("%d:%d", blocIndex, blocKeyIndex)
 }

--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -2,6 +2,7 @@ package dnsserver
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 
 	"github.com/coredns/coredns/plugin"
@@ -68,16 +69,22 @@ func (c *Config) HostAddresses() string {
 	return all
 }
 
+// build a key for identifying the configs during setup time
+func keyForConfig(blocIndex int, blocKeyIndex int) string {
+	return fmt.Sprintf("%d:%d", blocIndex, blocKeyIndex)
+}
+
 // GetConfig gets the Config that corresponds to c.
 // If none exist nil is returned.
 func GetConfig(c *caddy.Controller) *Config {
 	ctx := c.Context().(*dnsContext)
-	if cfg, ok := ctx.getConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex); ok {
+	key := keyForConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex)
+	if cfg, ok := ctx.keysToConfigs[key]; ok {
 		return cfg
 	}
 	// we should only get here during tests because directive
 	// actions typically skip the server blocks where we make
 	// the configs.
-	ctx.saveConfig(c.ServerBlockIndex, c.ServerBlockKeyIndex, &Config{ListenHosts: []string{""}})
+	ctx.saveConfig(key, &Config{ListenHosts: []string{""}})
 	return GetConfig(c)
 }

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -101,9 +101,6 @@ func (h *dnsContext) MakeServers() ([]caddy.Server, error) {
 	if errValid != nil {
 		return nil, errValid
 	}
-	// at this point, the Configs in context are saved in an array.
-	// the keyToConfig map is not needed anymore - reset.
-	h.keysToConfigs = map[string]*Config{}
 
 	// we must map (group) each config to a bind address
 	groups, err := groupConfigsByListenAddr(h.configs)

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -187,17 +187,17 @@ func (c *Config) Handlers() []plugin.Handler {
 
 func (h *dnsContext) validateZonesAndListeningAddresses() error {
 	//Validate Zone and addresses
-	checker := newZoneAddrOverlapValidator()
+	checker := newZoneValidator()
 	for _, conf := range h.configs {
 		for _, h := range conf.ListenHosts {
 			// Validate the overlapping of ZoneAddr
-			akey := &zoneAddr{Transport: conf.Transport, Zone: conf.Zone, Address: h, Port: conf.Port}
-			alreadyDefined, overlapDefined, overlapAddr := checker.registerAndCheck(akey)
-			if alreadyDefined {
+			akey := zoneAddr{Transport: conf.Transport, Zone: conf.Zone, Address: h, Port: conf.Port}
+			existZone, overlapZone := checker.registerAndCheck(akey)
+			if existZone != nil {
 				return fmt.Errorf("cannot serve %s - it is already defined", akey.String())
 			}
-			if overlapDefined {
-				return fmt.Errorf("cannot serve %s - zone overlap listener capacity with %v", akey.String(), overlapAddr.String())
+			if overlapZone != nil {
+				return fmt.Errorf("cannot serve %s - zone overlap listener capacity with %v", akey.String(), overlapZone.String())
 			}
 
 		}

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -187,7 +187,7 @@ func (c *Config) Handlers() []plugin.Handler {
 
 func (h *dnsContext) validateZonesAndListeningAddresses() error {
 	//Validate Zone and addresses
-	checker := newZoneValidator()
+	checker := newOverlapZone()
 	for _, conf := range h.configs {
 		for _, h := range conf.ListenHosts {
 			// Validate the overlapping of ZoneAddr

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -119,20 +119,3 @@ func TestGroupingServers(t *testing.T) {
 		}
 	}
 }
-
-func checkConfigvalues(t *testing.T, cfg *Config, zone string, hosts []string) {
-	if cfg == nil {
-		t.Errorf("expected config but got a nil pts")
-	}
-	if cfg.Zone != zone {
-		t.Errorf("expected zone %v, but got %v", zone, cfg.Zone)
-	}
-	if len(cfg.ListenHosts) != len(hosts) {
-		t.Errorf("expected count of listening host :  %v, but got %v", len(hosts), len(cfg.ListenHosts))
-	}
-	for i, h := range hosts {
-		if cfg.ListenHosts[i] != h {
-			t.Errorf("expected listening host %v, but got %v", h, cfg.ListenHosts[i])
-		}
-	}
-}

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -51,7 +51,7 @@ func TestGroupingServers(t *testing.T) {
 			expectedGroups: []string{"dns://:53", "dns://:54"},
 			failing:        false},
 
-		// 2 configs on same port, both undound, diff zones -> 1 group
+		// 2 configs on same port, both not using bind, diff zones -> 1 group
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{""}},
 			{Transport: "dns", Zone: "com.", Port: "53", ListenHosts: []string{""}},
@@ -59,7 +59,7 @@ func TestGroupingServers(t *testing.T) {
 			expectedGroups: []string{"dns://:53"},
 			failing:        false},
 
-		// 2 configs on same port, one addressed - one unbound, diff zones -> 1 group
+		// 2 configs on same port, one addressed - one not using bind, diff zones -> 1 group
 		{configs: []*Config{
 			{Transport: "dns", Zone: ".", Port: "53", ListenHosts: []string{"127.0.0.1"}},
 			{Transport: "dns", Zone: ".", Port: "54", ListenHosts: []string{""}},

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -136,38 +136,3 @@ func checkConfigvalues(t *testing.T, cfg *Config, zone string, hosts []string) {
 		}
 	}
 }
-func TestConfigPersistence(t *testing.T) {
-	// verify that the right config is saved in the right place
-	// verify we can now save configs with same zone
-	ctx := &dnsContext{keysToConfigs: make(map[string]*Config)}
-
-	test := []struct {
-		blocindex int
-		keyindex  int
-		cfg       *Config
-	}{
-		{blocindex: 1, keyindex: 1, cfg: &Config{Zone: "one", ListenHosts: []string{"one", "two"}}},
-		{blocindex: 1, keyindex: 2, cfg: &Config{Zone: "two", ListenHosts: []string{"one"}}},
-		{blocindex: 2, keyindex: 1, cfg: &Config{Zone: "one", ListenHosts: []string{"one", "two"}}},
-		{blocindex: 2, keyindex: 2, cfg: &Config{Zone: "one", ListenHosts: []string{"one"}}},
-		{blocindex: 0, keyindex: 0, cfg: &Config{Zone: ".", ListenHosts: []string{""}}},
-	}
-
-	for _, tt := range test {
-		ctx.saveConfig(tt.blocindex, tt.keyindex, tt.cfg)
-
-	}
-
-	if len(ctx.keysToConfigs) != len(test) {
-		t.Fatalf("expected %v configs saved in context, got %v", len(test), len(ctx.keysToConfigs))
-	}
-
-	// now verify there is no mixup in the saved zones
-	for i, tt := range test {
-		cfg, ok := ctx.getConfig(tt.blocindex, tt.keyindex)
-		if !ok {
-			t.Fatalf("test %v, cannot retrieve the config from context", i)
-		}
-		checkConfigvalues(t, cfg, tt.cfg.Zone, tt.cfg.ListenHosts)
-	}
-}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -65,6 +65,10 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		// set the config per zone
 		s.zones[site.Zone] = site
 		// compile custom plugin for everything
+		if site.registry != nil {
+			// this config is already computed with the chain of plugin
+			continue
+		}
 		var stack plugin.Handler
 		for i := len(site.Plugin) - 1; i >= 0; i-- {
 			stack = site.Plugin[i](stack)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

## 1. What does this pull request do?
Change the validation of overlapping zones of  ServerBlocs, by integrating the IP address that ServerBloc is bound too. 
(so far validation of overlapping was on Zone and Port only).

The support of overlapping zones implies changes in 2 areas:

### Validation of overlapping
The validator itself is moved a bit later in the process, after BIND defined the addresses of each ServerBloc. It is now moved in the MakeServer() - after the directives are processed, before we are grouping the Configs in order to create the Servers.

NOTE: the validation is now a little more complex as it has to take care of bound zones and unbound zones. I created an object to take care of it. see zoneAddrOverlapValidator in addresse.go

### registering the Configs in dnsContext
The key used to save Config in the dnsContext has to change because the keys of ServerBloc are no more discriminant for the ServerBlocs. It was the 'zone:port' information, it is now the concat of 2 index: position of the ServerBloc in the list, position of the Key in that ServerBloc.
=> GetConfig and SaveConfig has been changed accordingly.


Unit Tests are provided for each modified areas.
I prepare integration tests to validate the workflow of DNS messages inside the BlocLists. But it involves too much changes to integrate in this PR.
Will open a PR after this one will be approved.

## 2. Which issues (if any) are related?
#1478  and #1208 
it is second part of PR #1512

## 3. Which documentation changes (if any) need to be made?
- the global README of coredns does not specify the validation of overlapping zones/ports
- do we want to add an information in that doc ?

NOTE: I did not browse yet the blogs to check if there is a mention of overlapping check.
