### PR TITLE
Enforcing gofmt -s on linter check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ pb:
 linter:
 	go get -u github.com/alecthomas/gometalinter
 	gometalinter --install golint
-	gometalinter --deadline=2m --disable-all --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
+	gometalinter --deadline=2m --disable-all --enable=gofmt --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
 
 .PHONY: goimports
 goimports:

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -137,7 +137,6 @@ var dnsTestCases = []test.Case{
 			test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
-
 		},
 	},
 	// AAAA
@@ -422,11 +421,11 @@ var epsIndex = map[string][]*api.Endpoints{
 						IP: "172.0.0.3",
 					},
 					{
-						IP: "172.0.0.4",
+						IP:       "172.0.0.4",
 						Hostname: "dup-name",
 					},
 					{
-						IP: "172.0.0.5",
+						IP:       "172.0.0.5",
 						Hostname: "dup-name",
 					},
 					{

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -14,8 +14,8 @@ func TestTLS(t *testing.T) {
 		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-	// positive
-	// negative
+		// positive
+		// negative
 	}
 
 	for i, test := range tests {

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -14,8 +14,8 @@ func TestTLS(t *testing.T) {
 		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-		// positive
-		// negative
+	// positive
+	// negative
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?
This fix enforces gofmt -s on linter check in Makefile,
and fixes plugin/kubernetes/handler_test.go with `gofmt -s`

### 2. Which issues (if any) are related?


### 3. Which documentation changes (if any) need to be made?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
