### PR TITLE
Update broken proxy plugin readme links

### DIFF
--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -56,9 +56,7 @@ proxy FROM TO... {
 * `protocol` specifies what protocol to use to speak to an upstream, `dns` (the default) is plain
   old DNS, and `https_google` uses `https://dns.google.com` and speaks a JSON DNS dialect. Note when
   using this **TO** will be ignored. The `grpc` option will talk to a server that has implemented
-  the [DnsService](https://github.com/coredns/coredns/pb/dns.proto).
-  An out-of-tree plugin that implements the server side of this can be found at
-  [here](https://github.com/infobloxopen/coredns-grpc).
+  the [DnsService](https://github.com/coredns/coredns/blob/master/pb/dns.proto).
 
 ## Policies
 
@@ -90,8 +88,6 @@ payload over HTTPS). Note that with `https_google` the entire transport is encry
      certificate is verified with the system CAs.
   * **KEY** **CERT** **CACERT** - Client authentication is used with the specified key/cert pair. The
      server certificate is verified using the **CACERT** file.
-  An out-of-tree plugin that implements the server side of this can be found at
-  [here](https://github.com/infobloxopen/coredns-grpc).
 
 `https_google`
 :    bootstrap **ADDRESS...** is used to (re-)resolve `dns.google.com`.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
1. Updates a broken link to a pb file.
2. Removes references to the coredns-grpc plugin, which is no longer in use.

### 2. Which issues (if any) are related?
No open issue. Related to this other PR: https://github.com/coredns/coredns.io/pull/66

### 3. Which documentation changes (if any) need to be made?
It's a documentation change.
