### PR TITLE
plugin/cache: unroll minTTL loop

### DIFF
--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -100,7 +100,32 @@ func minMsgTTL(m *dns.Msg, mt response.Type) time.Duration {
 	}
 
 	minTTL := maxTTL
-	for _, r := range append(append(m.Answer, m.Ns...), m.Extra...) {
+	for _, r := range m.Answer {
+		switch mt {
+		case response.NameError, response.NoData:
+			if r.Header().Rrtype == dns.TypeSOA {
+				minTTL = time.Duration(r.(*dns.SOA).Minttl) * time.Second
+			}
+		case response.NoError, response.Delegation:
+			if r.Header().Ttl < uint32(minTTL.Seconds()) {
+				minTTL = time.Duration(r.Header().Ttl) * time.Second
+			}
+		}
+	}
+	for _, r := range m.Ns {
+		switch mt {
+		case response.NameError, response.NoData:
+			if r.Header().Rrtype == dns.TypeSOA {
+				minTTL = time.Duration(r.(*dns.SOA).Minttl) * time.Second
+			}
+		case response.NoError, response.Delegation:
+			if r.Header().Ttl < uint32(minTTL.Seconds()) {
+				minTTL = time.Duration(r.Header().Ttl) * time.Second
+			}
+		}
+	}
+
+	for _, r := range m.Extra {
 		if r.Header().Rrtype == dns.TypeOPT {
 			// OPT records use TTL field for extended rcode and flags
 			continue
@@ -108,7 +133,7 @@ func minMsgTTL(m *dns.Msg, mt response.Type) time.Duration {
 		switch mt {
 		case response.NameError, response.NoData:
 			if r.Header().Rrtype == dns.TypeSOA {
-				return time.Duration(r.(*dns.SOA).Minttl) * time.Second
+				minTTL = time.Duration(r.(*dns.SOA).Minttl) * time.Second
 			}
 		case response.NoError, response.Delegation:
 			if r.Header().Ttl < uint32(minTTL.Seconds()) {


### PR DESCRIPTION
This allocates memory because of the append, just unroll the loop.
Also add benchmark.

Before:
goos: linux
goarch: amd64
pkg: github.com/coredns/coredns/plugin/cache
BenchmarkCacheResponse-4   	  100000	     11910 ns/op
BenchmarkMinMsgTTL-4       	 1000000	      1494 ns/op
PASS

After:
goos: linux
goarch: amd64
pkg: github.com/coredns/coredns/plugin/cache
BenchmarkCacheResponse-4   	  100000	     12016 ns/op
BenchmarkMinMsgTTL-4       	 2000000	       668 ns/op
PASS

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

