### PR TITLE
plugin/forward: move Dial goroutine out

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -181,12 +181,11 @@ func (f *Forward) isAllowedDomain(name string) bool {
 func (f *Forward) list() []*Proxy { return f.p.List(f.proxies) }
 
 var (
-	errInvalidDomain  = errors.New("invalid domain for forward")
-	errNoHealthy      = errors.New("no healthy proxies")
-	errNoForward      = errors.New("no forwarder defined")
-	errCachedClosed   = errors.New("cached connection was closed by peer")
-	errStopped        = errors.New("proxy has been stopped")
-	errCachedNotFound = errors.New("no cached connection could be found")
+	errInvalidDomain = errors.New("invalid domain for forward")
+	errNoHealthy     = errors.New("no healthy proxies")
+	errNoForward     = errors.New("no forwarder defined")
+	errCachedClosed  = errors.New("cached connection was closed by peer")
+	errStopped       = errors.New("proxy has been stopped")
 )
 
 // policy tells forward what policy for selecting upstream it uses.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -181,11 +181,12 @@ func (f *Forward) isAllowedDomain(name string) bool {
 func (f *Forward) list() []*Proxy { return f.p.List(f.proxies) }
 
 var (
-	errInvalidDomain = errors.New("invalid domain for forward")
-	errNoHealthy     = errors.New("no healthy proxies")
-	errNoForward     = errors.New("no forwarder defined")
-	errCachedClosed  = errors.New("cached connection was closed by peer")
-	errStopped       = errors.New("proxy has been stopped")
+	errInvalidDomain  = errors.New("invalid domain for forward")
+	errNoHealthy      = errors.New("no healthy proxies")
+	errNoForward      = errors.New("no forwarder defined")
+	errCachedClosed   = errors.New("cached connection was closed by peer")
+	errStopped        = errors.New("proxy has been stopped")
+	errCachedNotFound = errors.New("no cached connection could be found")
 )
 
 // policy tells forward what policy for selecting upstream it uses.

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -43,7 +43,7 @@ func newTransport(addr string, tlsConfig *tls.Config) *transport {
 		close(t.stop)
 		close(t.yield)
 		close(t.dial)
-		// close(t.ret) // we can still be dialing and wanting to send back the socket on t.ret
+		close(t.ret)
 	}()
 	return t
 }


### PR DESCRIPTION
Move the dialing of the remote host out of the connManager. This saves
1 goroutine and also makes the t.ret channel not leak into it (which can
potentially hang for dialTimeout).

Run at least 50 local test runs to see if I could replicate the race.