### PR TITLE
Rename reverse zone constants

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -274,7 +274,7 @@ func (k *Kubernetes) Records(state request.Request, exact bool) ([]msg.Service, 
 		return nil, e
 	}
 
-	if dnsutil.IsReverse(state.Name()) {
+	if dnsutil.IsReverse(state.Name()) > 0 {
 		return nil, errNoItems
 	}
 

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/parse"
-
 	"github.com/coredns/coredns/plugin/pkg/upstream"
+
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,7 +114,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 
 	k8s.primaryZoneIndex = -1
 	for i, z := range k8s.Zones {
-		if strings.HasSuffix(z, "in-addr.arpa.") || strings.HasSuffix(z, "ip6.arpa.") {
+		if dnsutil.IsReverse(z) > 0 {
 			continue
 		}
 		k8s.primaryZoneIndex = i

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -16,10 +16,10 @@ func ExtractAddressFromReverse(reverseName string) string {
 	f := reverse
 
 	switch {
-	case strings.HasSuffix(reverseName, v4arpaSuffix):
-		search = strings.TrimSuffix(reverseName, v4arpaSuffix)
-	case strings.HasSuffix(reverseName, v6arpaSuffix):
-		search = strings.TrimSuffix(reverseName, v6arpaSuffix)
+	case strings.HasSuffix(reverseName, IP4arpa):
+		search = strings.TrimSuffix(reverseName, IP4arpa)
+	case strings.HasSuffix(reverseName, IP6arpa):
+		search = strings.TrimSuffix(reverseName, IP6arpa)
 		f = reverse6
 	default:
 		return ""
@@ -29,9 +29,17 @@ func ExtractAddressFromReverse(reverseName string) string {
 	return f(strings.Split(search, "."))
 }
 
-// IsReverse returns true if name is in a reverse zone
-func IsReverse(name string) bool {
-	return strings.HasSuffix(name, v4arpaSuffix) || strings.HasSuffix(name, v6arpaSuffix)
+// IsReverse returns 0 is name is not in a reverse zone. Anything > 0 indicates
+// name is in a reverse zone. The returned integer will be 1 for in-addr.arpa. (IPv4)
+// and 2 for ip6.arpa. (IPv6).
+func IsReverse(name string) int {
+	if strings.HasSuffix(name, IP4arpa) {
+		return 1
+	}
+	if strings.HasSuffix(name, IP6arpa) {
+		return 2
+	}
+	return 0
 }
 
 func reverse(slice []string) string {
@@ -66,8 +74,8 @@ func reverse6(slice []string) string {
 }
 
 const (
-	// v4arpaSuffix is the reverse tree suffix for v4 IP addresses.
-	v4arpaSuffix = ".in-addr.arpa."
-	// v6arpaSuffix is the reverse tree suffix for v6 IP addresses.
-	v6arpaSuffix = ".ip6.arpa."
+	// IP4arpa is the reverse tree suffix for v4 IP addresses.
+	IP4arpa = ".in-addr.arpa."
+	// IP6arpa is the reverse tree suffix for v6 IP addresses.
+	IP6arpa = ".ip6.arpa."
 )

--- a/plugin/pkg/dnsutil/reverse_test.go
+++ b/plugin/pkg/dnsutil/reverse_test.go
@@ -49,3 +49,23 @@ func TestExtractAddressFromReverse(t *testing.T) {
 		}
 	}
 }
+
+func TestIsReverse(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected int
+	}{
+		{"b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa.", 2},
+		{"d.0.1.0.0.2.in-addr.arpa.", 1},
+		{"example.com.", 0},
+		{"", 0},
+		{"in-addr.arpa.example.com.", 0},
+	}
+	for i, tc := range tests {
+		got := IsReverse(tc.name)
+		if got != tc.expected {
+			t.Errorf("Test %d, got %d, expected %d for %s", i, got, tc.expected, tc.name)
+		}
+
+	}
+}


### PR DESCRIPTION
Rename the constants to IP4arpa and IP6arpa (shorter and exported) and
make IsReverse return the type of the reverse zone which could be handy
for some callers.

Also add tests for IsReverse()