### PR TITLE
Plugin/metrics - Starting/stopping tuning for the listener and HTTPServer

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -8,40 +8,30 @@
 # For example: https://coredns.io/2016/09/18/coredns-001-release/ Also send an
 # email to coredns-discuss@ to announce the new version.
 #
-# We use https://github.com/progrium/gh-release to automate github stuff be sure
-# to have that binary in your path.
-#
-# Get a list of authors for this release with:
-#
-# git log --pretty=format:'%an' v001..master | sort -u (where v001 is the
-# previous release, obviously you'll need to adjust this)
+# Getting the authors for this release is done with the following command line
+# git log --pretty=format:'%an' v$(VERSION)..master | sort -u
 #
 # Steps:
-#
-# * Get an access token: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
-# * export GITHUB_ACCESS_TOKEN=<token>
 # * Up the version in coremain/version.go
-# * Run: make DOCKER=coredns -f Makefile.release release
-#   * runs make -f Makefile.doc
-#   	* this is a noop if ronn can't be found
-#   * perform a go generate
-#   * will *commit* your change(s) with 'Release $VERSION'
-#   * push to github
-#   * build the release and do all that fluff.
+# * Do a make -f Makefile.doc
+# * go generate
+# * Send PR to get this merged.
 #
-# Steps for docker:
+# * Open an issue for this release
+# * In an issue give the command: /release: master
+# * (to test as release /release: -t master can be used.
 #
-# * Login into docker: docker login (should have push creds for coredns registry)
-# * We use the manifest-tool from https://github.com/estesp/manifest-tool to build the manifest list
-# * Make sure you have the binary in your path.
+# See github.com/coredns/release for documentation README on what needs to be setup for this to be
+# automated (can still be done by hand if needed). Especially what environment variables need to be
+# set!
 #
-# * Run: make DOCKER=coredns -f Makefile.release docker
-#
-# Docker push should happen after you make the new release and uploaded it to Github.
-#
-# If you want to push to a personal registry, point DOCKER to something else, i.e.
-#
-# * make DOCKER=miek -f Makefile.release docker
+# To release we run, where 'release' and 'docker' only locally build assets; these are the same
+# targets that get executed in case of testing.
+# * make release
+# * make github-push
+# * make docker
+# * make docker-push
+
 EMPTY:=
 SPACE:=$(EMPTY) $(EMPTY)
 COMMA:=$(EMPTY),$(EMPTY)
@@ -50,16 +40,11 @@ ifeq (, $(shell which curl))
     $(error "No curl in $$PATH, please install")
 endif
 
-ifeq (, $(shell which manifest-tool))
-    $(error "No manifest-tool in $$PATH, install with: go get github.com/estesp/manifest-tool")
-endif
-
 DOCKER:=
 NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-GITCOMMIT:=$(shell git describe --dirty --always)
 LINUX_ARCH:=amd64 arm arm64 ppc64le s390x
 PLATFORMS:=$(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
 
@@ -68,38 +53,27 @@ ifeq ($(DOCKER),)
 endif
 
 all:
-	@echo Use the 'release' target to start a release
+	@echo Use the 'release' target to build a release, 'docker' for docker build.
 
-release: pre commit push build tar upload
+release: pre build tar
 
-docker: docker-build docker-push
+docker: docker-build
 
 .PHONY: pre
 pre:
-	go generate
-	$(MAKE) -f Makefile.doc
-
-.PHONY: push
-push:
-	@echo Pushing release to master
-	git push
-
-.PHONY: commit
-commit:
-	@echo Committing
-	git commit -am"Release $(VERSION)"
+	go get github.com/estesp/manifest-tool
 
 .PHONY: build
 build:
 	@echo Cleaning old builds
 	@rm -rf build && mkdir build
-	@echo Building: darwin $(VERSION)
+	@echo Building: darwin/amd64 - $(VERSION)
 	mkdir -p build/darwin/amd64 && $(MAKE) coredns BINARY=build/darwin/amd64/$(NAME) SYSTEM="GOOS=darwin GOARCH=amd64" CHECKS="godeps" VERBOSE=""
-	@echo Building: windows $(VERSION)
-	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME) SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="godeps" VERBOSE=""
-	@echo Building: linux/$(LINUX_ARCH)  $(VERSION) ;\
+	@echo Building: windows/amd64 - $(VERSION)
+	mkdir -p build/windows/amd64 && $(MAKE) coredns BINARY=build/windows/amd64/$(NAME) SYSTEM="GOOS=windows GOARCH=amd64" CHECKS="" VERBOSE=""
+	@echo Building: linux/$(LINUX_ARCH) - $(VERSION) ;\
 	for arch in $(LINUX_ARCH); do \
