### PR TITLE
plugin/tls: make CA parameter optional

### DIFF
--- a/plugin/tls/README.md
+++ b/plugin/tls/README.md
@@ -22,8 +22,10 @@ wire data of a DNS message.
 ## Syntax
 
 ~~~ txt
-tls CERT KEY CA
+tls CERT KEY [CA]
 ~~~
+
+Parameter CA is optional. If not set, system CAs can be used to verify the client certificate
 
 ## Examples
 

--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -24,10 +24,10 @@ func setup(c *caddy.Controller) error {
 
 	for c.Next() {
 		args := c.RemainingArgs()
-		if len(args) != 3 {
+		if len(args) < 2 || len(args) > 3 {
 			return plugin.Error("tls", c.ArgErr())
 		}
-		tls, err := tls.NewTLSConfig(args[0], args[1], args[2])
+		tls, err := tls.NewTLSConfigFromArgs(args...)
 		if err != nil {
 			return plugin.Error("tls", err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
make CA parameter of tls plugin optional

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?
updated README
