### PR TITLE
Clean up tests logging

### DIFF
--- a/core/dnsserver/log_test.go
+++ b/core/dnsserver/log_test.go
@@ -1,4 +1,4 @@
-package log
+package dnsserver
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/auto/log_test.go
+++ b/plugin/auto/log_test.go
@@ -1,4 +1,4 @@
-package log
+package auto
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/bind/log_test.go
+++ b/plugin/bind/log_test.go
@@ -1,4 +1,4 @@
-package log
+package bind
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/cache/log_test.go
+++ b/plugin/cache/log_test.go
@@ -1,4 +1,4 @@
-package log
+package cache
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/chaos/log_test.go
+++ b/plugin/chaos/log_test.go
@@ -1,4 +1,4 @@
-package log
+package chaos
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/debug/log_test.go
+++ b/plugin/debug/log_test.go
@@ -1,4 +1,4 @@
-package log
+package debug
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/dnssec/log_test.go
+++ b/plugin/dnssec/log_test.go
@@ -1,4 +1,4 @@
-package log
+package dnssec
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/dnstap/dnstapio/log_test.go
+++ b/plugin/dnstap/dnstapio/log_test.go
@@ -1,0 +1,5 @@
+package dnstapio
+
+import clog "github.com/coredns/coredns/plugin/pkg/log"
+
+func init() { clog.Discard() }

--- a/plugin/dnstap/log_test.go
+++ b/plugin/dnstap/log_test.go
@@ -1,4 +1,4 @@
-package log
+package dnstap
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/erratic/log_test.go
+++ b/plugin/erratic/log_test.go
@@ -1,4 +1,4 @@
-package log
+package erratic
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/errors/log_test.go
+++ b/plugin/errors/log_test.go
@@ -1,4 +1,4 @@
-package log
+package errors
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/etcd/log_test.go
+++ b/plugin/etcd/log_test.go
@@ -1,4 +1,4 @@
-package log
+package etcd
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/federation/log_test.go
+++ b/plugin/federation/log_test.go
@@ -1,4 +1,4 @@
-package log
+package federation
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/file/log_test.go
+++ b/plugin/file/log_test.go
@@ -1,4 +1,4 @@
-package log
+package file
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/forward/log_test.go
+++ b/plugin/forward/log_test.go
@@ -1,4 +1,4 @@
-package log
+package forward
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/health/log_test.go
+++ b/plugin/health/log_test.go
@@ -1,4 +1,4 @@
-package log
+package health
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/hosts/log_test.go
+++ b/plugin/hosts/log_test.go
@@ -1,4 +1,4 @@
-package log
+package hosts
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/kubernetes/log_test.go
+++ b/plugin/kubernetes/log_test.go
@@ -1,4 +1,4 @@
-package log
+package kubernetes
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/loadbalance/log_test.go
+++ b/plugin/loadbalance/log_test.go
@@ -1,4 +1,4 @@
-package log
+package loadbalance
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -1,5 +1,105 @@
 package log
 
-import clog "github.com/coredns/coredns/plugin/pkg/log"
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/response"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
 
 func init() { clog.Discard() }
