### PR TITLE
presubmit: check for uppercase

### DIFF
--- a/.presubmit/test-lowercase
+++ b/.presubmit/test-lowercase
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "** presubmit/$(basename $0)"
+
+# Get the tests that call t.* without capitalizing the first char - seems we standardized on that.
+if egrep -r 't\.Fatal.?\("[a-z]' "$@"; then
+    echo "** presubmit/$(basename $0): please start with an upper case letter when using t.Fatal*()"
+    exit 1
+fi
+
+if egrep -r 't\.Log.?\("[a-z]' "$@"; then
+    echo "** presubmit/$(basename $0): please start with an upper case letter when using t.Log*()"
+    exit 1
+fi

--- a/core/dnsserver/register_test.go
+++ b/core/dnsserver/register_test.go
@@ -100,15 +100,15 @@ func TestGroupingServers(t *testing.T) {
 		groups, err := groupConfigsByListenAddr(test.configs)
 		if err != nil {
 			if !test.failing {
-				t.Fatalf("test %d, expected no errors, but got: %v", i, err)
+				t.Fatalf("Test %d, expected no errors, but got: %v", i, err)
 			}
 			continue
 		}
 		if test.failing {
-			t.Fatalf("test %d, expected to failed but did not, returned values", i)
+			t.Fatalf("Test %d, expected to failed but did not, returned values", i)
 		}
 		if len(groups) != len(test.expectedGroups) {
-			t.Errorf("test %d : expected the group's size to be %d, was %d", i, len(test.expectedGroups), len(groups))
+			t.Errorf("Test %d : expected the group's size to be %d, was %d", i, len(test.expectedGroups), len(groups))
 			continue
 		}
 		for _, v := range test.expectedGroups {

--- a/plugin/autopath/autopath_test.go
+++ b/plugin/autopath/autopath_test.go
@@ -52,7 +52,7 @@ func TestAutoPath(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		_, err := ap.ServeDNS(ctx, rec, m)
 		if err != nil {
-			t.Errorf("expected no error, got %v\n", err)
+			t.Errorf("Expected no error, got %v\n", err)
 			continue
 		}
 
@@ -97,11 +97,11 @@ func TestAutoPathNoAnswer(t *testing.T) {
 		rec := dnstest.NewRecorder(&test.ResponseWriter{})
 		rcode, err := ap.ServeDNS(ctx, rec, m)
 		if err != nil {
-			t.Errorf("expected no error, got %v\n", err)
+			t.Errorf("Expected no error, got %v\n", err)
 			continue
 		}
 		if plugin.ClientWrite(rcode) {
-			t.Fatalf("expected no client write, got one for rcode %d", rcode)
+			t.Fatalf("Expected no client write, got one for rcode %d", rcode)
 		}
 	}
 }

--- a/plugin/bind/bind_test.go
+++ b/plugin/bind/bind_test.go
@@ -25,21 +25,21 @@ func TestSetup(t *testing.T) {
 		err := setup(c)
 		if err != nil {
 			if !test.failing {
-				t.Fatalf("test %d, expected no errors, but got: %v", i, err)
+				t.Fatalf("Test %d, expected no errors, but got: %v", i, err)
 			}
 			continue
 		}
 		if test.failing {
-			t.Fatalf("test %d, expected to failed but did not, returned values", i)
+			t.Fatalf("Test %d, expected to failed but did not, returned values", i)
 		}
 		cfg := dnsserver.GetConfig(c)
 		if len(cfg.ListenHosts) != len(test.expected) {
-			t.Errorf("test %d : expected the config's ListenHosts size to be %d, was %d", i, len(test.expected), len(cfg.ListenHosts))
+			t.Errorf("Test %d : expected the config's ListenHosts size to be %d, was %d", i, len(test.expected), len(cfg.ListenHosts))
 			continue
 		}
 		for i, v := range test.expected {
 			if got, want := cfg.ListenHosts[i], v; got != want {
-				t.Errorf("test %d : expected the config's ListenHost to be %s, was %s", i, want, got)
+				t.Errorf("Test %d : expected the config's ListenHost to be %s, was %s", i, want, got)
 			}
 		}
 	}

--- a/plugin/cache/prefech_test.go
+++ b/plugin/cache/prefech_test.go
@@ -117,20 +117,20 @@ func TestPrefetch(t *testing.T) {
 					select {
 					case <-fetchc:
 						if !v.fetch {
-							t.Fatalf("after %s: want request to trigger a prefetch", v.after)
+							t.Fatalf("After %s: want request to trigger a prefetch", v.after)
 						}
 					case <-time.After(time.Second):
-						t.Fatalf("after %s: want request to trigger a prefetch", v.after)
+						t.Fatalf("After %s: want request to trigger a prefetch", v.after)
 					}
 				}
 				if want, got := rec.Rcode, dns.RcodeSuccess; want != got {
-					t.Errorf("after %s: want rcode %d, got %d", v.after, want, got)
+					t.Errorf("After %s: want rcode %d, got %d", v.after, want, got)
 				}
 				if want, got := 1, len(rec.Msg.Answer); want != got {
-					t.Errorf("after %s: want %d answer RR, got %d", v.after, want, got)
+					t.Errorf("After %s: want %d answer RR, got %d", v.after, want, got)
 				}
 				if want, got := test.A(v.answer).String(), rec.Msg.Answer[0].String(); want != got {
-					t.Errorf("after %s: want answer %s, got %s", v.after, want, got)
+					t.Errorf("After %s: want answer %s, got %s", v.after, want, got)
 				}
 			}
 		})

