### PR TITLE
Add PTR record support for Route53 plugin

### DIFF
--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -50,6 +50,8 @@ func (rr Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		answers = a(qname, output.ResourceRecordSets)
 	case dns.TypeAAAA:
 		answers = aaaa(qname, output.ResourceRecordSets)
+	case dns.TypePTR:
+		answers = ptr(qname, output.ResourceRecordSets)
 	}
 
 	if len(answers) == 0 {
@@ -87,6 +89,19 @@ func aaaa(zone string, rrss []*route53.ResourceRecordSet) []dns.RR {
 			r := new(dns.AAAA)
 			r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: uint32(aws.Int64Value(rrs.TTL))}
 			r.AAAA = net.ParseIP(aws.StringValue(rr.Value)).To16()
+			answers = append(answers, r)
+		}
+	}
+	return answers
+}
+
+func ptr(zone string, rrss []*route53.ResourceRecordSet) []dns.RR {
+	answers := []dns.RR{}
+	for _, rrs := range rrss {
+		for _, rr := range rrs.ResourceRecords {
+			r := new(dns.PTR)
+			r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: uint32(aws.Int64Value(rrs.TTL))}
+			r.Ptr = aws.StringValue(rr.Value)
 			answers = append(answers, r)
 		}
 	}

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -24,6 +24,8 @@ func (mockedRoute53) ListResourceRecordSets(input *route53.ListResourceRecordSet
 		value = "10.2.3.4"
 	case "AAAA":
 		value = "2001:db8:85a3::8a2e:370:7334"
+	case "PTR":
+		value = "ptr.example.org"
 	}
 	return &route53.ListResourceRecordSetsOutput{
 		ResourceRecordSets: []*route53.ResourceRecordSet{
@@ -66,6 +68,13 @@ func TestRoute53(t *testing.T) {
 			expectedReply: []string{"2001:db8:85a3::8a2e:370:7334"},
 			expectedErr:   nil,
 		},
+		{
+			qname:         "example.org",
+			qtype:         dns.TypePTR,
+			expectedCode:  dns.RcodeSuccess,
+			expectedReply: []string{"ptr.example.org"},
+			expectedErr:   nil,
+		},
 	}
 
 	ctx := context.TODO()
@@ -91,6 +100,8 @@ func TestRoute53(t *testing.T) {
 					actual = rec.Msg.Answer[i].(*dns.A).A.String()
 				case dns.TypeAAAA:
 					actual = rec.Msg.Answer[i].(*dns.AAAA).AAAA.String()
+				case dns.TypePTR:
+					actual = rec.Msg.Answer[i].(*dns.PTR).Ptr
 				}
 				if actual != expected {
 					t.Errorf("Test %d: Expected answer %s, but got %s", i, expected, actual)


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix adds PTR record support for Route53 plugin



### 2. Which issues (if any) are related?

This fix fixes #1595.


### 3. Which documentation changes (if any) need to be made?


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>