### PR TITLE
Plugin/Metrics - add Healther interface and refactor uniqAddr storage

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -39,6 +39,13 @@ name "dropped" (without a closing dot - this is never a valid domain name).
 
 This plugin can only be used once per Server Block.
 
+## Health
+
+This plugin implements dynamic health checking. 
+Prometheus plugin is considered unhealthy if the HTTP server instance was not successfully started.
+(see bug description below on server fails to start)   
+
+
 ## Syntax
 
 ~~~

--- a/plugin/metrics/health.go
+++ b/plugin/metrics/health.go
@@ -1,0 +1,6 @@
+package metrics
+
+// Health implements the health.Healther interface.
+func (m *Metrics) Health() bool {
+	return !m.uniqAddr.HasTodo()
+}

--- a/plugin/metrics/metrics_test.go
+++ b/plugin/metrics/metrics_test.go
@@ -17,7 +17,7 @@ func TestMetrics(t *testing.T) {
 	if err := met.OnStartup(); err != nil {
 		t.Fatalf("Failed to start metrics handler: %s", err)
 	}
-	defer met.OnFinalShutdown()
+	defer met.OnShutdown()
 
 	met.AddZone("example.org.")
 

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -8,7 +8,7 @@ import (
 
 // U keeps track of item to be done.
 type U struct {
-	sync.Mutex
+	sync.RWMutex
 	u map[string]item
 }
 
@@ -31,18 +31,6 @@ func (u *U) Set(key string, f func() error) {
 	u.u[key] = item{todo, f}
 }
 
-// SetTodo sets key to 'todo' again.
-func (u *U) SetTodo(key string) {
-	u.Lock()
-	defer u.Unlock()
-	v, ok := u.u[key]
-	if !ok {
-		return
-	}
-	v.state = todo
-	u.u[key] = v
-}
-
 // ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done' - if f executes w/o error
 func (u *U) ForEach() error {
 	u.Lock()
@@ -61,8 +49,8 @@ func (u *U) ForEach() error {
 
 // HasTodo inform on weather some things are still in todo mode
 func (u *U) HasTodo() bool {
-	u.Lock()
-	defer u.Unlock()
+	u.RLock()
+	defer u.RUnlock()
 	for _, v := range u.u {
 		if v.state == todo {
 			return true

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -2,8 +2,13 @@
 // identical events will only be processed once.
 package uniq
 
+import (
+	"sync"
+)
+
 // U keeps track of item to be done.
 type U struct {
+	sync.Mutex
 	u map[string]item
 }
 
@@ -13,11 +18,13 @@ type item struct {
 }
 
 // New returns a new initialized U.
-func New() U { return U{u: make(map[string]item)} }
+func New() *U { return &U{u: make(map[string]item)} }
 
 // Set sets function f in U under key. If the key already exists
 // it is not overwritten.
-func (u U) Set(key string, f func() error) {
+func (u *U) Set(key string, f func() error) {
+	u.Lock()
+	defer u.Unlock()
 	if _, ok := u.u[key]; ok {
 		return
 	}
@@ -25,7 +32,9 @@ func (u U) Set(key string, f func() error) {
 }
 
 // SetTodo sets key to 'todo' again.
-func (u U) SetTodo(key string) {
+func (u *U) SetTodo(key string) {
+	u.Lock()
+	defer u.Unlock()
 	v, ok := u.u[key]
 	if !ok {
 		return
@@ -34,16 +43,32 @@ func (u U) SetTodo(key string) {
 	u.u[key] = v
 }
 
-// ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done'.
-func (u U) ForEach() error {
+// ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done' - if f executes w/o error
+func (u *U) ForEach() error {
+	u.Lock()
+	defer u.Unlock()
 	for k, v := range u.u {
 		if v.state == todo {
-			v.f()
+			if v.f() == nil {
+				// change the state only if an error did not occur
+				v.state = done
+				u.u[k] = v
+			}
 		}
-		v.state = done
-		u.u[k] = v
 	}
 	return nil
+}
+
+// HasTodo inform on weather some things are still in todo mode
+func (u *U) HasTodo() bool {
+	u.Lock()
+	defer u.Unlock()
+	for _, v := range u.u {
+		if v.state == todo {
+			return true
+		}
+	}
+	return false
 }
 
 const (

--- a/plugin/pkg/uniq/uniq_test.go
+++ b/plugin/pkg/uniq/uniq_test.go
@@ -6,9 +6,15 @@ func TestForEach(t *testing.T) {
 	u, i := New(), 0
 	u.Set("test", func() error { i++; return nil })
 
+	if !u.HasTodo() {
+		t.Errorf("Element %s - is not set as a 'todo'", "test")
+	}
 	u.ForEach()
 	if i != 1 {
 		t.Errorf("Failed to executed f for %s", "test")
+	}
+	if u.HasTodo() {
+		t.Errorf("Element %s - is not change to 'done'", "test")
 	}
 	u.ForEach()
 	if i != 1 {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -1,7 +1,10 @@
 package test
 
 import (
+	"fmt"
 	"io/ioutil"
+	"net"
+	"net/http"
 	"os"
 	"path"
 	"strings"

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -118,7 +118,7 @@ func TestReloadMetricsHealth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const proc = "process_virtual_memory_bytes"
+	const proc = "coredns_build_info"
 	metrics, _ := ioutil.ReadAll(resp.Body)
 	if !bytes.Contains(metrics, []byte(proc)) {
 		t.Errorf("Failed to see %s in metric output", proc)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Inform when Prometheus cannot provide service because HTTP server could not start.

NOTE: during testing, I found that the Tests could not run properly because the variable uniqAddr that is shared by all instance of metrics plugin was not reset  between Tests.
I moved that variable from global scope of "metrics" to the storage of each caddy instance.
(Caddy did that enhancement in purpose for the "reload" use case).

### Content
- register healther for metrics (return not ok if all listeners are not started properly)
- save the instance of uniqAddr, that is shared by all instances of metrics plugin, into the caddy's instance storage, instead global var.
- add UT with a sample of function RepairHealth for metrics

### 2. Which issues (if any) are related?
#1868. 
#1982 

#1868. is resolved by allowing a monitoring of the metrics using the health plugin. 
any monitor can then know when Prometheus does not provide the service and then decide to restart the process of CoreDNS.

#1982 is resolved because we create a new uniqAddr on every new instance : there is no more mismatch with setup of former instance.

### 3. Which documentation changes (if any) need to be made?
README of the plugin updated.


### NOTE: 
this PR overlaps with #1969 - the second to be merged will need a rebase before the merge.
