### PR TITLE
plugin/forward: close connection manager in proxy finalizer

### DIFF
--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"crypto/tls"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -36,6 +37,7 @@ func NewProxy(addr string, tlsConfig *tls.Config) *Proxy {
 		avgRtt:    int64(timeout / 2),
 	}
 	p.client = dnsClient(tlsConfig)
+	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
 }
 
@@ -88,6 +90,9 @@ func (p *Proxy) Down(maxfails uint32) bool {
 // close stops the health checking goroutine.
 func (p *Proxy) close() {
 	p.probe.Stop()
+}
+
+func (p *Proxy) finalizer() {
 	p.transport.Stop()
 }
 


### PR DESCRIPTION
### 1. What does this pull request do?
 - connManager() goroutine will stop when Proxy is about to be
   garbage collected. This means that no queries are in progress,
   and no queries are going to come

### 2. Which issues (if any) are related?
#1666

### 3. Which documentation changes (if any) need to be made?
none