-	    mkdir -p build/linux/$$arch  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="godeps" VERBOSE="" ;\
+	    mkdir -p build/linux/$$arch  && $(MAKE) coredns BINARY=build/linux/$$arch/$(NAME) SYSTEM="GOOS=linux GOARCH=$$arch" CHECKS="" VERBOSE="" ;\
 	done
 
 .PHONY: tar
@@ -112,10 +86,10 @@ tar:
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done
 
-.PHONY: upload
-upload:
+.PHONY: github-push
+github-push:
 	@echo Releasing: $(VERSION)
-	$(eval RELEASE:=$(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
+	@$(eval RELEASE:=$(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
 	@echo ReleaseID: $(RELEASE)
 	@for asset in `ls -A release`; do \
 	    curl -o /dev/null -X POST \
@@ -126,15 +100,10 @@ upload:
 
 .PHONY: docker-build
 docker-build: tar
-	# Steps:
-	# 1. Copy appropriate coredns binary to build/docker/linux/<arch>
-	# 2. Copy Dockerfile to build/docker/linux/<arch>
-	# 3. Replace base image from alpine:latest to <arch>/alpine:latest
-	# 4. Comment RUN in Dockerfile
-	# <arch>:
-	# arm: arm32v6
-	# arm64: arm64v8
-	rm -rf build/docker
+	@# Steps:
+	@# 1. Copy appropriate coredns binary to build/docker/linux/<arch>
+	@# 2. Copy Dockerfile to build/docker/linux/<arch>
+	@rm -rf build/docker
 	for arch in $(LINUX_ARCH); do \
 	    mkdir -p build/docker/linux/$$arch ;\
 	    tar -xzf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/docker/linux/$$arch ;\
@@ -145,6 +114,7 @@ docker-build: tar
 
 .PHONY: docker-push
 docker-push:
+	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
 	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
 	for arch in $(LINUX_ARCH); do \
 	    docker push $(DOCKER_IMAGE_NAME):coredns-$$arch ;\

--- a/OWNERS
+++ b/OWNERS
@@ -26,8 +26,10 @@ features:
   - reviewers
   - aliases
   - branches
+  - exec
 
 aliases:
   - |
     /plugin: (.*) -> /label add: plugin/$1
-
+  - |
+    /release: (.*) -> /exec: /opt/bin/release-coredns $1

--- a/README.md
+++ b/README.md
@@ -189,12 +189,11 @@ More resources can be found:
 
 ## Deployment
 
-Examples for deployment via systemd and other use cases can be found in the
-[deployment repository](https://github.com/coredns/deployment).
+Examples for deployment via systemd and other use cases can be found in the [deployment
+repository](https://github.com/coredns/deployment).
 
 ## Security
 
-If you find a security vulnerability or any security related issues,
-please DO NOT file a public issue, instead send your report privately to
-`security@coredns.io`. Security reports are greatly appreciated and we
-will publicly thank you for it.
+If you find a security vulnerability or any security related issues, please DO NOT file a public
+issue, instead send your report privately to `security@coredns.io`. Security reports are greatly
+appreciated and we will publicly thank you for it.

--- a/coremain/version.go
+++ b/coremain/version.go
@@ -2,7 +2,7 @@ package coremain
 
 // Various CoreDNS constants.
 const (
-	CoreVersion = "1.1.4"
+	CoreVersion = "1.2.0"
 	coreName    = "CoreDNS"
 	serverType  = "dns"
 )

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -31,6 +31,8 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("prometheus", err)
 	}
 
+	uniqAddr.Set(m.Addr, m.OnStartup)
+
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		m.Next = next
 		return m
@@ -54,10 +56,6 @@ func setup(c *caddy.Controller) error {
 
 func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	var met = New(defaultAddr)
-
-	defer func() {
-		uniqAddr.Set(met.Addr, met.OnStartup)
-	}()
 
 	i := 0
 	for c.Next() {

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -24,24 +24,24 @@ func (u U) Set(key string, f func() error) {
 	u.u[key] = item{todo, f}
 }
 
-// SetTodo sets key to 'todo' again.
-func (u U) SetTodo(key string) {
-	v, ok := u.u[key]
-	if !ok {
-		return
+// Unset sets function f in U under key. If the key already exists
+// it is not overwritten.
+func (u U) Unset(key string) {
+	if _, ok := u.u[key]; ok {
+		delete(u.u, key)
 	}
-	v.state = todo
-	u.u[key] = v
 }
 
 // ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done'.
 func (u U) ForEach() error {
 	for k, v := range u.u {
 		if v.state == todo {
-			v.f()
+			err := v.f()
+			if err == nil {
+				v.state = done
+				u.u[k] = v
+			}
 		}
-		v.state = done
-		u.u[k] = v
 	}
 	return nil
 }

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -122,6 +123,83 @@ func TestReloadMetricsHealth(t *testing.T) {
 	metrics, _ := ioutil.ReadAll(resp.Body)
 	if !bytes.Contains(metrics, []byte(proc)) {
 		t.Errorf("Failed to see %s in metric output", proc)
+	}
+}
+
+func collectMetricsInfo(addr string) error {
+	cl := &http.Client{}
+	resp, err := cl.Get(fmt.Sprintf("http://%s/metrics", addr))
+	if err != nil {
+		return err
+	}
+	const proc = "coredns_build_info"
+	metrics, _ := ioutil.ReadAll(resp.Body)
+	if !bytes.Contains(metrics, []byte(proc)) {
+		return fmt.Errorf("failed to see %s in metric output", proc)
+	}
+	return nil
+}
+
+// Because of behavior of default HttServer. This Test will work ONLY if metrics HTTP Server is closed with a shutdown
+// (a close will not completely end the service)
+func TestReloadTwiceMetrics(t *testing.T) {
+	promAddress := "127.0.0.1:53183"
+	corefilePrometheus := `
+.:0 {
+	prometheus ` + promAddress + `
+	whoami
+}`
+	corefileNoPrometheus := `
+.:0 {
+	whoami
+}`
+
+	// check no metrics available
+	err := collectMetricsInfo(promAddress)
+	if err == nil {
+		t.Errorf("Prometheus is listening BEFORE the test start")
+	}
+
+	// start coredns for first time
+	c, err := CoreDNSServer(corefilePrometheus)
+	if err != nil {
+		if strings.Contains(err.Error(), inUse) {
+			return // meh, but don't error
+		}
+		t.Errorf("Could not get service instance: %s", err)
+	}
+
+	// verify Metrics is running
+	err = collectMetricsInfo(promAddress)
+	if err != nil {
+		t.Errorf("Prometheus is not listening : %s", err)
+	}
+
+	nbRestarts := 2 // for local investigation it can be usefull to loop more than twice.
+	// restart several times
+	for i := 0; i < nbRestarts; i++ {
+		c, err = c.Restart(NewInput(corefilePrometheus))
+		if err != nil {
+			t.Errorf("Could not restart CoreDNS : %s, at loop %v", err, i)
+		}
+		// verify Metrics is running
+		err = collectMetricsInfo(promAddress)
+		if err != nil {
+			t.Errorf("Prometheus is not listening : %s", err)
+		}
+	}
+
+	// now restart w/o Prometheus
+	c2, err := c.Restart(NewInput(corefileNoPrometheus))
+	if err != nil {
+		t.Errorf("Could not restart a second time CoreDNS : %s", err)
+	}
+	c2.Stop()
+
+	// verify Metrics is NOT running
+	err = collectMetricsInfo(promAddress)
+	if err == nil {
+		t.Errorf("Prometheus is STILL listening")
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Initial problem is:
1- plugin metrics fail to follow metric directive after 2 restarts
2- plugin metrics fail to start listener (sometime ...)

Point 1 - is fixed by modifying the interaction with uniqAddr = Unset the usage of Addr when shutdown the listener. It ensures the new metrics setup will initialize - if needed - a new uniqAddr *with its own OnStart function*

Point 2, after investigation, seems due to latency in releasing the socket on some OS platform. Works great on Mac OS. But our install on Alpine needs a delay before being able to reuse the listener.
=> add a second retry for acquiring the listener after 1sec delay, if first is failing.


NOTE: In order to show the failing point 1, I created a test in "test_reload". However I found that the service metrics was still running after listener is down (???), unless we stop the HTTP Server with Shutdown instead of Close.
I added this change in the code to have a proper closing.

### 2. Which issues (if any) are related?
#1848 (for point 2)
There is no issue created for point 1.

### 3. Which documentation changes (if any) need to be made?
I do not think it needs. only fix or tuning.