### PR TITLE
core: remove HostAddresses()

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -3,7 +3,6 @@ package dnsserver
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 
 	"github.com/coredns/coredns/plugin"
 
@@ -51,22 +50,6 @@ type Config struct {
 	// on them should register themselves here. The name should be the name as return by the
 	// Handler's Name method.
 	registry map[string]plugin.Handler
-}
-
-//HostAddresses builds a representation of the addresses of this Config
-//after server is started ONLY, can be used as a Key for identifing that config
-// :53 or 127.0.0.1:53 or 127.0.0.1:53/::1:53
-func (c *Config) HostAddresses() string {
-	all := ""
-	for _, h := range c.ListenHosts {
-		addr := net.JoinHostPort(h, c.Port)
-		if all == "" {
-			all = addr
-			continue
-		}
-		all = all + "/" + addr
-	}
-	return all
 }
 
 // keyForConfig build a key for identifying the configs during setup time

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -41,7 +41,8 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	)
 
 	cfg := dnsserver.GetConfig(c)
-	tr.ServiceEndpoint = cfg.HostAddresses()
+	tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
+
 	for c.Next() { // trace
 		var err error
 		args := c.RemainingArgs()

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	// Plugin the trace package.
+	"github.com/coredns/coredns/plugin/metrics"
 	_ "github.com/coredns/coredns/plugin/pkg/trace"
 
 	ddtrace "github.com/DataDog/dd-trace-go/opentracing"
@@ -20,10 +21,10 @@ import (
 
 type trace struct {
 	Next            plugin.Handler
-	ServiceEndpoint string
 	Endpoint        string
 	EndpointType    string
 	tracer          ot.Tracer
+	serviceEndpoint string
 	serviceName     string
 	clientServer    bool
 	every           uint64
@@ -58,7 +59,7 @@ func (t *trace) setupZipkin() error {
 		return err
 	}
 
-	recorder := zipkin.NewRecorder(collector, false, t.ServiceEndpoint, t.serviceName)
+	recorder := zipkin.NewRecorder(collector, false, t.serviceEndpoint, t.serviceName)
 	t.tracer, err = zipkin.NewTracer(recorder, zipkin.ClientServerSameSpan(t.clientServer))
 
 	return err
@@ -81,9 +82,7 @@ func (t *trace) setupDatadog() error {
 }
 
 // Name implements the Handler interface.
-func (t *trace) Name() string {
-	return "trace"
-}
+func (t *trace) Name() string { return "trace" }
 
 // ServeDNS implements the plugin.Handle interface.
 func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
@@ -96,7 +95,7 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		}
 	}
 	if span := ot.SpanFromContext(ctx); span == nil && trace {
-		span := t.Tracer().StartSpan("servedns")
+		span := t.Tracer().StartSpan("servedns:" + metrics.WithServer(ctx))
 		defer span.Finish()
 		ctx = ot.ContextWithSpan(ctx, span)
 	}

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -9,8 +9,8 @@ import (
 	"sync/atomic"
 
 	"github.com/coredns/coredns/plugin"
-	// Plugin the trace package.
 	"github.com/coredns/coredns/plugin/metrics"
+	// Plugin the trace package.
 	_ "github.com/coredns/coredns/plugin/pkg/trace"
 
 	ddtrace "github.com/DataDog/dd-trace-go/opentracing"


### PR DESCRIPTION
config.HostAddresses() is a weird function that gathers
some data from the server and returns a string.

It is *only* used the trace plugin, to figure out what
server starts the trace.

Looks to be better to fit in the with metrics.WithServer label
on the trace itself to show which server handled the trace.

Remove HostAddresses() and cleanup trace a small bit