### PR TITLE
Make presubmit actually fail the build

### DIFF
--- a/.presubmit/filename-hyphen
+++ b/.presubmit/filename-hyphen
@@ -5,5 +5,6 @@ echo "** presubmit/$(basename $0)"
 for dir in "$@"; do
     if find $dir | grep '-'; then
         echo "** presubmit/$(basename $0): please use an underscore in filenames instead of a hyphen"
+        exit 1
     fi
 done

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ pb:
 # Presubmit runs all scripts in .presubmit; any non 0 exit code will fail the build.
 .PHONY: presubmit
 presubmit:
-	@for pre in $(MAKEPWD)/.presubmit/* ; do "$$pre" $(PRESUBMIT); done
+	@for pre in $(MAKEPWD)/.presubmit/* ; do "$$pre" $(PRESUBMIT) || exit 1 ; done
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The exit code wasn't properly acted upon in the makefile.
Make filename-hyphen actually return an non-zero exit code.

Signed-off-by: Miek Gieben <miek@miek.nl>