--- a/plugin/dnssec/black_lies_test.go
+++ b/plugin/dnssec/black_lies_test.go
@@ -19,7 +19,7 @@ func TestZoneSigningBlackLies(t *testing.T) {
 	state := request.Request{Req: m, Zone: "miek.nl."}
 	m = d.Sign(state, time.Now().UTC(), server)
 	if !section(m.Ns, 2) {
-		t.Errorf("authority section should have 2 sig")
+		t.Errorf("Authority section should have 2 sigs")
 	}
 	var nsec *dns.NSEC
 	for _, r := range m.Ns {
@@ -28,16 +28,16 @@ func TestZoneSigningBlackLies(t *testing.T) {
 		}
 	}
 	if m.Rcode != dns.RcodeSuccess {
-		t.Errorf("expected rcode %d, got %d", dns.RcodeSuccess, m.Rcode)
+		t.Errorf("Expected rcode %d, got %d", dns.RcodeSuccess, m.Rcode)
 	}
 	if nsec == nil {
-		t.Fatalf("expected NSEC, got none")
+		t.Fatalf("Expected NSEC, got none")
 	}
 	if nsec.Hdr.Name != "ww.miek.nl." {
-		t.Errorf("expected %s, got %s", "ww.miek.nl.", nsec.Hdr.Name)
+		t.Errorf("Expected %s, got %s", "ww.miek.nl.", nsec.Hdr.Name)
 	}
 	if nsec.NextDomain != "\\000.ww.miek.nl." {
-		t.Errorf("expected %s, got %s", "\\000.ww.miek.nl.", nsec.NextDomain)
+		t.Errorf("Expected %s, got %s", "\\000.ww.miek.nl.", nsec.NextDomain)
 	}
 }
 

