### PR TITLE
plugin/log: allow various combinations of classes of responses

### DIFF
--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -54,7 +54,9 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 		tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
 		class := response.Classify(tpe)
-		if rule.Class == response.All || rule.Class == class {
+		// If we don't set up a class in config, the default "all" will be added
+		// and we shouldn't have an empty rule.Class.
+		if rule.Class[response.All] || rule.Class[class] {
 			rep := replacer.New(r, rrw, CommonLogEmptyValue)
 			rule.Log.Println(rep.Replace(rule.Format))
 		}
@@ -71,7 +73,7 @@ func (l Logger) Name() string { return "log" }
 // Rule configures the logging plugin.
 type Rule struct {
 	NameScope string
-	Class     response.Class
+	Class     map[response.Class]bool
 	Format    string
 	Log       *log.Logger
 }

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -20,6 +20,7 @@ func TestLoggedStatus(t *testing.T) {
 		NameScope: ".",
 		Format:    DefaultLogFormat,
 		Log:       log.New(&f, "", 0),
+		Class:     map[response.Class]bool{response.All: true},
 	}
 
 	logger := Logger{
@@ -50,7 +51,7 @@ func TestLoggedClassDenial(t *testing.T) {
 		NameScope: ".",
 		Format:    DefaultLogFormat,
 		Log:       log.New(&f, "", 0),
-		Class:     response.Denial,
+		Class:     map[response.Class]bool{response.Denial: true},
 	}
 
 	logger := Logger{
@@ -78,7 +79,7 @@ func TestLoggedClassError(t *testing.T) {
 		NameScope: ".",
 		Format:    DefaultLogFormat,
 		Log:       log.New(&f, "", 0),
-		Class:     response.Error,
+		Class:     map[response.Class]bool{response.Error: true},
 	}
 
 	logger := Logger{

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -52,11 +52,13 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			rules = append(rules, Rule{
 				NameScope: ".",
 				Format:    DefaultLogFormat,
+				Class:     make(map[response.Class]bool),
 			})
 		} else if len(args) == 1 {
 			rules = append(rules, Rule{
 				NameScope: dns.Fqdn(args[0]),
 				Format:    DefaultLogFormat,
+				Class:     make(map[response.Class]bool),
 			})
 		} else {
 			// Name scope, and maybe a format specified
@@ -74,27 +76,32 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			rules = append(rules, Rule{
 				NameScope: dns.Fqdn(args[0]),
 				Format:    format,
+				Class:     make(map[response.Class]bool),
 			})
 		}
 
 		// Class refinements in an extra block.
 		for c.NextBlock() {
 			switch c.Val() {
-			// class followed by all, denial, error or success.
+			// class followed by combinations of all, denial, error and success.
 			case "class":
 				classes := c.RemainingArgs()
 				if len(classes) == 0 {
 					return nil, c.ArgErr()
 				}
-				cls, err := response.ClassFromString(classes[0])
-				if err != nil {
-					return nil, err
+				for _, c := range classes {
+					cls, err := response.ClassFromString(c)
+					if err != nil {
+						return nil, err
+					}
+					rules[len(rules)-1].Class[cls] = true
 				}
-				// update class and the last added Rule (bit icky)
-				rules[len(rules)-1].Class = cls
 			default:
 				return nil, c.ArgErr()
 			}
+		}
+		if len(rules[len(rules)-1].Class) == 0 {
+			rules[len(rules)-1].Class[response.All] = true
 		}
 	}
 


### PR DESCRIPTION
This allows to log responses of different classes, for example, denial and error.

I would propose to add an ability of the log plugin to mix classes of responses.
The goal is not to clutter up the log file with unnecessary messages.
The proposed changes in the log plugin could be useful, at least, in following cases:

1. we would want to log all queries which were not resolved successfully:
log . {
    class denial error
}

2. we would want to log all queries on which we did not get errors:
log . {
    class denial success
}

So, the classes "error, denial, success, all" could be mixed. Of course, the following combinations don't make sense (but allowed): "class denial error success" or even "class denial error success all" - it's just "class all" as well as we mix the class "all" with any other types - "class error all" and so on, the class "all" means that all messages will be logged whatever we mix together with "all".

Fixing [#1662](https://github.com/coredns/coredns/issues/1662)

Maybe it requires to fix the [documentation](https://coredns.io/plugins/log/) of the coredns log plugin.