### PR TITLE
adding sequential policy to forward plugin

### DIFF
--- a/man/coredns-forward.7
+++ b/man/coredns-forward.7
@@ -56,7 +56,7 @@ forward FROM TO\.\.\. {
     max_fails INTEGER
     tls CERT KEY CA
     tls_servername NAME
-    policy random|round_robin
+    policy random|round_robin|sequential
     health_check DURATION
 }
 .

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -47,7 +47,7 @@ forward FROM TO... {
     max_fails INTEGER
     tls CERT KEY CA
     tls_servername NAME
-    policy random|round_robin
+    policy random|round_robin|sequential
     health_check DURATION
 }
 ~~~

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -193,6 +193,7 @@ type policy int
 const (
 	randomPolicy policy = iota
 	roundRobinPolicy
+	sequentialPolicy
 )
 
 const defaultTimeout = 5 * time.Second

--- a/plugin/forward/policy.go
+++ b/plugin/forward/policy.go
@@ -53,3 +53,13 @@ func (r *roundRobin) List(p []*Proxy) []*Proxy {
 
 	return robin
 }
+
+// sequential is a policy that selects hosts based on sequential ordering.
+type sequential struct {}
+
+func (r *sequential) String() string { return "sequential" }
+
+func (r *sequential) List(p []*Proxy) []*Proxy {
+	return p
+}
+

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -225,6 +225,8 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			f.p = &random{}
 		case "round_robin":
 			f.p = &roundRobin{}
+		case "sequential":
+			f.p = &sequential{}
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}

--- a/plugin/forward/setup_policy_test.go
+++ b/plugin/forward/setup_policy_test.go
@@ -17,6 +17,7 @@ func TestSetupPolicy(t *testing.T) {
 		// positive
 		{"forward . 127.0.0.1 {\npolicy random\n}\n", false, "random", ""},
 		{"forward . 127.0.0.1 {\npolicy round_robin\n}\n", false, "round_robin", ""},
+		{"forward . 127.0.0.1 {\npolicy sequential\n}\n", false, "sequential", ""},
 		// negative
 		{"forward . 127.0.0.1 {\npolicy random2\n}\n", true, "random", "unknown policy"},
 	}

--- a/plugin/pkg/healthcheck/policy.go
+++ b/plugin/pkg/healthcheck/policy.go
@@ -29,6 +29,9 @@ func init() {
 	RegisterPolicy("least_conn", func() Policy { return &LeastConn{} })
 	RegisterPolicy("round_robin", func() Policy { return &RoundRobin{} })
 	RegisterPolicy("first", func() Policy { return &First{} })
+        // 'sequential' is an alias to 'first' to maintain consistency with the forward plugin
+        // should probably remove 'first' in a future release
+	RegisterPolicy("sequential", func() Policy { return &First{} })
 }
 
 // Random is a policy that selects up hosts from a pool at random.

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -25,7 +25,7 @@ However, advanced features including load balancing can be utilized with an expa
 
 ~~~
 proxy FROM TO... {
-    policy random|least_conn|round_robin|first
+    policy random|least_conn|round_robin|sequential
     fail_timeout DURATION
     max_fails INTEGER
     health_check PATH:PORT [DURATION]
@@ -39,7 +39,7 @@ proxy FROM TO... {
 * **TO** is the destination endpoint to proxy to. At least one is required, but multiple may be
   specified. **TO** may be an IP:Port pair, or may reference a file in resolv.conf format
 * `policy` is the load balancing policy to use; applies only with multiple backends. May be one of
-  random, least_conn, round_robin or first. Default is random.
+  random, least_conn, round_robin or sequential. Default is random. 
 * `fail_timeout` specifies how long to consider a backend as down after it has failed. While it is
   down, requests will not be routed to that backend. A backend is "down" if CoreDNS fails to
   communicate with it. The default value is 2 seconds ("2s").
@@ -64,7 +64,8 @@ There are four load-balancing policies available:
 * `random` (default) - Randomly select a backend
 * `least_conn` - Select the backend with the fewest active connections
 * `round_robin` - Select the backend in round-robin fashion
-* `first` - Select the first available backend looking by order of declaration from left to right
+* `sequential` - Select the first available backend looking by order of declaration from left to right
+* `first` - Deprecated.  Use sequential instead
 
 
 All polices implement randomly spraying packets to backend hosts when *no healthy* hosts are


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
It adds a sequential policy to the forward plugin.  This policy will just return the list of proxies in the order they appear in the config.  This will enable the plugin to provide default DNS resolution behavior.

### 2. Which issues (if any) are related?
#1691 

### 3. Which documentation changes (if any) need to be made?
The README.md from the forward plugin needs to be synced to the coredns/coredns.io repo.
