### PR TITLE
plugin/forward: use dynamic read timeout

### DIFF
--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -22,6 +22,8 @@ type Proxy struct {
 	// health checking
 	probe *up.Probe
 	fails uint32
+
+	avgRtt int64
 }
 
 // NewProxy returns a new proxy.
@@ -31,6 +33,7 @@ func NewProxy(addr string, tlsConfig *tls.Config) *Proxy {
 		fails:     0,
 		probe:     up.New(),
 		transport: newTransport(addr, tlsConfig),
+		avgRtt:    int64(timeout / 2),
 	}
 	p.client = dnsClient(tlsConfig)
 	return p


### PR DESCRIPTION
 - each proxy stores average RTT (round trip time) of last rttCount queries.
   For now, I assigned the value 4 to rttCount
 - the read timeout is calculated as doubled average RTT, but it cannot
   exceed default timeout
 - initial avg RTT is set to a half of default timeout, so initial timeout
   is equal to default timeout
 - the RTT for failed read is considered equal to default timeout, so any
   failed read will lead to increasing average RTT (up to default timeout)
 - dynamic timeouts will let us react faster on lost UDP packets
 - in future, we may develop a low-latency forward policy based on
   collected RTT values of proxies
