### PR TITLE
plugin/forward: retry udp queries if timed out

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -34,21 +34,16 @@ func (p *Proxy) connect(ctx context.Context, state request.Request, forceTCP, me
 		conn.UDPSize = 512
 	}
 
-	to := timeout
-	if proto == "udp" {
-		to = udpTimeout
-	}
-
 	udpRetry := udpRetryCnt
 	var ret *dns.Msg
 	for {
-		conn.SetWriteDeadline(time.Now().Add(to))
+		conn.SetWriteDeadline(time.Now().Add(timeout))
 		if err := conn.WriteMsg(state.Req); err != nil {
 			conn.Close() // not giving it back
 			return nil, err
 		}
 
-		conn.SetReadDeadline(time.Now().Add(to))
+		conn.SetReadDeadline(time.Now().Add(timeout))
 		ret, err = conn.ReadMsg()
 		if err != nil {
 			oe, ok := err.(*net.OpError)

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -47,9 +47,11 @@ func (p *Proxy) connect(ctx context.Context, state request.Request, forceTCP, me
 		ret, err = conn.ReadMsg()
 		if err != nil {
 			oe, ok := err.(*net.OpError)
-			if ok && oe.Timeout() && proto == "udp" && udpRetry > 0 {
-				udpRetry--
-				continue
+			if ok && oe.Timeout() {
+				if _, ok = conn.Conn.(*net.UDPConn); ok && udpRetry > 0 {
+					udpRetry--
+					continue
+				}
 			}
 			conn.Close() // not giving it back
 			return nil, err

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -89,4 +89,6 @@ const (
 	dialTimeout = 4 * time.Second
 	timeout     = 2 * time.Second
 	hcDuration  = 500 * time.Millisecond
+	udpTimeout  = 500 * time.Millisecond
+	udpRetryCnt = 2
 )

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -89,6 +89,5 @@ const (
 	dialTimeout = 4 * time.Second
 	timeout     = 2 * time.Second
 	hcDuration  = 500 * time.Millisecond
-	udpTimeout  = 500 * time.Millisecond
 	udpRetryCnt = 2
 )


### PR DESCRIPTION
### 1. What does this pull request do?
forward plugin will retry sending DNS queries to upstream server if UDP connection was used. The UDP is not reliable protocol, so it might worth to retry several times
In current implementation, in case if only one upstream was configured and if the response from upstream was lost the forward plugin returns SERVFAIL with error "no healthy proxies or upstream error" 

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none
