### PR TITLE
pkg/log: ability for debug logs

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
 	"github.com/coredns/coredns/plugin/pkg/edns"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 	"github.com/coredns/coredns/plugin/pkg/trace"
 	"github.com/coredns/coredns/request"
@@ -60,6 +61,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 	for _, site := range group {
 		if site.Debug {
 			s.debug = true
+			log.D = true
 		}
 		// set the config per zone
 		s.zones[site.Zone] = site

--- a/plugin.md
+++ b/plugin.md
@@ -35,12 +35,15 @@ See a couple of blog posts on how to write and add plugin to CoreDNS:
 
 ## Logging
 
-If your plugin needs to output a log line you should use the `plugin/pkg/log` package. CoreDNS does
-not implement log levels as such. The standard way of outputing is: `log.Printf("[LEVEL] ...")`, and
-LEVEL can be: `INFO`, `WARNING` or `ERROR`. In general, logging should be left to the higher layers
-by returning an error. However, if there is a reason to consume the error but notify the user, then
-logging in the plugin can be acceptable. The `log` package does have Debug* function that are used
-the debug logs; those logs are only outputted when the *debug* plugin is loaded in the server.
+If your plugin needs to output a log line you should use the `plugin/pkg/log` package. This package
+implements log levels. The standard way of outputting is: `log.Info` for info level messages. The
+levels available are `log.Info`, `log.Warning`, `log.Error`, `log.Debug`. Each of these also has
+a `f` variant.
+
+In general, logging should be left to the higher layers by returning an error. However, if there is
+a reason to consume the error and notify the user, then logging in the plugin itself can be
+acceptable. The `Debug*` functions only output something when the *debug* plugin is loaded in the
+server.
 
 ## Metrics
 

--- a/plugin.md
+++ b/plugin.md
@@ -35,11 +35,12 @@ See a couple of blog posts on how to write and add plugin to CoreDNS:
 
 ## Logging
 
-If your plugin needs to output a log line you should use the `log` package. CoreDNS does not
-implement log levels. The standard way of outputing is: `log.Printf("[LEVEL] ...")`, and LEVEL
-can be: `INFO`, `WARNING` or `ERROR`.
-In general, logging should be left to the higher layers by returning an error. However, if there is
-a reason to consume the error but notify the user, then logging in the plugin can be acceptable.
+If your plugin needs to output a log line you should use the `plugin/pkg/log` package. CoreDNS does
+not implement log levels as such. The standard way of outputing is: `log.Printf("[LEVEL] ...")`, and
+LEVEL can be: `INFO`, `WARNING` or `ERROR`. In general, logging should be left to the higher layers
+by returning an error. However, if there is a reason to consume the error but notify the user, then
+logging in the plugin can be acceptable. The `log` package does have Debug* function that are used
+the debug logs; those logs are only outputted when the *debug* plugin is loaded in the server.
 
 ## Metrics
 

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -1,12 +1,11 @@
 // Package log implements a small wrapper around the std lib log package.
-// All logging can be done as-is, but in addition debug logging is available.
+// It implements log levels by prefixing the logs with [INFO], [DEBUG],
+// [WARNING] or [ERROR].
+// Debug logging is available and enabled if the *debug* plugin is used.
 //
-// I.e. normal use: log.Print("[INFO] this is some logging").
+// log.Info("this is some logging"), will log on the Info level.
 //
-// Debug logging: log.Debug("this is debug output"). Note "[DEBUG] " is prepended
-// to the output.
-//
-// These last one only show output when the *debug* plugin is loaded.
+// log.Debug("this is debug output"), will log in the Debug level.
 package log
 
 import (
@@ -17,40 +16,54 @@ import (
 // D controls whether we should ouput debug logs. If true, we do.
 var D bool
 
-// Debug is equivalent to log.Print() but prefixed with "[DEBUG] ".
+// logf calls log.Printf prefixed with level.
+func logf(level, format string, v ...interface{}) {
+	s := level + fmt.Sprintf(format, v...)
+	golog.Print(s)
+}
+
+// log calls log.Print prefixed with level.
+func log(level string, v ...interface{}) { s := level + fmt.Sprint(v...); golog.Print(s) }
+
+// Debug is equivalent to log.Print(), but prefixed with "[DEBUG] ". It only outputs something
+// if D is true.
 func Debug(v ...interface{}) {
 	if !D {
 		return
 	}
-	s := debug + fmt.Sprint(v...)
-	golog.Print(s)
+	log(debug, v...)
 }
 
-// Debugf is equivalent to log.Printf() but prefixed with "[DEBUG] ".
+// Debugf is equivalent to log.Printf(), but prefixed with "[DEBUG] ". It only outputs something
+// if D is true.
 func Debugf(format string, v ...interface{}) {
 	if !D {
 		return
 	}
-	s := debug + fmt.Sprintf(format, v...)
-	golog.Print(s)
+	logf(debug, format, v...)
 }
 
-// Debugln is equivalent to log.Println() but prefixed with "[DEBUG] ".
-func Debugln(v ...interface{}) {
-	if !D {
-		return
-	}
-	s := debug + fmt.Sprintln(v...)
-	golog.Print(s)
-}
+// Info is equivalent to log.Print, but prefixed with "[INFO] ".
+func Info(v ...interface{}) { log(info, v...) }
 
-// Printf calls log.Printf.
-func Printf(format string, v ...interface{}) { golog.Printf(format, v...) }
+// Infof is equivalent to log.Printf, but prefixed with "[INFO] ".
+func Infof(format string, v ...interface{}) { logf(info, format, v...) }
 
-// Print calls log.Print.
-func Print(v ...interface{}) { golog.Print(v...) }
+// Warning is equivalent to log.Print, but prefixed with "[WARNING] ".
+func Warning(v ...interface{}) { log(warning, v...) }
 
-// Println calls log.Println.
-func Println(v ...interface{}) { golog.Println(v...) }
+// Warningf is equivalent to log.Printf, but prefixed with "[WARNING] ".
+func Warningf(format string, v ...interface{}) { logf(warning, format, v...) }
 
-const debug = "[DEBUG] "
+// Error is equivalent to log.Print, but prefixed with "[ERROR] ".
+func Error(v ...interface{}) { log(err, v...) }
+
+// Errorf is equivalent to log.Printf, but prefixed with "[ERROR] ".
+func Errorf(format string, v ...interface{}) { logf(err, format, v...) }
+
+const (
+	debug   = "[DEBUG] "
+	err     = "[ERROR] "
+	warning = "[WARNING] "
+	info    = "[INFO] "
+)

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -1,8 +1,12 @@
 // The log package implements a small wrapper around the std lib log package.
-// All logging can be done as-is, but in addition debug logging can be done
-// as well.
+// All logging can be done as-is, but in addition debug logging is available.
 //
-// These last ones only show output when the *debug* plugin is loaded.
+// I.e. normal use: log.Print("[INFO] this is some logging").
+//
+// Debug logging: log.Debug("this is debug output"). Note "[DEBUG] " is prepended
+// to the output.
+//
+// These last one only show output when the *debug* plugin is loaded.
 package log
 
 import (

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -1,0 +1,52 @@
+// The log package implements a small wrapper around the std lib log package.
+// All logging can be done as-is, but in addition debug logging can be done
+// as well.
+//
+// These last ones only show output when the *debug* plugin is loaded.
+package log
+
+import (
+	"fmt"
+	golog "log"
+)
+
+// When D is true, debugging output will be shown.
+var D bool
+
+// Debug is equivalent to log.Print() but prefixed with "[DEBUG] ".
+func Debug(v ...interface{}) {
+	if !D {
+		return
+	}
+	s := debug + fmt.Sprint(v...)
+	golog.Print(s)
+}
+
+// Debug is equivalent to log.Printf() but prefixed with "[DEBUG] ".
+func Debugf(format string, v ...interface{}) {
+	if !D {
+		return
+	}
+	s := debug + fmt.Sprintf(format, v...)
+	golog.Print(s)
+}
+
+// Debugln is equivalent to log.Println() but prefixed with "[DEBUG] ".
+func Debugln(v ...interface{}) {
+	if !D {
+		return
+	}
+	s := debug + fmt.Sprintln(v...)
+	golog.Print(s)
+}
+
+// Printf calls log.Printf.
+func Printf(format string, v ...interface{}) { golog.Printf(format, v...) }
+
+// Print calls log.Print.
+func Print(v ...interface{}) { golog.Print(v...) }
+
+// Println calls log.Println.
+func Println(v ...interface{}) { golog.Println(v...) }
+
+const debug = "[DEBUG] "

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -1,4 +1,4 @@
-// The log package implements a small wrapper around the std lib log package.
+// Package log implements a small wrapper around the std lib log package.
 // All logging can be done as-is, but in addition debug logging is available.
 //
 // I.e. normal use: log.Print("[INFO] this is some logging").
@@ -14,7 +14,7 @@ import (
 	golog "log"
 )
 
-// When D is true, debugging output will be shown.
+// D controls whether we should ouput debug logs. If true, we do.
 var D bool
 
 // Debug is equivalent to log.Print() but prefixed with "[DEBUG] ".
@@ -26,7 +26,7 @@ func Debug(v ...interface{}) {
 	golog.Print(s)
 }
 
-// Debug is equivalent to log.Printf() but prefixed with "[DEBUG] ".
+// Debugf is equivalent to log.Printf() but prefixed with "[DEBUG] ".
 func Debugf(format string, v ...interface{}) {
 	if !D {
 		return

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -2,14 +2,14 @@ package log
 
 import (
 	"bytes"
-	"log"
+	golog "log"
 	"strings"
 	"testing"
 )
 
 func TestDebug(t *testing.T) {
 	var f bytes.Buffer
-	log.SetOutput(&f)
+	golog.SetOutput(&f)
 
 	// D == false
 	Debug("debug")
@@ -26,7 +26,7 @@ func TestDebug(t *testing.T) {
 
 func TestDebugx(t *testing.T) {
 	var f bytes.Buffer
-	log.SetOutput(&f)
+	golog.SetOutput(&f)
 
 	D = true
 
@@ -35,19 +35,27 @@ func TestDebugx(t *testing.T) {
 		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
 	}
 
-	Debugln("debug")
-	if x := f.String(); !strings.Contains(x, debug+"debug\n") {
+	Debug("debug")
+	if x := f.String(); !strings.Contains(x, debug+"debug") {
 		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
 	}
-
 }
 
-func TestPrint(t *testing.T) {
+func TestLevels(t *testing.T) {
 	var f bytes.Buffer
-	log.SetOutput(&f)
+	const ts = "test"
+	golog.SetOutput(&f)
 
-	Print("debug")
-	if x := f.String(); !strings.Contains(x, "debug") {
-		t.Errorf("Expected log to be %s, got %s", "debug", x)
+	Info(ts)
+	if x := f.String(); !strings.Contains(x, info+ts) {
+		t.Errorf("Expected log to be %s, got %s", info+ts, x)
+	}
+	Warning(ts)
+	if x := f.String(); !strings.Contains(x, warning+ts) {
+		t.Errorf("Expected log to be %s, got %s", warning+ts, x)
+	}
+	Error(ts)
+	if x := f.String(); !strings.Contains(x, err+ts) {
+		t.Errorf("Expected log to be %s, got %s", err+ts, x)
 	}
 }

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestDebugLog(t *testing.T) {
+func TestDebug(t *testing.T) {
 	var f bytes.Buffer
 	log.SetOutput(&f)
 
@@ -21,5 +21,15 @@ func TestDebugLog(t *testing.T) {
 	Debug("debug")
 	if x := f.String(); !strings.Contains(x, debug+"debug") {
 		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
+	}
+}
+
+func TestPrint(t *testing.T) {
+	var f bytes.Buffer
+	log.SetOutput(&f)
+
+	Print("debug")
+	if x := f.String(); !strings.Contains(x, "debug") {
+		t.Errorf("Expected log to be %s, got %s", "debug", x)
 	}
 }

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -24,6 +24,24 @@ func TestDebug(t *testing.T) {
 	}
 }
 
+func TestDebugx(t *testing.T) {
+	var f bytes.Buffer
+	log.SetOutput(&f)
+
+	D = true
+
+	Debugf("%s", "debug")
+	if x := f.String(); !strings.Contains(x, debug+"debug") {
+		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
+	}
+
+	Debugln("debug")
+	if x := f.String(); !strings.Contains(x, debug+"debug\n") {
+		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
+	}
+
+}
+
 func TestPrint(t *testing.T) {
 	var f bytes.Buffer
 	log.SetOutput(&f)

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -1,0 +1,25 @@
+package log
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestDebugLog(t *testing.T) {
+	var f bytes.Buffer
+	log.SetOutput(&f)
+
+	// D == false
+	Debug("debug")
+	if x := f.String(); x != "" {
+		t.Errorf("Expected no debug logs, got %s", x)
+	}
+
+	D = true
+	Debug("debug")
+	if x := f.String(); !strings.Contains(x, debug+"debug") {
+		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
+	}
+}


### PR DESCRIPTION
When the debug plugin is enabled all log.Debug calls will print to
standard; if not there are a noop (almost).

The log package wraps some standard log functions as well, so just
replacing "log" with "plugin/pkg/log" should be enough to use this
package.

Fixes #1626 