### PR TITLE
Review REWRIE operation when Metadata return an empty value

### DIFF
--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -203,7 +203,10 @@ func (rule *edns0VariableRule) ruleData(ctx context.Context, state request.Reque
 
 	fetcher := metadata.ValueFunc(ctx, rule.variable[1:len(rule.variable)-1])
 	if fetcher != nil {
-		return []byte(fetcher()), nil
+		value := fetcher()
+		if len(value) > 0 {
+			return []byte(value), nil
+		}
 	}
 
 	return nil, fmt.Errorf("unable to extract data for variable %s", rule.variable)

--- a/plugin/rewrite/rewrite_test.go
+++ b/plugin/rewrite/rewrite_test.go
@@ -523,8 +523,8 @@ func TestRewriteEDNS0LocalVariable(t *testing.T) {
 		{
 			[]dns.EDNS0{},
 			[]string{"local", "set", "0xffee", "{test/empty}"},
-			[]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xffee, Data: []byte("")}},
-			true,
+			nil,
+			false,
 		},
 		{
 			[]dns.EDNS0{},


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Update REWRITE for edns0 variable process : 
to be compliant with documentation of metadata, just avoid to set EDNS0 LOCAL if the Label contains an empty value.

### 2. Which issues (if any) are related?
Compliance with #1951 

### 3. Which documentation changes (if any) need to be made?
Documentation is in #1951 
