### PR TITLE
Remove trailing whitespace

### DIFF
--- a/.presubmit/trailing-whitespace
+++ b/.presubmit/trailing-whitespace
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "** presubmit/$(basename $0)"
+
+if grep -r '[[:blank:]]$' "$@"; then
+    echo "** presubmit/$(basename $0): please remove any trailing white space"
+fi

--- a/plugin/bind/README.md
+++ b/plugin/bind/README.md
@@ -7,7 +7,7 @@
 ## Description
 
 Normally, the listener binds to the wildcard host. However, you may want the listener to bind to
-another IP instead.      
+another IP instead.
 
 If several addresses are provided, a listener will be open on each of the IP provided.
 
@@ -42,10 +42,10 @@ To allow processing DNS requests only local host on both IPv4 and IPv6 stacks, u
 
 If the configuration comes up with several *bind* directives, all addresses are consolidated together:
 The following sample is equivalent to the preceding:
- 
+
 ~~~ corefile
 . {
-    bind 127.0.0.1 
+    bind 127.0.0.1
     bind ::1
 }
 ~~~

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -24,8 +24,8 @@ cache [TTL] [ZONES...]
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
-For the negative cache, the SOA's MinTTL value is used. A TTL of zero is not allowed. 
-A cache is divided into 256 shards, each holding up to 512 items by default - for a total size 
+For the negative cache, the SOA's MinTTL value is used. A TTL of zero is not allowed.
+A cache is divided into 256 shards, each holding up to 512 items by default - for a total size
 of 256 * 512 = 131,072 items.
 
 If you want more control:

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -124,7 +124,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 		}
 		etc.Client = client
 		etc.endpoints = endpoints
-		
+
 		return &etc, stubzones, nil
 	}
 	return &Etcd{}, false, nil

--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -96,7 +96,7 @@ Set a lameduck duration of 1 second:
 
 ## Bugs
 
-When reloading, the Health handler is stopped before the new server instance is started. 
-If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
-but Health handler stays down. 
+When reloading, the Health handler is stopped before the new server instance is started.
+If that new server fails to start, then the initial server instance is still available and DNS queries still served,
+but Health handler stays down.
 Health will not reply HTTP request until a successful reload or a complete restart of CoreDNS.

--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -31,7 +31,7 @@ fdfc:a744:27b5:3b0e::1  example.com example
 
 ### PTR records
 
-PTR records for reverse lookups are generated automatically by CoreDNS (based on the hosts file entries) and cannot be created manually. 
+PTR records for reverse lookups are generated automatically by CoreDNS (based on the hosts file entries) and cannot be created manually.
 
 ## Syntax
 

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -26,7 +26,7 @@ type staticHostEntry struct {
 var (
 	hosts = `255.255.255.255	broadcasthost
 	127.0.0.2	odin
-	127.0.0.3	odin  # inline comment 
+	127.0.0.3	odin  # inline comment
 	::2             odin
 	127.1.1.1	thor
 	# aliases

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -101,8 +101,8 @@ kubernetes [ZONES...] {
   the query. If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only
   queries for those zones will be subject to fallthrough.
-* `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g. ready pods). 
-  This allows the querying pod to continue searching for the service in the search path. 
+* `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g. ready pods).
+  This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another kubernetes cluster.
 
 ## Health

--- a/plugin/loadbalance/README.md
+++ b/plugin/loadbalance/README.md
@@ -8,7 +8,7 @@
 
 The *loadbalance* will act as a round-robin DNS loadbalancer by randomizing the order of A, AAAA,
 and MX records in the answer.
- 
+
 See [Wikipedia](https://en.wikipedia.org/wiki/Round-robin_DNS) about the pros and cons on this
 setup. It will take care to sort any CNAMEs before any address records, because some stub resolver
 implementations (like glibc) are particular about that.

--- a/plugin/metadata/README.md
+++ b/plugin/metadata/README.md
@@ -18,7 +18,7 @@ metadata a plugin might be interested in.
 The meta data is added by setting a label with a value in the context. These labels should be named
 `plugin/NAME`, where **NAME** is something descriptive. The only hard requirement the *metadata*
 plugin enforces is that the labels contains a slash. See the documentation for
-`metadata.SetValueFunc`. 
+`metadata.SetValueFunc`.
 
 The value stored is a string. The empty string signals "no meta data". See the documentation for
 `metadata.ValueFunc` on how to retrieve this.

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -71,7 +71,7 @@ then:
 
 ## Bugs
 
-When reloading, the Prometheus handler is stopped before the new server instance is started. 
-If that new server fails to start, then the initial server instance is still available and DNS queries still served, 
-but Prometheus handler stays down. 
+When reloading, the Prometheus handler is stopped before the new server instance is started.
+If that new server fails to start, then the initial server instance is still available and DNS queries still served,
+but Prometheus handler stays down.
 Prometheus will not reply HTTP request until a successful reload or a complete restart of CoreDNS.

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -209,9 +209,9 @@ rewrites the first local option with code 0xffee, setting the data to "abcd". Eq
 * A variable data is specified with a pair of curly brackets `{}`. Following are the supported variables:
   {qname}, {qtype}, {client_ip}, {client_port}, {protocol}, {server_ip}, {server_port}.
 
-* If the metadata plugin is enabled, then labels are supported as variables if they are presented within curly brackets. 
-the variable data will be filled with the value associated with that label. If that label is not provided, 
-the variable will be silently substitute by an empty string.  
+* If the metadata plugin is enabled, then labels are supported as variables if they are presented within curly brackets.
+the variable data will be filled with the value associated with that label. If that label is not provided,
+the variable will be silently substitute by an empty string.
 
 Examples:
 

--- a/plugin/whoami/README.md
+++ b/plugin/whoami/README.md
@@ -2,7 +2,7 @@
 
 ## Name
 
-*whoami* - returns your resolver's local IP address, port and transport. 
+*whoami* - returns your resolver's local IP address, port and transport.
 
 ## Description
 

--- a/test/hosts_file_test.go
+++ b/test/hosts_file_test.go
@@ -17,7 +17,7 @@ func TestHostsInlineLookup(t *testing.T) {
                        hosts highly_unlikely_to_exist_hosts_file example.org {
                          10.0.0.1 example.org
                          fallthrough
-                      }	
+                      }
                     }`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)


### PR DESCRIPTION
Prevent future; "remove trailing whitespace" PR, but adding a simple
presubmit that checks for this.

This presubmit flagged quite some offenders, remove all trailing
whitespace from. Apart from that there aren't any other changes.

Signed-off-by: Miek Gieben <miek@miek.nl>