### PR TITLE
remove deprecated code

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -29,7 +29,6 @@ func init() {
 	flag.StringVar(&caddy.PidFile, "pidfile", "", "Path to write pid file")
 	flag.BoolVar(&version, "version", false, "Show version")
 	flag.BoolVar(&dnsserver.Quiet, "quiet", false, "Quiet mode (no initialization output)")
-	flag.BoolVar(&logfile, "log", false, "Log to standard output") // noop for 1.1.4; drop in 1.2.0.
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -38,7 +38,6 @@ cache:cache
 rewrite:rewrite
 dnssec:dnssec
 autopath:autopath
-reverse:deprecated
 template:template
 hosts:hosts
 route53:route53

--- a/plugin/proxy/upstream.go
+++ b/plugin/proxy/upstream.go
@@ -164,8 +164,6 @@ func parseBlock(c *caddyfile.Dispenser, u *staticUpstream) error {
 			} else {
 				u.ex = newDNSEx()
 			}
-		case "https_google":
-			// allow the config, but make noop
 		case "grpc":
 			if len(encArgs) == 2 && encArgs[1] == "insecure" {
 				u.ex = newGrpcClient(nil, u)


### PR DESCRIPTION
This removes:
* reverse plugin from plugin.cfg
* https_google option from proxy
* the -log flag

The -log was not described in README.md anyway.