### PR TITLE
plugin/pkg/up: implement backoff

### DIFF
--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"log"
 	"sync/atomic"
 
 	"github.com/miekg/dns"
@@ -15,6 +16,7 @@ func (p *Proxy) Check() error {
 	if err != nil {
 		HealthcheckFailureCount.WithLabelValues(p.addr).Add(1)
 		atomic.AddUint32(&p.fails, 1)
+		log.Printf("[WARNING] Health check of %q failed with: %s", p.addr, err)
 		return err
 	}
 

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -43,9 +43,8 @@ func NewProxy(addr string, tlsConfig *tls.Config) *Proxy {
 func dnsClient(tlsConfig *tls.Config) *dns.Client {
 	c := new(dns.Client)
 	c.Net = "udp"
-	// TODO(miek): this should be half of hcDuration?
-	c.ReadTimeout = 1 * time.Second
-	c.WriteTimeout = 1 * time.Second
+	c.ReadTimeout = 4 * time.Second
+	c.WriteTimeout = 4 * time.Second
 
 	if tlsConfig != nil {
 		c.Net = "tcp-tls"


### PR DESCRIPTION
The backoff is not exponential on every 3rd error increase the duration
with 'interval'.

Also log the errors we see from failed healthchecks.