### PR TITLE
plugin/deprecated: add an easy way to error on deprecated plugin

### DIFF
--- a/plugin/deprecated/setup.go
+++ b/plugin/deprecated/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mholt/caddy"
 )
 
+// removed has the names of the plugins that need to error on startup.
 var removed = []string{"startup", "shutdown"}
 
 func setup(c *caddy.Controller) error {

--- a/plugin/deprecated/setup.go
+++ b/plugin/deprecated/setup.go
@@ -1,15 +1,13 @@
-/*
-package deprecated is used when we deprecated plugin. In plugin.cfg just go from
-
-startup:github.com/mholt/caddy/startupshutdown
-
-To:
-
-startup:deprecated
-
-And things should work as expected. This means starting CoreDNS will fail with an error. We can only
-point to the release notes and what are the next steps to take
-*/
+// Package deprecated is used when we deprecated plugin. In plugin.cfg just go from
+//
+// startup:github.com/mholt/caddy/startupshutdown
+//
+// To:
+//
+// startup:deprecated
+//
+// And things should work as expected. This means starting CoreDNS will fail with an error. We can only
+// point to the release notes and what are the next steps to take
 package deprecated
 
 import (

--- a/plugin/deprecated/setup.go
+++ b/plugin/deprecated/setup.go
@@ -1,0 +1,38 @@
+/*
+package deprecated is used when we deprecated plugin. In plugin.cfg just go from
+
+startup:github.com/mholt/caddy/startupshutdown
+
+To:
+
+startup:deprecated
+
+And things should work as expected. This means starting CoreDNS will fail with an error. We can only
+point to the release notes and what are the next steps to take
+*/
+package deprecated
+
+import (
+	"errors"
+
+	"github.com/coredns/coredns/plugin"
+
+	"github.com/mholt/caddy"
+)
+
+var removed = []string{"startup", "shutdown"}
+
+func setup(c *caddy.Controller) error {
+	c.Next()
+	x := c.Val()
+	return plugin.Error(x, errors.New("this plugin has been deprecated"))
+}
+
+func init() {
+	for _, plugin := range removed {
+		caddy.RegisterPlugin(plugin, caddy.Plugin{
+			ServerType: "dns",
+			Action:     setup,
+		})
+	}
+}

--- a/plugin/deprecated/setup.go
+++ b/plugin/deprecated/setup.go
@@ -7,7 +7,8 @@
 // startup:deprecated
 //
 // And things should work as expected. This means starting CoreDNS will fail with an error. We can only
-// point to the release notes and what are the next steps to take
+// point to the release notes to details what next steps a user should take. I.e. there is no way to add this
+// to the error generated.
 package deprecated
 
 import (


### PR DESCRIPTION
See package docs; will send another PR that enables this for startup and shutdown; i.e. trigger erorr on startup.