--- a/plugin/dnssec/cache_test.go
+++ b/plugin/dnssec/cache_test.go
@@ -17,7 +17,7 @@ func TestCacheSet(t *testing.T) {
 
 	dnskey, err := ParseKeyFile(fPub, fPriv)
 	if err != nil {
-		t.Fatalf("failed to parse key: %v\n", err)
+		t.Fatalf("Failed to parse key: %v\n", err)
 	}
 
 	c := cache.New(defaultCap)
@@ -29,7 +29,7 @@ func TestCacheSet(t *testing.T) {
 
 	_, ok := d.get(k, server)
 	if !ok {
-		t.Errorf("signature was not added to the cache")
+		t.Errorf("Signature was not added to the cache")
 	}
 }
 
@@ -41,7 +41,7 @@ func TestCacheNotValidExpired(t *testing.T) {
 
 	dnskey, err := ParseKeyFile(fPub, fPriv)
 	if err != nil {
-		t.Fatalf("failed to parse key: %v\n", err)
+		t.Fatalf("Failed to parse key: %v\n", err)
 	}
 
 	c := cache.New(defaultCap)
@@ -53,7 +53,7 @@ func TestCacheNotValidExpired(t *testing.T) {
 
 	_, ok := d.get(k, server)
 	if ok {
-		t.Errorf("signature was added to the cache even though not valid")
+		t.Errorf("Signature was added to the cache even though not valid")
 	}
 }
 
@@ -65,7 +65,7 @@ func TestCacheNotValidYet(t *testing.T) {
 
 	dnskey, err := ParseKeyFile(fPub, fPriv)
 	if err != nil {
-		t.Fatalf("failed to parse key: %v\n", err)
+		t.Fatalf("Failed to parse key: %v\n", err)
 	}
 
 	c := cache.New(defaultCap)
@@ -77,6 +77,6 @@ func TestCacheNotValidYet(t *testing.T) {
 
 	_, ok := d.get(k, server)
 	if ok {
-		t.Errorf("signature was added to the cache even though not valid yet")
+		t.Errorf("Signature was added to the cache even though not valid yet")
 	}
 }

--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -228,7 +228,7 @@ func newKey(t *testing.T) (*DNSKEY, func(), func()) {
 
 	key, err := ParseKeyFile(fPub, fPriv)
 	if err != nil {
-		t.Fatalf("failed to parse key: %v\n", err)
+		t.Fatalf("Failed to parse key: %v\n", err)
 	}
 	return key, rmPriv, rmPub
 }

--- a/plugin/dnstap/dnstapio/dnstap_encoder_test.go
+++ b/plugin/dnstap/dnstapio/dnstap_encoder_test.go
@@ -48,6 +48,6 @@ func TestEncoderCompatibility(t *testing.T) {
 
 	//compare results
 	if !bytes.Equal(fsW.Bytes(), dnstapW.Bytes()) {
-		t.Fatal("dnstapEncoder is not compatible with framestream Encoder")
+		t.Fatal("DnstapEncoder is not compatible with framestream Encoder")
 	}
 }

--- a/plugin/dnstap/dnstapio/io_test.go
+++ b/plugin/dnstap/dnstapio/io_test.go
@@ -23,7 +23,7 @@ var (
 func accept(t *testing.T, l net.Listener, count int) {
 	server, err := l.Accept()
 	if err != nil {
-		t.Fatalf("server accept: %s", err)
+		t.Fatalf("Server accepted: %s", err)
 		return
 	}
 
@@ -32,13 +32,13 @@ func accept(t *testing.T, l net.Listener, count int) {
 		Bidirectional: true,
 	})
 	if err != nil {
-		t.Fatalf("server decoder: %s", err)
+		t.Fatalf("Server decoder: %s", err)
 		return
 	}
 
 	for i := 0; i < count; i++ {
 		if _, err := dec.Decode(); err != nil {
-			t.Errorf("server decode: %s", err)
+			t.Errorf("Server decode: %s", err)
 		}
 	}
 

--- a/plugin/dnstap/handler_test.go
+++ b/plugin/dnstap/handler_test.go
@@ -103,7 +103,7 @@ func TestError(t *testing.T) {
 	// the dnstap error will show only if there is no plugin error
 	_, err := h.ServeDNS(context.TODO(), rw, nil)
 	if err == nil || !strings.HasPrefix(err.Error(), "plugin/dnstap") {
-		t.Fatal("must return the dnstap error but have:", err)
+		t.Fatal("Must return the dnstap error but have:", err)
 	}
 
 	// plugin errors will always overwrite dnstap errors
@@ -111,6 +111,6 @@ func TestError(t *testing.T) {
 	h.Next = endWith(0, pluginErr)
 	_, err = h.ServeDNS(context.TODO(), rw, nil)
 	if err != pluginErr {
-		t.Fatal("must return the plugin error but have:", err)
+		t.Fatal("Must return the plugin error but have:", err)
 	}
 }

--- a/plugin/dnstap/msg/msg_test.go
+++ b/plugin/dnstap/msg/msg_test.go
@@ -19,7 +19,7 @@ func testRequest(t *testing.T, expected Builder, r request.Request) {
 		d.SocketFam != expected.SocketFam ||
 		!reflect.DeepEqual(d.Address, expected.Address) ||
 		d.Port != expected.Port {
-		t.Fatalf("expected: %v, have: %v", expected, d)
+		t.Fatalf("Expected: %v, have: %v", expected, d)
 		return
 	}
 }

--- a/plugin/dnstap/taprw/writer_test.go
+++ b/plugin/dnstap/taprw/writer_test.go
@@ -39,7 +39,7 @@ func TestClientQueryResponse(t *testing.T) {
 		return
 	}
 	if l := len(trapper.Trap); l != 2 {
-		t.Fatalf("%d msg trapped", l)
+		t.Fatalf("Mmsg %d trapped", l)
 		return
 	}
 	want, err := d.ToClientQuery()
@@ -48,7 +48,7 @@ func TestClientQueryResponse(t *testing.T) {
 	}
 	have := trapper.Trap[0]
 	if !test.MsgEqual(want, have) {
-		t.Fatalf("query: want: %v\nhave: %v", want, have)
+		t.Fatalf("Query: want: %v\nhave: %v", want, have)
 	}
 	want, err = d.ToClientResponse()
 	if err != nil {
@@ -56,7 +56,7 @@ func TestClientQueryResponse(t *testing.T) {
 	}
 	have = trapper.Trap[1]
 	if !test.MsgEqual(want, have) {
-		t.Fatalf("response: want: %v\nhave: %v", want, have)
+		t.Fatalf("Response: want: %v\nhave: %v", want, have)
 	}
 }
 

--- a/plugin/etcd/msg/service_test.go
+++ b/plugin/etcd/msg/service_test.go
@@ -13,19 +13,19 @@ func TestSplit255(t *testing.T) {
 	}
 	xs = split255(s)
 	if len(xs) != 1 && xs[0] != s {
-		t.Errorf("failure to split 255 char long string")
+		t.Errorf("Failure to split 255 char long string")
 	}
 	s += "b"
 	xs = split255(s)
 	if len(xs) != 2 || xs[1] != "b" {
-		t.Errorf("failure to split 256 char long string: %d", len(xs))
+		t.Errorf("Failure to split 256 char long string: %d", len(xs))
 	}
 	for i := 0; i < 255; i++ {
 		s += "a"
 	}
 	xs = split255(s)
 	if len(xs) != 3 || xs[2] != "a" {
-		t.Errorf("failure to split 510 char long string: %d", len(xs))
+		t.Errorf("Failure to split 510 char long string: %d", len(xs))
 	}
 }
 
@@ -39,10 +39,10 @@ func TestGroup(t *testing.T) {
 	)
 	// Expecting to return the shortest key with a Group attribute.
 	if len(sx) != 1 {
-		t.Fatalf("failure to group zeroth set: %v", sx)
+		t.Fatalf("Failure to group zeroth set: %v", sx)
 	}
 	if sx[0].Key != "a/dom1/skydns/test" {
-		t.Fatalf("failure to group zeroth set: %v, wrong Key", sx)
+		t.Fatalf("Failure to group zeroth set: %v, wrong Key", sx)
 	}
 
 	// Groups disagree, so we will not do anything.
@@ -53,7 +53,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 2 {
-		t.Fatalf("failure to group first set: %v", sx)
+		t.Fatalf("Failure to group first set: %v", sx)
 	}
 
 	// Group is g1, include only the top-level one.
@@ -64,7 +64,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 1 {
-		t.Fatalf("failure to group second set: %v", sx)
+		t.Fatalf("Failure to group second set: %v", sx)
 	}
 
 	// Groupless services must be included.
@@ -76,7 +76,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 2 {
-		t.Fatalf("failure to group third set: %v", sx)
+		t.Fatalf("Failure to group third set: %v", sx)
 	}
 
 	// Empty group on the highest level: include that one also.
@@ -88,7 +88,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 2 {
-		t.Fatalf("failure to group fourth set: %v", sx)
+		t.Fatalf("Failure to group fourth set: %v", sx)
 	}
 
 	// Empty group on the highest level: include that one also, and the rest.
@@ -100,7 +100,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 3 {
-		t.Fatalf("failure to group fith set: %v", sx)
+		t.Fatalf("Failure to group fith set: %v", sx)
 	}
 
 	// One group.
@@ -110,7 +110,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 1 {
-		t.Fatalf("failure to group sixth set: %v", sx)
+		t.Fatalf("Failure to group sixth set: %v", sx)
 	}
 
 	// No group, once service
@@ -120,6 +120,6 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 1 {
-		t.Fatalf("failure to group seventh set: %v", sx)
+		t.Fatalf("Failure to group seventh set: %v", sx)
 	}
 }

--- a/plugin/etcd/stub_test.go
+++ b/plugin/etcd/stub_test.go
@@ -17,7 +17,7 @@ import (
 func fakeStubServerExampleNet(t *testing.T) (*dns.Server, string) {
 	server, addr, err := test.UDPServer("127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("failed to create a UDP server: %s", err)
+		t.Fatalf("Failed to create a UDP server: %s", err)
 	}
 	// add handler for example.net
 	dns.HandleFunc("example.net.", func(w dns.ResponseWriter, r *dns.Msg) {

--- a/plugin/file/closest_test.go
+++ b/plugin/file/closest_test.go
@@ -8,7 +8,7 @@ import (
 func TestClosestEncloser(t *testing.T) {
 	z, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
 	if err != nil {
-		t.Fatalf("expect no error when reading zone, got %q", err)
+		t.Fatalf("Expect no error when reading zone, got %q", err)
 	}
 
 	tests := []struct {

--- a/plugin/file/ent_test.go
+++ b/plugin/file/ent_test.go
@@ -33,7 +33,7 @@ var entTestCases = []test.Case{
 func TestLookupEnt(t *testing.T) {
 	zone, err := Parse(strings.NewReader(dbMiekENTNL), testzone, "stdin", 0)
 	if err != nil {
-		t.Fatalf("expect no error when reading zone, got %q", err)
+		t.Fatalf("Expect no error when reading zone, got %q", err)
 	}
 
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: zone}, Names: []string{testzone}}}

--- a/plugin/file/file_test.go
+++ b/plugin/file/file_test.go
@@ -14,10 +14,10 @@ func BenchmarkFileParseInsert(b *testing.B) {
 func TestParseNoSOA(t *testing.T) {
 	_, err := Parse(strings.NewReader(dbNoSOA), "example.org.", "stdin", 0)
 	if err == nil {
-		t.Fatalf("zone %q should have failed to load", "example.org.")
+		t.Fatalf("Zone %q should have failed to load", "example.org.")
 	}
 	if !strings.Contains(err.Error(), "no SOA record") {
-		t.Fatalf("zone %q should have failed to load with no soa error: %s", "example.org.", err)
+		t.Fatalf("Zone %q should have failed to load with no soa error: %s", "example.org.", err)
 	}
 }
 

--- a/plugin/file/lookup_test.go
+++ b/plugin/file/lookup_test.go
@@ -105,7 +105,7 @@ const (
 func TestLookup(t *testing.T) {
 	zone, err := Parse(strings.NewReader(dbMiekNL), testzone, "stdin", 0)
 	if err != nil {
-		t.Fatalf("expect no error when reading zone, got %q", err)
+		t.Fatalf("Expected no error when reading zone, got %q", err)
 	}
 
 	fm := File{Next: test.ErrorHandler(), Zones: Zones{Z: map[string]*Zone{testzone: zone}, Names: []string{testzone}}}

--- a/plugin/file/nsec3_test.go
+++ b/plugin/file/nsec3_test.go
@@ -8,14 +8,14 @@ import (
 func TestParseNSEC3PARAM(t *testing.T) {
 	_, err := Parse(strings.NewReader(nsec3paramTest), "miek.nl", "stdin", 0)
 	if err == nil {
-		t.Fatalf("expected error when reading zone, got nothing")
+		t.Fatalf("Expected error when reading zone, got nothing")
 	}
 }
 
 func TestParseNSEC3(t *testing.T) {
 	_, err := Parse(strings.NewReader(nsec3Test), "miek.nl", "stdin", 0)
 	if err == nil {
-		t.Fatalf("expected error when reading zone, got nothing")
+		t.Fatalf("Expected error when reading zone, got nothing")
 	}
 }
 

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -16,16 +16,16 @@ import (
 func TestZoneReload(t *testing.T) {
 	fileName, rm, err := test.TempFile(".", reloadZoneTest)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 	reader, err := os.Open(fileName)
 	if err != nil {
-		t.Fatalf("failed to open zone: %s", err)
+		t.Fatalf("Failed to open zone: %s", err)
 	}
 	z, err := Parse(reader, "miek.nl", fileName, 0)
 	if err != nil {
-		t.Fatalf("failed to parse zone: %s", err)
+		t.Fatalf("Failed to parse zone: %s", err)
 	}
 
 	TickTime = 500 * time.Millisecond
@@ -36,34 +36,34 @@ func TestZoneReload(t *testing.T) {
 	r.SetQuestion("miek.nl", dns.TypeSOA)
 	state := request.Request{W: &test.ResponseWriter{}, Req: r}
 	if _, _, _, res := z.Lookup(state, "miek.nl."); res != Success {
-		t.Fatalf("failed to lookup, got %d", res)
+		t.Fatalf("Failed to lookup, got %d", res)
 	}
 
 	r = new(dns.Msg)
 	r.SetQuestion("miek.nl", dns.TypeNS)
 	state = request.Request{W: &test.ResponseWriter{}, Req: r}
 	if _, _, _, res := z.Lookup(state, "miek.nl."); res != Success {
-		t.Fatalf("failed to lookup, got %d", res)
+		t.Fatalf("Failed to lookup, got %d", res)
 	}
 
 	if len(z.All()) != 5 {
-		t.Fatalf("expected 5 RRs, got %d", len(z.All()))
+		t.Fatalf("Expected 5 RRs, got %d", len(z.All()))
 	}
 	if err := ioutil.WriteFile(fileName, []byte(reloadZone2Test), 0644); err != nil {
-		t.Fatalf("failed to write new zone data: %s", err)
+		t.Fatalf("Failed to write new zone data: %s", err)
 	}
 	// Could still be racy, but we need to wait a bit for the event to be seen
 	time.Sleep(1 * time.Second)
 
 	if len(z.All()) != 3 {
-		t.Fatalf("expected 3 RRs, got %d", len(z.All()))
+		t.Fatalf("Expected 3 RRs, got %d", len(z.All()))
 	}
 }
 
 func TestZoneReloadSOAChange(t *testing.T) {
 	_, err := Parse(strings.NewReader(reloadZoneTest), "miek.nl.", "stdin", 1460175181)
 	if err == nil {
-		t.Fatalf("zone should not have been re-parsed")
+		t.Fatalf("Zone should not have been re-parsed")
 	}
 
 }

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -23,16 +23,16 @@ func TestLess(t *testing.T) {
 	)
 
 	if less(min, max) {
-		t.Fatalf("less: should be false")
+		t.Fatalf("Less: should be false")
 	}
 	if !less(max, min) {
-		t.Fatalf("less: should be true")
+		t.Fatalf("Less: should be true")
 	}
 	if !less(high, low) {
-		t.Fatalf("less: should be true")
+		t.Fatalf("Less: should be true")
 	}
 	if !less(7, 9) {
-		t.Fatalf("less; should be true")
+		t.Fatalf("Less; should be true")
 	}
 }
 
@@ -76,7 +76,7 @@ func TestShouldTransfer(t *testing.T) {
 
 	s, addrstr, err := test.TCPServer("127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("unable to run test server: %v", err)
+		t.Fatalf("Unable to run test server: %v", err)
 	}
 	defer s.Shutdown()
 
@@ -87,28 +87,28 @@ func TestShouldTransfer(t *testing.T) {
 	// when we have a nil SOA (initial state)
 	should, err := z.shouldTransfer()
 	if err != nil {
-		t.Fatalf("unable to run shouldTransfer: %v", err)
+		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if !should {
-		t.Fatalf("shouldTransfer should return true for serial: %d", soa.serial)
+		t.Fatalf("ShouldTransfer should return true for serial: %d", soa.serial)
 	}
 	// Serial smaller
 	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, soa.serial-1))
 	should, err = z.shouldTransfer()
 	if err != nil {
-		t.Fatalf("unable to run shouldTransfer: %v", err)
+		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if !should {
-		t.Fatalf("shouldTransfer should return true for serial: %q", soa.serial-1)
+		t.Fatalf("ShouldTransfer should return true for serial: %q", soa.serial-1)
 	}
 	// Serial equal
 	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, soa.serial))
 	should, err = z.shouldTransfer()
 	if err != nil {
-		t.Fatalf("unable to run shouldTransfer: %v", err)
+		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if should {
-		t.Fatalf("shouldTransfer should return false for serial: %d", soa.serial)
+		t.Fatalf("ShouldTransfer should return false for serial: %d", soa.serial)
 	}
 }
 
@@ -120,7 +120,7 @@ func TestTransferIn(t *testing.T) {
 
 	s, addrstr, err := test.TCPServer("127.0.0.1:0")
 	if err != nil {
-		t.Fatalf("unable to run test server: %v", err)
+		t.Fatalf("Unable to run test server: %v", err)
 	}
 	defer s.Shutdown()
 
@@ -131,10 +131,10 @@ func TestTransferIn(t *testing.T) {
 
 	err = z.TransferIn()
 	if err != nil {
-		t.Fatalf("unable to run TransferIn: %v", err)
+		t.Fatalf("Unable to run TransferIn: %v", err)
 	}
 	if z.Apex.SOA.String() != fmt.Sprintf("%s	3600	IN	SOA	bla. bla. 250 0 0 0 0", testZone) {
-		t.Fatalf("unknown SOA transferred")
+		t.Fatalf("Unknown SOA transferred")
 	}
 }
 
@@ -148,11 +148,11 @@ func TestIsNotify(t *testing.T) {
 
 	z.TransferFrom = []string{"10.240.0.1:53"} // IP from from testing/responseWriter
 	if !z.isNotify(state) {
-		t.Fatal("should have been valid notify")
+		t.Fatal("Should have been valid notify")
 	}
 	z.TransferFrom = []string{"10.240.0.2:53"}
 	if z.isNotify(state) {
-		t.Fatal("should have been invalid notify")
+		t.Fatal("Should have been invalid notify")
 	}
 }
 

--- a/plugin/proxy/dnstap_test.go
+++ b/plugin/proxy/dnstap_test.go
@@ -24,13 +24,13 @@ func testCase(t *testing.T, ex Exchanger, q, r *dns.Msg, datq, datr *msg.Builder
 		t.Fatal(err)
 	}
 	if len(ctx.Trap) != 2 {
-		t.Fatalf("messages: %d", len(ctx.Trap))
+		t.Fatalf("Messages: %d", len(ctx.Trap))
 	}
 	if !test.MsgEqual(ctx.Trap[0], tapq) {
-		t.Errorf("want: %v\nhave: %v", tapq, ctx.Trap[0])
+		t.Errorf("Want: %v\nhave: %v", tapq, ctx.Trap[0])
 	}
 	if !test.MsgEqual(ctx.Trap[1], tapr) {
-		t.Errorf("want: %v\nhave: %v", tapr, ctx.Trap[1])
+		t.Errorf("Want: %v\nhave: %v", tapr, ctx.Trap[1])
 	}
 }
 

--- a/plugin/proxy/grpc_test.go
+++ b/plugin/proxy/grpc_test.go
@@ -42,7 +42,7 @@ func buildPool(size int) ([]*healthcheck.UpstreamHost, func(), error) {
 		for _, e := range errs {
 			valErr += fmt.Sprintf("%v\n", e)
 		}
-		return nil, nil, fmt.Errorf("error at allocation of the pool : %v", valErr)
+		return nil, nil, fmt.Errorf("Error at allocation of the pool : %v", valErr)
 	}
 	return ups, stopIt, nil
 }
@@ -51,7 +51,7 @@ func TestGRPCStartupShutdown(t *testing.T) {
 
 	pool, closePool, err := buildPool(2)
 	if err != nil {
-		t.Fatalf("error creating the pool of upstream for the test : %s", err)
+		t.Fatalf("Error creating the pool of upstream for the test : %s", err)
 	}
 	defer closePool()
 
@@ -91,7 +91,7 @@ func TestGRPCRunAQuery(t *testing.T) {
 
 	pool, closePool, err := buildPool(2)
 	if err != nil {
-		t.Fatalf("error creating the pool of upstream for the test : %s", err)
+		t.Fatalf("Error creating the pool of upstream for the test : %s", err)
 	}
 	defer closePool()
 
@@ -131,7 +131,7 @@ func TestGRPCRunAQueryOnSecureLinkWithInvalidCert(t *testing.T) {
 
 	pool, closePool, err := buildPool(1)
 	if err != nil {
-		t.Fatalf("error creating the pool of upstream for the test : %s", err)
+		t.Fatalf("Error creating the pool of upstream for the test : %s", err)
 	}
 	defer closePool()
 

--- a/plugin/test/file_test.go
+++ b/plugin/test/file_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestTempFile(t *testing.T) {
 	_, f, e := TempFile(".", "test")
 	if e != nil {
-		t.Fatalf("failed to create temp file: %s", e)
+		t.Fatalf("Failed to create temp file: %s", e)
 	}
 	defer f()
 }


### PR DESCRIPTION
Another thing we can test automatically, we sorta settled on using an
uppercase letter in in t.Log and t.Fatal calls.

Let's just check for this.

<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?


### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

