### PR TITLE
plugin/forward: erase expired connections by timer

### DIFF
--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -69,6 +69,8 @@ Wait:
 				}
 				// clear entire cache if the last conn is expired
 				t.conns[proto] = nil
+				// now, the connections being passed to closeConns() are not reachable from
+				// transport methods anymore. So, it's safe to close them in a separate goroutine
 				go closeConns(stack)
 			}
 			SocketGauge.WithLabelValues(t.addr).Set(float64(t.len()))
@@ -119,6 +121,8 @@ func (t *transport) cleanup(all bool) {
 		}
 		if all {
 			t.conns[proto] = nil
+			// now, the connections being passed to closeConns() are not reachable from
+			// transport methods anymore. So, it's safe to close them in a separate goroutine
 			go closeConns(stack)
 			continue
 		}
@@ -131,6 +135,8 @@ func (t *transport) cleanup(all bool) {
 			return stack[i].used.After(staleTime)
 		})
 		t.conns[proto] = stack[good:]
+		// now, the connections being passed to closeConns() are not reachable from
+		// transport methods anymore. So, it's safe to close them in a separate goroutine
 		go closeConns(stack[:good])
 	}
 }

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -118,8 +118,8 @@ func (t *transport) cleanup(all bool) {
 			continue
 		}
 		if all {
-			go closeConns(stack)
 			t.conns[proto] = nil
+			go closeConns(stack)
 			continue
 		}
 		if stack[0].used.After(staleTime) {

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -2,13 +2,14 @@ package forward
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 
 	"github.com/miekg/dns"
 )
 
-func TestPersistent(t *testing.T) {
+func TestCached(t *testing.T) {
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
@@ -21,13 +22,136 @@ func TestPersistent(t *testing.T) {
 
 	c1, cache1, _ := tr.Dial("udp")
 	c2, cache2, _ := tr.Dial("udp")
-	c3, cache3, _ := tr.Dial("udp")
 
-	if cache1 || cache2 || cache3 {
+	if cache1 || cache2 {
 		t.Errorf("Expected non-cached connection")
 	}
 
 	tr.Yield(c1)
 	tr.Yield(c2)
+	c3, cached3, _ := tr.Dial("udp")
+	if !cached3 {
+		t.Error("Expected cached connection (c3)")
+	}
+	if c2 != c3 {
+		t.Error("Expected c2 == c3")
+	}
+
 	tr.Yield(c3)
+
+	// dial another protocol
+	c4, cached4, _ := tr.Dial("tcp")
+	if cached4 {
+		t.Errorf("Expected non-cached connection (c4)")
+	}
+	tr.Yield(c4)
+}
+
+func TestCleanup(t *testing.T) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	tr := newTransport(s.Addr, nil /* no TLS */)
+	defer tr.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+	tr.SetExpire(100 * time.Millisecond)
+
+	// partially expired
+	c1, _, _ := tr.Dial("udp")
+	c2, _, _ := tr.Dial("udp")
+	c3, _, _ := tr.Dial("udp")
+	c4, _, _ := tr.Dial("udp")
+	c5, _, _ := tr.Dial("udp")
+
+	tr.Yield(c1)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c2)
+	time.Sleep(60 * time.Millisecond)
+	tr.Yield(c3)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c4)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c5)
+	time.Sleep(40 * time.Millisecond)
+	tr.cleanup(false)
+	if l := tr.len(); l != 3 {
+		t.Errorf("Expected 3 connections, got %d", l)
+	}
+
+	// dial when all expired
+	time.Sleep(80 * time.Millisecond)
+	if l := tr.len(); l != 3 {
+		t.Errorf("Still expected 3 connections, got %d", l)
+	}
+	var cached bool
+	c1, cached, _ = tr.Dial("udp")
+	if cached {
+		t.Errorf("Expected non-cached connection")
+	}
+	if l := tr.len(); l != 0 {
+		t.Errorf("Expected 0 connections, got %d", l)
+	}
+
+	// noone expired
+	c2, _, _ = tr.Dial("udp")
+	c3, _, _ = tr.Dial("udp")
+	c4, _, _ = tr.Dial("udp")
+	c5, _, _ = tr.Dial("udp")
+
+	tr.Yield(c1)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c2)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c3)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c4)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c5)
+	time.Sleep(10 * time.Millisecond)
+	tr.cleanup(false)
+	if l := tr.len(); l != 5 {
+		t.Errorf("Expected 0 connections, got %d", l)
+	}
+
+	// all expired
+	c1, _, _ = tr.Dial("udp")
+	c2, _, _ = tr.Dial("udp")
+	c3, _, _ = tr.Dial("udp")
+	c4, _, _ = tr.Dial("udp")
+	c5, _, _ = tr.Dial("udp")
+
+	tr.Yield(c1)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c2)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c3)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c4)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c5)
+	time.Sleep(120 * time.Millisecond)
+	tr.cleanup(false)
+	if l := tr.len(); l != 0 {
+		t.Errorf("Expected 0 connections, got %d", l)
+	}
+
+	// clean all connections
+	c1, _, _ = tr.Dial("udp")
+	c2, _, _ = tr.Dial("udp")
+	c3, _, _ = tr.Dial("udp")
+
+	tr.Yield(c1)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c2)
+	time.Sleep(10 * time.Millisecond)
+	tr.Yield(c3)
+	tr.cleanup(true)
+	if l := tr.len(); l != 0 {
+		t.Errorf("Expected 0 connections, got %d", l)
+	}
 }

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -92,7 +92,10 @@ func (p *Proxy) close() {
 }
 
 // start starts the proxy's healthchecking.
-func (p *Proxy) start(duration time.Duration) { p.probe.Start(duration) }
+func (p *Proxy) start(duration time.Duration) {
+	p.probe.Start(duration)
+	p.transport.Start()
+}
 
 const (
 	dialTimeout = 4 * time.Second


### PR DESCRIPTION
### 1. What does this pull request do?
 - in previous implementation, the expired connections resided in
   cache until new request to the same upstream/protocol came. In
   case if the upstream was unhealthy new request may come long time
   later or may not come at all. All this time expired connections
   held system resources (file descriptors, ephemeral ports). In my
   fix the expired connections and related resources are released
   by timer
 - decreased the complexity of taking connection from cache. The list
   of connections is treated as stack (LIFO queue), i.e. the connection
   is taken from the end of queue (the most fresh connection) and
   returned to the end (as it was implemented before). The remarkable
   thing is that all connections in the stack appear to be ordered by
   'used' field
 - the cleanup() method finds the first good (not expired) connection
   in stack with binary search, since all connections are ordered by
   'used' field

### 2. Which issues (if any) are related?
#1768

### 3. Which documentation changes (if any) need to be made?

