### PR TITLE
 Fix `make check` dependency error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,8 @@ linter:
 
 .PHONY: goimports
 goimports:
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install goimports
 	( gometalinter --deadline=2m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
 
 # Presubmit runs all scripts in .presubmit; any non 0 exit code will fail the build.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

While invoking `make check` from a fresh new environment
the following failure occured:
```
[ec2-user@..... coredns]$ docker run -i -t --rm -v $PWD:/go/src/github.com/coredns/coredns -w /go/src/github.com/coredns/coredns golang:1.10
root@e2d6a6c:/go/src/github.com/coredns/coredns# make check
** presubmit/context
** presubmit/test-lowercase
( gometalinter --deadline=2m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
/bin/sh: 1: gometalinter: not found
go generate coredns.go
```

This fix fixes the issue in Makefile so that deps could be installed first.

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
