### PR TITLE
Allow DNS name to be specified in place of IP address (forward plugin)

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -109,7 +109,7 @@ func parseForward(c *caddy.Controller) (*Forward, error) {
 
 		// If parseHostPortOrFile expands a file with a lot of nameserver our accounting in protocols doesn't make
 		// any sense anymore... For now: lets don't care.
-		toHosts, err := dnsutil.ParseHostPortOrFile(to...)
+		toHosts, err := dnsutil.ParseHostPortOrFileOrDNSName(to...)
 		if err != nil {
 			return f, err
 		}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -28,7 +28,7 @@ func TestSetup(t *testing.T) {
 		{"forward . [::1]:53", false, ".", nil, 2, false, ""},
 		{"forward . [2003::1]:53", false, ".", nil, 2, false, ""},
 		// negative
-		{"forward . a27.0.0.1", true, "", nil, 0, false, "not an IP"},
+		{"forward . -27.0.0.1", true, "", nil, 0, false, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, false, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, false, "plugin"},

--- a/plugin/pkg/dnsutil/host.go
+++ b/plugin/pkg/dnsutil/host.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"regexp"
 
 	"github.com/miekg/dns"
 )
@@ -12,6 +13,17 @@ import (
 // address:port or a filename. The address part is checked and the filename case a
 // resolv.conf like file is parsed and the nameserver found are returned.
 func ParseHostPortOrFile(s ...string) ([]string, error) {
+	return parseHostPortOrFileOrDNSName(false, s...)
+}
+
+// ParseHostPortOrFileOrDNSName parses the strings in s, each string can either be a address,
+// address:port or a filename or a DNS name. The address part is checked, DNS name is validated
+//  and the filename case a resolv.conf like file is parsed and the nameserver found are returned.
+func ParseHostPortOrFileOrDNSName(s ...string) ([]string, error) {
+	return parseHostPortOrFileOrDNSName(true, s...)
+}
+
+func parseHostPortOrFileOrDNSName(allowDNSName bool, s ...string) ([]string, error) {
 	var servers []string
 	for _, host := range s {
 		addr, _, err := net.SplitHostPort(host)
@@ -19,11 +31,18 @@ func ParseHostPortOrFile(s ...string) ([]string, error) {
 			// Parse didn't work, it is not a addr:port combo
 			if net.ParseIP(host) == nil {
 				// Not an IP address.
+				if allowDNSName && isDNSName(host) {
+					// consider address to be DNS name
+					servers = append(servers, net.JoinHostPort(host, "53"))
+					continue
+				}
+
 				ss, err := tryFile(host)
 				if err == nil {
 					servers = append(servers, ss...)
 					continue
 				}
+
 				return servers, fmt.Errorf("not an IP address or file: %q", host)
 			}
 			ss := net.JoinHostPort(host, "53")
@@ -33,11 +52,18 @@ func ParseHostPortOrFile(s ...string) ([]string, error) {
 
 		if net.ParseIP(addr) == nil {
 			// No an IP address.
+			if allowDNSName && isDNSName(host) {
+				// consider address to be hostname
+				servers = append(servers, host)
+				continue
+			}
+
 			ss, err := tryFile(host)
 			if err == nil {
 				servers = append(servers, ss...)
 				continue
 			}
+
 			return servers, fmt.Errorf("not an IP address or file: %q", host)
 		}
 		servers = append(servers, host)
@@ -48,7 +74,7 @@ func ParseHostPortOrFile(s ...string) ([]string, error) {
 // Try to open this is a file first.
 func tryFile(s string) ([]string, error) {
 	c, err := dns.ClientConfigFromFile(s)
-	if err == os.ErrNotExist {
+	if os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to open file %q: %q", s, err)
 	} else if err != nil {
 		return nil, err
@@ -59,6 +85,13 @@ func tryFile(s string) ([]string, error) {
 		servers = append(servers, net.JoinHostPort(s, c.Port))
 	}
 	return servers, nil
+}
+
+const dnsName string = `^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*[\._]?$`
+
+// Verify that string validates as DNS name
+func isDNSName(s string) bool {
+	return regexp.MustCompile(dnsName).MatchString(s)
 }
 
 // ParseHostPort will check if the host part is a valid IP address, if the


### PR DESCRIPTION
### 1. What does this pull request do?

Configuring DNS upstreams via DNS names might be considered a bad idea,
but sometimes it's inevitable - if DNS server runs in a container platform,
getting fixed IP for a service might be really tricky.

This change tries to keep backwards compatibility - for non-IP config
entries files are checked first, and only if file doesn't exist and string
looks like DNS name, it's used as input.

I've verified this `forward` plugin, and it works as expected.

### 2. Which issues (if any) are related?

None that I'm aware of.

### 3. Which documentation changes (if any) need to be made?

There should be a lot of documentation and test updates, but I would like to see if such change might be considered appropriate or not.

Sample config:

```
service.consul {
    log
    errors
    forward service.consul marathon.service.example.com:53 {
         force_tcp
    }
}
``` 