### PR TITLE
plugin/metadata: some cleanups

### DIFF
--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -20,12 +21,12 @@ func (m testProvider) MetadataVarNames() []string {
 	return keys
 }
 
-func (m testProvider) Metadata(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, key string) (val interface{}, ok bool) {
+func (m testProvider) Metadata(ctx context.Context, state request.Request, key string) (val interface{}, ok bool) {
 	value, ok := m[key]
 	return value, ok
 }
 
-// testHandler implements plugin.Handler
+// testHandler implements plugin.Handler.
 type testHandler struct{ ctx context.Context }
 
 func (m *testHandler) Name() string { return "testHandler" }
@@ -35,7 +36,7 @@ func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 	return 0, nil
 }
 
-func TestMetadataServDns(t *testing.T) {
+func TestMetadataServeDNS(t *testing.T) {
 	expectedMetadata := []testProvider{
 		testProvider{"testkey1": "testvalue1"},
 		testProvider{"testkey2": 2, "testkey3": "testvalue3"},
@@ -45,9 +46,8 @@ func TestMetadataServDns(t *testing.T) {
 	for _, e := range expectedMetadata {
 		providers = append(providers, e)
 	}
-	// Fake handler which stores the resulting context
-	next := &testHandler{}
 
+	next := &testHandler{} // fake handler which stores the resulting context
 	metadata := Metadata{
 		Zones:     []string{"."},
 		Providers: providers,

--- a/plugin/metadata/provider_test.go
+++ b/plugin/metadata/provider_test.go
@@ -25,23 +25,24 @@ func TestMD(t *testing.T) {
 
 	// Using one same md and ctx for all test cases
 	ctx := context.TODO()
-	md, ctx := newMD(ctx)
+	ctx = context.WithValue(ctx, metadataKey{}, M{})
+	m, _ := FromContext(ctx)
 
 	for i, tc := range tests {
 		for k, v := range tc.addValues {
-			md.setValue(k, v)
+			m.SetValue(k, v)
 		}
-		if !reflect.DeepEqual(tc.expectedValues, map[string]interface{}(md)) {
-			t.Errorf("Test %d: Expected %v but got %v", i, tc.expectedValues, md)
+		if !reflect.DeepEqual(tc.expectedValues, map[string]interface{}(m)) {
+			t.Errorf("Test %d: Expected %v but got %v", i, tc.expectedValues, m)
 		}
 
-		// Make sure that MD is recieved from context successfullly
-		mdFromContext, ok := FromContext(ctx)
+		// Make sure that md is recieved from context successfullly
+		mFromContext, ok := FromContext(ctx)
 		if !ok {
-			t.Errorf("Test %d: MD is not recieved from the context", i)
+			t.Errorf("Test %d: md is not recieved from the context", i)
 		}
-		if !reflect.DeepEqual(md, mdFromContext) {
-			t.Errorf("Test %d: MD recieved from context differs from initial. Initial: %v, from context: %v", i, md, mdFromContext)
+		if !reflect.DeepEqual(m, mFromContext) {
+			t.Errorf("Test %d: md recieved from context differs from initial. Initial: %v, from context: %v", i, m, mFromContext)
 		}
 	}
 }

--- a/plugin/pkg/variables/variables.go
+++ b/plugin/pkg/variables/variables.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 
 	"github.com/coredns/coredns/request"
-
-	"github.com/miekg/dns"
 )
 
 const (
@@ -26,35 +24,32 @@ var All = []string{queryName, queryType, clientIP, clientPort, protocol, serverI
 
 // GetValue calculates and returns the data specified by the variable name.
 // Supported varNames are listed in allProvidedVars.
-func GetValue(varName string, w dns.ResponseWriter, r *dns.Msg) ([]byte, error) {
-	req := request.Request{W: w, Req: r}
+func GetValue(state request.Request, varName string) ([]byte, error) {
 	switch varName {
 	case queryName:
-		//Query name is written as ascii string
-		return []byte(req.QName()), nil
+		return []byte(state.QName()), nil
 
 	case queryType:
-		return uint16ToWire(req.QType()), nil
+		return uint16ToWire(state.QType()), nil
 
 	case clientIP:
-		return ipToWire(req.Family(), req.IP())
+		return ipToWire(state.Family(), state.IP())
 
 	case clientPort:
-		return portToWire(req.Port())
+		return portToWire(state.Port())
 
 	case protocol:
-		// Proto is written as ascii string
-		return []byte(req.Proto()), nil
+		return []byte(state.Proto()), nil
 
 	case serverIP:
-		ip, _, err := net.SplitHostPort(w.LocalAddr().String())
+		ip, _, err := net.SplitHostPort(state.W.LocalAddr().String())
 		if err != nil {
-			ip = w.RemoteAddr().String()
+			ip = state.W.RemoteAddr().String()
 		}
-		return ipToWire(family(w.RemoteAddr()), ip)
+		return ipToWire(state.Family(), ip)
 
 	case serverPort:
-		_, port, err := net.SplitHostPort(w.LocalAddr().String())
+		_, port, err := net.SplitHostPort(state.W.LocalAddr().String())
 		if err != nil {
 			port = "0"
 		}

--- a/plugin/pkg/variables/variables_test.go
+++ b/plugin/pkg/variables/variables_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
 	"github.com/miekg/dns"
 )
 
@@ -63,8 +65,9 @@ func TestGetValue(t *testing.T) {
 		m := new(dns.Msg)
 		m.SetQuestion("example.com.", dns.TypeA)
 		m.Question[0].Qclass = dns.ClassINET
+		state := request.Request{W: &test.ResponseWriter{}, Req: m}
 
-		value, err := GetValue(tc.varName, &test.ResponseWriter{}, m)
+		value, err := GetValue(state, tc.varName)
 
 		if tc.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error, but didn't recieve", i)

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -202,7 +202,8 @@ func (rule *edns0VariableRule) ruleData(ctx context.Context, w dns.ResponseWrite
 			}
 		}
 	} else { // No metadata available means metadata plugin is disabled. Try to get the value directly.
-		return variables.GetValue(rule.variable, w, r)
+		state := request.Request{W: w, Req: r} // TODO(miek): every rule needs to take a request.Request.
+		return variables.GetValue(state, rule.variable)
 	}
 	return nil, fmt.Errorf("unable to extract data for variable %s", rule.variable)
 }


### PR DESCRIPTION
Name to provider.go as that's what being defined right now in the file.
Use request.Request because that's done in variables.go anyway. Name the
main storage M, because there is no further meaning behind.

Remove superfluous methods.

Signed-off-by: Miek Gieben <miek@miek.nl>
