### PR TITLE
Remove setting minimum number of cache entries per shard

### DIFF
--- a/plugin/pkg/cache/cache.go
+++ b/plugin/pkg/cache/cache.go
@@ -31,10 +31,6 @@ type shard struct {
 // New returns a new cache.
 func New(size int) *Cache {
 	ssize := size / shardSize
-	if ssize < 512 {
-		ssize = 512
-	}
-
 	c := &Cache{}
 
 	// Initialize all the shards

--- a/plugin/pkg/cache/cache.go
+++ b/plugin/pkg/cache/cache.go
@@ -31,6 +31,9 @@ type shard struct {
 // New returns a new cache.
 func New(size int) *Cache {
 	ssize := size / shardSize
+	if ssize < 4 {
+		ssize = 4
+	}
 	c := &Cache{}
 
 	// Initialize all the shards


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This pull request removes the minimum requirement for number of cache entries per shard. 
With minimum requirement,  the current cache capacity has the minimum cache capacity of 131,072 entries which could cause issue for running coredns on platform where memory is limited.

### 2. Which issues (if any) are related?
#2017 

### 3. Which documentation changes (if any) need to be made?
README.md in plugin/cache need to be updated with the change. 
