### PR TITLE
plugin/forward: set the RD bit in the hc

### DIFF
--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -25,7 +25,6 @@ func (p *Proxy) Check() error {
 func (p *Proxy) send() error {
 	hcping := new(dns.Msg)
 	hcping.SetQuestion(".", dns.TypeNS)
-	hcping.RecursionDesired = false
 
 	m, _, err := p.client.Exchange(hcping, p.addr)
 	// If we got a header, we're alright, basically only care about I/O errors 'n stuff


### PR DESCRIPTION
My routers acts funny when it sees it non RD query; make this HC as
boring as possible