### PR TITLE
RELOAD capability for HEALTH, METRICS and any plugin that would use TCP Listeners

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -33,47 +33,42 @@ health [ADDRESS] {
 * Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
   shuts down.
 
-If you have multiple Server Block and need to export health for each of the plugins, 
-you can either run all health enpoints on the same port, or on different ports. 
-In that case, 
+If you have multiple Server Blocks and need to export health for each of the plugins, 
+you can either run all health enpoints, like below:
 
 ~~~ corefile
-com {
+com. {
+    whoami
+    health
+}
+
+net. {
+    erratic
+    health
+}
+~~~
+
+
+or on different ports:
+
+~~~ corefile
+com. {
     whoami
     health :8080
 }
 
-net {
+net. {
     erratic
     health :8081
 }
 ~~~
 
-~~~ corefile
-com {
-    whoami
-    health
-}
-
-net {
-    erratic
-    health
-}
-~~~
 
  
-~~~ corefile
-com org net {
-    whoami
-    health
-}
-~~~
-
 ## Plugins
 
 Any plugin that implements the Healther interface will be used to report health.
-When the same port is reused, all the instances of the all the plugins that are associated with "health" 
-will participate to the result
+If ports are shared, multiple server plugins will be included as well.
 
 ## Metrics
 

--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -33,8 +33,9 @@ health [ADDRESS] {
 * Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
   shuts down.
 
-If you have multiple Server Block and need to export health for each of the plugins, you must run
-health endpoints on different ports:
+If you have multiple Server Block and need to export health for each of the plugins, 
+you can either run all health enpoints on the same port, or on different ports. 
+In that case, 
 
 ~~~ corefile
 com {
@@ -48,9 +49,31 @@ net {
 }
 ~~~
 
+~~~ corefile
+com {
+    whoami
+    health
+}
+
+net {
+    erratic
+    health
+}
+~~~
+
+ 
+~~~ corefile
+com org net {
+    whoami
+    health
+}
+~~~
+
 ## Plugins
 
 Any plugin that implements the Healther interface will be used to report health.
+When the same port is reused, all the instances of the all the plugins that are associated with "health" 
+will participate to the result
 
 ## Metrics
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -2,12 +2,13 @@
 package health
 
 import (
-	"github.com/coredns/coredns/plugin/pkg/listener"
 	"io"
 	"net"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/listener"
 
 	"github.com/coredns/coredns/plugin/pkg/log"
 )

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -34,7 +34,7 @@ func newHealth(alloc listener.AllocationToken) *health {
 	return &health{alloc: alloc, stop: make(chan bool), pollstop: make(chan bool)}
 }
 
-func (h *health) Tag() string {
+func (h *health) Name() string {
 	return "health"
 }
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/listener"
-
 	"github.com/coredns/coredns/plugin/pkg/log"
 )
 

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -8,10 +8,12 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/erratic"
+	"github.com/coredns/coredns/plugin/test"
 )
 
 func TestHealth(t *testing.T) {
-	h := newHealth(":0")
+	alloc := test.NewDefaultAllocator()
+	h := newHealth(alloc)
 	h.h = append(h.h, &erratic.Erratic{})
 
 	if err := h.OnStartup(); err != nil {
@@ -58,7 +60,7 @@ func TestHealth(t *testing.T) {
 }
 
 func TestHealthLameduck(t *testing.T) {
-	h := newHealth(":0")
+	h := newHealth(test.NewDefaultAllocator())
 	h.lameduck = 250 * time.Millisecond
 	h.h = append(h.h, &erratic.Erratic{})
 

--- a/plugin/health/healther.go
+++ b/plugin/health/healther.go
@@ -26,7 +26,10 @@ func (h *health) SetOk(ok bool) {
 
 // poll polls all healthers and sets the global state.
 func (h *health) poll() {
-	for _, m := range h.h {
+	h.RLock()
+	healther := h.h
+	h.RUnlock()
+	for _, m := range healther {
 		if !m.Health() {
 			h.SetOk(false)
 			return

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -16,7 +16,7 @@ func (h *health) overloaded() {
 	client := http.Client{
 		Timeout: timeout,
 	}
-	url := "http://" + h.Addr
+	url := "http://" + h.ln.Addr().String()
 	tick := time.NewTicker(1 * time.Second)
 
 	for {

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -33,7 +33,7 @@ func setup(c *caddy.Controller) error {
 	if booked {
 		x, ok := booker.(*health)
 		if !ok {
-			return plugin.Error("health", fmt.Errorf("the address (%s) for listening is already booked by %s (and is not recognized as prometheus)", addr, booker.Tag()))
+			return plugin.Error("health", fmt.Errorf("the address (%s) for listening is already booked by %s (and is not recognized as prometheus)", addr, booker.Name()))
 		}
 		// we consolidate the health plugin on that existing health plugin
 		h = x

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -68,7 +68,3 @@ then:
 }
 ~~~
 
-## Bugs
-
-When reloading, we keep the handler running, meaning that any changes to the handler's address
-aren't picked up. You'll need to restart CoreDNS for that to happen.

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -49,6 +49,10 @@ For each zone that you want to see metrics for.
 It optionally takes an address to which the metrics are exported; the default
 is `localhost:9153`. The metrics path is fixed to `/metrics`.
 
+The plugin can by used on one or several of the ServerBloc of Corefile.
+All the queries handled by prometheus plugins having the same address will be reported on that address. 
+The 'server' and 'zone' labels can be used to identify what plugins served this DNS query. 
+
 ## Examples
 
 Use an alternative address:

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"fmt"
+
 	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -111,7 +111,7 @@ func newListener(alloc listener.AllocationToken) *metricsListener {
 	return met
 }
 
-func (m *metricsListener) Tag() string { return "prometheus" }
+func (m *metricsListener) Name() string { return "prometheus" }
 
 // MustRegister wraps m.Reg.MustRegister.
 func (m *metricsListener) MustRegister(c prometheus.Collector) { m.Reg.MustRegister(c) }

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -13,9 +13,8 @@ import (
 	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
-	"github.com/coredns/coredns/plugin/pkg/log"
-
 	"github.com/coredns/coredns/plugin/pkg/listener"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -8,11 +8,13 @@ import (
 	"runtime"
 	"sync"
 
+	"fmt"
 	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/log"
 
+	"github.com/coredns/coredns/plugin/pkg/listener"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -20,45 +22,44 @@ import (
 // Metrics holds the prometheus configuration. The metrics' path is fixed to be /metrics
 type Metrics struct {
 	Next plugin.Handler
-	Addr string
-	Reg  *prometheus.Registry
-	ln   net.Listener
-	mux  *http.ServeMux
 
 	zoneNames []string
 	zoneMap   map[string]bool
 	zoneMu    sync.RWMutex
+	lsn       *metricsListener
 }
 
-// New returns a new instance of Metrics with the given address
-func New(addr string) *Metrics {
-	met := &Metrics{
-		Addr:    addr,
-		Reg:     prometheus.NewRegistry(),
-		zoneMap: make(map[string]bool),
+// metricsListener is the HTTP Server that will return the data on external request
+// it may be shared by several Metrics objects, allowing a consolitation of all metrics on the same server
+type metricsListener struct {
+	Reg   *prometheus.Registry
+	alloc listener.AllocationToken
+	ln    net.Listener
+	mux   *http.ServeMux
+}
+
+// New returns a new instance of Metrics with the given zones
+func New(listener *metricsListener, zones []string) *Metrics {
+	zMap := map[string]bool{}
+	for _, z := range zones {
+		zMap[z] = true
 	}
-	// Add the default collectors
-	met.MustRegister(prometheus.NewGoCollector())
-	met.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
-
-	// Add all of our collectors
-	met.MustRegister(buildInfo)
-	met.MustRegister(vars.RequestCount)
-	met.MustRegister(vars.RequestDuration)
-	met.MustRegister(vars.RequestSize)
-	met.MustRegister(vars.RequestDo)
-	met.MustRegister(vars.RequestType)
-	met.MustRegister(vars.ResponseSize)
-	met.MustRegister(vars.ResponseRcode)
-
-	// Initialize metrics.
-	buildInfo.WithLabelValues(coremain.CoreVersion, coremain.GitCommit, runtime.Version()).Set(1)
+	met := &Metrics{
+		zoneMap:   zMap,
+		zoneNames: keys(zMap),
+		lsn:       listener,
+	}
 
 	return met
 }
 
-// MustRegister wraps m.Reg.MustRegister.
-func (m *Metrics) MustRegister(c prometheus.Collector) { m.Reg.MustRegister(c) }
+func keys(m map[string]bool) []string {
+	sx := []string{}
+	for k := range m {
+		sx = append(sx, k)
+	}
+	return sx
+}
 
 // AddZone adds zone z to m.
 func (m *Metrics) AddZone(z string) {
@@ -84,17 +85,46 @@ func (m *Metrics) ZoneNames() []string {
 	return s
 }
 
-// OnStartup sets up the metrics on startup.
-func (m *Metrics) OnStartup() error {
-	ln, err := net.Listen("tcp", m.Addr)
+func newListener(alloc listener.AllocationToken) *metricsListener {
+	met := &metricsListener{
+		Reg:   prometheus.NewRegistry(),
+		alloc: alloc,
+	}
+
+	// Add the default collectors
+	met.MustRegister(prometheus.NewGoCollector())
+	met.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+
+	// Add all of our collectors
+	met.MustRegister(buildInfo)
+	met.MustRegister(vars.RequestCount)
+	met.MustRegister(vars.RequestDuration)
+	met.MustRegister(vars.RequestSize)
+	met.MustRegister(vars.RequestDo)
+	met.MustRegister(vars.RequestType)
+	met.MustRegister(vars.ResponseSize)
+	met.MustRegister(vars.ResponseRcode)
+
+	// Initialize metrics.
+	buildInfo.WithLabelValues(coremain.CoreVersion, coremain.GitCommit, runtime.Version()).Set(1)
+
+	return met
+}
+
+func (m *metricsListener) Tag() string { return "prometheus" }
+
+// MustRegister wraps m.Reg.MustRegister.
+func (m *metricsListener) MustRegister(c prometheus.Collector) { m.Reg.MustRegister(c) }
+
+// OnStartup sets up the HTTP Listener for all Metrics associated with this address.
+func (m *metricsListener) OnStartup() error {
+	ln, err := m.alloc.AllocateListener()
 	if err != nil {
 		log.Errorf("Failed to start metrics handler: %s", err)
 		return err
 	}
 
 	m.ln = ln
-	ListenAddr = m.ln.Addr().String()
-
 	m.mux = http.NewServeMux()
 	m.mux.Handle("/metrics", promhttp.HandlerFor(m.Reg, promhttp.HandlerOpts{}))
 
@@ -104,8 +134,16 @@ func (m *Metrics) OnStartup() error {
 	return nil
 }
 
+//ListeningAddr return the listening addr. An error is thrown if listener is not listening yet
+func (m *metricsListener) ListeningAddr() (string, error) {
+	if m.ln == nil {
+		return "", fmt.Errorf("Server not yet spawn up - address is unknown")
+	}
+	return m.ln.Addr().String(), nil
+}
+
 // OnShutdown tears down the metrics listener on shutdown and restart.
-func (m *Metrics) OnShutdown() error {
+func (m *metricsListener) OnShutdown() error {
 	// We allow prometheus statements in multiple Server Blocks, but only the first
 	// will open the listener, for the rest they are all nil; guard against that.
 	if m.ln != nil {
@@ -113,18 +151,6 @@ func (m *Metrics) OnShutdown() error {
 	}
 	return nil
 }
-
-func keys(m map[string]bool) []string {
-	sx := []string{}
-	for k := range m {
-		sx = append(sx, k)
-	}
-	return sx
-}
-
-// ListenAddr is assigned the address of the prometheus listener. Its use is mainly in tests where
-// we listen on "localhost:0" and need to retrieve the actual address.
-var ListenAddr string
 
 var (
 	buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/plugin/metrics/register.go
+++ b/plugin/metrics/register.go
@@ -18,6 +18,6 @@ func MustRegister(c *caddy.Controller, cs ...prometheus.Collector) {
 		return
 	}
 	for _, c := range cs {
-		x.MustRegister(c)
+		x.lsn.MustRegister(c)
 	}
 }

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -31,7 +31,7 @@ func setup(c *caddy.Controller) error {
 	if booked {
 		x, ok := booker.(*metricsListener)
 		if !ok {
-			return plugin.Error("prometheus", fmt.Errorf("the address (%s) for listening is already booked by %s (and is not recognized as prometheus)", addr, booker.Tag()))
+			return plugin.Error("prometheus", fmt.Errorf("the address (%s) for listening is already booked by %s (and is not recognized as prometheus)", addr, booker.Name()))
 		}
 		mlsn = x
 	} else {

--- a/plugin/metrics/setup_test.go
+++ b/plugin/metrics/setup_test.go
@@ -3,8 +3,9 @@ package metrics
 import (
 	"testing"
 
-	"github.com/mholt/caddy"
 	"strings"
+
+	"github.com/mholt/caddy"
 )
 
 func TestPrometheusParse(t *testing.T) {

--- a/plugin/metrics/setup_test.go
+++ b/plugin/metrics/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mholt/caddy"
+	"strings"
 )
 
 func TestPrometheusParse(t *testing.T) {
@@ -11,18 +12,19 @@ func TestPrometheusParse(t *testing.T) {
 		input     string
 		shouldErr bool
 		addr      string
+		zones     []string
 	}{
 		// oks
-		{`prometheus`, false, "localhost:9153"},
-		{`prometheus localhost:53`, false, "localhost:53"},
+		{`prometheus`, false, "localhost:9153", []string{}},
+		{`prometheus localhost:53`, false, "localhost:53", []string{}},
 		// fails
-		{`prometheus {}`, true, ""},
-		{`prometheus /foo`, true, ""},
-		{`prometheus a b c`, true, ""},
+		{`prometheus {}`, true, "", []string{}},
+		{`prometheus /foo`, true, "", []string{}},
+		{`prometheus a b c`, true, "", []string{}},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		m, err := prometheusParse(c)
+		addr, zones, err := prometheusParse(c)
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %v: Expected error but found nil", i)
 			continue
@@ -35,8 +37,13 @@ func TestPrometheusParse(t *testing.T) {
 			continue
 		}
 
-		if test.addr != m.Addr {
-			t.Errorf("Test %v: Expected address %s but found: %s", i, test.addr, m.Addr)
+		if test.addr != addr {
+			t.Errorf("Test %v: Expected address %s but found: %s", i, test.addr, addr)
+		}
+		jtzones := strings.Join(test.zones, ",")
+		jzones := strings.Join(zones, ",")
+		if jtzones != jzones {
+			t.Errorf("Test %v: Expected zones %s but found: %s", i, jtzones, zones)
 		}
 	}
 }

--- a/plugin/pkg/listener/listener.go
+++ b/plugin/pkg/listener/listener.go
@@ -51,7 +51,7 @@ func areSameIP(ip1 string, ip2 string) bool {
 	return false
 }
 
-func (b booking) isSame(protocol string, hostname string, port string) bool {
+func (b booking) equal(protocol string, hostname string, port string) bool {
 	// Consider that port "0" means "a new port" and will never match another port
 	// Consider that "localhost" or "" is matching both "127.0.01" or "[::1]"
 	if protocol == b.protocol {
@@ -150,7 +150,7 @@ func (l *Distributor) IsBooked(network string, address string) (bool, Booker) {
 		return false, nil
 	}
 	for _, b := range l.booked {
-		if b.isSame(network, hostname, port) {
+		if b.equal(network, hostname, port) {
 			return true, b.booker
 		}
 	}
@@ -165,7 +165,7 @@ func (l *Distributor) BookListener(network string, address string, bookerInfo Bo
 	}
 	// check if already booked - raise error
 	for _, booking := range l.booked {
-		if booking.isSame(network, hostname, port) {
+		if booking.equal(network, hostname, port) {
 			return nil, fmt.Errorf("listener booking for %s, (%s, %s) - an overlaping listener is already booked for %s (%s, %s) - sharing is not allowed", bookerInfo.Tag(), network, address, booking.booker.Tag(), booking.protocol, net.JoinHostPort(booking.hostname, booking.port))
 		}
 	}
@@ -175,8 +175,8 @@ func (l *Distributor) BookListener(network string, address string, bookerInfo Bo
 		if reuse != nil {
 			ntw := (*reuse.allocated).Addr().Network()
 			host, port, _ := net.SplitHostPort((*reuse.allocated).Addr().String())
-			if toBook.isSame(ntw, host, port) {
-				if reuse.isSame(network, hostname, port) && reuse.allocated != nil {
+			if toBook.equal(ntw, host, port) {
+				if reuse.equal(network, hostname, port) && reuse.allocated != nil {
 					// check that we reuse for the same family of Booker (same Tag)
 					if reuse.booker.Tag() != bookerInfo.Tag() {
 						return nil, fmt.Errorf("listener booking for %s, (%s, %s) - an overlaping listener is already in use for %s (%s, %s)", bookerInfo.Tag(), network, address, reuse.booker.Tag(), reuse.protocol, net.JoinHostPort(reuse.hostname, reuse.port))

--- a/plugin/pkg/listener/listener.go
+++ b/plugin/pkg/listener/listener.go
@@ -1,0 +1,209 @@
+package listener
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/mholt/caddy"
+)
+
+// Booker - generic type providing information on the booker
+type Booker interface {
+	// Tag is used to verify re-usability of a Listener - listener is reusable only for Booker with the same Tag
+	Tag() string
+}
+
+// booking structure use at booking, and allocation time of the listener
+type booking struct {
+	booker    Booker
+	hostname  string
+	port      string
+	protocol  string
+	reusable  *net.Listener
+	allocated *net.Listener
+}
+
+// a way to identify same hostname
+// TODO: manage properly the difference between localhost/"" and Ipv4 or Ipv6
+var (
+	sameIPList = [][]string{
+		{"127.0.0.1", "localhost", ""},
+		{"::1", "localhost", ""},
+	}
+)
+
+func contains(list []string, ip string) bool {
+	for _, v := range list {
+		if v == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func areSameIP(ip1 string, ip2 string) bool {
+	for _, l := range sameIPList {
+		if contains(l, ip1) && contains(l, ip2) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b booking) isSame(protocol string, hostname string, port string) bool {
+	// Consider that port "0" means "a new port" and will never match another port
+	// Consider that "localhost" or "" is matching both "127.0.01" or "[::1]"
+	if protocol == b.protocol {
+		if port == "0" || b.port == "0" {
+			return false
+		}
+		if port == b.port {
+			return areSameIP(hostname, b.hostname)
+		}
+	}
+	return false
+}
+
+// AllocationToken is an interface that is able to allocated the Listener
+type AllocationToken interface {
+	AllocateListener() (net.Listener, error)
+}
+
+//AllocateListener will act upon configuration of the booking:
+// - either reuse an existing listener
+// - either spin-up a new one
+// - keep track of the new Listener in order to provide for next RELOAD
+func (b *booking) AllocateListener() (net.Listener, error) {
+	// Cannot allocate several times
+	if b.allocated != nil {
+		return nil, fmt.Errorf("listener already allocated for %s, at address (%s, %s)", b.booker.Tag(), (*b.allocated).Addr().Network(), (*b.allocated).Addr().String())
+	}
+
+	var ln net.Listener
+	var err error
+	if b.reusable != nil {
+		// we want to reuse the same address - duplicate the FD and open a listener on that FD
+		// If this is a reload and s is a GracefulServer,
+		// reuse the listener for a graceful restart.
+		if fileLn, ok := (*b.reusable).(caddy.Listener); ok {
+			file, err := fileLn.File()
+			if err != nil {
+				return nil, err
+			}
+			ln, err = net.FileListener(file)
+			if err != nil {
+				return nil, err
+			}
+			err = file.Close()
+			if err != nil {
+				return nil, err
+			}
+
+		}
+	}
+	if ln == nil {
+		ln, err = net.Listen(b.protocol, net.JoinHostPort(b.hostname, b.port))
+		if err != nil {
+			return nil, err
+		}
+	}
+	b.allocated = &ln
+	log.Printf("[INFO] %s - listening on network %s - address %s", b.booker.Tag(), ln.Addr().Network(), ln.Addr().String())
+	return ln, err
+}
+
+// Distributor provide ability to distribute and re-distribute the listeners. Ensuring bridge for gracefull continuation after a reload
+type Distributor struct {
+	// Distribution is done in 2 times:
+	// 1- Book the listener - (expected during Setup of plugin) - we expect to be able to reuse existing listener, but raise any error during that phase
+	// 2- Allocate the listener - (expected after Start of the Servers) - an error here can happen, but would be unfortunate, leaving the system in unknown status
+
+	// need to fail at Book time if:
+	//   - address is already in used by ANOTHER plugin
+	//   - address is already booked (reusing or not)
+	//   - NOTE: need to take care of 'similar addresses' or address always different (port 0)
+	//
+	reusable []*booking
+	booked   []*booking
+}
+
+// NewListenerDistributor : provide an new Distributor with ability to reuse the allocated listener of a former Distributor
+func NewListenerDistributor(seedDistributor *Distributor) *Distributor {
+	reusable := make([]*booking, 0)
+	if seedDistributor != nil {
+		for _, v := range seedDistributor.booked {
+			if v.allocated != nil {
+				reusable = append(reusable, v)
+			}
+		}
+	}
+	return &Distributor{reusable: reusable, booked: make([]*booking, 0)}
+}
+
+// IsBooked return status of booking for this address. The Booker info is returned
+// it is typically used for the booker to be able to share the same new Listener - as re-Book the same address is forbidden.
+// (see metrics plugin)
+func (l *Distributor) IsBooked(network string, address string) (bool, Booker) {
+	hostname, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return false, nil
+	}
+	for _, b := range l.booked {
+		if b.isSame(network, hostname, port) {
+			return true, b.booker
+		}
+	}
+	return false, nil
+}
+
+// BookListener ask for booking a new listener. Will return an allocation interface to use when need to really instanciate the listener
+func (l *Distributor) BookListener(network string, address string, bookerInfo Booker, allowReuse bool) (AllocationToken, error) {
+	hostname, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("listener booking for %s, (%s, %s) - address provider is invalid : %v", bookerInfo.Tag(), network, address, err)
+	}
+	// check if already booked - raise error
+	for _, booking := range l.booked {
+		if booking.isSame(network, hostname, port) {
+			return nil, fmt.Errorf("listener booking for %s, (%s, %s) - an overlaping listener is already booked for %s (%s, %s) - sharing is not allowed", bookerInfo.Tag(), network, address, booking.booker.Tag(), booking.protocol, net.JoinHostPort(booking.hostname, booking.port))
+		}
+	}
+	toBook := &booking{protocol: network, hostname: hostname, port: port, reusable: nil, booker: bookerInfo}
+	// check if reusable Listener
+	for r, reuse := range l.reusable {
+		if reuse != nil {
+			ntw := (*reuse.allocated).Addr().Network()
+			host, port, _ := net.SplitHostPort((*reuse.allocated).Addr().String())
+			if toBook.isSame(ntw, host, port) {
+				if reuse.isSame(network, hostname, port) && reuse.allocated != nil {
+					// check that we reuse for the same family of Booker (same Tag)
+					if reuse.booker.Tag() != bookerInfo.Tag() {
+						return nil, fmt.Errorf("listener booking for %s, (%s, %s) - an overlaping listener is already in use for %s (%s, %s)", bookerInfo.Tag(), network, address, reuse.booker.Tag(), reuse.protocol, net.JoinHostPort(reuse.hostname, reuse.port))
+					}
+					if !allowReuse {
+						return nil, fmt.Errorf("listener booking for %s, (%s, %s) - this listener is already in use, and re-use is not allowed", bookerInfo.Tag(), network, address)
+					}
+					toBook.reusable = reuse.allocated
+					// We prevent to reuse a second time - although the test on booking should also prevent it
+					l.reusable[r] = nil
+					break
+				}
+			}
+		}
+	}
+	// book it anyway, whatever reuse status
+	l.booked = append(l.booked, toBook)
+	return toBook, nil
+}
+
+//Bookings return all listeners that match the provide tag
+func (l *Distributor) Bookings(tag string) []*net.Listener {
+	match := make([]*net.Listener, 0)
+	for _, b := range l.booked {
+		if b.booker.Tag() == tag {
+			match = append(match, b.allocated)
+		}
+	}
+	return match
+}

--- a/plugin/pkg/listener/listener_test.go
+++ b/plugin/pkg/listener/listener_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 type booker struct {
-	tag string
+	name string
 }
 
-func (b booker) Tag() string {
-	return b.tag
+func (b booker) Name() string {
+	return b.name
 }
 
 func TestProviderSimpleBooking(t *testing.T) {
@@ -21,7 +21,7 @@ func TestProviderSimpleBooking(t *testing.T) {
 
 	// Dry-run mode
 
-	booker := booker{tag: "sample"}
+	booker := booker{name: "sample"}
 	dist := NewListenerDistributor(nil)
 	alloc, err := dist.BookListener("tcp", "127.0.0.1:4010", booker, false)
 	if err != nil {

--- a/plugin/pkg/listener/listener_test.go
+++ b/plugin/pkg/listener/listener_test.go
@@ -1,0 +1,52 @@
+package listener
+
+import (
+	"testing"
+)
+
+type booker struct {
+	tag string
+}
+
+func (b booker) Tag() string {
+	return b.tag
+}
+
+func TestProviderSimpleBooking(t *testing.T) {
+	// make a Provider for listener
+	// verify
+	// 1- new one is allocated if none
+	// 2- a second one with the same key, same port reallocated the initial one
+	// 3- a second one with the diff key, same port will fail
+
+	// Dry-run mode
+
+	booker := booker{tag: "sample"}
+	dist := NewListenerDistributor(nil)
+	alloc, err := dist.BookListener("tcp", "127.0.0.1:4010", booker, false)
+	if err != nil {
+		t.Errorf("cannot book a simple address : %v", err)
+	}
+	listener, err := alloc.AllocateListener()
+	if err != nil {
+		t.Errorf("cannot allocate the listener after simple booking : %v", err)
+	}
+	if listener.Addr().String() != "127.0.0.1:4010" {
+		t.Errorf("simple listener allocated on the wrong address : %v, expected %v", listener.Addr().String(), "127.0.0.1:4010")
+	}
+
+	// now try to reuse this listener
+	nextDist := NewListenerDistributor(dist)
+	nextAlloc, err := nextDist.BookListener("tcp", "127.0.0.1:4010", booker, true)
+	if err != nil {
+		t.Errorf("cannot reuse the address of a listener : %v", err)
+	}
+	nextListener, err := nextAlloc.AllocateListener()
+	if err != nil {
+		t.Errorf("cannot allocate the listener of a booking including a reused listener : %v", err)
+	}
+	if nextListener.Addr().String() != listener.Addr().String() {
+		t.Errorf("reallocated listener seems on the wrong address : %v, expected %v", nextListener.Addr().String(), listener.Addr().String())
+	}
+
+}

--- a/plugin/test/server.go
+++ b/plugin/test/server.go
@@ -8,6 +8,27 @@ import (
 	"github.com/miekg/dns"
 )
 
+//ListenerAllocator is able to generate a generic tcp Listener on any address
+type ListenerAllocator struct {
+	Network string
+	Address string
+}
+
+//AllocateListener provide a tcp Listener on protocol and address specified
+func (lsn ListenerAllocator) AllocateListener() (net.Listener, error) {
+	return net.Listen(lsn.Network, lsn.Address)
+}
+
+//NewListenerAllocator creates a new allocator at defined protocol and address
+func NewListenerAllocator(network string, address string) ListenerAllocator {
+	return ListenerAllocator{Network: network, Address: address}
+}
+
+//NewDefaultAllocator provides a convenient ListenerAllocator for default next available port
+func NewDefaultAllocator() ListenerAllocator {
+	return NewListenerAllocator("tcp", "localhost:0")
+}
+
 // TCPServer starts a DNS server with a TCP listener on laddr.
 func TCPServer(laddr string) (*dns.Server, string, error) {
 	l, err := net.Listen("tcp", laddr)

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -66,7 +66,7 @@ example.com:0 {
 func getCurrentListeningAddress(key string) string {
 	var listenAddr = ""
 	for _, v := range dnsserver.GetActiveListenerDistributor().Bookings(key) {
-		listenAddr = (*v).Addr().String()
+		listenAddr = v.Addr().String()
 	}
 	return listenAddr
 }

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -71,9 +71,13 @@ func TestReadme(t *testing.T) {
 		for _, in := range inputs {
 			dnsserver.Port = strconv.Itoa(port)
 			server, err := caddy.Start(in)
+			// Execute after startup events, mandatory for a full started service
+			caddy.EmitEvent(caddy.InstanceStartupEvent, server)
+
 			if err != nil {
 				t.Errorf("Failed to start server with %s, for input %q:\n%s", readme, err, in.Body())
 			}
+			server.ShutdownCallbacks()
 			server.Stop()
 			port++
 		}

--- a/test/server.go
+++ b/test/server.go
@@ -23,7 +23,14 @@ func CoreDNSServer(corefile string) (*caddy.Instance, error) {
 	dnsserver.Quiet = true
 	log.SetOutput(ioutil.Discard)
 
-	return caddy.Start(NewInput(corefile))
+	instance, err := caddy.Start(NewInput(corefile))
+	if err != nil {
+		return nil, err
+	}
+	// Execute after startup events, mandatory for a full started service
+	caddy.EmitEvent(caddy.InstanceStartupEvent, instance)
+	return instance, nil
+
 }
 
 // CoreDNSServerStop stops a server.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

1- introduce reusable Listener to allow the graceful Restart process of Caddy to success with Plugin that instanciate HTTP Listeners.
2- Use that new capability to ensure HEALTH and METRICS plugins are compatible with RELOAD
3- Fix HEALTH issue : #1686, and now allow sharing the listener among BlocServer or the whole Corefile 
4- METRICS: allow the directives "prometheus" to share the same HTTP Listener. (fix partially #1492)

NOTE: this PR replace the PR https://github.com/coredns/coredns/pull/1621, that I will close.

### 2. Which issues (if any) are related?
#1604
#1618
#1686 
#1492 

### 3. High level description of the PR

NOTE: Each of the following part is commited in a separated commit. That may help for review.

#### Adding Listener Distributor
plugins/pkg/listener
A Listener Distributor is a tool that is able to take reservations (booking) for listener to setup. It is able to:
- verify the address is not booked yet - at time of booking
- when allocate the Listener, is able to chain/reuse any existing Listener from the instance of CoreDNS to be stopped

#### Allow the Listener Distributor to be shared inside one instance, and chained on subsequent instances (RESTART process)
core/register
dnsContext is changed to be able to register a global listener Distributor available for all plugins of the coreDNS instance, and linked together the Distributor of the instance to be stopped with the Distributor of the new instance to be created (in order to be able to reuse the Listeners)

#### Fix and Enhance plugin HEALTH
plugin/health
Use the distributor to allow reuse of same Listener when restart
Allow sharing the HEALTH object (same listener) between several ServerChain (several ServerBloc of the same ServerBloc re-instanciated for another DNS listener). 

#### Fix and Enhance plugin METRICS
plugin/metrics
Use the distributor to allow reuse of same Listener when restart
Separated the METRICS objects in 2 parts: the Metrics that collect the data, and the LsnMetrics that server HTTP request and can be shared among several Metrics.
NOTE: to complete the fix of #1492, the PR https://github.com/coredns/coredns/pull/1682 will be needed in order to make difference between DNS queries served by different servers.


### 4. Which documentation changes (if any) need to be made?
TODO:
- update README for Health and Metrics
- will need to enhance a plugin blogs to explain for developers the logic of Setup, and how to use this new Distributor tool.


