### PR TITLE
Plugin/Forward - autotune the dialTimeout for connection

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -82,6 +82,10 @@ forward FROM TO... {
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.
 
+On each endpoint, the timeouts of the communication are set by default and automatically tuned depending early results.
+- dialTimeout by default is 30 sec, and can decrease automatically down to 100ms
+- readTimeout by default is 2 sec, and can decrease automatically down to 10ms
+
 ## Metrics
 
 If monitoring is enabled (via the *prometheus* directive) then the following metric are exported:

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -16,21 +16,65 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (p *Proxy) readTimeout() time.Duration {
-	rtt := time.Duration(atomic.LoadInt64(&p.avgRtt))
+// utility function to auto-tune timeout values
+// average observed time is moved towards the last observed delay moderated by a weight
+// next timeout to use will be the double of the computed average, limited by min and max frame.
+func limitTimeout(currentAvg *int64, minValue time.Duration, maxValue time.Duration) time.Duration {
+	rt := time.Duration(atomic.LoadInt64(currentAvg))
+	if rt < minValue {
+		return minValue
+	}
+	if rt < maxValue/2 {
+		return 2 * rt
+	}
+	return maxValue
+}
 
-	if rtt < minTimeout {
-		return minTimeout
+func averageTimeout(currentAvg *int64, observedDuration time.Duration, weight int64) {
+	dt := time.Duration(atomic.LoadInt64(currentAvg))
+	atomic.AddInt64(currentAvg, int64(observedDuration-dt)/weight)
+}
+
+func (t *transport) dialTimeout() time.Duration {
+	return limitTimeout(&t.avgDialTime, minDialTimeout, maxDialTimeout)
+}
+
+func (t *transport) updateDialTimeout(newDialTime time.Duration) {
+	averageTimeout(&t.avgDialTime, newDialTime, cumulativeAvgWeight)
+}
+
+// Dial dials the address configured in transport, potentially reusing a connection or creating a new one.
+func (t *transport) Dial(proto string) (*dns.Conn, bool, error) {
+	// If tls has been configured; use it.
+	if t.tlsConfig != nil {
+		proto = "tcp-tls"
 	}
-	if rtt < maxTimeout/2 {
-		return 2 * rtt
+
+	t.dial <- proto
+	c := <-t.ret
+
+	if c != nil {
+		return c, true, nil
 	}
-	return maxTimeout
+
+	reqTime := time.Now()
+	timeout := t.dialTimeout()
+	if proto == "tcp-tls" {
+		conn, err := dns.DialTimeoutWithTLS("tcp", t.addr, t.tlsConfig, timeout)
+		t.updateDialTimeout(time.Since(reqTime))
+		return conn, false, err
+	}
+	conn, err := dns.DialTimeout(proto, t.addr, timeout)
+	t.updateDialTimeout(time.Since(reqTime))
+	return conn, false, err
+}
+
+func (p *Proxy) readTimeout() time.Duration {
+	return limitTimeout(&p.avgRtt, minTimeout, maxTimeout)
 }
 
 func (p *Proxy) updateRtt(newRtt time.Duration) {
-	rtt := time.Duration(atomic.LoadInt64(&p.avgRtt))
-	atomic.AddInt64(&p.avgRtt, int64((newRtt-rtt)/rttCount))
+	averageTimeout(&p.avgRtt, newRtt, cumulativeAvgWeight)
 }
 
 // Connect selects an upstream, sends the request and waits for a response.
@@ -92,4 +136,4 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, forceTCP, me
 	return ret, nil
 }
 
-const rttCount = 4
+const cumulativeAvgWeight = 4

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -16,7 +16,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// utility function to auto-tune timeout values
+// limitTimeout is a utility function to auto-tune timeout values
 // average observed time is moved towards the last observed delay moderated by a weight
 // next timeout to use will be the double of the computed average, limited by min and max frame.
 func limitTimeout(currentAvg *int64, minValue time.Duration, maxValue time.Duration) time.Duration {

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -140,9 +140,9 @@ func TestCleanupAll(t *testing.T) {
 
 	tr := newTransport(s.Addr, nil /* no TLS */)
 
-	c1, _ := dns.DialTimeout("udp", tr.addr, dialTimeout)
-	c2, _ := dns.DialTimeout("udp", tr.addr, dialTimeout)
-	c3, _ := dns.DialTimeout("udp", tr.addr, dialTimeout)
+	c1, _ := dns.DialTimeout("udp", tr.addr, defaultDialTimeout)
+	c2, _ := dns.DialTimeout("udp", tr.addr, defaultDialTimeout)
+	c3, _ := dns.DialTimeout("udp", tr.addr, defaultDialTimeout)
 
 	tr.conns["udp"] = []*persistConn{
 		{c1, time.Now()},

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -106,9 +106,8 @@ func (p *Proxy) start(duration time.Duration) {
 }
 
 const (
-	dialTimeout = 4 * time.Second
-	timeout     = 2 * time.Second
-	maxTimeout  = 2 * time.Second
-	minTimeout  = 10 * time.Millisecond
-	hcDuration  = 500 * time.Millisecond
+	timeout    = 2 * time.Second
+	maxTimeout = 2 * time.Second
+	minTimeout = 10 * time.Millisecond
+	hcDuration = 500 * time.Millisecond
 )

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -14,8 +14,8 @@ func TestTLS(t *testing.T) {
 		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-	// positive
-	// negative
+		// positive
+		// negative
 	}
 
 	for i, test := range tests {

--- a/plugin/tls/tls_test.go
+++ b/plugin/tls/tls_test.go
@@ -14,8 +14,8 @@ func TestTLS(t *testing.T) {
 		expectedRoot       string // expected root, set to the controller. Empty for negative cases.
 		expectedErrContent string // substring from the expected error. Empty for positive cases.
 	}{
-		// positive
-		// negative
+	// positive
+	// negative
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!

Please provide the following information to help us make the most of your pull request:
-->

### 1. What does this pull request do?

- implement an auto-tunable dialTimeout for fallback in a way very similar to readTimeout.
- timeout will start at 4sec and can vary from 100ms to 30sec depending success of former Dial of the same fallback.Proxy.

NOTE: this change depends of the merge of https://github.com/miekg/dns/pull/691

### 2. Which issues (if any) are related?
#1849 

### 3. Which documentation changes (if any) need to be made?
- good question. I do not see anything about timeout in README. Should we add one ?
