### PR TITLE
WIP: plugin/secondary: make initial zone transfer async

### DIFF
--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -29,9 +29,11 @@ func setup(c *caddy.Controller) error {
 		if len(z.TransferFrom) > 0 {
 			c.OnStartup(func() error {
 				z.StartupOnce.Do(func() {
-					z.TransferIn()
 					go func() {
-						z.Update()
+						z.TransferIn()
+						go func() {
+							z.Update()
+						}()
 					}()
 				})
 				return nil


### PR DESCRIPTION
Just run the whole thing in (another) go routine. This doesn't block
startup and is an easy fix for #1609. With the erratic axfr improvements
going on some more failure modes can be tested.

Fixes: #1609

Signed-off-by: Miek Gieben <miek@miek.nl>