### PR TITLE
plugin/forward: expose TLSConfig and error messages to public

### DIFF
--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -58,7 +58,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, forceTCP, me
 	if err := conn.WriteMsg(state.Req); err != nil {
 		conn.Close() // not giving it back
 		if err == io.EOF && cached {
-			return nil, errCachedClosed
+			return nil, ErrCachedClosed
 		}
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, forceTCP, me
 		p.updateRtt(timeout)
 		conn.Close() // not giving it back
 		if err == io.EOF && cached {
-			return nil, errCachedClosed
+			return nil, ErrCachedClosed
 		}
 		return ret, err
 	}

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -104,7 +104,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		)
 		for {
 			ret, err = proxy.Connect(ctx, state, f.forceTCP, true)
-			if err != nil && err == errCachedClosed { // Remote side closed conn, can only happen with TCP.
+			if err != nil && err == ErrCachedClosed { // Remote side closed conn, can only happen with TCP.
 				continue
 			}
 			break
@@ -150,7 +150,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		return dns.RcodeServerFailure, upstreamErr
 	}
 
-	return dns.RcodeServerFailure, errNoHealthy
+	return dns.RcodeServerFailure, ErrNoHealthy
 }
 
 func (f *Forward) match(state request.Request) bool {
@@ -186,10 +186,12 @@ func (f *Forward) ForceTCP() bool { return f.forceTCP }
 func (f *Forward) List() []*Proxy { return f.p.List(f.proxies) }
 
 var (
-	errInvalidDomain = errors.New("invalid domain for forward")
-	errNoHealthy     = errors.New("no healthy proxies")
-	errNoForward     = errors.New("no forwarder defined")
-	errCachedClosed  = errors.New("cached connection was closed by peer")
+	// ErrNoHealthy means no healthy proxies left
+	ErrNoHealthy = errors.New("no healthy proxies")
+	// ErrNoForward means no forwarder defined
+	ErrNoForward = errors.New("no forwarder defined")
+	// ErrCachedClosed means cached connection was closed by peer
+	ErrCachedClosed = errors.New("cached connection was closed by peer")
 )
 
 // policy tells forward what policy for selecting upstream it uses.

--- a/plugin/forward/lookup.go
+++ b/plugin/forward/lookup.go
@@ -16,7 +16,7 @@ import (
 // Forward may be called with a nil f, an error is returned in that case.
 func (f *Forward) Forward(state request.Request) (*dns.Msg, error) {
 	if f == nil {
-		return nil, errNoForward
+		return nil, ErrNoForward
 	}
 
 	fails := 0
@@ -56,7 +56,7 @@ func (f *Forward) Forward(state request.Request) (*dns.Msg, error) {
 		return nil, upstreamErr
 	}
 
-	return nil, errNoHealthy
+	return nil, ErrNoHealthy
 }
 
 // Lookup will use name and type to forge a new message and will send that upstream. It will
@@ -64,7 +64,7 @@ func (f *Forward) Forward(state request.Request) (*dns.Msg, error) {
 // Lookup may be called with a nil f, an error is returned in that case.
 func (f *Forward) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
 	if f == nil {
-		return nil, errNoForward
+		return nil, ErrNoForward
 	}
 
 	req := new(dns.Msg)

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -63,6 +63,9 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 	p.client = dnsClient(cfg)
 }
 
+// TLSConfig provides current TLS config.
+func (p *Proxy) TLSConfig() *tls.Config { return p.transport.tlsConfig }
+
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
 

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -63,8 +63,8 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 	p.client = dnsClient(cfg)
 }
 
-// TLSConfig provides current TLS config.
-func (p *Proxy) TLSConfig() *tls.Config { return p.transport.tlsConfig }
+// IsTLS returns true if proxy uses tls.
+func (p *Proxy) IsTLS() bool { return p.transport.tlsConfig != nil }
 
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
* Adds public method IsTLS()
* Makes error messages public
### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/1762
### 3. Which documentation changes (if any) need to be made?