### PR TITLE
plugin/loop: add missing break

### DIFF
--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -37,10 +37,10 @@ func setup(c *caddy.Controller) error {
 		go func() {
 			deadline := time.Now().Add(30 * time.Second)
 			conf := dnsserver.GetConfig(c)
+			lh := conf.ListenHosts[0]
+			addr := net.JoinHostPort(lh, conf.Port)
 
 			for time.Now().Before(deadline) {
-				lh := conf.ListenHosts[0]
-				addr := net.JoinHostPort(lh, conf.Port)
 				if _, err := l.exchange(addr); err != nil {
 					time.Sleep(1 * time.Second)
 					continue
@@ -50,6 +50,8 @@ func setup(c *caddy.Controller) error {
 					time.Sleep(2 * time.Second)
 					l.setDisabled()
 				}()
+
+				break
 			}
 			l.setDisabled()
 		}()


### PR DESCRIPTION
The Onstartup loop wouldn't call break after the first success, thereby
sending the query multiple times and halting the process.

Some small other optimizations as well.

Signed-off-by: Miek Gieben <miek@miek.nl>

(still having trouble distilling this into a test)