### PR TITLE
plugin/reload: mention auto in reload

### DIFF
--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -2,7 +2,9 @@
 
 ## Name
 
-*reload* - allows automatic reload of a changed Corefile
+*reload* - allows automatic reload of a changed _Corefile_<sup>*</sup>
+
+<sub>* To enable automatic reloading of a _zone file_, use the `auto` plugin.</sub>
 
 ## Description
 

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -2,11 +2,12 @@
 
 ## Name
 
-*reload* - allows automatic reload of a changed _Corefile_<sup>*</sup>
-
-<sub>* To enable automatic reloading of a _zone file_, use the [`auto`](https://github.com/coredns/coredns/blob/master/plugin/auto/README.md) plugin.</sub>
+*reload* - allows automatic reload of a changed Corefile
 
 ## Description
+
+This plugin allows automatic reload of a changed _Corefile_.
+To enable automatic reloading of _zone file_ changes, use the `auto` plugin.
 
 This plugin periodically checks if the Corefile has changed by reading
 it and calculating its MD5 checksum. If the file has changed, it reloads

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -4,7 +4,7 @@
 
 *reload* - allows automatic reload of a changed _Corefile_<sup>*</sup>
 
-<sub>* To enable automatic reloading of a _zone file_, use the `auto` plugin.</sub>
+<sub>* To enable automatic reloading of a _zone file_, use the [`auto`](https://github.com/coredns/coredns/blob/master/plugin/auto/README.md) plugin.</sub>
 
 ## Description
 


### PR DESCRIPTION
### 1. What does this pull request do?

Mention early and clearly (within TLDR; threshold), that automatic zone file reloads can be done with `auto` plugin.

### 2. Which issues (if any) are related?

This has come up many times, people expecting the `reload` plugin to automatically reload changes to zone files.

### 3. Which documentation changes (if any) need to be made?
