### PR TITLE
dnstap.TapperFromContext always returns nil

### DIFF
--- a/plugin/dnstap/context_test.go
+++ b/plugin/dnstap/context_test.go
@@ -10,6 +10,6 @@ func TestDnstapContext(t *testing.T) {
 	tapper := TapperFromContext(ctx)
 
 	if tapper == nil {
-		t.Fatal("can't get tapper")
+		t.Fatal("Can't get tapper")
 	}
 }

--- a/plugin/dnstap/context_test.go
+++ b/plugin/dnstap/context_test.go
@@ -1,0 +1,15 @@
+package dnstap
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDnstapContext(t *testing.T) {
+	ctx := tapContext{context.TODO(), Dnstap{}}
+	tapper := TapperFromContext(ctx)
+
+	if tapper == nil {
+		t.Fatal("can't get tapper")
+	}
+}

--- a/plugin/dnstap/handler.go
+++ b/plugin/dnstap/handler.go
@@ -51,7 +51,7 @@ func TapperFromContext(ctx context.Context) (t Tapper) {
 }
 
 // TapMessage implements Tapper.
-func (h *Dnstap) TapMessage(m *tap.Message) {
+func (h Dnstap) TapMessage(m *tap.Message) {
 	t := tap.Dnstap_MESSAGE
 	h.IO.Dnstap(tap.Dnstap{
 		Type:    &t,


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Because of this bug, plugin proxy wasn't sending its DNS messages to dnstap.

I don't know what caused this since it was introduced, but now there will be a test on this function.