### PR TITLE
Replace gh-release with curl

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -115,10 +115,10 @@ tar:
 .PHONY: upload
 upload:
 	@echo Releasing: $(VERSION)
-	$(eval RELEASE := $(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
+	$(eval RELEASE:=$(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
 	@echo ReleaseID: $(RELEASE)
-	for asset in `ls -A release`; do \
-	    curl -X POST \
+	@for asset in `ls -A release`; do \
+	    curl -o /dev/null -X POST \
 	      -H "Content-Type: application/gzip" \
 	      --data-binary "@release/$$asset" \
 	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}&access_token=${GITHUB_ACCESS_TOKEN}" ; \

--- a/Makefile.release
+++ b/Makefile.release
@@ -46,8 +46,8 @@ EMPTY:=
 SPACE:=$(EMPTY) $(EMPTY)
 COMMA:=$(EMPTY),$(EMPTY)
 
-ifeq (, $(shell which gh-release))
-    $(error "No gh-release in $$PATH, install with: go get github.com/progrium/gh-release")
+ifeq (, $(shell which curl))
+    $(error "No curl in $$PATH, please install")
 endif
 
 ifeq (, $(shell which manifest-tool))
@@ -115,7 +115,14 @@ tar:
 .PHONY: upload
 upload:
 	@echo Releasing: $(VERSION)
-	gh-release create $(GITHUB)/$(NAME) $(VERSION)
+	$(eval RELEASE := $(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
+	@echo ReleaseID: $(RELEASE)
+	for asset in `ls -A release`; do \
+	    curl -X POST \
+	      -H "Content-Type: application/gzip" \
+	      --data-binary "@release/$$asset" \
+	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}&access_token=${GITHUB_ACCESS_TOKEN}" ; \
+	done
 
 .PHONY: docker-build
 docker-build: tar


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This fix tries to address the issue raised in #1895 where gh-release is deprecated.

As GitHub provides API that could be accessed easily, and gh-release itself is just a wrapper to the API, this fix replaces gh-release with the direct interaction with GitHub API, so that it could be maintained by coredns team.

### 2. Which issues (if any) are related?

This fix fixes #1895.

### 3. Which documentation changes (if any) need to be made?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
