### PR TITLE
Fix #1685

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -14,7 +14,7 @@ import (
 
 // A returns A records from Backend or an error.
 func A(b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
-	services, err := b.Services(state, false, opt)
+	services, err := checkZoneForRecord(b, zone, state, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 
 // AAAA returns AAAA records from Backend or an error.
 func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
-	services, err := b.Services(state, false, opt)
+	services, err := checkZoneForRecord(b, zone, state, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -401,6 +401,39 @@ func newAddress(s msg.Service, name string, ip net.IP, what uint16) dns.RR {
 	}
 	// Should always be dns.TypeAAAA
 	return &dns.AAAA{Hdr: hdr, AAAA: ip}
+}
+
+func checkZoneForRecord(b ServiceBackend, zone string, state request.Request, opt Options) ([]msg.Service, error) {
+	var services []msg.Service
+	var err error
+	// if the zone name itself is queried we fake the query to search for a special entry
+	// this is equivalent to the NS search code
+	if state.Name() == zone {
+		old := state.QName()
+		state.Clear()
+		state.Req.Question[0].Name = dnsutil.Join([]string{"apex.dns", zone})
+
+		services, err = b.Services(state, false, opt)
+		if err != nil {
+			// it might be possible, that "apex.dns.zone" does not exists
+			// we set back the query and try it once again to restore the backward compatibility behavior
+			state.Req.Question[0].Name = old
+			services, err = b.Services(state, false, opt)
+			// if it still errors, we return the error
+			if err != nil {
+				return services, err
+			}
+		}
+
+		state.Req.Question[0].Name = old
+	} else {
+		services, err = b.Services(state, false, opt)
+		if err != nil {
+			return services, err
+		}
+	}
+
+	return services, err
 }
 
 const hostmaster = "hostmaster"

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -128,6 +128,48 @@ Querying with dig:
 reverse.skydns.local.
 ~~~
 
+### Zone name as A record
+
+The zone name itself can be used A record. This behavior can be achieved by writing special entries to the ETCD path of your zone. If your zone is named `skydns.local` for example, you can create an `A` record for this zone as follows:
+
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex -d value='{"host":"1.1.1.1","ttl":"60"}'
+~~~
+
+If you query the zone name itself, you will receive the created `A` record:
+
+~~~ sh
+% dig +short skydns.local @localhost
+1.1.1.1
+~~~
+
+If you would like to use DNS RR for the zone name, you can set the following:
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x1 -d value='{"host":"1.1.1.1","ttl":"60"}'
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x2 -d value='{"host":"1.1.1.2","ttl":"60"}'
+~~~
+
+If you query the zone name now, you will get the following response:
+
+~~~ sh
+dig +short skydns.local @localhost
+1.1.1.1
+1.1.1.2
+~~~
+
+If you would like to use `AAAA` records for the zone name too, you can set the following:
+~~~
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x3 -d value='{"host":"2003::8:1","ttl":"60"}'
+% curl -XPUT http://127.0.0.1:2379/v2/keys/skydns/local/skydns/dns/apex/x4 -d value='{"host":"2003::8:2","ttl":"60"}'
+~~~
+
+If you query the zone name now for `AAAA` now, you will get the following response:
+~~~ sh
+dig +short skydns.local AAAA @localhost
+2003::8:1
+2003::8:2
+~~~
+
 ## Bugs
 
 Only the etcdv2 protocol is supported.

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -43,6 +43,25 @@ var services = []*msg.Service{
 	// Nameservers.
 	{Host: "10.0.0.2", Key: "a.ns.dns.skydns.test."},
 	{Host: "10.0.0.3", Key: "b.ns.dns.skydns.test."},
+	// Zone name as A record (basic, return all)
+	{Host: "10.0.0.2", Key: "x.skydns_zonea.test."},
+	{Host: "10.0.0.3", Key: "y.skydns_zonea.test."},
+	// Zone name as A (single entry).
+	{Host: "10.0.0.2", Key: "x.skydns_zoneb.test."},
+	{Host: "10.0.0.3", Key: "y.skydns_zoneb.test."},
+	{Host: "10.0.0.4", Key: "apex.dns.skydns_zoneb.test."},
+	// A zone record (rr multiple entries).
+	{Host: "10.0.0.2", Key: "x.skydns_zonec.test."},
+	{Host: "10.0.0.3", Key: "y.skydns_zonec.test."},
+	{Host: "10.0.0.4", Key: "a1.apex.dns.skydns_zonec.test."},
+	{Host: "10.0.0.5", Key: "a2.apex.dns.skydns_zonec.test."},
+	// AAAA zone record (rr multiple entries mixed with A).
+	{Host: "10.0.0.2", Key: "x.skydns_zoned.test."},
+	{Host: "10.0.0.3", Key: "y.skydns_zoned.test."},
+	{Host: "10.0.0.4", Key: "a1.apex.dns.skydns_zoned.test."},
+	{Host: "10.0.0.5", Key: "a2.apex.dns.skydns_zoned.test."},
+	{Host: "2003::8:1", Key: "a3.apex.dns.skydns_zoned.test."},
+	{Host: "2003::8:2", Key: "a4.apex.dns.skydns_zoned.test."},
 	// Reverse.
 	{Host: "reverse.example.com", Key: "1.0.0.10.in-addr.arpa."}, // 10.0.0.1
 }
@@ -214,6 +233,43 @@ var dnsTestCases = []test.Case{
 		Qname: "skydns_extra.test.", Qtype: dns.TypeSOA,
 		Answer: []dns.RR{test.SOA("skydns_extra.test. 300 IN SOA ns.dns.skydns_extra.test. hostmaster.skydns_extra.test. 1460498836 14400 3600 604800 60")},
 	},
+	// A Record Test for backward compatibility for zone records
+	{
+		Qname: "skydns_zonea.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("skydns_zonea.test. 300 A 10.0.0.2"),
+			test.A("skydns_zonea.test. 300 A 10.0.0.3"),
+		},
+	},
+	// A Record Test for single A zone record
+	{
+		Qname: "skydns_zoneb.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{test.A("skydns_zoneb.test. 300 A 10.0.0.4")},
+	},
+	// A Record Test for multiple A zone records
+	{
+		Qname: "skydns_zonec.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("skydns_zonec.test. 300 A 10.0.0.4"),
+			test.A("skydns_zonec.test. 300 A 10.0.0.5"),
+		},
+	},
+	// A Record Test for multiple mixed A and AAAA records
+	{
+		Qname: "skydns_zoned.test.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("skydns_zoned.test. 300 A 10.0.0.4"),
+			test.A("skydns_zoned.test. 300 A 10.0.0.5"),
+		},
+	},
+	// AAAA Record Test for multiple mixed A and AAAA records
+	{
+		Qname: "skydns_zoned.test.", Qtype: dns.TypeAAAA,
+		Answer: []dns.RR{
+			test.AAAA("skydns_zoned.test. 300 AAAA 2003::8:1"),
+			test.AAAA("skydns_zoned.test. 300 AAAA 2003::8:2"),
+		},
+	},
 	// Reverse lookup
 	{
 		Qname: "1.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
@@ -233,7 +289,7 @@ func newEtcdPlugin() *Etcd {
 		Upstream:   upstream.Upstream{Forward: &p},
 		PathPrefix: "skydns",
 		Ctx:        context.Background(),
-		Zones:      []string{"skydns.test.", "skydns_extra.test.", "in-addr.arpa."},
+		Zones:      []string{"skydns.test.", "skydns_extra.test.", "skydns_zonea.test.", "skydns_zoneb.test.", "skydns_zonec.test.", "skydns_zoned.test.", "in-addr.arpa."},
 		Client:     client,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mario Kleinsasser <mario.kleinsasser@gmail.com>

### 1. What does this pull request do?
This is WIP. I have added a demo code to the A function of `backend_lookup.go` to allow the possibility to create A (and later AAAA) record(s) with the name of the zone itself. This is supported by bind and this should be possible with the ETCD backend too.

Therefore the ETCD path a.dns.zone or a1.a.dns.zone (for loadbalancing) is used to realize the behavior

### 2. Which issues (if any) are related?
#1685 

### 3. Which documentation changes (if any) need to be made?
Should be made if we are sure how we like to handle it of course