+
+func TestLoggedStatus(t *testing.T) {
+	var f bytes.Buffer
+	rule := Rule{
+		NameScope: ".",
+		Format:    DefaultLogFormat,
+		Log:       log.New(&f, "", 0),
+		Class:     map[response.Class]bool{response.All: true},
+	}
+
+	logger := Logger{
+		Rules: []Rule{rule},
+		Next:  test.ErrorHandler(),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	rcode, _ := logger.ServeDNS(ctx, rec, r)
+	if rcode != 0 {
+		t.Errorf("Expected rcode to be 0 - was: %d", rcode)
+	}
+
+	logged := f.String()
+	if !strings.Contains(logged, "A IN example.org. udp 29 false 512") {
+		t.Errorf("Expected it to be logged. Logged string: %s", logged)
+	}
+}
+
+func TestLoggedClassDenial(t *testing.T) {
+	var f bytes.Buffer
+	rule := Rule{
+		NameScope: ".",
+		Format:    DefaultLogFormat,
+		Log:       log.New(&f, "", 0),
+		Class:     map[response.Class]bool{response.Denial: true},
+	}
+
+	logger := Logger{
+		Rules: []Rule{rule},
+		Next:  test.ErrorHandler(),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	logger.ServeDNS(ctx, rec, r)
+
+	logged := f.String()
+	if len(logged) != 0 {
+		t.Errorf("Expected it not to be logged, but got string: %s", logged)
+	}
+}
+
+func TestLoggedClassError(t *testing.T) {
+	var f bytes.Buffer
+	rule := Rule{
+		NameScope: ".",
+		Format:    DefaultLogFormat,
+		Log:       log.New(&f, "", 0),
+		Class:     map[response.Class]bool{response.Error: true},
+	}
+
+	logger := Logger{
+		Rules: []Rule{rule},
+		Next:  test.ErrorHandler(),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	logger.ServeDNS(ctx, rec, r)
+
+	logged := f.String()
+	if !strings.Contains(logged, "SERVFAIL") {
+		t.Errorf("Expected it to be logged. Logged string: %s", logged)
+	}
+}

--- a/plugin/log_test.go
+++ b/plugin/log_test.go
@@ -1,4 +1,4 @@
-package log
+package plugin
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/metadata/log_test.go
+++ b/plugin/metadata/log_test.go
@@ -1,4 +1,4 @@
-package log
+package metadata
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/metrics/log_test.go
+++ b/plugin/metrics/log_test.go
@@ -1,4 +1,4 @@
-package log
+package metrics
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/nsid/log_test.go
+++ b/plugin/nsid/log_test.go
@@ -1,4 +1,4 @@
-package log
+package nsid
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/pkg/healthcheck/log_test.go
+++ b/plugin/pkg/healthcheck/log_test.go
@@ -1,4 +1,4 @@
-package log
+package healthcheck
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -10,6 +10,7 @@ package log
 
 import (
 	"fmt"
+	"io/ioutil"
 	golog "log"
 )
 
@@ -60,6 +61,9 @@ func Error(v ...interface{}) { log(err, v...) }
 
 // Errorf is equivalent to log.Printf, but prefixed with "[ERROR] ".
 func Errorf(format string, v ...interface{}) { logf(err, format, v...) }
+
+// Discard sets the log output to /dev/null.
+func Discard() { golog.SetOutput(ioutil.Discard) }
 
 const (
 	debug   = "[DEBUG] "

--- a/plugin/pprof/log_test.go
+++ b/plugin/pprof/log_test.go
@@ -1,4 +1,4 @@
-package log
+package pprof
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/proxy/log_test.go
+++ b/plugin/proxy/log_test.go
@@ -1,4 +1,4 @@
-package log
+package proxy
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/reload/log_test.go
+++ b/plugin/reload/log_test.go
@@ -1,4 +1,4 @@
-package log
+package reload
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/rewrite/log_test.go
+++ b/plugin/rewrite/log_test.go
@@ -1,4 +1,4 @@
-package log
+package rewrite
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/root/log_test.go
+++ b/plugin/root/log_test.go
@@ -1,4 +1,4 @@
-package log
+package root
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/route53/log_test.go
+++ b/plugin/route53/log_test.go
@@ -1,4 +1,4 @@
-package log
+package route53
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/secondary/log_test.go
+++ b/plugin/secondary/log_test.go
@@ -1,4 +1,4 @@
-package log
+package secondary
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/template/log_test.go
+++ b/plugin/template/log_test.go
@@ -1,4 +1,4 @@
-package log
+package template
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/tls/log_test.go
+++ b/plugin/tls/log_test.go
@@ -1,4 +1,4 @@
-package log
+package tls
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/trace/log_test.go
+++ b/plugin/trace/log_test.go
@@ -1,4 +1,4 @@
-package log
+package trace
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/plugin/whoami/log_test.go
+++ b/plugin/whoami/log_test.go
@@ -1,4 +1,4 @@
-package log
+package whoami
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"testing"
@@ -34,8 +33,6 @@ func TestAuto(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
@@ -82,7 +79,6 @@ func TestAutoNonExistentZone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.SetOutput(ioutil.Discard)
 
 	corefile := `.:0 {
 		auto {
@@ -117,7 +113,6 @@ func TestAutoNonExistentZone(t *testing.T) {
 
 func TestAutoAXFR(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
 	if err != nil {

--- a/test/chaos_test.go
+++ b/test/chaos_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	// Plug in CoreDNS, needed for AppVersion and AppName in this test.
@@ -23,8 +21,6 @@ func TestChaos(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	m := new(dns.Msg)
 	m.SetQuestion("version.bind.", dns.TypeTXT)

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -48,8 +46,6 @@ func TestLookupDS(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &mtest.ResponseWriter{}, Req: new(dns.Msg)}

--- a/test/etcd_cache_test.go
+++ b/test/etcd_cache_test.go
@@ -4,8 +4,6 @@ package test
 
 import (
 	"context"
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/etcd/msg"
@@ -33,7 +31,6 @@ func TestEtcdCache(t *testing.T) {
 	defer ex.Stop()
 
 	etc := etcdPlugin()
-	log.SetOutput(ioutil.Discard)
 
 	var ctx = context.TODO()
 	for _, serv := range servicesCacheTest {

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -5,8 +5,6 @@ package test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
@@ -53,7 +51,6 @@ func TestEtcdStubAndProxyLookup(t *testing.T) {
 	defer ex.Stop()
 
 	etc := etcdPlugin()
-	log.SetOutput(ioutil.Discard)
 
 	var ctx = context.TODO()
 	for _, serv := range servicesStub { // adds example.{net,org} as stubs

--- a/test/file_cname_proxy_test.go
+++ b/test/file_cname_proxy_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -14,7 +12,6 @@ import (
 
 func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", exampleOrg)
 	if err != nil {
@@ -48,7 +45,6 @@ func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
 
 func TestZoneExternalCNAMELookupWithProxy(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", exampleOrg)
 	if err != nil {

--- a/test/file_serve_test.go
+++ b/test/file_serve_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -10,7 +8,6 @@ import (
 
 func TestZoneEDNS0Lookup(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", `$ORIGIN example.org.
 @	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
@@ -58,7 +55,6 @@ www     IN AAAA ::1
 
 func TestZoneNoNS(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", `$ORIGIN example.org.
 @	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (

--- a/test/file_srv_additional_test.go
+++ b/test/file_srv_additional_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -14,7 +12,6 @@ import (
 
 func TestZoneSRVAdditional(t *testing.T) {
 	t.Parallel()
-	log.SetOutput(ioutil.Discard)
 
 	name, rm, err := TempFile(".", exampleOrg)
 	if err != nil {

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"context"
-	"io/ioutil"
-	"log"
 	"testing"
 	"time"
 
@@ -14,8 +12,6 @@ import (
 )
 
 func TestGrpc(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	corefile := `grpc://.:0 {
 		whoami
 }

--- a/test/hosts_file_test.go
+++ b/test/hosts_file_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -25,8 +23,6 @@ func TestHostsInlineLookup(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}

--- a/test/log_test.go
+++ b/test/log_test.go
@@ -1,4 +1,4 @@
-package log
+package test
 
 import clog "github.com/coredns/coredns/plugin/pkg/log"
 

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"testing"
@@ -144,8 +143,6 @@ func TestMetricsAuto(t *testing.T) {
 		t.Fatalf("Could not get UDP listening port")
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	// Write db.example.org to get example.org.
 	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
@@ -36,7 +35,6 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 	}
 	defer ex.Stop()
 
-	log.SetOutput(ioutil.Discard)
 	c := new(dns.Client)
 	m := new(dns.Msg)
 	m.SetQuestion("example.org.", dns.TypeA)

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
@@ -34,7 +32,6 @@ func benchmarkLookupBalanceRewriteCache(b *testing.B) {
 	}
 	defer ex.Stop()
 
-	log.SetOutput(ioutil.Discard)
 	c := new(dns.Client)
 	m := new(dns.Msg)
 	m.SetQuestion("example.org.", dns.TypeA)

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -13,8 +11,6 @@ import (
 )
 
 func TestProxyErratic(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	corefile := `example.org:0 {
 		erratic {
 			drop 2
@@ -39,8 +35,7 @@ func TestProxyErratic(t *testing.T) {
 
 func TestProxyThreeWay(t *testing.T) {
 	// Run 3 CoreDNS server, 2 upstream ones and a proxy. 1 Upstream is unhealthy after 1 query, but after
-	// that we should still be able to send to the other one
-	log.SetOutput(ioutil.Discard)
+	// that we should still be able to send to the other one.
 
 	// Backend CoreDNS's.
 	corefileUp1 := `example.org:0 {

--- a/test/proxy_http_health_test.go
+++ b/test/proxy_http_health_test.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"io"
-	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -17,8 +15,6 @@ import (
 )
 
 func TestProxyWithHTTPCheckOK(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-
 	healthCheckServer := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -30,8 +28,6 @@ func TestLookupProxy(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
@@ -69,8 +65,6 @@ func TestLookupDnsWithForcedTcp(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookupWithOption([]string{tcp}, proxy.Options{ForceTCP: true})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
@@ -113,8 +107,6 @@ func BenchmarkProxyLookup(b *testing.B) {
 		t.Fatalf("Could not get udp listening port")
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}

--- a/test/readme_test.go
+++ b/test/readme_test.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bufio"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -47,8 +46,6 @@ func TestReadme(t *testing.T) {
 
 	create(contents)
 	defer remove(contents)
-
-	log.SetOutput(ioutil.Discard)
 
 	middle := filepath.Join("..", "plugin")
 	dirs, err := ioutil.ReadDir(middle)

--- a/test/reverse_test.go
+++ b/test/reverse_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -27,8 +25,6 @@ func TestReverseCorefile(t *testing.T) {
 	if udp == "" {
 		t.Fatalf("Could not get UDP listening port")
 	}
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -2,8 +2,6 @@ package test
 
 import (
 	"bytes"
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -25,8 +23,6 @@ func TestRewrite(t *testing.T) {
 	}
 
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	testMX(t, udp)
 	testEdns0(t, udp)

--- a/test/server.go
+++ b/test/server.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"sync"
 
 	"github.com/coredns/coredns/core/dnsserver"
@@ -21,7 +19,6 @@ func CoreDNSServer(corefile string) (*caddy.Instance, error) {
 	defer mu.Unlock()
 	caddy.Quiet = true
 	dnsserver.Quiet = true
-	log.SetOutput(ioutil.Discard)
 
 	return caddy.Start(NewInput(corefile))
 }

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -1,8 +1,6 @@
 package test
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/proxy"
@@ -30,8 +28,6 @@ func TestLookupWildcard(t *testing.T) {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
-
-	log.SetOutput(ioutil.Discard)
 
 	p := proxy.NewLookup([]string{udp})
 	state := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}


### PR DESCRIPTION
This cleans up the travis logs so you can see the failures better.

Older tests in tests/ would call log.SetOutput(ioutil.Discard) in
a haphazard way. This add log.Discard and put an `init` function in each
package's dir (no way to do this globally). The cleanup in tests/ is
clear.

All plugins also got this init function to have some uniformity and kill
any (future) logging there in the tests as well.

There is a one-off in pkg/healthcheck because that does log.

Signed-off-by: Miek Gieben <miek@miek.nl>