### PR TITLE
Makefile: remove goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ coredns: $(CHECKS)
 	CGO_ENABLED=0 $(SYSTEM) go build $(VERBOSE) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
-check: presubmit goimports core/zplugin.go core/dnsserver/zdirectives.go godeps
+check: presubmit core/zplugin.go core/dnsserver/zdirectives.go godeps
 
 .PHONY: test
 test: check
@@ -77,12 +77,6 @@ gen:
 .PHONY: pb
 pb:
 	$(MAKE) -C pb
-
-.PHONY: goimports
-goimports:
-	go get -u github.com/alecthomas/gometalinter
-	gometalinter --install goimports > /dev/null
-	( gometalinter --deadline=2m --disable-all --enable=goimports --enable=golint --enable=vet --vendor --exclude=^pb/ ./... || true )
 
 # Presubmit runs all scripts in .presubmit; any non 0 exit code will fail the build.
 .PHONY: presubmit


### PR DESCRIPTION
This downloads gometalinter (which is now breaking in the CI tests).
Also the goimports target is run with ||true, so nothing will break
if this flags anything (done because of gofmt changes in between
release).

Probably I will setup something to use github's linter API:
https://github.com/markstory/lint-review

Signed-off-by: Miek Gieben <miek@miek.nl>
