### PR TITLE
Fix and replace message truncation

### DIFF
--- a/request/request_test.go
+++ b/request/request_test.go
@@ -121,6 +121,7 @@ func TestRequestScrubExtraEdns0(t *testing.T) {
 		reply.Extra = append(reply.Extra, test.SRV(
 			fmt.Sprintf("large.example.com. 10 IN SRV 0 0 80 10-0-0-%d.default.pod.k8s.example.com.", i)))
 	}
+	req.SizeAndDo(reply)
 
 	_, got := req.Scrub(reply)
 	if want := ScrubExtra; want != got {
@@ -154,6 +155,7 @@ func TestRequestScrubExtraRegression(t *testing.T) {
 		reply.Extra = append(reply.Extra, test.A(
 			fmt.Sprintf("10-0-0-%d.default.pod.k8s.example.com. 10 IN A 10.0.0.%d", i, i)))
 	}
+	req.SizeAndDo(reply)
 
 	_, got := req.Scrub(reply)
 	if want := ScrubExtra; want != got {

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -138,6 +138,39 @@ func TestRequestScrubExtraEdns0(t *testing.T) {
 	}
 }
 
+func TestRequestScrubExtraRegression(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion("large.example.com.", dns.TypeSRV)
+	m.SetEdns0(2048, true)
+	req := Request{W: &test.ResponseWriter{}, Req: m}
+
+	reply := new(dns.Msg)
+	reply.SetReply(m)
+	for i := 1; i < 33; i++ {
+		reply.Answer = append(reply.Answer, test.SRV(
+			fmt.Sprintf("large.example.com. 10 IN SRV 0 0 80 10-0-0-%d.default.pod.k8s.example.com.", i)))
+	}
+	for i := 1; i < 33; i++ {
+		reply.Extra = append(reply.Extra, test.A(
+			fmt.Sprintf("10-0-0-%d.default.pod.k8s.example.com. 10 IN A 10.0.0.%d", i, i)))
+	}
+
+	_, got := req.Scrub(reply)
+	if want := ScrubExtra; want != got {
+		t.Errorf("Want scrub result %d, got %d", want, got)
+	}
+	if want, got := req.Size(), reply.Len(); want < got {
+		t.Errorf("Want scrub to reduce message length below %d bytes, got %d bytes", want, got)
+	}
+	if reply.Truncated {
+		t.Errorf("Want scrub to not set truncated bit")
+	}
+	opt := reply.Extra[len(reply.Extra)-1]
+	if opt.Header().Rrtype != dns.TypeOPT {
+		t.Errorf("Last RR must be OPT record")
+	}
+}
+
 func TestRequestScrubAnswerExact(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("large.example.com.", dns.TypeSRV)

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -229,10 +229,30 @@ func BenchmarkRequestSize(b *testing.B) {
 	}
 }
 
+func BenchmarkRequestScrub(b *testing.B) {
+	st := testRequest()
+
+	reply := new(dns.Msg)
+	reply.SetReply(st.Req)
+	for i := 1; i < 33; i++ {
+		reply.Answer = append(reply.Answer, test.SRV(
+			fmt.Sprintf("large.example.com. 10 IN SRV 0 0 80 10-0-0-%d.default.pod.k8s.example.com.", i)))
+	}
+	for i := 1; i < 33; i++ {
+		reply.Extra = append(reply.Extra, test.A(
+			fmt.Sprintf("10-0-0-%d.default.pod.k8s.example.com. 10 IN A 10.0.0.%d", i, i)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		st.Scrub(reply.Copy())
+	}
+}
+
 func testRequest() Request {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
-	m.SetEdns0(4097, true)
+	m.SetEdns0(4096, true)
 	return Request{W: &test.ResponseWriter{}, Req: m}
 }
 


### PR DESCRIPTION
With the addition of the Truncate() function in miekg/dns, the Scrub
implementation can be replaced. This fixes the following issues:

- Scrub would return invalid messages larger than the advertised client
  buffer size by adding an OPT record to responses without making room
  for it. This breaks at least the Java DNS client.
- Scrub would not keep the OPT record in truncated messages, even though
  it's mandated by rfc6891.
- As Scrub doesn't have access to the internal DNS len() functions, it
  had to loop over all resource record lists multiple times in order to
  find the maximum number of records fitting the advertised size. This
  can be implemented more efficiently in miekg/dns.

---

Depends on https://github.com/miekg/dns/pull/708.

As a follow up change, I'd suggest to move SizeAndDo and Scrub from each plugin into a ResponseWriter injected in the Server. Handling the requirements of the DNS spec correctly shouldn't be a concern of plugins but of the server. That will reduce a lot copy&pasted code and remove the possibility that CoreDNS can return invalid messages when plugin authors forget to call these functions.