### PR TITLE
global: move to context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ godeps:
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
-	(cd $(GOPATH)/src/golang.org/x/net 2>/dev/null                    && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/golang.org/x/text 2>/dev/null                   && git checkout -q master 2>/dev/null || true)
 	go get -u github.com/mholt/caddy
 	go get -u github.com/miekg/dns
@@ -38,7 +37,6 @@ godeps:
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.11)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.5)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
-	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.10)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q v0.3.0)
 	# github.com/flynn/go-shlex is required by mholt/caddy at the moment
 	go get -u github.com/flynn/go-shlex

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,18 @@ godeps:
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
+	(cd $(GOPATH)/src/golang.org/x/net 2>/dev/null                    && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/golang.org/x/text 2>/dev/null                   && git checkout -q master 2>/dev/null || true)
 	go get -u github.com/mholt/caddy
 	go get -u github.com/miekg/dns
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
+	go get -u golang.org/x/net/context
 	go get -u golang.org/x/text
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.11)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.5)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
+	(cd $(GOPATH)/src/golang.org/x/net                    && git checkout -q release-branch.go1.10)
 	(cd $(GOPATH)/src/golang.org/x/text                   && git checkout -q v0.3.0)
 	# github.com/flynn/go-shlex is required by mholt/caddy at the moment
 	go get -u github.com/flynn/go-shlex

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ godeps:
 	go get -u github.com/miekg/dns
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
-	go get -u golang.org/x/net/context
 	go get -u golang.org/x/text
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.11)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.5)

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -2,6 +2,7 @@
 package dnsserver
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"runtime"
@@ -18,7 +19,6 @@ import (
 
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 )
 
 // Server represents an instance of a server, which serves

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -1,6 +1,7 @@
 package dnsserver
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -1,13 +1,13 @@
 package dnsserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/test"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type testPlugin struct{}

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -1,12 +1,12 @@
 package dnsserver
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // ServerTLS represents an instance of a TLS-over-DNS-server.

--- a/pb/dns.pb.go
+++ b/pb/dns.pb.go
@@ -18,7 +18,8 @@ import fmt "fmt"
 import math "math"
 
 import (
-	context "golang.org/x/net/context"
+	context "context"
+
 	grpc "google.golang.org/grpc"
 )
 

