### PR TITLE
plugin/forward: expose few methods and attributes to public

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -33,7 +33,7 @@ func (p *Proxy) updateRtt(newRtt time.Duration) {
 	atomic.AddInt64(&p.avgRtt, int64((newRtt-rtt)/rttCount))
 }
 
-// Connect sets connection and sends the request
+// Connect selects an upstream, sends the request and waits for a response.
 func (p *Proxy) Connect(ctx context.Context, state request.Request, forceTCP, metric bool) (*dns.Msg, error) {
 	start := time.Now()
 

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -33,7 +33,8 @@ func (p *Proxy) updateRtt(newRtt time.Duration) {
 	atomic.AddInt64(&p.avgRtt, int64((newRtt-rtt)/rttCount))
 }
 
-func (p *Proxy) connect(ctx context.Context, state request.Request, forceTCP, metric bool) (*dns.Msg, error) {
+// Connect sets connection and sends the request
+func (p *Proxy) Connect(ctx context.Context, state request.Request, forceTCP, metric bool) (*dns.Msg, error) {
 	start := time.Now()
 
 	proto := state.Proto()

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -68,7 +68,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	var upstreamErr error
 	span = ot.SpanFromContext(ctx)
 	i := 0
-	list := f.list()
+	list := f.List()
 	deadline := time.Now().Add(defaultTimeout)
 
 	for time.Now().Before(deadline) {
@@ -103,7 +103,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			err error
 		)
 		for {
-			ret, err = proxy.connect(ctx, state, f.forceTCP, true)
+			ret, err = proxy.Connect(ctx, state, f.forceTCP, true)
 			if err != nil && err == errCachedClosed { // Remote side closed conn, can only happen with TCP.
 				continue
 			}
@@ -176,8 +176,14 @@ func (f *Forward) isAllowedDomain(name string) bool {
 	return true
 }
 
+// From returns the base domain to match for the request to be forwarded.
+func (f *Forward) From() string { return f.from }
+
+// ForceTCP returns if TCP is forced to be used even when the request comes in over UDP.
+func (f *Forward) ForceTCP() bool { return f.forceTCP }
+
 // List returns a set of proxies to be used for this client depending on the policy in f.
-func (f *Forward) list() []*Proxy { return f.p.List(f.proxies) }
+func (f *Forward) List() []*Proxy { return f.p.List(f.proxies) }
 
 var (
 	errInvalidDomain = errors.New("invalid domain for forward")

--- a/plugin/forward/lookup.go
+++ b/plugin/forward/lookup.go
@@ -21,7 +21,7 @@ func (f *Forward) Forward(state request.Request) (*dns.Msg, error) {
 
 	fails := 0
 	var upstreamErr error
-	for _, proxy := range f.list() {
+	for _, proxy := range f.List() {
 		if proxy.Down(f.maxfails) {
 			fails++
 			if fails < len(f.proxies) {
@@ -29,10 +29,10 @@ func (f *Forward) Forward(state request.Request) (*dns.Msg, error) {
 			}
 			// All upstream proxies are dead, assume healtcheck is complete broken and randomly
 			// select an upstream to connect to.
-			proxy = f.list()[0]
+			proxy = f.List()[0]
 		}
 
-		ret, err := proxy.connect(context.Background(), state, f.forceTCP, true)
+		ret, err := proxy.Connect(context.Background(), state, f.forceTCP, true)
 
 		ret, err = truncated(state, ret, err)
 		upstreamErr = err

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -39,7 +39,7 @@ func NewProxy(addr string, tlsConfig *tls.Config) *Proxy {
 	return p
 }
 
-// Addr returns destination endpoints address to forward to
+// Addr returns the address to forward to.
 func (p *Proxy) Addr() (addr string) { return p.addr }
 
 // dnsClient returns a client used for health checking.

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -39,6 +39,9 @@ func NewProxy(addr string, tlsConfig *tls.Config) *Proxy {
 	return p
 }
 
+// Addr returns destination endpoints address to forward to
+func (p *Proxy) Addr() (addr string) { return p.addr }
+
 // dnsClient returns a client used for health checking.
 func dnsClient(tlsConfig *tls.Config) *dns.Client {
 	c := new(dns.Client)

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -29,10 +29,10 @@ func TestProxyClose(t *testing.T) {
 		p := NewProxy(s.Addr, nil)
 		p.start(hcDuration)
 
-		go func() { p.connect(ctx, state, false, false) }()
-		go func() { p.connect(ctx, state, true, false) }()
-		go func() { p.connect(ctx, state, false, false) }()
-		go func() { p.connect(ctx, state, true, false) }()
+		go func() { p.Connect(ctx, state, false, false) }()
+		go func() { p.Connect(ctx, state, true, false) }()
+		go func() { p.Connect(ctx, state, false, false) }()
+		go func() { p.Connect(ctx, state, true, false) }()
 
 		p.close()
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
 * Makes Proxy.Connect() and Forward.List() methods public
 * Adds getters for Proxy.addr, Forward.from and Forward.forceTCP

### 2. Which issues (if any) are related?
It implements https://github.com/coredns/coredns/issues/1762

### 3. Which documentation changes (if any) need to be made?

