### PR TITLE
logging: Don't use PrintF when not needed

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -177,7 +177,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key int, mt response.Type, duration tim
 
 // Write implements the dns.ResponseWriter interface.
 func (w *ResponseWriter) Write(buf []byte) (int, error) {
-	log.Printf("[WARNING] Caching called with Write: not caching reply")
+	log.Print("[WARNING] Caching called with Write: not caching reply")
 	if w.prefetch {
 		return 0, nil
 	}

--- a/plugin/dnssec/responsewriter.go
+++ b/plugin/dnssec/responsewriter.go
@@ -40,7 +40,7 @@ func (d *ResponseWriter) WriteMsg(res *dns.Msg) error {
 
 // Write implements the dns.ResponseWriter interface.
 func (d *ResponseWriter) Write(buf []byte) (int, error) {
-	log.Printf("[WARNING] Dnssec called with Write: not signing reply")
+	log.Print("[WARNING] Dnssec called with Write: not signing reply")
 	n, err := d.ResponseWriter.Write(buf)
 	return n, err
 }

--- a/plugin/dnstap/dnstapio/io.go
+++ b/plugin/dnstap/dnstapio/io.go
@@ -70,7 +70,7 @@ func (dio *dnstapIO) newConnect() error {
 // Connect connects to the dnstop endpoint.
 func (dio *dnstapIO) Connect() {
 	if err := dio.newConnect(); err != nil {
-		log.Printf("[ERROR] No connection to dnstap endpoint")
+		log.Print("[ERROR] No connection to dnstap endpoint")
 	}
 	go dio.serve()
 }
@@ -102,7 +102,7 @@ func (dio *dnstapIO) flushBuffer() {
 		if err := dio.newConnect(); err != nil {
 			return
 		}
-		log.Printf("[INFO] Reconnected to dnstap")
+		log.Print("[INFO] Reconnected to dnstap")
 	}
 
 	if err := dio.enc.flushBuffer(); err != nil {
@@ -111,7 +111,7 @@ func (dio *dnstapIO) flushBuffer() {
 		if err := dio.newConnect(); err != nil {
 			log.Printf("[ERROR] Cannot connect to dnstap: %s", err)
 		} else {
-			log.Printf("[INFO] Reconnected to dnstap")
+			log.Print("[INFO] Reconnected to dnstap")
 		}
 	}
 }

--- a/plugin/file/notify.go
+++ b/plugin/file/notify.go
@@ -53,7 +53,7 @@ func notify(zone string, to []string) error {
 			continue
 		}
 		if err := notifyAddr(c, m, t); err != nil {
-			log.Printf("[ERROR] " + err.Error())
+			log.Print("[ERROR] " + err.Error())
 		} else {
 			log.Printf("[INFO] Sent notify for zone %q to %q", zone, t)
 		}

--- a/plugin/kubernetes/apiproxy.go
+++ b/plugin/kubernetes/apiproxy.go
@@ -33,7 +33,7 @@ func (p *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	hj, ok := w.(http.Hijacker)
 	if !ok {
-		log.Printf("[ERROR] Unable to establish connection: no hijacker")
+		log.Print("[ERROR] Unable to establish connection: no hijacker")
 		http.Error(w, "Unable to establish connection: no hijacker", 500)
 		return
 	}

--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -75,7 +75,7 @@ func roundRobinShuffle(records []dns.RR) {
 // Write implements the dns.ResponseWriter interface.
 func (r *RoundRobinResponseWriter) Write(buf []byte) (int, error) {
 	// Should we pack and unpack here to fiddle with the packet... Not likely.
-	log.Printf("[WARNING] RoundRobin called with Write: no shuffling records")
+	log.Print("[WARNING] RoundRobin called with Write: no shuffling records")
 	n, err := r.ResponseWriter.Write(buf)
 	return n, err
 }


### PR DESCRIPTION
These log prints don't have any verbs, so just use plain Print
