### PR TITLE
WIP - Allocator for Graceful TCP servers - issue #1604 and #1618

### DIFF
--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -2,6 +2,7 @@
 package health
 
 import (
+	"github.com/coredns/coredns/plugin/pkg/listener"
 	"io"
 	"log"
 	"net"
@@ -12,8 +13,9 @@ import (
 
 // Health implements healthchecks by polling plugins.
 type health struct {
-	Addr     string
-	lameduck time.Duration
+	serverKey string
+	Addr      string
+	lameduck  time.Duration
 
 	ln  net.Listener
 	mux *http.ServeMux
@@ -28,8 +30,8 @@ type health struct {
 }
 
 // newHealth returns a new initialized health.
-func newHealth(addr string) *health {
-	return &health{Addr: addr, stop: make(chan bool), pollstop: make(chan bool)}
+func newHealth(addr string, key string) *health {
+	return &health{serverKey: key, Addr: addr, stop: make(chan bool), pollstop: make(chan bool)}
 }
 
 func (h *health) OnStartup() error {
@@ -37,7 +39,7 @@ func (h *health) OnStartup() error {
 		h.Addr = defAddr
 	}
 
-	ln, err := net.Listen("tcp", h.Addr)
+	ln, err := listener.LsnProvider.AllocateListener("health-"+h.serverKey, "tcp", h.Addr)
 	if err != nil {
 		return err
 	}

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
+	"github.com/coredns/coredns/plugin/pkg/listener"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -85,7 +86,7 @@ func (m *Metrics) ZoneNames() []string {
 
 // OnStartup sets up the metrics on startup.
 func (m *Metrics) OnStartup() error {
-	ln, err := net.Listen("tcp", m.Addr)
+	ln, err := listener.LsnProvider.AllocateListener("metrics", "tcp", m.Addr)
 	if err != nil {
 		log.Printf("[ERROR] Failed to start metrics handler: %s", err)
 		return err

--- a/plugin/pkg/listener/listener.go
+++ b/plugin/pkg/listener/listener.go
@@ -1,0 +1,62 @@
+package listener
+
+import (
+	"github.com/mholt/caddy"
+	"log"
+	"net"
+)
+
+// LsnProvider : a tool to provide listeners for TCP or Unix
+var LsnProvider = provider{listeners: map[string]net.Listener{}}
+
+type provider struct {
+	// when start listening organize per key to not allow reuse of address on several listeners
+	//   - check if reallocate in the per-address
+	//   - allocate in the per-key
+	// after service is started, subscript to onRestart
+	// on Restart - then push all allocate in per-address for next restart
+	//
+	// if restart fails : => there will be onRestart on the same instance. So be prepared to have the sequence run several times
+	//
+	inuse     map[string]net.Listener
+	listeners map[string]net.Listener
+}
+
+// AllocateListener : provide an access to expected listener
+func (l *provider) AllocateListener(key string, network string, address string) (net.Listener, error) {
+	old, ok := l.listeners[key]
+	var ln net.Listener
+	var err error
+	if ok {
+		addr := old.Addr()
+		if addr.String() == address && addr.Network() == network {
+			// we want to reuse the same address - duplicate the FD and open a listener on that FD
+			// If this is a reload and s is a GracefulServer,
+			// reuse the listener for a graceful restart.
+			if fileLn, ok := old.(caddy.Listener); ok {
+				file, err := fileLn.File()
+				if err != nil {
+					return nil, err
+				}
+				ln, err = net.FileListener(file)
+				if err != nil {
+					return nil, err
+				}
+				err = file.Close()
+				if err != nil {
+					return nil, err
+				}
+
+			}
+		}
+	}
+	if ln == nil {
+		ln, err = net.Listen(network, address)
+		if err != nil {
+			return nil, err
+		}
+	}
+	l.listeners[key] = ln
+	log.Printf("[INFO] %s - listening on network %s - address %s", key, ln.Addr().Network(), ln.Addr().String())
+	return ln, err
+}


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Implement a Listener Allocator for of TCPListeners for additional Servers used by plugin (Health, Metrics, ...) that is able to handle graceful restarts.

WIP : 
- Health is modified to use this allocator. (also modified to run only once per BlocServer)
- Metrics not yet updated 

Need to dive into problem with reallocating the SAME port but for a different usage. In that case the current graceful restart would not work.

### 2. Which issues (if any) are related?
#1604 
#1618 

### 3. Which documentation changes (if any) need to be made?
not sure which one here.
