### PR TITLE
plugin/forward: close channels when connManager returns

### DIFF
--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -51,7 +51,14 @@ func newTransport(addr string, tlsConfig *tls.Config) *transport {
 		lenc:    make(chan bool),
 		lencOut: make(chan int),
 	}
-	go t.connManager()
+	go func() {
+		t.connManager()
+		// if connManager returns it has been stopped.
+		close(t.stop)
+		close(t.yield)
+		close(t.dial)
+		// close(t.ret) // we can still be dialing and wanting to send back the socket on t.ret
+	}()
 	return t
 }
 

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -25,9 +25,7 @@ func TestProxyClose(t *testing.T) {
 	state := request.Request{W: &test.ResponseWriter{}, Req: req}
 	ctx := context.TODO()
 
-	repeatCnt := 1000
-	for repeatCnt > 0 {
-		repeatCnt--
+	for i := 0; i < 100; i++ {
 		p := NewProxy(s.Addr, nil /* no TLS */)
 		p.start(hcDuration)
 


### PR DESCRIPTION
Close a bunch of channels, also change the test to just use a for loop
with a counter.