### PR TITLE
plugin/forward: Don't panic when healthchecking nameservers from resolv.conf

### DIFF
--- a/plugin/forward/fixtures/resolv.conf
+++ b/plugin/forward/fixtures/resolv.conf
@@ -1,0 +1,15 @@
+# This file is managed by man:systemd-resolved(8). Do not edit.
+#
+# This is a dynamic resolv.conf file for connecting local clients directly to
+# all known uplink DNS servers. This file lists all configured search domains.
+#
+# Third party programs must not access this file directly, but only through the
+# symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a different way,
+# replace this symlink by a static file or a different symlink.
+#
+# See man:systemd-resolved.service(8) for details about the supported modes of
+# operation for /etc/resolv.conf.
+
+nameserver 8.8.8.8
+nameserver 4.3.2.1
+search c.my-project.internal google.internal

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -17,9 +17,9 @@ type HealthChecker interface {
 // dnsHc is a health checker for a DNS endpoint (DNS, and DoT).
 type dnsHc struct{ c *dns.Client }
 
-// NewHealthChecker returns a new HealthChecker based on protocol.
-func NewHealthChecker(protocol int) HealthChecker {
-	switch protocol {
+// NewHealthChecker returns a new HealthChecker.
+func NewHealthChecker(p Protocol) HealthChecker {
+	switch p {
 	case DNS, TLS:
 		c := new(dns.Client)
 		c.Net = "udp"
@@ -29,7 +29,10 @@ func NewHealthChecker(protocol int) HealthChecker {
 		return &dnsHc{c: c}
 	}
 
-	return nil
+	// Panic early if we're asked to healthcheck an unknown protocol, rather
+	// than returning a nil HealthChecker that will panic when Check() is
+	// called.
+	panic("unknown protocol: only DNS or TLS health checks are currently supported")
 }
 
 func (h *dnsHc) SetTLSConfig(cfg *tls.Config) {

--- a/plugin/forward/protocol.go
+++ b/plugin/forward/protocol.go
@@ -8,7 +8,7 @@ import (
 
 // protocol returns the protocol of the string s. The second string returns s
 // with the prefix chopped off.
-func protocol(s string) (int, string) {
+func protocol(s string) (Protocol, string) {
 	switch {
 	case strings.HasPrefix(s, _tls+"://"):
 		return TLS, s[len(_tls)+3:]
@@ -18,9 +18,13 @@ func protocol(s string) (int, string) {
 	return DNS, s
 }
 
+// A Protocol used to query DNS.
+type Protocol int
+
 // Supported protocols.
 const (
-	DNS = iota + 1
+	Unknown Protocol = iota
+	DNS
 	TLS
 )
 

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -26,7 +26,7 @@ type Proxy struct {
 }
 
 // NewProxy returns a new proxy.
-func NewProxy(addr string, protocol int) *Proxy {
+func NewProxy(addr string, proto Protocol) *Proxy {
 	p := &Proxy{
 		addr:      addr,
 		fails:     0,
@@ -34,7 +34,7 @@ func NewProxy(addr string, protocol int) *Proxy {
 		transport: newTransport(addr),
 		avgRtt:    int64(maxTimeout / 2),
 	}
-	p.health = NewHealthChecker(protocol)
+	p.health = NewHealthChecker(proto)
 	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
 }

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -52,20 +52,22 @@ func TestSetup(t *testing.T) {
 			if !strings.Contains(err.Error(), test.expectedErr) {
 				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
 			}
+
+			continue
 		}
 
-		if !test.shouldErr && f.from != test.expectedFrom {
+		if f.from != test.expectedFrom {
 			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedFrom, f.from)
 		}
-		if !test.shouldErr && test.expectedIgnored != nil {
+		if test.expectedIgnored != nil {
 			if !reflect.DeepEqual(f.ignored, test.expectedIgnored) {
 				t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedIgnored, f.ignored)
 			}
 		}
-		if !test.shouldErr && f.maxfails != test.expectedFails {
+		if f.maxfails != test.expectedFails {
 			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedFails, f.maxfails)
 		}
-		if !test.shouldErr && f.opts != test.expectedOpts {
+		if f.opts != test.expectedOpts {
 			t.Errorf("Test %d: expected: %v, got: %v", i, test.expectedOpts, f.opts)
 		}
 	}
@@ -107,13 +109,15 @@ func TestSetupTLS(t *testing.T) {
 			if !strings.Contains(err.Error(), test.expectedErr) {
 				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
 			}
+
+			continue
 		}
 
-		if !test.shouldErr && test.expectedServerName != "" && test.expectedServerName != f.tlsConfig.ServerName {
+		if test.expectedServerName != "" && test.expectedServerName != f.tlsConfig.ServerName {
 			t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedServerName, f.tlsConfig.ServerName)
 		}
 
-		if !test.shouldErr && test.expectedServerName != "" && test.expectedServerName != f.proxies[0].health.(*dnsHc).c.TLSConfig.ServerName {
+		if test.expectedServerName != "" && test.expectedServerName != f.proxies[0].health.(*dnsHc).c.TLSConfig.ServerName {
 			t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedServerName, f.proxies[0].health.(*dnsHc).c.TLSConfig.ServerName)
 		}
 	}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -90,19 +90,20 @@ func TestSetupTLS(t *testing.T) {
 		input              string
 		shouldErr          bool
 		expectedServerName string
+		expectedProxies    int
 		expectedErr        string
 	}{
 		// positive
 		{`forward . tls://127.0.0.1 {
 				tls_servername dns
-			}`, false, "dns", ""},
+			}`, false, "dns", 1, ""},
 		{`forward . 127.0.0.1 {
 				tls_servername dns
-			}`, false, "", ""},
+			}`, false, "", 1, ""},
 		{`forward . 127.0.0.1 {
 				tls
-			}`, false, "", ""},
-		{`forward . tls://127.0.0.1`, false, "", ""},
+			}`, false, "", 1, ""},
+		{`forward . tls://127.0.0.1`, false, "", 1, ""},
 	}
 
 	for i, test := range tests {
@@ -127,6 +128,10 @@ func TestSetupTLS(t *testing.T) {
 
 		if test.expectedServerName != "" && test.expectedServerName != f.tlsConfig.ServerName {
 			t.Errorf("Test %d: expected: %q, actual: %q", i, test.expectedServerName, f.tlsConfig.ServerName)
+		}
+
+		if len(f.proxies) != test.expectedProxies {
+			t.Errorf("Test %d: expected %d proxies, got %d", i, test.expectedProxies, len(f.proxies))
 		}
 
 		if test.expectedServerName != "" && test.expectedServerName != f.proxies[0].health.(*dnsHc).c.TLSConfig.ServerName {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR prevents `forward` from panicing at healthcheck time when configured to load proxies from a `resolv.conf` file with more than one `nameserver` entry. See #2003 for more context.

I've also slightly refactored some tests I touched, and attempted to make the protocol type slightly more resilient to future issues of the same class.

### 2. Which issues (if any) are related?
Fixes #2003.

### 3. Which documentation changes (if any) need to be made?
None to my knowledge. I believe this PR retains the (seemingly) intended configuration semantics of the existing `forward` plugin implementation.