### PR TITLE
plugin/forward: Split setup to reuse it from external plugins

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -13,6 +13,7 @@ import (
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 
 	"github.com/mholt/caddy"
+	"github.com/mholt/caddy/caddyfile"
 )
 
 func init() {
@@ -70,68 +71,80 @@ func (f *Forward) OnShutdown() error {
 func (f *Forward) Close() { f.OnShutdown() }
 
 func parseForward(c *caddy.Controller) (*Forward, error) {
-	f := New()
-
-	protocols := map[int]int{}
-
-	i := 0
+	var (
+		f   *Forward
+		err error
+		i   int
+	)
 	for c.Next() {
 		if i > 0 {
 			return nil, plugin.ErrOnce
 		}
 		i++
-
-		if !c.Args(&f.from) {
-			return f, c.ArgErr()
-		}
-		f.from = plugin.Host(f.from).Normalize()
-
-		to := c.RemainingArgs()
-		if len(to) == 0 {
-			return f, c.ArgErr()
-		}
-
-		// A bit fiddly, but first check if we've got protocols and if so add them back in when we create the proxies.
-		protocols = make(map[int]int)
-		for i := range to {
-			protocols[i], to[i] = protocol(to[i])
-		}
-
-		// If parseHostPortOrFile expands a file with a lot of nameserver our accounting in protocols doesn't make
-		// any sense anymore... For now: lets don't care.
-		toHosts, err := dnsutil.ParseHostPortOrFile(to...)
+		f, err = ParseForwardStanza(&c.Dispenser)
 		if err != nil {
+			return nil, err
+		}
+	}
+	return f, nil
+}
+
+// ParseForwardStanza parses one forward stanza
+func ParseForwardStanza(c *caddyfile.Dispenser) (*Forward, error) {
+	f := New()
+
+	protocols := map[int]int{}
+
+	if !c.Args(&f.from) {
+		return f, c.ArgErr()
+	}
+	f.from = plugin.Host(f.from).Normalize()
+
+	to := c.RemainingArgs()
+	if len(to) == 0 {
+		return f, c.ArgErr()
+	}
+
+	// A bit fiddly, but first check if we've got protocols and if so add them back in when we create the proxies.
+	protocols = make(map[int]int)
+	for i := range to {
+		protocols[i], to[i] = protocol(to[i])
+	}
+
+	// If parseHostPortOrFile expands a file with a lot of nameserver our accounting in protocols doesn't make
+	// any sense anymore... For now: lets don't care.
+	toHosts, err := dnsutil.ParseHostPortOrFile(to...)
+	if err != nil {
+		return f, err
+	}
+
+	for i, h := range toHosts {
+		// Double check the port, if e.g. is 53 and the transport is TLS make it 853.
+		// This can be somewhat annoying because you *can't* have TLS on port 53 then.
+		switch protocols[i] {
+		case TLS:
+			h1, p, err := net.SplitHostPort(h)
+			if err != nil {
+				break
+			}
+
+			// This is more of a bug in dnsutil.ParseHostPortOrFile that defaults to
+			// 53 because it doesn't know about the tls:// // and friends (that should be fixed). Hence
+			// Fix the port number here, back to what the user intended.
+			if p == "53" {
+				h = net.JoinHostPort(h1, "853")
+			}
+		}
+
+		// We can't set tlsConfig here, because we haven't parsed it yet.
+		// We set it below at the end of parseBlock, use nil now.
+		p := NewProxy(h, protocols[i])
+		f.proxies = append(f.proxies, p)
+	}
+
+	for c.NextBlock() {
+		if err := parseBlock(c, f); err != nil {
 			return f, err
-		}
-
-		for i, h := range toHosts {
-			// Double check the port, if e.g. is 53 and the transport is TLS make it 853.
-			// This can be somewhat annoying because you *can't* have TLS on port 53 then.
-			switch protocols[i] {
-			case TLS:
-				h1, p, err := net.SplitHostPort(h)
-				if err != nil {
-					break
-				}
-
-				// This is more of a bug in dnsutil.ParseHostPortOrFile that defaults to
-				// 53 because it doesn't know about the tls:// // and friends (that should be fixed). Hence
-				// Fix the port number here, back to what the user intended.
-				if p == "53" {
-					h = net.JoinHostPort(h1, "853")
-				}
-			}
-
-			// We can't set tlsConfig here, because we haven't parsed it yet.
-			// We set it below at the end of parseBlock, use nil now.
-			p := NewProxy(h, protocols[i])
-			f.proxies = append(f.proxies, p)
-		}
-
-		for c.NextBlock() {
-			if err := parseBlock(c, f); err != nil {
-				return f, err
-			}
 		}
 	}
 
@@ -148,7 +161,7 @@ func parseForward(c *caddy.Controller) (*Forward, error) {
 	return f, nil
 }
 
-func parseBlock(c *caddy.Controller, f *Forward) error {
+func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 	switch c.Val() {
 	case "except":
 		ignore := c.RemainingArgs()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It splits setup of forward plugin to reuse it from external plugin "alternate".
No logic changed.
### 2. Which issues (if any) are related?
https://github.com/coredns/fallback/issues/9
### 3. Which documentation changes (if any) need to be made?
No.