### PR TITLE
plugin/loop - ensure zone/qname declared on the right domain

### DIFF
--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -73,8 +73,8 @@ func parse(c *caddy.Controller) (*Loop, error) {
 			return nil, c.ArgErr()
 		}
 
-		if len(c.ServerBlockKeys) > 0 {
-			zone = plugin.Host(c.ServerBlockKeys[0]).Normalize()
+		if len(c.Key) > 0 {
+			zone = plugin.Host(c.Key).Normalize()
 		}
 	}
 	return New(zone), nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
error (I guess a corner case though) in the setup of plugin loop

### 2. Which issues (if any) are related?
#1995 

### 3. Which documentation changes (if any) need to be made?
None.
