### PR TITLE
Fix start mesg for all protocols

### DIFF
--- a/core/dnsserver/onstartup.go
+++ b/core/dnsserver/onstartup.go
@@ -1,0 +1,29 @@
+package dnsserver
+
+import "fmt"
+
+// startUpZones create the text that we show when starting up:
+// grpc://example.com.:1055
+// example.com.:1053 on 127.0.0.1
+func startUpZones(protocol, addr string, zones map[string]*Config) string {
+	s := ""
+
+	for zone := range zones {
+		// split addr into protocol, IP and Port
+		_, ip, port, err := SplitProtocolHostPort(addr)
+
+		if err != nil {
+			// this should not happen, but we need to take care of it anyway
+			s += fmt.Sprintln(protocol + zone + ":" + addr)
+			continue
+		}
+		if ip == "" {
+			s += fmt.Sprintln(protocol + zone + ":" + port)
+			continue
+		}
+		// if the server is listening on a specific address let's make it visible in the log,
+		// so one can differentiate between all active listeners
+		s += fmt.Sprintln(protocol + zone + ":" + port + " on " + ip)
+	}
+	return s
+}

--- a/core/dnsserver/server-grpc.go
+++ b/core/dnsserver/server-grpc.go
@@ -88,9 +88,11 @@ func (s *ServergRPC) OnStartupComplete() {
 		return
 	}
 
-	for zone, config := range s.zones {
-		fmt.Println(TransportGRPC + "://" + zone + ":" + config.Port)
+	out := startUpZones(TransportGRPC+"://", s.Addr, s.zones)
+	if out != "" {
+		fmt.Print(out)
 	}
+	return
 }
 
 // Stop stops the server. It blocks until the server is

--- a/core/dnsserver/server-tls.go
+++ b/core/dnsserver/server-tls.go
@@ -72,7 +72,9 @@ func (s *ServerTLS) OnStartupComplete() {
 		return
 	}
 
-	for zone, config := range s.zones {
-		fmt.Println(TransportTLS + "://" + zone + ":" + config.Port)
+	out := startUpZones(TransportTLS+"://", s.Addr, s.zones)
+	if out != "" {
+		fmt.Print(out)
 	}
+	return
 }

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -294,23 +294,11 @@ func (s *Server) OnStartupComplete() {
 		return
 	}
 
-	for zone := range s.zones {
-		// split addr into protocol, IP and Port
-		_, ip, port, err := SplitProtocolHostPort(s.Addr)
-
-		if err != nil {
-			// this should not happen, but we need to take care of it anyway
-			fmt.Println(zone + ":" + s.Addr)
-			continue
-		}
-		if ip == "" {
-			fmt.Println(zone + ":" + port)
-			continue
-		}
-		// if the server is listening on a specific address let's make it visible in the log,
-		// so one can differentiate between all active listeners
-		fmt.Println(zone + ":" + port + " on " + ip)
+	out := startUpZones("", s.Addr, s.zones)
+	if out != "" {
+		fmt.Print(out)
 	}
+	return
 }
 
 // Tracer returns the tracer in the server if defined.


### PR DESCRIPTION
Recent bind refactoring missed this:

    grpc://example.com.:1055
    example.com.:1053 on 127.0.0.1

now becomes

    grpc://example.com.:1055 on 127.0.0.1
    example.com.:1053 on 127.0.0.1

If you're using *bind* directive.

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

