### PR TITLE
Plugin/Rewrite - review documentation of "append"

### DIFF
--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -180,7 +180,7 @@ rewrite [continue|stop] name regex STRING STRING answer name STRING STRING
 Using FIELD edns0, you can set, append, or replace specific EDNS0 options on the request.
 
 * `replace` will modify any matching (what that means may vary based on EDNS0 type) option with the specified option
-* `append` will add the option regardless of what options already exist
+* `append` will add the option if does not find any matching option
 * `set` will modify a matching option or add one if none is found
 
 Currently supported are `EDNS0_LOCAL`, `EDNS0_NSID` and `EDNS0_SUBNET`.

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -179,8 +179,8 @@ rewrite [continue|stop] name regex STRING STRING answer name STRING STRING
 
 Using FIELD edns0, you can set, append, or replace specific EDNS0 options on the request.
 
-* `replace` will modify any matching (what that means may vary based on EDNS0 type) option with the specified option
-* `append` will add the option if does not find any matching option
+* `replace` will modify any "matching" option with the specified option. The criteria for "matching" varies based on EDNS0 type.
+* `append` will add the option only if no matching option exists
 * `set` will modify a matching option or add one if none is found
 
 Currently supported are `EDNS0_LOCAL`, `EDNS0_NSID` and `EDNS0_SUBNET`.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix mistake in the  documentation of plugin rewrite
from the code, the command 'append' is adding the option ONLY if that option is not already matching existing option in the OPT record.
NOTE: the "matching" part encoded make sense, and then it is better to fix the documentation than the code.

### 2. Which issues (if any) are related?
NONE

### 3. Which documentation changes (if any) need to be made?
Done in this PR.
