### PR TITLE
plugin/kubernetes: PTR/A reverse query corner cases

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -122,7 +122,7 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		return []msg.Service{svc}, nil
 	}
 
-	if dnsutil.IsReverse(state.Name()){
+	if dnsutil.IsReverse(state.Name()) {
 		// If the query is in a reverse zone, don't look up services
 		// instead return no answer, with error code of reverse lookup
 		_, err := k.Reverse(state, exact, opt)

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -122,14 +122,6 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		return []msg.Service{svc}, nil
 	}
 
-	if dnsutil.IsReverse(state.Name()) {
-		// If the query is in a reverse zone, don't look up services
-		// instead return no answer, with error code of reverse lookup
-		_, err := k.Reverse(state, exact, opt)
-		return svcs, err
-
-	}
-
 	s, e := k.Records(state, false)
 
 	// SRV for external services is not yet implemented, so remove those records.
@@ -280,6 +272,10 @@ func (k *Kubernetes) Records(state request.Request, exact bool) ([]msg.Service, 
 	r, e := parseRequest(state)
 	if e != nil {
 		return nil, e
+	}
+
+	if dnsutil.IsReverse(state.Name()) {
+		return nil, errNoItems
 	}
 
 	if !wildcard(r.namespace) && !k.namespaceExposed(r.namespace) {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -122,6 +122,14 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		return []msg.Service{svc}, nil
 	}
 
+	if dnsutil.IsReverse(state.Name()){
+		// If the query is in a reverse zone, don't look up services
+		// instead return no answer, with error code of reverse lookup
+		_, err := k.Reverse(state, exact, opt)
+		return svcs, err
+
+	}
+
 	s, e := k.Records(state, false)
 
 	// SRV for external services is not yet implemented, so remove those records.

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -14,7 +14,7 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
-		return nil, nil
+		return nil, errNoItems
 	}
 
 	records := k.serviceRecordForIP(ip, state.Name())

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -14,7 +14,11 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
-		return nil, errNoItems
+		if dnsutil.IsReverse(state.Name()) {
+			return nil, errNoItems
+		}
+		_, e := k.Records(state, exact)
+		return nil, e
 	}
 
 	records := k.serviceRecordForIP(ip, state.Name())

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -14,9 +14,6 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
-		if dnsutil.IsReverse(state.Name()) {
-			return nil, errNoItems
-		}
 		_, e := k.Records(state, exact)
 		return nil, e
 	}

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -29,7 +29,7 @@ func ExtractAddressFromReverse(reverseName string) string {
 	return f(strings.Split(search, "."))
 }
 
-// IsReverse returns true of the name is in a reverse zone
+// IsReverse returns true if name is in a reverse zone
 func IsReverse(name string) bool {
 	return strings.HasSuffix(name, v4arpaSuffix) || strings.HasSuffix(name, v6arpaSuffix)
 }

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -29,6 +29,11 @@ func ExtractAddressFromReverse(reverseName string) string {
 	return f(strings.Split(search, "."))
 }
 
+// IsReverse returns true of the name is in a reverse zone
+func IsReverse(name string) bool {
+	return strings.HasSuffix(name, v4arpaSuffix) || strings.HasSuffix(name, v6arpaSuffix)
+}
+
 func reverse(slice []string) string {
 	for i := 0; i < len(slice)/2; i++ {
 		j := len(slice) - i - 1


### PR DESCRIPTION
### 1. What does this pull request do?

Corrects some answers for _corner case_ queries when reverse zones are in the zones list.
Assuming `kubernetes cluster.local in-addr.arpa`, and that `svc1.default.cluster.local A 10.0.0.100` exists ...

`svc1.default.svc.in-addr.arpa.` `A` => `NXDOMAIN` (previously returned an `A` record for the service)
`100.0.0.10.in-addr.arpa.` `A` => `NODATA` (previously returned `NXDOMAIN`)
`svc1.default.svc.in-addr.arpa.` `PTR` => `NXDOMAIN` (previously returned `NODATA`)
`not-a-service.default.svc.cluster.local.` `PTR` => `NXDOMAIN` (previously returned `NODATA`)

coredns/ci tests will need to be adjusted/amended...

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?