### PR TITLE
plugin/autopath: per server metrics

### DIFF
--- a/plugin/autopath/README.md
+++ b/plugin/autopath/README.md
@@ -29,7 +29,9 @@ If a plugin implements the `AutoPather` interface then it can be used.
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric is exported:
 
-* `coredns_autopath_success_count_total{}` - counter of successfully autopath-ed queries.
+* `coredns_autopath_success_count_total{server}` - counter of successfully autopath-ed queries.
+
+The `server` label is explained in the *metrics* plugin documentation.
 
 ## Examples
 

--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -35,6 +35,7 @@ import (
 	"context"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/request"
@@ -132,7 +133,7 @@ func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 		// Write whatever non-nxdomain answer we've found.
 		w.WriteMsg(msg)
-		AutoPathCount.WithLabelValues().Add(1)
+		autoPathCount.WithLabelValues(metrics.WithServer(ctx)).Add(1)
 		return rcode, err
 
 	}

--- a/plugin/autopath/metrics.go
+++ b/plugin/autopath/metrics.go
@@ -8,14 +8,13 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Metrics for autopath.
 var (
-	AutoPathCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+	autoPathCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "autopath",
 		Name:      "success_count_total",
 		Help:      "Counter of requests that did autopath.",
-	}, []string{})
+	}, []string{"server"})
 )
 
 var once sync.Once

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, AutoPathCount) })
+		once.Do(func() { metrics.MustRegister(c, autoPathCount) })
 		return nil
 	})
 


### PR DESCRIPTION
Implement per server metrics in autopath; also don't export the metric.

Updated readme as well.