### PR TITLE
Rename forward metrics socket_count_total to sockets_open

### DIFF
--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -44,7 +44,7 @@ var (
 	SocketGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",
-		Name:      "socket_count_total",
+		Name:      "sockets_open",
 		Help:      "Gauge of open sockets per upstream.",
 	}, []string{"to"})
 )


### PR DESCRIPTION
The prometheus naming convention states only counters should have a
`_total` suffix, so that gagues and counters can be easily
distinguished.

Most of the metrics don't follow the idiomatic naming of Prometheus, e.g. using `_count_total` suffixes.