### PR TITLE
Only check 1.10 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ services:
 
 language: go
 go:
-  - "1.9"
   - "1.10"
 
 go_import_path: github.com/coredns/coredns


### PR DESCRIPTION
This double checking for 1.9 and 1.10 is nice, but doubles the
travis test duration.
