### PR TITLE
reload: use OnRestart

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -17,9 +17,9 @@ health [ADDRESS]
 ~~~
 
 Optionally takes an address; the default is `:8080`. The health path is fixed to `/health`. The
-health endpoint returns a 200 response code and the word "OK" when CoreDNS is healthy. It returns
-a 503. *health* periodically (1s) polls plugin that exports health information. If any of the
-plugin signals that it is unhealthy, the server will go unhealthy too. Each plugin that supports
+health endpoint returns a 200 response code and the word "OK" when this server is healthy. It returns
+a 503. *health* periodically (1s) polls plugins that exports health information. If any of the
+plugins signals that it is unhealthy, the server will go unhealthy too. Each plugin that supports
 health checks has a section "Health" in their README.
 
 More options can be set with this extended syntax:
@@ -33,7 +33,7 @@ health [ADDRESS] {
 * Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
   shuts down.
 
-If you have multiple Server Block and need to export health for each of the plugins, you must run
+If you have multiple Server Blocks and need to export health for each of the plugins, you must run
 health endpoints on different ports:
 
 ~~~ corefile

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -61,6 +61,17 @@ func (h *health) OnStartup() error {
 	return nil
 }
 
+func (h *health) OnRestart() error {
+	// relingish our listener as we re-listen on successfull reload
+	if h.ln != nil {
+		if err := h.ln.Close(); err != nil {
+			return err
+		}
+		h.ln = nil
+	}
+	return nil
+}
+
 func (h *health) OnShutdown() error {
 	// Stop polling plugins
 	h.pollstop <- true

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -83,11 +83,14 @@ func (h *health) OnShutdown() error {
 		time.Sleep(h.lameduck)
 	}
 
+	h.stop <- true
+	return nil
+}
+
+func (h *health) OnFinalShutdown() error {
 	if h.ln != nil {
 		return h.ln.Close()
 	}
-
-	h.stop <- true
 	return nil
 }
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -72,7 +72,7 @@ func (h *health) OnRestart() error {
 	return nil
 }
 
-func (h *health) OnShutdown() error {
+func (h *health) OnFinalShutdown() error {
 	// Stop polling plugins
 	h.pollstop <- true
 	// NACK health
@@ -83,14 +83,11 @@ func (h *health) OnShutdown() error {
 		time.Sleep(h.lameduck)
 	}
 
-	h.stop <- true
-	return nil
-}
-
-func (h *health) OnFinalShutdown() error {
 	if h.ln != nil {
 		return h.ln.Close()
 	}
+
+	h.stop <- true
 	return nil
 }
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -61,18 +61,13 @@ func (h *health) OnStartup() error {
 	return nil
 }
 
-func (h *health) OnRestart() error {
-	// relingish our listener as we re-listen on successfull reload
-	if h.ln != nil {
-		if err := h.ln.Close(); err != nil {
-			return err
-		}
-		h.ln = nil
-	}
-	return nil
-}
+func (h *health) OnRestart() error { return h.OnFinalShutdown() }
 
 func (h *health) OnFinalShutdown() error {
+	if h == nil {
+		return nil
+	}
+
 	// Stop polling plugins
 	h.pollstop <- true
 	// NACK health
@@ -83,11 +78,10 @@ func (h *health) OnFinalShutdown() error {
 		time.Sleep(h.lameduck)
 	}
 
-	if h.ln != nil {
-		return h.ln.Close()
-	}
+	h.ln.Close()
 
 	h.stop <- true
+	h.ln = nil
 	return nil
 }
 

--- a/plugin/health/health_test.go
+++ b/plugin/health/health_test.go
@@ -17,7 +17,7 @@ func TestHealth(t *testing.T) {
 	if err := h.OnStartup(); err != nil {
 		t.Fatalf("Unable to startup the health server: %v", err)
 	}
-	defer h.OnShutdown()
+	defer h.OnFinalShutdown()
 
 	go func() {
 		<-h.pollstop
@@ -73,5 +73,5 @@ func TestHealthLameduck(t *testing.T) {
 		return
 	}()
 
-	h.OnShutdown()
+	h.OnFinalShutdown()
 }

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -61,6 +61,7 @@ func setup(c *caddy.Controller) error {
 
 	c.OnStartup(h.OnStartup)
 	c.OnShutdown(h.OnShutdown)
+	c.OnRestart(h.OnRestart)
 
 	// Don't do AddPlugin, as health is not *really* a plugin just a separate webserver running.
 	return nil

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -60,9 +60,8 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(h.OnStartup)
-	c.OnShutdown(h.OnShutdown)
-	c.OnFinalShutdown(h.OnFinalShutdown)
 	c.OnRestart(h.OnRestart)
+	c.OnFinalShutdown(h.OnFinalShutdown)
 
 	// Don't do AddPlugin, as health is not *really* a plugin just a separate webserver running.
 	return nil

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -61,6 +61,7 @@ func setup(c *caddy.Controller) error {
 
 	c.OnStartup(h.OnStartup)
 	c.OnShutdown(h.OnShutdown)
+	c.OnFinalShutdown(h.OnFinalShutdown)
 	c.OnRestart(h.OnRestart)
 
 	// Don't do AddPlugin, as health is not *really* a plugin just a separate webserver running.

--- a/plugin/metrics/addr.go
+++ b/plugin/metrics/addr.go
@@ -1,0 +1,42 @@
+package metrics
+
+// addrs keeps track on which addrs we listen, so we only start one listener, is
+// prometheus is used in multiple Server Blocks.
+type addrs struct {
+	a map[string]int
+}
+
+var uniqAddr addrs
+
+func (a *addrs) setAddress(addr string) {
+	// If already there and set to done, we've already started this listener.
+	if a.a[addr] == done {
+		return
+	}
+	a.a[addr] = todo
+}
+
+// forEachTodo iterates for a and executes f for each element that is 'todo' and sets it to 'done'.
+func (a *addrs) forEachTodo(f func() error) {
+	for a, v := range uniqAddr.a {
+		if v == todo {
+			f()
+		}
+		uniqAddr.a[a] = done
+	}
+}
+
+// forEachDone iterates for a and executes f for each element that is 'done' and sets it to 'todo'.
+func (a *addrs) forEachDone(f func() error) {
+	for a, v := range uniqAddr.a {
+		if v == done {
+			f()
+		}
+		uniqAddr.a[a] = todo
+	}
+}
+
+const (
+	todo = 1
+	done = 2
+)

--- a/plugin/metrics/addr.go
+++ b/plugin/metrics/addr.go
@@ -24,6 +24,16 @@ func (a addrs) setAddress(addr string, f func() error) {
 	a.a[addr] = value{todo, f}
 }
 
+// setAddressTodo sets addr to 'todo' again.
+func (a addrs) setAddressTodo(addr string) {
+	v, ok := a.a[addr]
+	if !ok {
+		return
+	}
+	v.state = todo
+	a.a[addr] = v
+}
+
 // forEachTodo iterates for a and executes f for each element that is 'todo' and sets it to 'done'.
 func (a addrs) forEachTodo() error {
 	for k, v := range a.a {

--- a/plugin/metrics/addr_test.go
+++ b/plugin/metrics/addr_test.go
@@ -1,0 +1,17 @@
+package metrics
+
+import "testing"
+
+func TestForEachTodo(t *testing.T) {
+	a, i := newAddress(), 0
+	a.setAddress("test", func() error { i++; return nil })
+
+	a.forEachTodo()
+	if i != 1 {
+		t.Errorf("Failed to executed f for %s", "test")
+	}
+	a.forEachTodo()
+	if i != 1 {
+		t.Errorf("Executed f twice instead of once")
+	}
+}

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -116,8 +116,8 @@ func (m *Metrics) OnRestart() error {
 	return nil
 }
 
-// OnShutdown tears down the metrics listener on shutdown and restart.
-func (m *Metrics) OnShutdown() error {
+// OnFinalShutdown tears down the metrics listener on shutdown and restart.
+func (m *Metrics) OnFinalShutdown() error {
 	// We allow prometheus statements in multiple Server Blocks, but only the first
 	// will open the listener, for the rest they are all nil; guard against that.
 	if m.ln != nil {

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -86,10 +86,6 @@ func (m *Metrics) ZoneNames() []string {
 
 // OnStartup sets up the metrics on startup.
 func (m *Metrics) OnStartup() error {
-	if m.ln != nil {
-		return nil
-	}
-
 	ln, err := net.Listen("tcp", m.Addr)
 	if err != nil {
 		log.Errorf("Failed to start metrics handler: %s", err)

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -86,7 +86,10 @@ func (m *Metrics) ZoneNames() []string {
 
 // OnStartup sets up the metrics on startup.
 func (m *Metrics) OnStartup() error {
-	println("Listening for", m.Addr)
+	if m.ln != nil {
+		return nil
+	}
+
 	ln, err := net.Listen("tcp", m.Addr)
 	if err != nil {
 		log.Errorf("Failed to start metrics handler: %s", err)

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -104,6 +104,7 @@ func (m *Metrics) OnStartup() error {
 	return nil
 }
 
+// OnRestart stops the listener on reload.
 func (m *Metrics) OnRestart() error {
 	// relingish our listener as we re-listen on successfull reload
 	if m.ln != nil {

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -104,6 +104,17 @@ func (m *Metrics) OnStartup() error {
 	return nil
 }
 
+func (m *Metrics) OnRestart() error {
+	// relingish our listener as we re-listen on successfull reload
+	if m.ln != nil {
+		if err := m.ln.Close(); err != nil {
+			return err
+		}
+		m.ln = nil
+	}
+	return nil
+}
+
 // OnShutdown tears down the metrics listener on shutdown and restart.
 func (m *Metrics) OnShutdown() error {
 	// We allow prometheus statements in multiple Server Blocks, but only the first

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -86,6 +86,7 @@ func (m *Metrics) ZoneNames() []string {
 
 // OnStartup sets up the metrics on startup.
 func (m *Metrics) OnStartup() error {
+	println("Listening for", m.Addr)
 	ln, err := net.Listen("tcp", m.Addr)
 	if err != nil {
 		log.Errorf("Failed to start metrics handler: %s", err)

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -18,7 +18,7 @@ func TestMetrics(t *testing.T) {
 	if err := met.OnStartup(); err != nil {
 		t.Fatalf("Failed to start metrics handler: %s", err)
 	}
-	defer met.OnShutdown()
+	defer met.OnFinalShutdown()
 
 	met.AddZone("example.org.")
 

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -36,7 +36,7 @@ func setup(c *caddy.Controller) error {
 		uniqAddr.a[a] = done
 	}
 
-	c.OnShutdown(m.OnShutdown)
+	c.OnShutdown(m.OnFinalShutdown)
 	c.OnRestart(m.OnRestart)
 
 	return nil

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -30,13 +30,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		for a, v := range uniqAddr.a {
-			println("setting up for", a)
-			if v == todo {
-				c.OncePerServerBlock(m.OnStartup)
-			}
-			uniqAddr.a[a] = done
-		}
+		uniqAddr.forEachTodo(m.OnStartup)
 		return nil
 	})
 
@@ -50,7 +44,7 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	var met = New(defaultAddr)
 
 	defer func() {
-		uniqAddr.SetAddress(met.Addr)
+		uniqAddr.setAddress(met.Addr)
 	}()
 
 	i := 0
@@ -80,26 +74,5 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	return met, nil
 }
 
-// addrs keeps track on which addrs we listen, so we only start one listener, is
-// prometheus is used in multiple Server Blocks.
-type addrs struct {
-	a map[string]int
-}
-
-var uniqAddr addrs
-
-func (a *addrs) SetAddress(addr string) {
-	// If already there and set to done, we've already started this listener.
-	if a.a[addr] == done {
-		return
-	}
-	a.a[addr] = todo
-}
-
 // defaultAddr is the address the where the metrics are exported by default.
 const defaultAddr = "localhost:9153"
-
-const (
-	todo = 1
-	done = 2
-)

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -15,7 +15,7 @@ func init() {
 		Action:     setup,
 	})
 
-	uniqAddr = addrs{a: make(map[string]int)}
+	uniqAddr = newAddress()
 }
 
 func setup(c *caddy.Controller) error {
@@ -29,8 +29,10 @@ func setup(c *caddy.Controller) error {
 		return m
 	})
 
-	c.OnStartup(func() error {
-		uniqAddr.forEachTodo(m.OnStartup)
+	c.OncePerServerBlock(func() error {
+		c.OnStartup(func() error {
+			return uniqAddr.forEachTodo()
+		})
 		return nil
 	})
 
@@ -44,7 +46,7 @@ func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	var met = New(defaultAddr)
 
 	defer func() {
-		uniqAddr.setAddress(met.Addr)
+		uniqAddr.setAddress(met.Addr, met.OnStartup)
 	}()
 
 	i := 0

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -37,6 +37,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	c.OnShutdown(m.OnShutdown)
+	c.OnRestart(m.OnRestart)
 
 	return nil
 }

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -36,8 +36,8 @@ func setup(c *caddy.Controller) error {
 		return nil
 	})
 
-	c.OnShutdown(m.OnFinalShutdown)
 	c.OnRestart(m.OnRestart)
+	c.OnFinalShutdown(m.OnFinalShutdown)
 
 	return nil
 }

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -79,7 +79,8 @@ is already listening on that port. The process reloads, and performs the followi
 1. close the listener on 8080
 2. reload and parse the config again
 3. fail to start a new listener on 443
+4. fail loading the new Corefile, abort and keep using the old process
 
-Now failing step 3 *does not cause* the reload to fail, instead almost everything works, except the
-health exporting because there is no new listener. Note the same is true for prometheus metrics plugin.
-In general be careful with assigning new port and expecting reload to work.
+After the aborted attempt to reload we are left with the old proceses running, but the listener is
+still closes (on step 1.). Note the same is true for prometheus metrics plugin. In general be
+careful with assigning new port and expecting reload to work fully.

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -66,7 +66,7 @@ Check every 10 seconds (jitter is automatically set to 10 / 2 = 5 in this case):
 The reload happens without data loss (i.e. DNS queries keep flowing), but there is a corner case
 where the reload "succeeds", but you can still loose functionally. Consider the following Corefile:
 
-~~~ corefile
+~~~ txt
 . {
 	health :8080
 	whoami
@@ -81,6 +81,5 @@ is already listening on that port. The process reloads, and performs the followi
 3. fail to start a new listener on 443
 
 Now failing step 3 *does not cause* the reload to fail, instead almost everything works, except the
-health exporting because there is no new listener.
-
-Note the same is true for prometheus metrics plugin.
+health exporting because there is no new listener. Note the same is true for prometheus metrics plugin.
+In general be careful with assigning new port and expecting reload to work.

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -64,7 +64,7 @@ Check every 10 seconds (jitter is automatically set to 10 / 2 = 5 in this case):
 ## Bugs
 
 The reload happens without data loss (i.e. DNS queries keep flowing), but there is a corner case
-where the reload "succeeds", but you can still loose functionally. Consider the following Corefile:
+where the reload fails, and you loose functionality. Consider the following Corefile:
 
 ~~~ txt
 . {
@@ -74,7 +74,7 @@ where the reload "succeeds", but you can still loose functionally. Consider the 
 ~~~
 
 CoreDNS starts and serves health from :8080. Now you change `:8080` to `:443` not knowing a process
-is already listening on that port. The process reloads, and performs the following steps:
+is already listening on that port. The process reloads and performs the following steps:
 
 1. close the listener on 8080
 2. reload and parse the config again
@@ -82,5 +82,6 @@ is already listening on that port. The process reloads, and performs the followi
 4. fail loading the new Corefile, abort and keep using the old process
 
 After the aborted attempt to reload we are left with the old proceses running, but the listener is
-still closes (on step 1.). Note the same is true for prometheus metrics plugin. In general be
-careful with assigning new port and expecting reload to work fully.
+closed in step 1; so the health endpoint is broken. The same can hopen in the prometheus metrics plugin.
+
+In general be careful with assigning new port and expecting reload to work fully.

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -52,3 +52,20 @@ func send(t *testing.T, server string) {
 		t.Fatalf("Expected 2 RRs in additional, got %d", len(r.Extra))
 	}
 }
+
+func TestReloadHealth(t *testing.T) {
+	corefile := `
+.:0 {
+	health 127.0.0.1:8080
+	proxy . 8.8.8.8:53
+}`
+	c, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get service instance: %s", err)
+	}
+
+	// This fails with address 8080 already in use, it shouldn't.
+	if _, err = c.Restart(NewInput(corefile)); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -56,8 +56,8 @@ func send(t *testing.T, server string) {
 func TestReloadHealth(t *testing.T) {
 	corefile := `
 .:0 {
-	health 127.0.0.1:8080
-	proxy . 8.8.8.8:53
+	health 127.0.0.1:52182
+	whoami
 }`
 	c, err := CoreDNSServer(corefile)
 	if err != nil {

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -1,6 +1,9 @@
 package test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -65,7 +68,58 @@ func TestReloadHealth(t *testing.T) {
 	}
 
 	// This fails with address 8080 already in use, it shouldn't.
-	if _, err = c.Restart(NewInput(corefile)); err != nil {
+	if c1, err := c.Restart(NewInput(corefile)); err != nil {
 		t.Fatal(err)
+	} else {
+		c1.Stop()
+	}
+}
+
+func TestReloadMetricsHealth(t *testing.T) {
+	corefile := `
+.:0 {
+	prometheus 127.0.0.1:53183
+	health 127.0.0.1:53184
+	whoami
+}`
+	c, err := CoreDNSServer(corefile)
+	if err != nil {
+		t.Fatalf("Could not get service instance: %s", err)
+	}
+
+	c1, err := c.Restart(NewInput(corefile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c1.Stop()
+
+	// Send query to trigger monitoring to export on the new process
+	udp, _ := CoreDNSServerPorts(c1, 0)
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	if _, err := dns.Exchange(m, udp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Health
+	resp, err := http.Get("http://localhost:53184/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(ok) != "OK" {
+		t.Errorf("Failed to receive OK, got %s", ok)
+	}
+
+	// Metrics
+	resp, err = http.Get("http://localhost:53183/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const proc = "process_virtual_memory_bytes"
+	metrics, _ := ioutil.ReadAll(resp.Body)
+	if !bytes.Contains(metrics, []byte(proc)) {
+		t.Errorf("Failed to see %s in metric output", proc)
 	}
 }


### PR DESCRIPTION
Close the listener on OnRestart for health and metrics so the default
setup function can setup the listener when the plugin is "starting up".

Lightly test with some SIGUSR1-ing. Also checked the reload plugin with
this, seems fine:

.com.:1043
.:1043
2018/04/20 15:01:25 [INFO] CoreDNS-1.1.1
2018/04/20 15:01:25 [INFO] linux/amd64, go1.10,
CoreDNS-1.1.1
linux/amd64, go1.10,
2018/04/20 15:01:25 [INFO] Running configuration MD5 = aa8b3f03946fb60546ca1f725d482714
2018/04/20 15:02:01 [INFO] Reloading
2018/04/20 15:02:01 [INFO] Running configuration MD5 = b34a96d99e01db4015a892212560155f
2018/04/20 15:02:01 [INFO] Reloading complete
^C2018/04/20 15:02:06 [INFO] SIGINT: Shutting down

With this corefile:
.com {
  proxy . 127.0.0.1:53
  prometheus :9054
  whoami
  reload
}

. {
  proxy . 127.0.0.1:53
  prometheus :9054
  whoami
  reload
}

The prometheus port was 9053, changed that to 54 so reload would pick it
up.

From a cursory look it seems this also fixes:
Fixes #1604 #1706 