### PR TITLE
dockerignore: ignore .git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git/*
 core/*
 coremain/*
 hooks/*
@@ -7,3 +8,5 @@ plugin/*
 request/*
 test/*
 vendor/*
+build/*
+release/*


### PR DESCRIPTION
also ignore build/ and release/ as they may be left over from releasing
coredns.

Sending build context to Docker daemon  490.9MB ->
 Sending build context to Docker daemon  98.82kB