### PR TITLE
plugin/pkg/log: add plugin logging

### DIFF
--- a/plugin/pkg/log/plugin.go
+++ b/plugin/pkg/log/plugin.go
@@ -1,0 +1,63 @@
+package log
+
+import (
+	"fmt"
+	golog "log"
+
+	"github.com/coredns/coredns/plugin"
+)
+
+// P is a logger that includes the plugin doing the logging.
+type P struct {
+	plugin string
+}
+
+// NewWithPlugin return a logger that shows the plugin that logs the message.
+// I.e [INFO] plugin/<name>: message.
+func NewWithPlugin(h plugin.Handler) P { return P{h.Name()} }
+
+func (p P) logf(level, format string, v ...interface{}) {
+	s := level + pFormat(p.plugin) + fmt.Sprintf(format, v...)
+	golog.Print(s)
+}
+
+func (p P) log(level string, v ...interface{}) {
+	s := level + pFormat(p.plugin) + fmt.Sprint(v...)
+	golog.Print(s)
+}
+
+// Debug logs as log.Debug.
+func (p P) Debug(v ...interface{}) {
+	if !D {
+		return
+	}
+	p.log(debug, v...)
+}
+
+// Debugf logs as log.Debugf.
+func (p P) Debugf(format string, v ...interface{}) {
+	if !D {
+		return
+	}
+	p.logf(debug, format, v...)
+}
+
+// Info logs as log.Info.
+func (p P) Info(v ...interface{}) { p.log(info, v...) }
+
+// Infof logs as log.Infof.
+func (p P) Infof(format string, v ...interface{}) { p.logf(info, format, v...) }
+
+// Warning logs as log.Warning.
+func (p P) Warning(v ...interface{}) { p.log(warning, v...) }
+
+// Warningf logs as log.Warningf.
+func (p P) Warningf(format string, v ...interface{}) { p.logf(warning, format, v...) }
+
+// Error logs as log.Error.
+func (p P) Error(v ...interface{}) { p.log(err, v...) }
+
+// Errorf logs as log.Errorf.
+func (p P) Errorf(format string, v ...interface{}) { p.logf(err, format, v...) }
+
+func pFormat(s string) string { return "plugin/" + s + ": " }

--- a/plugin/pkg/log/plugin_test.go
+++ b/plugin/pkg/log/plugin_test.go
@@ -1,0 +1,32 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	golog "log"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+type p struct{}
+
+func (p p) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return 0, nil
+}
+
+func (p p) Name() string { return "testplugin" }
+
+func TestPlugins(t *testing.T) {
+	var f bytes.Buffer
+	const ts = "test"
+	golog.SetOutput(&f)
+
+	lg := NewWithPlugin(p{})
+
+	lg.Info(ts)
+	if x := f.String(); !strings.Contains(x, "plugin/testplugin") {
+		t.Errorf("Expected log to be %s, got %s", info+ts, x)
+	}
+}


### PR DESCRIPTION
Add per plugin logging to make it explicit what is logging, if you
include this package under the name clog (coredns log), you can do the
following:

log := clog.NewWithPlugin{whoami{}} // e.g.

And then just log.Info(...); these will then include the plugin ala:
[INFO] plugin/whoami: stuff

So we only need to init the logger and then just use it.