--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -11,8 +11,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type (

--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -37,8 +37,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Func defines the function plugin should implement to return a search

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var autopathTestCases = []test.Case{

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/miekg/dns"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ServiceBackend defines a (dynamic) backend that returns a slice of service definitions.

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/response"

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -8,9 +8,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 )
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/cache/prefech_test.go
+++ b/plugin/cache/prefech_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
+	"context"
+
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestPrefetch(t *testing.T) {

--- a/plugin/cache/spoof_test.go
+++ b/plugin/cache/spoof_test.go
@@ -6,9 +6,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
+	"context"
+
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestSpoof(t *testing.T) {

--- a/plugin/chaos/chaos.go
+++ b/plugin/chaos/chaos.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Chaos allows CoreDNS to reply to CH TXT queries and return author or

--- a/plugin/chaos/chaos_test.go
+++ b/plugin/chaos/chaos_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestChaos(t *testing.T) {

--- a/plugin/dnssec/handler.go
+++ b/plugin/dnssec/handler.go
@@ -6,9 +6,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 )
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/dnssec/handler_test.go
+++ b/plugin/dnssec/handler_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var dnssecTestCases = []test.Case{

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -6,9 +6,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/dnstap/taprw"
 
+	"context"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Dnstap is the dnstap handler.

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/coredns/coredns/plugin/dnstap/test"
 	mwtest "github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func testCase(t *testing.T, tapq, tapr *tap.Message, q, r *dns.Msg) {

--- a/plugin/dnstap/test/helpers.go
+++ b/plugin/dnstap/test/helpers.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 
+	"context"
+
 	tap "github.com/dnstap/golang-dnstap"
-	"golang.org/x/net/context"
 )
 
 // Context is a message trap.

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Erratic is a plugin that returns erratic repsonses to each client.

--- a/plugin/erratic/erratic_test.go
+++ b/plugin/erratic/erratic_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestErraticDrop(t *testing.T) {

--- a/plugin/errors/errors.go
+++ b/plugin/errors/errors.go
@@ -11,8 +11,9 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // errorHandler handles DNS errors (and errors from other plugin).

--- a/plugin/errors/errors_test.go
+++ b/plugin/errors/errors_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestErrors(t *testing.T) {

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -13,10 +13,11 @@ import (
 	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Etcd is a plugin talks to an etcd cluster.

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -5,8 +5,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -14,9 +14,10 @@ import (
 	"github.com/coredns/coredns/plugin/proxy"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func init() {

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -9,9 +9,10 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/proxy"
 
+	"context"
+
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/mholt/caddy"
-	"golang.org/x/net/context"
 )
 
 func init() {

--- a/plugin/etcd/stub_handler.go
+++ b/plugin/etcd/stub_handler.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Stub wraps an Etcd. We have this type so that it can have a ServeDNS method.

--- a/plugin/etcd/xfr.go
+++ b/plugin/etcd/xfr.go
@@ -3,9 +3,10 @@ package etcd
 import (
 	"time"
 
+	"context"
+
 	"github.com/coredns/coredns/request"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Serial implements the Transferer interface.

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -20,8 +20,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Federation contains the name to zone mapping used for federation in kubernetes.

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestIsNameFederation(t *testing.T) {

--- a/plugin/file/cname_test.go
+++ b/plugin/file/cname_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestLookupCNAMEChain(t *testing.T) {

--- a/plugin/file/delegation_test.go
+++ b/plugin/file/delegation_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var delegationTestCases = []test.Case{

--- a/plugin/file/dname_test.go
+++ b/plugin/file/dname_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // RFC 6672, Section 2.2. Assuming QTYPE != DNAME.

--- a/plugin/file/dnssec_test.go
+++ b/plugin/file/dnssec_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var dnssecTestCases = []test.Case{

--- a/plugin/file/ds_test.go
+++ b/plugin/file/ds_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var dsTestCases = []test.Case{

--- a/plugin/file/ent_test.go
+++ b/plugin/file/ent_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var entTestCases = []test.Case{

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type (

--- a/plugin/file/glue_test.go
+++ b/plugin/file/glue_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // another personal zone (helps in testing as my secondary is NSD

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var dnsTestCases = []test.Case{

--- a/plugin/file/wildcard_test.go
+++ b/plugin/file/wildcard_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var wildcardTestCases = []test.Case{

--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Xfr serves up an AXFR.

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -12,8 +12,9 @@ import (
 
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func (p *Proxy) readTimeout() time.Duration {

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -12,9 +12,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 )
 
 // Forward represents a plugin instance that can proxy requests to another (DNS) server. It has a list

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestHealth(t *testing.T) {

--- a/plugin/forward/lookup.go
+++ b/plugin/forward/lookup.go
@@ -7,8 +7,9 @@ package forward
 import (
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Forward forward the request in state as-is. Unlike Lookup that adds EDNS0 suffix to the message.

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -3,7 +3,7 @@ package hosts
 import (
 	"net"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestLookupA(t *testing.T) {

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -5,8 +5,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/kubernetes/handler_pod_disabled_test.go
+++ b/plugin/kubernetes/handler_pod_disabled_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var podModeDisabledCases = []test.Case{

--- a/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/plugin/kubernetes/handler_pod_insecure_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var podModeInsecureCases = []test.Case{

--- a/plugin/kubernetes/handler_pod_verified_test.go
+++ b/plugin/kubernetes/handler_pod_verified_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var podModeVerifiedCases = []test.Case{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/plugin/kubernetes/kubernetes_apex_test.go
+++ b/plugin/kubernetes/kubernetes_apex_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 var kubeApexCases = []test.Case{

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -10,8 +10,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
 )
 

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
-	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/plugin/loadbalance/handler.go
+++ b/plugin/loadbalance/handler.go
@@ -4,8 +4,9 @@ package loadbalance
 import (
 	"github.com/coredns/coredns/plugin"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // RoundRobin is plugin to rewrite responses for "load balancing".

--- a/plugin/loadbalance/loadbalance_test.go
+++ b/plugin/loadbalance/loadbalance_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestLoadBalance(t *testing.T) {

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -13,8 +13,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Logger is a basic request logging plugin.

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestLoggedStatus(t *testing.T) {

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -94,16 +94,13 @@ func TestLogParse(t *testing.T) {
 		}}},
 		{`log {
 			class abracadabra
-		}`, true, []Rule{
-		}},
+		}`, true, []Rule{}},
 		{`log {
 			class
-		}`, true, []Rule{
-		}},
+		}`, true, []Rule{}},
 		{`log {
 			unknown
-		}`, true, []Rule{
-		}},
+		}`, true, []Rule{}},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputLogRules)

--- a/plugin/metrics/context.go
+++ b/plugin/metrics/context.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"github.com/coredns/coredns/plugin/metrics/vars"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // WithServer returns the current server handling the request. It returns the

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // ServeDNS implements the Handler interface.

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestMetrics(t *testing.T) {

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Report reports the metrics data associcated with request.

--- a/plugin/nsid/nsid.go
+++ b/plugin/nsid/nsid.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Nsid plugin

--- a/plugin/nsid/nsid_test.go
+++ b/plugin/nsid/nsid_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/plugin/whoami"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestNsid(t *testing.T) {

--- a/plugin/pkg/fuzz/do.go
+++ b/plugin/pkg/fuzz/do.go
@@ -5,8 +5,9 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Do will fuzz p - used by gofuzz. See Maefile.fuzz for comments and context.

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"fmt"
 
+	"context"
+
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
-	"golang.org/x/net/context"
 )
 
 type (

--- a/plugin/proxy/dns.go
+++ b/plugin/proxy/dns.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type dnsEx struct {

--- a/plugin/proxy/dnstap.go
+++ b/plugin/proxy/dnstap.go
@@ -7,9 +7,10 @@ import (
 	"github.com/coredns/coredns/plugin/dnstap/msg"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func toDnstap(ctx context.Context, host string, ex Exchanger, state request.Request, reply *dns.Msg, start time.Time) error {

--- a/plugin/proxy/dnstap_test.go
+++ b/plugin/proxy/dnstap_test.go
@@ -9,9 +9,10 @@ import (
 	mwtest "github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	tap "github.com/dnstap/golang-dnstap"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func testCase(t *testing.T, ex Exchanger, q, r *dns.Msg, datq, datr *msg.Builder) {

--- a/plugin/proxy/exchanger.go
+++ b/plugin/proxy/exchanger.go
@@ -3,8 +3,9 @@ package proxy
 import (
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Exchanger is an interface that specifies a type implementing a DNS resolver that

--- a/plugin/proxy/google.go
+++ b/plugin/proxy/google.go
@@ -14,8 +14,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type google struct {

--- a/plugin/proxy/grpc.go
+++ b/plugin/proxy/grpc.go
@@ -9,10 +9,11 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/trace"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
 	opentracing "github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/plugin/proxy/grpc_test.go
+++ b/plugin/proxy/grpc_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 )
 

--- a/plugin/proxy/lookup.go
+++ b/plugin/proxy/lookup.go
@@ -11,8 +11,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/healthcheck"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // NewLookup create a new proxy with the hosts in host and a Random policy.

--- a/plugin/proxy/proxy.go
+++ b/plugin/proxy/proxy.go
@@ -13,9 +13,10 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/healthcheck"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/plugin/reverse/reverse.go
+++ b/plugin/reverse/reverse.go
@@ -8,8 +8,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Reverse provides dynamic reverse DNS and the related forward RR.

--- a/plugin/reverse/reverse_test.go
+++ b/plugin/reverse/reverse_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestReverse(t *testing.T) {

--- a/plugin/rewrite/reverter_test.go
+++ b/plugin/rewrite/reverter_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestResponseReverter(t *testing.T) {

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/miekg/dns"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Result is the result of a rewrite

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func msgPrinter(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -8,11 +8,12 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Route53 is a plugin that returns RR from AWS route53

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -6,11 +6,12 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/route53/route53iface"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type mockedRoute53 struct {

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -11,8 +11,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Handler is a plugin handler that takes a query and templates a response.

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/mholt/caddy"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestHandler(t *testing.T) {

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -4,8 +4,9 @@ import (
 	"sort"
 	"testing"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type sect int

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -11,11 +11,12 @@ import (
 	// Plugin the trace package.
 	_ "github.com/coredns/coredns/plugin/pkg/trace"
 
+	"context"
+
 	ddtrace "github.com/DataDog/dd-trace-go/opentracing"
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
-	"golang.org/x/net/context"
 )
 
 type trace struct {

--- a/plugin/whoami/whoami.go
+++ b/plugin/whoami/whoami.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/coredns/coredns/request"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Whoami is a plugin that returns your IP address, port and the protocol used for connecting

--- a/plugin/whoami/whoami_test.go
+++ b/plugin/whoami/whoami_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
 
+	"context"
+
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func TestWhoami(t *testing.T) {


### PR DESCRIPTION
Move from golang.org/x/net/context to std lib's context.

Change done with:

for i in $(grep -l '/context' **/*.go); do sed -e 's|golang.org/x/net/context|context|' -i $i; echo $i; done
for i in **/*.go; do goimports -w $i; done

~~Removed 'go get' from Makefile as well.~~


