### PR TITLE
Extend presubmit to covert test and request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SYSTEM:=
 CHECKS:=check godeps
 VERBOSE:=-v
 GOPATH?=$(HOME)/go
-PRESUBMIT:=core coremain plugin
+PRESUBMIT:=core coremain plugin test request
 
 all: coredns
 

--- a/request/request.go
+++ b/request/request.go
@@ -2,13 +2,13 @@
 package request
 
 import (
+	"context"
 	"net"
 	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/edns"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // Request contains some connection state and is useful in plugin.

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -14,7 +14,7 @@ func TestLookupCache(t *testing.T) {
 	// Start auth. CoreDNS holding the auth zone.
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -34,7 +34,7 @@ func TestLookupDS(t *testing.T) {
 	t.Parallel()
 	name, rm, err := TempFile(".", miekNL)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/etcd_cache_test.go
+++ b/test/etcd_cache_test.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"testing"
@@ -13,7 +14,6 @@ import (
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 // uses some stuff from etcd_tests.go

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -17,7 +18,6 @@ import (
 
 	etcdc "github.com/coreos/etcd/client"
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 func etcdPlugin() *etcd.Etcd {

--- a/test/external_test.go
+++ b/test/external_test.go
@@ -36,7 +36,7 @@ func testExternalPluginCompile(t *testing.T) {
 	}
 
 	if !strings.Contains(string(out), "dns.example") {
-		t.Fatal("dns.example plugin should be there")
+		t.Fatal("Plugin dns.example should be there")
 	}
 }
 
@@ -44,7 +44,7 @@ func run(t *testing.T, c *exec.Cmd) ([]byte, error) {
 	c.Dir = ".."
 	out, err := c.Output()
 	if err != nil {
-		return nil, fmt.Errorf("run: failed to run %s %s: %q", c.Args[0], c.Args[1], err)
+		return nil, fmt.Errorf("Run: failed to run %s %s: %q", c.Args[0], c.Args[1], err)
 	}
 	return out, nil
 

--- a/test/file_test.go
+++ b/test/file_test.go
@@ -6,7 +6,7 @@ func TestTempFile(t *testing.T) {
 	t.Parallel()
 	_, f, e := TempFile(".", "test")
 	if e != nil {
-		t.Fatalf("failed to create temp file: %s", e)
+		t.Fatalf("Failed to create temp file: %s", e)
 	}
 	defer f()
 }

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -1,13 +1,13 @@
 package test
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/coredns/coredns/pb"

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -15,7 +15,7 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 	rm1 := createKeyFile(t)

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -17,7 +17,7 @@ func benchmarkLookupBalanceRewriteCache(b *testing.B) {
 	t := new(testing.T)
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/proxy_http_health_test.go
+++ b/test/proxy_http_health_test.go
@@ -38,7 +38,7 @@ func TestProxyWithHTTPCheckOK(t *testing.T) {
 
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -16,7 +16,7 @@ func TestLookupProxy(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 
@@ -55,7 +55,7 @@ func TestLookupDnsWithForcedTcp(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 
@@ -94,7 +94,7 @@ func BenchmarkProxyLookup(b *testing.B) {
 	t := new(testing.T)
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to created zone: %s", err)
+		t.Fatalf("Failed to created zone: %s", err)
 	}
 	defer rm()
 
@@ -105,12 +105,12 @@ func BenchmarkProxyLookup(b *testing.B) {
 
 	i, err := CoreDNSServer(corefile)
 	if err != nil {
-		t.Fatalf("could not get CoreDNS serving instance: %s", err)
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 
 	udp, _ := CoreDNSServerPorts(i, 0)
 	if udp == "" {
-		t.Fatalf("could not get udp listening port")
+		t.Fatalf("Could not get udp listening port")
 	}
 	defer i.Stop()
 

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -40,7 +40,7 @@ func TestEmptySecondaryZone(t *testing.T) {
 func TestSecondaryZoneTransfer(t *testing.T) {
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -16,7 +16,7 @@ func TestLookupWildcard(t *testing.T) {
 	t.Parallel()
 	name, rm, err := test.TempFile(".", exampleOrg)
 	if err != nil {
-		t.Fatalf("failed to create zone: %s", err)
+		t.Fatalf("Failed to create zone: %s", err)
 	}
 	defer rm()
 


### PR DESCRIPTION
Fix the casing *and* fix use of context as we were still referencing
the non-std lib context - now wondering how this could have worked...