### PR TITLE
Makefile fixes:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,5 @@ before_script:
 script:
   - make TEST_TYPE=$TEST_TYPE travis
 
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CHECKS:=check godeps
 VERBOSE:=-v
 GOPATH?=$(HOME)/go
 PRESUBMIT:=core coremain plugin test request
+MAKEPWD:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 all: coredns
 
@@ -14,7 +15,7 @@ coredns: $(CHECKS)
 	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
-check: presubmit goimports core/zplugin.go core/dnsserver/zdirectives.go godeps linter
+check: presubmit goimports core/zplugin.go core/dnsserver/zdirectives.go godeps
 
 .PHONY: test
 test: check
@@ -26,9 +27,9 @@ testk8s: check
 
 .PHONY: godeps
 godeps:
-	# Not vendored so external plugin compile, avoiding:
-	# cannot use c (type *"github.com/mholt/caddy".Controller) as type
-	# *"github.com/coredns/coredns/vendor/github.com/mholt/caddy".Controller like errors.
+	@ # Not vendoring these, so external plugins compile, avoiding:
+	@ # cannot use c (type *"github.com/mholt/caddy".Controller) as type
+	@ # *"github.com/coredns/coredns/vendor/github.com/mholt/caddy".Controller like errors.
 	(cd $(GOPATH)/src/github.com/mholt/caddy 2>/dev/null              && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/miekg/dns 2>/dev/null                && git checkout -q master 2>/dev/null || true)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang 2>/dev/null && git checkout -q master 2>/dev/null || true)
@@ -77,22 +78,16 @@ gen:
 pb:
 	$(MAKE) -C pb
 
-.PHONY: linter
-linter:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install golint
-	gometalinter --deadline=2m --disable-all --enable=gofmt --enable=golint --enable=vet --vendor --exclude=^pb/ ./...
-
 .PHONY: goimports
 goimports:
 	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install goimports
-	( gometalinter --deadline=2m --disable-all --enable=goimports --vendor --exclude=^pb/ ./... || true )
+	gometalinter --install goimports > /dev/null
+	( gometalinter --deadline=2m --disable-all --enable=goimports --enable=golint --enable=vet --vendor --exclude=^pb/ ./... || true )
 
 # Presubmit runs all scripts in .presubmit; any non 0 exit code will fail the build.
 .PHONY: presubmit
 presubmit:
-	@for pre in $(PWD)/.presubmit/* ; do "$$pre" $(PRESUBMIT); done
+	@for pre in $(MAKEPWD)/.presubmit/* ; do "$$pre" $(PRESUBMIT); done
 
 .PHONY: clean
 clean:

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/coredns/coredns/pb"
+
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
 	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
-
-	"github.com/coredns/coredns/pb"
 )
 
 // ServergRPC represents an instance of a DNS-over-gRPC server.

--- a/plugin/kubernetes/handler_ignore_emptyservice_test.go
+++ b/plugin/kubernetes/handler_ignore_emptyservice_test.go
@@ -2,9 +2,10 @@ package kubernetes
 
 import (
 	"context"
+	"testing"
+
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
-	"testing"
 
 	"github.com/miekg/dns"
 )


### PR DESCRIPTION
Correctly set the path for the presubmits, fix some typos and make
the goimport target do the linting to the lint target can be removed.

Also don't make it a fatal error because gofmt changes between releases.

Fixes #1891 