### PR TITLE
plugin/log: log remote port addr as well

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -59,7 +59,7 @@ The following place holders are supported:
 * `{class}`: qclass of the request
 * `{proto}`: protocol used (tcp or udp)
 * `{when}`: time of the query
-* `{remote}`: client's IP address
+* `{remote}`: client's IP address, for IPv6 addresses these are enclosed in brackets: `[::1]`
 * `{size}`: request size in bytes
 * `{port}`: client's port
 * `{duration}`: response duration
@@ -75,7 +75,7 @@ The following place holders are supported:
 The default Common Log Format is:
 
 ~~~ txt
-`{remote} - [{when}] {>id} "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
+`{remote}:{port} - [{when}] {>id} "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
 ~~~
 
 ## Examples

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -78,7 +78,7 @@ type Rule struct {
 
 const (
 	// CommonLogFormat is the common log format.
-	CommonLogFormat = `{remote} ` + CommonLogEmptyValue + ` [{when}] {>id} "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
+	CommonLogFormat = `{remote}:{port} ` + CommonLogEmptyValue + ` [{when}] {>id} "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
 	// CommonLogEmptyValue is the common empty log value.
 	CommonLogEmptyValue = "-"
 	// CombinedLogFormat is the combined log format.

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -43,7 +43,7 @@ func New(r *dns.Msg, rr *dnstest.Recorder, emptyValue string) Replacer {
 				return time.Now().Format(timeFormat)
 			}(),
 			"{size}":   strconv.Itoa(req.Len()),
-			"{remote}": req.IP(),
+			"{remote}": addrToRFC3986(req.IP()),
 			"{port}":   req.Port(),
 		},
 		emptyValue: emptyValue,
@@ -153,6 +153,14 @@ func flagsToString(h dns.MsgHdr) string {
 		i++
 	}
 	return strings.Join(flags[:i], ",")
+}
+
+// addrToRFC3986 will add brackets to the address if it is an IPv6 address.
+func addrToRFC3986(addr string) string {
+	if strings.Contains(addr, ":") {
+		return "[" + addr + "]"
+	}
+	return addr
 }
 
 const (


### PR DESCRIPTION
Log the remote's port, for IPv6 addr this means we should enclose the v6
address in brackets; make this the default for 'remote'.

Fixes #1572