### PR TITLE
plugin/metrics - fails to follow metric directive after 2 restarts

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
@@ -87,18 +86,8 @@ func (m *Metrics) ZoneNames() []string {
 func (m *Metrics) OnStartup() error {
 	ln, err := net.Listen("tcp", m.Addr)
 	if err != nil {
-		log.Warningf("failed to start metrics handler on %s - error : %s", m.Addr, err)
-
-		// on some OS (Alpine) the listener seems reating the socekt a few delay after the closing the listener.
-		// in case of restart of server, it needs to delay a little but the opening of a new listener on the same address:port
-		time.Sleep(1 * time.Second)
-		ln, err = net.Listen("tcp", m.Addr)
-		if err != nil {
-			// complete fail to listen
-			log.Errorf("failed to start metrics handler second time (one sec delay): %s", err)
-			return err
-		}
-		log.Infof("eventually succeeded to start metrics handler on %s", err)
+		log.Errorf("Failed to start metrics handler: %s", err)
+		return err
 	}
 
 	m.ln = ln

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -31,6 +31,8 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error("prometheus", err)
 	}
 
+	uniqAddr.Set(m.Addr, m.OnStartup)
+
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		m.Next = next
 		return m
@@ -54,10 +56,6 @@ func setup(c *caddy.Controller) error {
 
 func prometheusParse(c *caddy.Controller) (*Metrics, error) {
 	var met = New(defaultAddr)
-
-	defer func() {
-		uniqAddr.Set(met.Addr, met.OnStartup)
-	}()
 
 	i := 0
 	for c.Next() {

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -24,24 +24,24 @@ func (u U) Set(key string, f func() error) {
 	u.u[key] = item{todo, f}
 }
 
-// SetTodo sets key to 'todo' again.
-func (u U) SetTodo(key string) {
-	v, ok := u.u[key]
-	if !ok {
-		return
+// Unset sets function f in U under key. If the key already exists
+// it is not overwritten.
+func (u U) Unset(key string) {
+	if _, ok := u.u[key]; ok {
+		delete(u.u, key)
 	}
-	v.state = todo
-	u.u[key] = v
 }
 
 // ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done'.
 func (u U) ForEach() error {
 	for k, v := range u.u {
 		if v.state == todo {
-			v.f()
+			err := v.f()
+			if err == nil {
+				v.state = done
+				u.u[k] = v
+			}
 		}
-		v.state = done
-		u.u[k] = v
 	}
 	return nil
 }

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -122,6 +123,85 @@ func TestReloadMetricsHealth(t *testing.T) {
 	metrics, _ := ioutil.ReadAll(resp.Body)
 	if !bytes.Contains(metrics, []byte(proc)) {
 		t.Errorf("Failed to see %s in metric output", proc)
+	}
+}
+
+func collectMetricsInfo(addr string) error {
+	cl := &http.Client{}
+	resp, err := cl.Get(fmt.Sprintf("http://%s/metrics", addr))
+	if err != nil {
+		return err
+	}
+	const proc = "coredns_build_info"
+	metrics, _ := ioutil.ReadAll(resp.Body)
+	if !bytes.Contains(metrics, []byte(proc)) {
+		return fmt.Errorf("failed to see %s in metric output", proc)
+	}
+	return nil
+}
+
+// Because of behavior of default HttServer. This Test will work ONLY if metrics HTTP Server is closed with a shutdown
+// (a close will not completely end the service)
+func TestReloadSeveralTimeMetrics(t *testing.T) {
+	promAddress := "127.0.0.1:53183"
+	corefilePrometheus := `
+.:0 {
+	prometheus ` + promAddress + `
+	whoami
+}`
+	corefileNoPrometheus := `
+.:0 {
+	whoami
+}`
+
+	// The target of the test is to show that after several reloads,
+	// plugin metrics still follow directive of the LAST reloaded config
+	// check no metrics available
+	err := collectMetricsInfo(promAddress)
+	if err == nil {
+		t.Errorf("Prometheus is listening BEFORE the test start")
+	}
+
+	// start coredns for first time
+	c, err := CoreDNSServer(corefilePrometheus)
+	if err != nil {
+		if strings.Contains(err.Error(), inUse) {
+			return // meh, but don't error
+		}
+		t.Errorf("Could not get service instance: %s", err)
+	}
+
+	// verify Metrics is running
+	err = collectMetricsInfo(promAddress)
+	if err != nil {
+		t.Errorf("Prometheus is not listening : %s", err)
+	}
+
+	nbRestarts := 2 // for local investigation it can be usefull to loop more than twice.
+	// restart several times
+	for i := 0; i < nbRestarts; i++ {
+		c, err = c.Restart(NewInput(corefilePrometheus))
+		if err != nil {
+			t.Errorf("Could not restart CoreDNS : %s, at loop %v", err, i)
+		}
+		// verify Metrics is running
+		err = collectMetricsInfo(promAddress)
+		if err != nil {
+			t.Errorf("Prometheus is not listening : %s", err)
+		}
+	}
+
+	// now restart w/o Prometheus
+	c2, err := c.Restart(NewInput(corefileNoPrometheus))
+	if err != nil {
+		t.Errorf("Could not restart a second time CoreDNS : %s", err)
+	}
+	c2.Stop()
+
+	// verify Metrics is NOT running
+	err = collectMetricsInfo(promAddress)
+	if err == nil {
+		t.Errorf("Prometheus is STILL listening")
 	}
 }
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -119,11 +119,13 @@ func TestReloadMetricsHealth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const proc = "process_virtual_memory_bytes"
-	metrics, _ := ioutil.ReadAll(resp.Body)
-	if !bytes.Contains(metrics, []byte(proc)) {
-		t.Errorf("Failed to see %s in metric output", proc)
+
+	// verify Metrics is running
+	err = collectMetricsInfo("localhost:53183")
+	if err != nil {
+		t.Errorf("Prometheus is not listening : %s", err)
 	}
+
 }
 
 func collectMetricsInfo(addr string) error {
@@ -143,7 +145,8 @@ func collectMetricsInfo(addr string) error {
 // Because of behavior of default HttServer. This Test will work ONLY if metrics HTTP Server is closed with a shutdown
 // (a close will not completely end the service)
 func TestReloadSeveralTimeMetrics(t *testing.T) {
-	promAddress := "127.0.0.1:53183"
+	//TODO: add a tool that find an available port.
+	promAddress := "127.0.0.1:53185" // need to be a port that is not used in another test ! not very convenient
 	corefilePrometheus := `
 .:0 {
 	prometheus ` + promAddress + `


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Initial problem is:
Plugin metrics fail to follow metric directive after 2 restarts

is fixed by modifying the interaction with uniqAddr = Unset the usage of Addr when shutdown the listener. It ensures the new metrics setup will initialize - if needed - a new uniqAddr *with its own OnStart function*

NOTE: In order to show the failing point, I created a test in "test_reload". 
However I found that the service metrics was still running after listener is down (???), unless we stop the HTTP Server with Shutdown instead of Close.
I added this change in the code to have a proper closing.

### 2. Which issues (if any) are related?
#1982


### 3. Which documentation changes (if any) need to be made?
I do not think it needs. only fix or tuning.