### PR TITLE
plugin/kubernetes: exclude terminating pods

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -351,6 +351,11 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 			continue
 		}
 
+		// exclude pods in the process of termination
+		if !p.ObjectMeta.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		// check for matching ip and namespace
 		if ip == p.Status.PodIP && match(namespace, p.Namespace) {
 			s := msg.Service{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}


### PR DESCRIPTION
### 1. What does this pull request do?

In pods verified mode, do not produce a record for a pod if it is being terminated.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
