### PR TITLE
Update README for Health and Prometheus

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -93,3 +93,10 @@ Set a lameduck duration of 1 second:
     }
 }
 ~~~
+
+## Bugs
+
+When reloading, the Health handler is stopped before the new server instance is started. 
+If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
+but Health handler stays down. 
+Health will not reply HTTP request until a successful reload or a complete restart of CoreDNS.

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -71,5 +71,7 @@ then:
 
 ## Bugs
 
-When reloading, we keep the handler running, meaning that any changes to the handler's address
-aren't picked up. You'll need to restart CoreDNS for that to happen.
+When reloading, the Prometheus handler is stopped before the new server instance is started. 
+If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
+but Prometheus handler stays down. 
+Prometheus will not reply HTTP request until a successful reload or a complete restart of CoreDNS.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

Update the BUG part of the README, after the change of behavior for reload.
- a fail during reload operation (SIGUSR1 or Plugin RELAOD) will leave these 2 plugins without HTTP Listener.
- but they now accept to change of port following the new Corefile configuration

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?

only these 2 README.
