### PR TITLE
Update golang.org/x/net and golang.org/x/text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ godeps:
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.11)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.4)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
-	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.9)
-	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q e19ae1496984b1c655b8044a65c0300a3c878dd3)
+	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.10)
+	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q v0.3.0)
 
 .PHONY: travis
 travis: check

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ a Go environment, you could build CoreDNS easily:
 
 ```
 $ docker run --rm -i -t -v $PWD:/go/src/github.com/coredns/coredns \
-      -w /go/src/github.com/coredns/coredns golang:1.9 make
+      -w /go/src/github.com/coredns/coredns golang:1.10 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix updates golang.org/x/net to release-branch.go1.10
and golang.org/x/text to v0.3.0, for the purpose of
aligning with go version 1.10.


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

This fix also updates README.md to promote using go 1.10.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>