### PR TITLE
Rewrite metadata

### DIFF
--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-type StaticProvider map[string]Func
+type testProvider map[string]Func
 
-func (tp StaticProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
 	for k, v := range tp {
 		SetValueFunc(ctx, k, v)
 	}
@@ -29,7 +29,7 @@ func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 }
 
 func TestMetadataServeDNS(t *testing.T) {
-	expectedMetadata := []StaticProvider{
+	expectedMetadata := []testProvider{
 		{"test/key1": func() string { return "testvalue1" }},
 		{"test/key2": func() string { return "two" }, "test/key3": func() string { return "testvalue3" }},
 	}

--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -47,15 +47,8 @@ func TestMetadataServeDNS(t *testing.T) {
 	}
 
 	ctx := context.TODO()
-	if IsMetadataSet(ctx) {
-		t.Errorf("Context provide Metadata information whereas metadata is not yet activated")
-	}
 	m.ServeDNS(ctx, &test.ResponseWriter{}, new(dns.Msg))
 	nctx := next.ctx
-
-	if !IsMetadataSet(nctx) {
-		t.Errorf("Context does not provide Metadata information")
-	}
 
 	for _, expected := range expectedMetadata {
 		for label, expVal := range expected {
@@ -76,11 +69,14 @@ func TestLabelFormat(t *testing.T) {
 		isValid bool
 	}{
 		{"plugin/LABEL", true},
+		{"p/LABEL", true},
+		{"plugin/L", true},
 		{"LABEL", false},
 		{"plugin.LABEL", false},
-		{"/NO-PLUGIN-ACCEPTED", true},
-		{"ONLY-PLUGIN-ACCEPTED/", true},
-		{"PLUGIN/LABEL/SUB-LABEL", true},
+		{"/NO-PLUGIN-NOT-ACCEPTED", false},
+		{"ONLY-PLUGIN-NOT-ACCEPTED/", false},
+		{"PLUGIN/LABEL/SUB-LABEL", false},
+		{"/", false},
 	}
 
 	for _, test := range labels {

--- a/plugin/metadata/metadata_test.go
+++ b/plugin/metadata/metadata_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-type testProvider map[string]Func
+type StaticProvider map[string]Func
 
-func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp StaticProvider) Metadata(ctx context.Context, state request.Request) context.Context {
 	for k, v := range tp {
 		SetValueFunc(ctx, k, v)
 	}
@@ -29,9 +29,9 @@ func (m *testHandler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 }
 
 func TestMetadataServeDNS(t *testing.T) {
-	expectedMetadata := []testProvider{
-		testProvider{"test/key1": func() string { return "testvalue1" }},
-		testProvider{"test/key2": func() string { return "two" }, "test/key3": func() string { return "testvalue3" }},
+	expectedMetadata := []StaticProvider{
+		{"test/key1": func() string { return "testvalue1" }},
+		{"test/key2": func() string { return "two" }, "test/key3": func() string { return "testvalue3" }},
 	}
 	// Create fake Providers based on expectedMetadata
 	providers := []Provider{}

--- a/plugin/metadata/provider.go
+++ b/plugin/metadata/provider.go
@@ -51,12 +51,16 @@ type Func func() string
 
 // IsLabel check that the provided name looks like a valid label name
 func IsLabel(label string) bool {
-	return strings.Index(label, "/") >= 0
-}
-
-// IsMetadataSet check that the ctx is initialized to receive metadata information
-func IsMetadataSet(ctx context.Context) bool {
-	return ctx.Value(key{}) != nil
+	p := strings.Index(label, "/")
+	if p <= 0 || p >= len(label)-1 {
+		// cannot accept namespace empty nor label empty
+		return false
+	}
+	if strings.LastIndex(label, "/") != p {
+		// several slash in the Label
+		return false
+	}
+	return true
 
 }
 

--- a/plugin/metadata/provider.go
+++ b/plugin/metadata/provider.go
@@ -32,6 +32,7 @@ package metadata
 
 import (
 	"context"
+	"strings"
 
 	"github.com/coredns/coredns/request"
 )
@@ -47,6 +48,18 @@ type Provider interface {
 
 // Func is the type of function in the metadata, when called they return the value of the label.
 type Func func() string
+
+// IsLabel check that the provided name looks like a valid label name
+func IsLabel(label string) bool {
+	parts := strings.Split(label, "/")
+	return len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0
+}
+
+// IsMetadataSet check that the ctx is initialized to receive metadata information
+func IsMetadataSet(ctx context.Context) bool {
+	return ctx.Value(key{}) != nil
+
+}
 
 // Labels returns all metadata keys stored in the context. These label names should be named
 // as: plugin/NAME, where NAME is something descriptive.

--- a/plugin/metadata/provider.go
+++ b/plugin/metadata/provider.go
@@ -51,8 +51,7 @@ type Func func() string
 
 // IsLabel check that the provided name looks like a valid label name
 func IsLabel(label string) bool {
-	parts := strings.Split(label, "/")
-	return len(parts) == 2 && len(parts[0]) > 0 && len(parts[1]) > 0
+	return strings.Index(label, "/") >= 0
 }
 
 // IsMetadataSet check that the ctx is initialized to receive metadata information

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -209,10 +209,19 @@ rewrites the first local option with code 0xffee, setting the data to "abcd". Eq
 * A variable data is specified with a pair of curly brackets `{}`. Following are the supported variables:
   {qname}, {qtype}, {client_ip}, {client_port}, {protocol}, {server_ip}, {server_port}.
 
-Example:
+* If metadata plugin is enabled, then labels are supported as variables if they are presented within curly brackets. 
+the variable data will be filled with the value associated with that label. If that label is not provided, 
+the variable will be silently substitute by an empty string.  
+
+Examples:
 
 ~~~
 rewrite edns0 local set 0xffee {client_ip}
+~~~
+
+~~~
+metadata
+rewrite edns0 local set 0xffee {mac/address}
 ~~~
 
 ### EDNS0_NSID

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -209,7 +209,7 @@ rewrites the first local option with code 0xffee, setting the data to "abcd". Eq
 * A variable data is specified with a pair of curly brackets `{}`. Following are the supported variables:
   {qname}, {qtype}, {client_ip}, {client_port}, {protocol}, {server_ip}, {server_port}.
 
-* If metadata plugin is enabled, then labels are supported as variables if they are presented within curly brackets. 
+* If the metadata plugin is enabled, then labels are supported as variables if they are presented within curly brackets. 
 the variable data will be filled with the value associated with that label. If that label is not provided, 
 the variable will be silently substitute by an empty string.  
 
@@ -219,9 +219,12 @@ Examples:
 rewrite edns0 local set 0xffee {client_ip}
 ~~~
 
+The following example uses metadata and an imaginary "some-plugin" that would provide "some-label" as metadata information.
+
 ~~~
 metadata
-rewrite edns0 local set 0xffee {mac/address}
+some-plugin
+rewrite edns0 local set 0xffee {some-plugin/some-label}
 ~~~
 
 ### EDNS0_NSID

--- a/plugin/rewrite/class.go
+++ b/plugin/rewrite/class.go
@@ -1,6 +1,7 @@
 package rewrite
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -29,7 +30,7 @@ func newClassRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the the current request.
-func (rule *classRule) Rewrite(state request.Request) Result {
+func (rule *classRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if rule.fromClass > 0 && rule.toClass > 0 {
 		if state.Req.Question[0].Qclass == rule.fromClass {
 			state.Req.Question[0].Qclass = rule.toClass

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -203,7 +203,10 @@ func (rule *edns0VariableRule) ruleData(ctx context.Context, state request.Reque
 
 	fetcher := metadata.ValueFunc(ctx, rule.variable[1:len(rule.variable)-1])
 	if fetcher != nil {
-		return []byte(fetcher()), nil
+		value := fetcher()
+		if len(value) > 0 {
+			return []byte(value), nil
+		}
 	}
 
 	return nil, fmt.Errorf("unable to extract data for variable %s", rule.variable)

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -201,16 +201,13 @@ func (rule *edns0VariableRule) ruleData(ctx context.Context, state request.Reque
 		return []byte(state.Proto()), nil
 	}
 
-	if metadata.IsMetadataSet(ctx) {
-		fetcher := metadata.ValueFunc(ctx, rule.variable[1:len(rule.variable)-1])
-		if fetcher != nil {
-			return []byte(fetcher()), nil
-		}
-		return []byte{}, nil
+	// starting with metadata support, rewrite will silently accept to rewrite an unknown metadata label
+	// even though metadata is not involved in the stanza
+	fetcher := metadata.ValueFunc(ctx, rule.variable[1:len(rule.variable)-1])
+	if fetcher != nil {
+		return []byte(fetcher()), nil
 	}
-
-	// if metadata is not set, then keep current behavior that return an error for an invalid variable.
-	return nil, fmt.Errorf("unable to extract data for variable %s", rule.variable)
+	return []byte{}, nil
 }
 
 // Rewrite will alter the request EDNS0 local options with specified variables.

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -201,13 +201,12 @@ func (rule *edns0VariableRule) ruleData(ctx context.Context, state request.Reque
 		return []byte(state.Proto()), nil
 	}
 
-	// starting with metadata support, rewrite will silently accept to rewrite an unknown metadata label
-	// even though metadata is not involved in the stanza
 	fetcher := metadata.ValueFunc(ctx, rule.variable[1:len(rule.variable)-1])
 	if fetcher != nil {
 		return []byte(fetcher()), nil
 	}
-	return []byte{}, nil
+
+	return nil, fmt.Errorf("unable to extract data for variable %s", rule.variable)
 }
 
 // Rewrite will alter the request EDNS0 local options with specified variables.

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -1,6 +1,7 @@
 package rewrite
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -56,7 +57,7 @@ const (
 
 // Rewrite rewrites the current request based upon exact match of the name
 // in the question section of the request.
-func (rule *nameRule) Rewrite(state request.Request) Result {
+func (rule *nameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if rule.From == state.Name() {
 		state.Req.Question[0].Name = rule.To
 		return RewriteDone
@@ -65,7 +66,7 @@ func (rule *nameRule) Rewrite(state request.Request) Result {
 }
 
 // Rewrite rewrites the current request when the name begins with the matching string.
-func (rule *prefixNameRule) Rewrite(state request.Request) Result {
+func (rule *prefixNameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if strings.HasPrefix(state.Name(), rule.Prefix) {
 		state.Req.Question[0].Name = rule.Replacement + strings.TrimLeft(state.Name(), rule.Prefix)
 		return RewriteDone
@@ -74,7 +75,7 @@ func (rule *prefixNameRule) Rewrite(state request.Request) Result {
 }
 
 // Rewrite rewrites the current request when the name ends with the matching string.
-func (rule *suffixNameRule) Rewrite(state request.Request) Result {
+func (rule *suffixNameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if strings.HasSuffix(state.Name(), rule.Suffix) {
 		state.Req.Question[0].Name = strings.TrimRight(state.Name(), rule.Suffix) + rule.Replacement
 		return RewriteDone
@@ -84,7 +85,7 @@ func (rule *suffixNameRule) Rewrite(state request.Request) Result {
 
 // Rewrite rewrites the current request based upon partial match of the
 // name in the question section of the request.
-func (rule *substringNameRule) Rewrite(state request.Request) Result {
+func (rule *substringNameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if strings.Contains(state.Name(), rule.Substring) {
 		state.Req.Question[0].Name = strings.Replace(state.Name(), rule.Substring, rule.Replacement, -1)
 		return RewriteDone
@@ -94,7 +95,7 @@ func (rule *substringNameRule) Rewrite(state request.Request) Result {
 
 // Rewrite rewrites the current request when the name in the question
 // section of the request matches a regular expression.
-func (rule *regexNameRule) Rewrite(state request.Request) Result {
+func (rule *regexNameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	regexGroups := rule.Pattern.FindStringSubmatch(state.Name())
 	if len(regexGroups) == 0 {
 		return RewriteIgnored

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -42,7 +42,7 @@ func (rw Rewrite) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	state := request.Request{W: w, Req: r}
 
 	for _, rule := range rw.Rules {
-		switch result := rule.Rewrite(state); result {
+		switch result := rule.Rewrite(ctx, state); result {
 		case RewriteDone:
 			respRule := rule.GetResponseRule()
 			if respRule.Active == true {
@@ -71,7 +71,7 @@ func (rw Rewrite) Name() string { return "rewrite" }
 // Rule describes a rewrite rule.
 type Rule interface {
 	// Rewrite rewrites the current request.
-	Rewrite(state request.Request) Result
+	Rewrite(ctx context.Context, state request.Request) Result
 	// Mode returns the processing mode stop or continue.
 	Mode() string
 	// GetResponseRule returns the rule to rewrite response with, if any.

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -523,8 +523,8 @@ func TestRewriteEDNS0LocalVariable(t *testing.T) {
 		{
 			[]dns.EDNS0{},
 			[]string{"local", "set", "0xffee", "{test/empty}"},
-			[]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xffee, Data: []byte("")}},
-			true,
+			nil,
+			false,
 		},
 		{
 			[]dns.EDNS0{},

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -529,8 +529,8 @@ func TestRewriteEDNS0LocalVariable(t *testing.T) {
 		{
 			[]dns.EDNS0{},
 			[]string{"local", "set", "0xffee", "{test/does-not-exist}"},
-			[]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xffee, Data: []byte("")}},
-			true,
+			nil,
+			false,
 		},
 	}
 
@@ -551,11 +551,13 @@ func TestRewriteEDNS0LocalVariable(t *testing.T) {
 
 		resp := rec.Msg
 		o := resp.IsEdns0()
-		o.SetDo(tc.doBool)
 		if o == nil {
-			t.Errorf("Test %d: EDNS0 options not set", i)
+			if tc.toOpts != nil {
+				t.Errorf("Test %d: EDNS0 options not set", i)
+			}
 			continue
 		}
+		o.SetDo(tc.doBool)
 		if o.Do() != tc.doBool {
 			t.Errorf("Test %d: Expected %v but got %v", i, tc.doBool, o.Do())
 		}

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -6,13 +6,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/coredns/coredns/request"
-
-	"github.com/coredns/coredns/plugin/metadata"
-
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
@@ -438,9 +436,9 @@ func optsEqual(a, b []dns.EDNS0) bool {
 	return true
 }
 
-type StaticProvider map[string]metadata.Func
+type testProvider map[string]metadata.Func
 
-func (tp StaticProvider) Metadata(ctx context.Context, state request.Request) context.Context {
+func (tp testProvider) Metadata(ctx context.Context, state request.Request) context.Context {
 	for k, v := range tp {
 		metadata.SetValueFunc(ctx, k, v)
 	}
@@ -454,8 +452,8 @@ func TestRewriteEDNS0LocalVariable(t *testing.T) {
 	}
 
 	expectedMetadata := []metadata.Provider{
-		StaticProvider{"test/label": func() string { return "my-value" }},
-		StaticProvider{"test/empty": func() string { return "" }},
+		testProvider{"test/label": func() string { return "my-value" }},
+		testProvider{"test/empty": func() string { return "" }},
 	}
 
 	meta := metadata.Metadata{

--- a/plugin/rewrite/type.go
+++ b/plugin/rewrite/type.go
@@ -2,6 +2,7 @@
 package rewrite
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -30,7 +31,7 @@ func newTypeRule(nextAction string, args ...string) (Rule, error) {
 }
 
 // Rewrite rewrites the the current request.
-func (rule *typeRule) Rewrite(state request.Request) Result {
+func (rule *typeRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if rule.fromType > 0 && rule.toType > 0 {
 		if state.QType() == rule.fromType {
 			state.Req.Question[0].Qtype = rule.toType


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Update REWRITE for edns0 variable process : 
to be compliant with documentation of metadata, just avoid to set EDNS0 LOCAL if the Label contains an empty value.

### 2. Which issues (if any) are related?
Compliance with #1951 

### 3. Which documentation changes (if any) need to be made?
Documentation is in #1951 
