### PR TITLE
Document two lookups by CoreDNS etcdv3 plugin

### DIFF
--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -59,6 +59,13 @@ etcd [ZONES...] {
       file - if the server certificate is not signed by a system-installed CA and client certificate
       is needed.
 
+## Special Behaviour
+CoreDNS etcd plugin leverages directory structure to look for related entries. For example an entry `/skydns/test/skydns/mx` would have entries like `/skydns/test/skydns/mx/a`, `/skydns/test/skydns/mx/b` and so on. Similarly a directory `/skydns/test/skydns/mx1` will have all `mx1` entries.
+
+With etcd3, support for [hierarchial keys are dropped](https://coreos.com/etcd/docs/latest/learning/api.html). This means there are no directories but only flat keys with prefixes in etcd3. To accomodate lookups, etcdv3 plugin now does a lookup on prefix `/skydns/test/skydns/mx/` to search for entries like `/skydns/test/skydns/mx/a` etc, and if there is nothing found on `/skydns/test/skydns/mx/`, it looks for `/skydns/test/skydns/mx` to find entries like `/skydns/test/skydns/mx1`.
+
+This causes two lookups from CoreDNS to etcdv3 in certain cases.
+
 ## Examples
 
 This is the default SkyDNS setup, with everying specified in full:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
With #1702 support for etcdv3 was added. There is a behavioural change in how CoreDNS does
lookups to etcd and needs to be documented. 

This PR documents the lookup change.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
