### PR TITLE
plugin/secondary: fix for #1609

### DIFF
--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -83,8 +83,7 @@ func TestShouldTransfer(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	z := new(Zone)
-	z.origin = testZone
+	z := NewZone(testZone, "stdin")
 	z.TransferFrom = []string{addrstr}
 
 	// when we have a nil SOA (initial state)
@@ -128,9 +127,7 @@ func TestTransferIn(t *testing.T) {
 	}
 	defer s.Shutdown()
 
-	z := new(Zone)
-	z.Expired = new(bool)
-	z.origin = testZone
+	z := NewZone(testZone, "stdin")
 	z.TransferFrom = []string{addrstr}
 
 	err = z.TransferIn()

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -20,7 +20,7 @@ type Zone struct {
 	origLen int
 	file    string
 	*tree.Tree
-	Apex Apex
+	Apex *Apex
 
 	TransferTo   []string
 	StartupOnce  sync.Once
@@ -48,6 +48,7 @@ func NewZone(name, file string) *Zone {
 		origLen:        dns.CountLabel(dns.Fqdn(name)),
 		file:           path.Clean(file),
 		Tree:           &tree.Tree{},
+		Apex:           &Apex{},
 		Expired:        new(bool),
 		reloadShutdown: make(chan bool),
 	}

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -29,8 +29,8 @@ func setup(c *caddy.Controller) error {
 		if len(z.TransferFrom) > 0 {
 			c.OnStartup(func() error {
 				z.StartupOnce.Do(func() {
-					z.TransferIn()
 					go func() {
+						z.TransferIn()
 						z.Update()
 					}()
 				})


### PR DESCRIPTION
Fixes #1609

With this Corefile:

~~~
example.com {
    bind 127.0.0.1
    log
    cache
    secondary {
        transfer from 127.0.0.53
    }
}

. {
    bind 127.0.0.1
    forward . 8.8.8.8
    log
    cache
}
~~~

starting: `% ./coredns -dns.port=1053`

queries flow:

~~~
example.com.:1053 on 127.0.0.1
.:1053 on 127.0.0.1
2018/03/14 18:24:59 [INFO] CoreDNS-1.1.0
2018/03/14 18:24:59 [INFO] linux/amd64, go1.10,
CoreDNS-1.1.0
linux/amd64, go1.10,
127.0.0.1:35698 - [14/Mar/2018:18:25:26 +0000] 15569 "MX IN miek.nl. udp 37 false 4096" NOERROR qr,rd,ra,ad 170 57.437457ms
127.0.0.1:37304 - [14/Mar/2018:18:25:28 +0000] 27556 "MX IN miek.nl. udp 37 false 4096" NOERROR qr,rd,ra,ad 170 104.4µs
127.0.0.1:34495 - [14/Mar/2018:18:25:30 +0000] 18816 "MX IN miek.nl. udp 37 false 4096" NOERROR qr,rd,ra,ad 170 92.186µs
~~~

Without this patch:
~~~
% ./coredns -dns.port=1053
<nothing>
~~~