### PR TITLE
Docker: drop alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM alpine:latest
+FROM debian:stable-slim
 
-# Only need ca-certificates & openssl if want to use DNS over TLS (RFC 7858).
-RUN apk --no-cache add bind-tools ca-certificates openssl && update-ca-certificates
+RUN apt-get update && apt-get -uy upgrade
+RUN apt-get -y install ca-certificates && update-ca-certificates
 
+FROM scratch
+
+COPY --from=0 /etc/ca-certificates /etc/ca-certificates
+COPY --from=0 /etc/ssl /etc/ssl
 ADD coredns /coredns
 
 EXPOSE 53 53/udp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN apt-get -y install ca-certificates && update-ca-certificates
 
 FROM scratch
 
-COPY --from=0 /etc/ca-certificates /etc/ca-certificates
-COPY --from=0 /etc/ssl /etc/ssl
+COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 ADD coredns /coredns
 
 EXPOSE 53 53/udp


### PR DESCRIPTION
Create a multistage docker build image that uses debian to install certs
and then create the final image by using FROM: scratch. This creates a
(slightly) smaller images and drops busybox and alpine.
