### PR TITLE
WIP - Ensure Graceful shutdown of DNS Servers

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -156,7 +156,9 @@ func (s *Server) Serve(l net.Listener) error {
 		s.ServeDNS(ctx, w, r)
 	}),
 		DecorateReader: func(r dns.Reader) dns.Reader {
+			s.m.Lock()
 			s.tcpReader = &OnOffReader{r, s.readerOff}
+			s.m.Unlock()
 			return s.tcpReader
 		}}
 	s.m.Unlock()
@@ -175,7 +177,9 @@ func (s *Server) ServePacket(p net.PacketConn) error {
 		s.ServeDNS(ctx, w, r)
 	}),
 		DecorateReader: func(r dns.Reader) dns.Reader {
+			s.m.Lock()
 			s.udpReader = &OnOffReader{r, s.readerOff}
+			s.m.Unlock()
 			return s.udpReader
 		}}
 	s.m.Unlock()

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -208,8 +208,13 @@ func (s *Server) ListenPacket() (net.PacketConn, error) {
 // This implements Caddy.Stopper interface.
 func (s *Server) Stop() (err error) {
 	// close listeners
-	s.tcpReader.Off()
-	s.udpReader.Off()
+	// it may happen that some of the readers are not initialized (e.g. if not using TCP)
+	if s.tcpReader != nil {
+		s.tcpReader.Off()
+	}
+	if s.udpReader != nil {
+		s.udpReader.Off()
+	}
 
 	// wait few ms to ensure all queries are started to be handled
 	time.Sleep(100 * time.Millisecond)

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -29,8 +30,10 @@ import (
 type Server struct {
 	Addr string // Address we listen on
 
-	server [2]*dns.Server // 0 is a net.Listener, 1 is a net.PacketConn (a *UDPConn) in our case.
-	m      sync.Mutex     // protects the servers
+	server    [2]*dns.Server // 0 is a net.Listener, 1 is a net.PacketConn (a *UDPConn) in our case.
+	udpReader *OnOffReader   // Reader for UDP protocol that can stop accepting in queries when asked
+	tcpReader *OnOffReader
+	m         sync.Mutex // protects the servers
 
 	zones       map[string]*Config // zones keyed by their address
 	dnsWg       sync.WaitGroup     // used to wait on outstanding connections
@@ -38,6 +41,40 @@ type Server struct {
 	trace       trace.Trace        // the trace plugin for the server
 	debug       bool               // disable recover()
 	classChaos  bool               // allow non-INET class queries
+
+}
+
+// TCP/UDP reader that can silently stop off demand to accept new input, simulating no data input
+// used to shutdown gracefully a Server : no more input while last queries are processing
+type OnOffReader struct {
+	rd  dns.Reader // underlying default Reader that do the reading job.
+	off uint32     // off act as boolean for allowing or not incoming queries - 0 = allowed (default value)
+}
+
+func (r *OnOffReader) Off() {
+	atomic.StoreUint32(&r.off, 1)
+}
+
+// ReadTCP reads a raw message from a TCP connection. Implementations may alter
+// connection properties, for example the read-deadline.
+func (r *OnOffReader) ReadTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
+	if atomic.LoadUint32(&r.off) == 0 {
+		return r.rd.ReadTCP(conn, timeout)
+	}
+	// just wait the timout and return error
+	time.Sleep(timeout)
+	return nil, fmt.Errorf("Reader is in off mode for TCP")
+}
+
+// ReadUDP reads a raw message from a UDP connection. Implementations may alter
+// connection properties, for example the read-deadline.
+func (r *OnOffReader) ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *dns.SessionUDP, error) {
+	if atomic.LoadUint32(&r.off) == 0 {
+		return r.rd.ReadUDP(conn, timeout)
+	}
+	// just wait the timout and return error
+	time.Sleep(timeout)
+	return nil, nil, fmt.Errorf("Reader is in off mode for UDP")
 }
 
 // NewServer returns a new CoreDNS server and compiles all plugins in to it. By default CH class
@@ -111,9 +148,15 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 func (s *Server) Serve(l net.Listener) error {
 	s.m.Lock()
 	s.server[tcp] = &dns.Server{Listener: l, Net: "tcp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		s.dnsWg.Add(1)
+		defer s.dnsWg.Done()
 		ctx := context.WithValue(context.Background(), Key{}, s)
 		s.ServeDNS(ctx, w, r)
-	})}
+	}),
+		DecorateReader: func(r dns.Reader) dns.Reader {
+			s.tcpReader = &OnOffReader{rd: r}
+			return s.tcpReader
+		}}
 	s.m.Unlock()
 
 	return s.server[tcp].ActivateAndServe()
@@ -124,9 +167,15 @@ func (s *Server) Serve(l net.Listener) error {
 func (s *Server) ServePacket(p net.PacketConn) error {
 	s.m.Lock()
 	s.server[udp] = &dns.Server{PacketConn: p, Net: "udp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		s.dnsWg.Add(1)
+		defer s.dnsWg.Done()
 		ctx := context.WithValue(context.Background(), Key{}, s)
 		s.ServeDNS(ctx, w, r)
-	})}
+	}),
+		DecorateReader: func(r dns.Reader) dns.Reader {
+			s.udpReader = &OnOffReader{rd: r}
+			return s.udpReader
+		}}
 	s.m.Unlock()
 
 	return s.server[udp].ActivateAndServe()
@@ -158,6 +207,14 @@ func (s *Server) ListenPacket() (net.PacketConn, error) {
 // immediately.
 // This implements Caddy.Stopper interface.
 func (s *Server) Stop() (err error) {
+	// close listeners
+	s.tcpReader.Off()
+	s.udpReader.Off()
+
+	// wait few ms to ensure all queries are started to be handled
+	time.Sleep(100 * time.Millisecond)
+
+	// and then stop the service : it will wait all queries are served
 
 	if runtime.GOOS != "windows" {
 		// force connections to close after timeout


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
We found that when "restarting" CoreDNS there were some query lost.
In our usage we try to minimize this lost.

I used prepared infrastructure to improve a little the shutdown process of the Server (TCP/UDP)
- During the closing process, i used DecoratorReader to stop accepting new queries.
- There is already a mechanism to wait completion before closing the service. 
=> I just added handle of the queries as part of the completion

NOTES: 
- the test performed so far show we stopped to loose queries when restarting.
- further tests are still in progress : 
-- same test but with higher QPS 
-- verification of impact of performance (we are using sync to count queries)

I am not sure how to proceed for UT here ...

### 2. Which issues (if any) are related?

#1666 

### 3. Which documentation changes (if any) need to be made?
I am not sure here as it is an improvement of the graceful restart of CoreDNS.
