### PR TITLE
plugin/forward: Return original message on truncation

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -66,7 +66,7 @@ func (p *Proxy) connect(ctx context.Context, state request.Request, forceTCP, me
 		if err == io.EOF && cached {
 			return nil, errCachedClosed
 		}
-		return nil, err
+		return ret, err
 	}
 
 	p.updateRtt(time.Since(reqTime))

--- a/plugin/forward/truncated_test.go
+++ b/plugin/forward/truncated_test.go
@@ -49,6 +49,9 @@ func TestLookupTruncated(t *testing.T) {
 	if !resp.Truncated {
 		t.Error("Expected to receive reply with TC bit set, but didn't")
 	}
+	if len(resp.Answer) != 1 {
+		t.Error("Expected to receive original reply, but answer is missing")
+	}
 
 	resp, err = f.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {
@@ -101,6 +104,9 @@ func TestForwardTruncated(t *testing.T) {
 	// expect answer with TC
 	if !resp.Truncated {
 		t.Error("Expected to receive reply with TC bit set, but didn't")
+	}
+	if len(resp.Answer) != 1 {
+		t.Error("Expected to receive original reply, but answer is missing")
 	}
 
 	resp, err = f.Forward(state)


### PR DESCRIPTION
### 1. What does this pull request do?

With this change the original truncated message returned by requested
server is returned to the client, instead of returning an empty dummy
message with only the truncation bit set.

### 2. Which issues (if any) are related?

Resolves #1669 

### 3. Which documentation changes (if any) need to be made?

n/a