### PR TITLE
plugin/template: Support NODATA responses

### DIFF
--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -159,7 +159,7 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 			t.regex = append(t.regex, regexp.MustCompile(".*"))
 		}
 
-		if len(t.answer) == 0 && len(t.additional) == 0 && t.rcode == dns.RcodeSuccess {
+		if len(t.answer) == 0 && len(t.authority) == 0 && t.rcode == dns.RcodeSuccess {
 			return handler, c.Errf("no answer section for template found: %v", handler)
 		}
 

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -101,10 +101,18 @@ func TestSetupParse(t *testing.T) {
 			false,
 		},
 		{
+			`template ANY AAAA example.com {
+				match ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com
+				authority "example.com 60 IN SOA ns.example.com hostmaster.example.com (1 60 60 60 60)"
+				fallthrough
+			}`,
+			false,
+		},
+		{
 			`template IN ANY example.com {
 				match "[.](example[.]com[.]dc1[.]example[.]com[.])$"
 				rcode NXDOMAIN
-				answer "{{ index .Match 1 }} 60 IN SOA a.{{ index .Match 1 }} b.{{ index .Match 1 }} (1 60 60 60 60)"
+				authority "{{ index .Match 1 }} 60 IN SOA ns.{{ index .Match 1 }} hostmaster.example.com (1 60 60 60 60)"
 				fallthrough example.com
 			}`,
 			false,


### PR DESCRIPTION
A NODATA response has no answers and rcode NOERROR, but should have a
SOA record in the authority section.
