### PR TITLE
Caddy 0.10.11 Fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ godeps:
 	go get -u github.com/prometheus/client_golang/prometheus
 	go get -u golang.org/x/net/context
 	go get -u golang.org/x/text
-	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.10)
+	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.11)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.4)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
 	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)

--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -34,7 +34,7 @@ func init() {
 	})
 }
 
-func newContext() caddy.Context {
+func newContext(i *caddy.Instance) caddy.Context {
 	return &dnsContext{keysToConfigs: make(map[string]*Config)}
 }
 


### PR DESCRIPTION
Caddy 0.10.11 is released. Fix CoreDNS to compile against that version.
This also helps people compiling CoreDNS and go getting non-vendored
deps.