### PR TITLE
Document the service with ClusterIP wildcard

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -198,3 +198,10 @@ or the word "any"), then that label will match all values.  The labels that acce
  * _port and/or protocol_ in an `SRV` request: __port_.__protocol_.service.namespace.svc.zone.,
    e.g. `_http.*.service.ns.svc.`
  * multiple wild cards are allowed in a single query, e.g. `A` Request `*.*.svc.zone.` or `SRV` request `*.*.*.*.svc.zone.`
+ 
+ * Wildcard can be used also to resolve PODs IPs as `A` records in a Service with ClusterIP. e.g.: `*.service.ns.svc.myzone.local` will return the PODs IPs as the following:
+ ```
+*.service.default.svc.cluster.local. 5	IN A	192.168.10.10
+*.service.default.svc.cluster.local. 5	IN A	192.168.25.15
+```
+ This response can be randomized using the `loadbalance` plugin


### PR DESCRIPTION
### 1. What does this pull request do?
This PR documents the trick exposed in coredns/coredns#1357 about using wildcards to get all POD IPs from a service with ClusterIP (as used in 'endpoints')

### 2. Which issues (if any) are related?
#1357 

### 3. Which documentation changes (if any) need to be made?
This is a Documentation change :)
