### PR TITLE
plugin/forward: implement two phased stop

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -185,6 +185,7 @@ var (
 	errNoHealthy     = errors.New("no healthy proxies")
 	errNoForward     = errors.New("no forwarder defined")
 	errCachedClosed  = errors.New("cached connection was closed by peer")
+	errStopped       = errors.New("proxy has been stopped")
 )
 
 // policy tells forward what policy for selecting upstream it uses.

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -152,7 +152,7 @@ func (t *transport) Yield(c *dns.Conn) { t.yield <- c }
 // Stop stops the transport's connection manager.
 func (t *transport) Stop() {
 	t.signal <- true
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	close(t.stop)
 }
 

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -25,10 +25,12 @@ func TestProxyClose(t *testing.T) {
 	state := request.Request{W: &test.ResponseWriter{}, Req: req}
 	ctx := context.TODO()
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		p := NewProxy(s.Addr, nil)
 		p.start(hcDuration)
 
+		go func() { p.connect(ctx, state, false, false) }()
+		go func() { p.connect(ctx, state, true, false) }()
 		go func() { p.connect(ctx, state, false, false) }()
 		go func() { p.connect(ctx, state, true, false) }()
 		go func() { p.connect(ctx, state, false, false) }()
@@ -60,7 +62,7 @@ func TestProxy(t *testing.T) {
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 
 	if _, err := f.ServeDNS(context.TODO(), rec, m); err != nil {
-		t.Fatal("Expected to receive reply, but didn't")
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 	if x := rec.Msg.Answer[0].Header().Name; x != "example.org." {
 		t.Errorf("Expected %s, got %s", "example.org.", x)

--- a/plugin/forward/truncated_test.go
+++ b/plugin/forward/truncated_test.go
@@ -43,7 +43,7 @@ func TestLookupTruncated(t *testing.T) {
 
 	resp, err := f.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {
-		t.Fatal("Expected to receive reply, but didn't")
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 	// expect answer with TC
 	if !resp.Truncated {
@@ -55,7 +55,7 @@ func TestLookupTruncated(t *testing.T) {
 
 	resp, err = f.Lookup(state, "example.org.", dns.TypeA)
 	if err != nil {
-		t.Fatal("Expected to receive reply, but didn't")
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 	// expect answer without TC
 	if resp.Truncated {
@@ -98,7 +98,7 @@ func TestForwardTruncated(t *testing.T) {
 	state.Req.SetQuestion("example.org.", dns.TypeA)
 	resp, err := f.Forward(state)
 	if err != nil {
-		t.Fatal("Expected to receive reply, but didn't")
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 
 	// expect answer with TC
@@ -111,7 +111,7 @@ func TestForwardTruncated(t *testing.T) {
 
 	resp, err = f.Forward(state)
 	if err != nil {
-		t.Fatal("Expected to receive reply, but didn't")
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}
 	// expect answer without TC
 	if resp.Truncated {


### PR DESCRIPTION
First signal that we stop; this inhbits new dial into the connmanager.
Then sleep (*shrudder*) for a bit and close and return from the
connmanager.

It also cleans up the accumulated connections on stop.

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

