### PR TITLE
make: default to default go path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ BINARY:=coredns
 SYSTEM:=
 CHECKS:=check godeps
 VERBOSE:=-v
+GOPATH?=$(HOME)/go
 
 all: coredns
 


### PR DESCRIPTION
if GOPATH is not set use $HOME/go which is the current default in Go.

Fixes #1642