### PR TITLE
go 1.10: update travis and gofmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 
 language: go
 go:
-  - 1.9
+  - "1.9"
+  - "1.10"
 
 go_import_path: github.com/coredns/coredns
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ gen:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --deadline=2m --disable-all --enable=gofmt --enable=golint --enable=vet --enable=goimports --exclude=^vendor/ --exclude=^pb/ ./...
+	gometalinter --deadline=2m --disable-all --enable=golint --enable=vet --enable=goimports --vendor --exclude=^pb/ ./...
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ coredns: $(CHECKS)
 	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
-check: linter core/zplugin.go core/dnsserver/zdirectives.go godeps
+check: linter goimports core/zplugin.go core/dnsserver/zdirectives.go godeps
 
 .PHONY: test
 test: check
@@ -78,7 +78,11 @@ gen:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --deadline=2m --disable-all --enable=golint --enable=vet --enable=goimports --vendor --exclude=^pb/ ./...
+	gometalinter --deadline=2m --disable-all --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
+
+.PHONY: goimports
+goimports:
+	( gometalinter --deadline=2m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
 
 .PHONY: clean
 clean:

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -18,8 +18,8 @@ func TestTLS(t *testing.T) {
 		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-	// positive
-	// negative
+		// positive
+		// negative
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
fmt now complains about on file tls_test.go, fix that. Also remove
gofmt, as goimports also checks, so this was done twice.

Put go 1.9 and 1.10 in travis for the time being.