### PR TITLE
Fix #1625

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -217,6 +217,9 @@ func (r *Request) Scrub(reply *dns.Msg) (*dns.Msg, Result) {
 			re = m - 1
 			continue
 		}
+		if rl == size {
+			break
+		}
 	}
 	// We may come out of this loop with one rotation too many as we don't break on rl == size.
 	// I.e. m makes it too large, but m-1 works.
@@ -244,6 +247,9 @@ func (r *Request) Scrub(reply *dns.Msg) (*dns.Msg, Result) {
 		if rl > size {
 			ra = m - 1
 			continue
+		}
+		if rl == size {
+			break
 		}
 	}
 	// We may come out of this loop with one rotation too many as we don't break on rl == size.


### PR DESCRIPTION
Signed-off-by: Mario Kleinsasser <mario.kleinsasser@gmail.com>

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
Fixes a problem in the request.go when the rl and size values are equal. If this is the case the loop cannot break and spins up the CPU to full load.

### 2. Which issues (if any) are related?
#1625 



