### PR TITLE
deprecate startup/shutdown

### DIFF
--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/cache"
 	_ "github.com/coredns/coredns/plugin/chaos"
 	_ "github.com/coredns/coredns/plugin/debug"
+	_ "github.com/coredns/coredns/plugin/deprecated"
 	_ "github.com/coredns/coredns/plugin/dnssec"
 	_ "github.com/coredns/coredns/plugin/dnstap"
 	_ "github.com/coredns/coredns/plugin/erratic"
@@ -37,5 +38,4 @@ import (
 	_ "github.com/coredns/coredns/plugin/trace"
 	_ "github.com/coredns/coredns/plugin/whoami"
 	_ "github.com/mholt/caddy/onevent"
-	_ "github.com/mholt/caddy/startupshutdown"
 )

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -53,5 +53,5 @@ proxy:proxy
 erratic:erratic
 whoami:whoami
 on:github.com/mholt/caddy/onevent
-startup:github.com/mholt/caddy/startupshutdown
-shutdown:github.com/mholt/caddy/startupshutdown
+startup:deprecated
+shutdown:deprecated


### PR DESCRIPTION
error on startup when we see these in a corefile:

~~~
% ./coredns
2018/03/01 06:51:23 plugin/startup: this plugin has been deprecated
% ./coredns
2018/03/01 06:51:32 plugin/shutdown: this plugin has been deprecated
~~~

Release are (or should get updated)