### PR TITLE
request.Do: use pointer to bool

### DIFF
--- a/request/request_test.go
+++ b/request/request_test.go
@@ -13,7 +13,7 @@ func TestRequestDo(t *testing.T) {
 	st := testRequest()
 
 	st.Do()
-	if st.do == 0 {
+	if st.do == nil {
 		t.Fatalf("Expected st.do to be set")
 	}
 }


### PR DESCRIPTION
Drop the doTrue and doFalse and use a pointer to a bool to do a proper
tri-bool.