### PR TITLE
fixed typo in kubernetes plugin man page and README.

### DIFF
--- a/man/coredns-kubernetes.7
+++ b/man/coredns-kubernetes.7
@@ -73,7 +73,7 @@ kubernetes [ZONES\.\.\.] {
 \fBdisabled\fR: Default\. Do not process pod requests, always returning \fBNXDOMAIN\fR
 .
 .IP "\(bu" 4
-\fBinsecure\fR: Always return an A record with IP from request (without checking k8s)\. This option is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs\. This option is provided for backward compatibility with kube\-dns\.
+\fBinsecure\fR: Always return an A record with IP from request (without checking k8s)\. This option is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs\. This option is provided for backward compatibility with kube\-dns\.
 .
 .IP "\(bu" 4
 \fBverified\fR: Return an A record if there exists a pod in same namespace with matching IP\. This option requires substantially more memory than in insecure mode, since it will maintain a watch on all pods\.

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -67,7 +67,7 @@ kubernetes [ZONES...] {
 
    * `disabled`: Default. Do not process pod requests, always returning `NXDOMAIN`
    * `insecure`: Always return an A record with IP from request (without checking k8s).  This option
-     is is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This
+     is vulnerable to abuse if used maliciously in conjunction with wildcard SSL certs.  This
      option is provided for backward compatibility with kube-dns.
    * `verified`: Return an A record if there exists a pod in same namespace with matching IP.  This
      option requires substantially more memory than in insecure mode, since it will maintain a watch


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Fixes typo "This option is is vulnerable" > "This option is vulnerable".

### 2. Which issues (if any) are related?
-

### 3. Which documentation changes (if any) need to be made?
-

I created  [pr](https://github.com/coredns/coredns.io/pull/101) against coredns.io repo first, but was told to reopen it against this repo.