### PR TITLE
plugin/forward: add query timeout

### DIFF
--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -45,6 +45,7 @@ func TestHealth(t *testing.T) {
 func TestHealthTimeout(t *testing.T) {
 	const expected = 1
 	i := uint32(0)
+	q := uint32(0)
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		if r.Question[0].Name == "." {
 			// health check, answer
@@ -52,8 +53,13 @@ func TestHealthTimeout(t *testing.T) {
 			ret := new(dns.Msg)
 			ret.SetReply(r)
 			w.WriteMsg(ret)
+		} else if atomic.LoadUint32(&q) == 0 { //drop only first query
+			atomic.AddUint32(&q, 1)
+		} else {
+			ret := new(dns.Msg)
+			ret.SetReply(r)
+			w.WriteMsg(ret)
 		}
-		// not a health check, do a timeout
 	})
 	defer s.Close()
 
@@ -77,6 +83,7 @@ func TestHealthTimeout(t *testing.T) {
 func TestHealthFailTwice(t *testing.T) {
 	const expected = 2
 	i := uint32(0)
+	q := uint32(0)
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		if r.Question[0].Name == "." {
 			atomic.AddUint32(&i, 1)
@@ -85,6 +92,12 @@ func TestHealthFailTwice(t *testing.T) {
 			if i1 < 2 {
 				return
 			}
+			ret := new(dns.Msg)
+			ret.SetReply(r)
+			w.WriteMsg(ret)
+		} else if atomic.LoadUint32(&q) == 0 { //drop only first query
+			atomic.AddUint32(&q, 1)
+		} else {
 			ret := new(dns.Msg)
 			ret.SetReply(r)
 			w.WriteMsg(ret)
@@ -110,10 +123,39 @@ func TestHealthFailTwice(t *testing.T) {
 }
 
 func TestHealthMaxFails(t *testing.T) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		// timeout
+	})
+	defer s.Close()
+
+	p := NewProxy(s.Addr, nil /* no TLS */)
+	f := New()
+	f.maxfails = 2
+	f.SetProxy(p)
+	defer f.Close()
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+
+	time.Sleep(1 * time.Second)
+	if !p.Down(f.maxfails) {
+		t.Errorf("Expected Proxy fails to be greater than %d, got %d", f.maxfails, p.fails)
+	}
+}
+
+func TestHealthNoMaxFails(t *testing.T) {
 	const expected = 0
 	i := uint32(0)
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
-		// timeout
+		if r.Question[0].Name == "." {
+			// health check, answer
+			atomic.AddUint32(&i, 1)
+			ret := new(dns.Msg)
+			ret.SetReply(r)
+			w.WriteMsg(ret)
+		}
 	})
 	defer s.Close()
 


### PR DESCRIPTION
 - subsequently retry sending query via different proxies
   until query timeout occurs. A proxy can be tried again if
   all other proxies were already tried

this fix is an alternative to #1624
