### PR TITLE
Metrics listener fix

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -147,7 +147,7 @@ var ListenAddr string
 
 // shutdownTimeout is the maximum amount of time the metrics plugin will wait
 // before erroring when it tries to close the metrics server
-var shutdownTimeout time.Duration = time.Second * 1
+const shutdownTimeout time.Duration = time.Second * 5
 
 var buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: plugin.Namespace,

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -2,10 +2,12 @@
 package metrics
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
@@ -22,6 +24,7 @@ type Metrics struct {
 	ln      net.Listener
 	lnSetup bool
 	mux     *http.ServeMux
+	srv     *http.Server
 
 	zoneNames []string
 	zoneMap   map[string]bool
@@ -94,9 +97,9 @@ func (m *Metrics) OnStartup() error {
 
 	m.mux = http.NewServeMux()
 	m.mux.Handle("/metrics", promhttp.HandlerFor(m.Reg, promhttp.HandlerOpts{}))
-
+	m.srv = &http.Server{Handler: m.mux}
 	go func() {
-		http.Serve(m.ln, m.mux)
+		m.srv.Serve(m.ln)
 	}()
 	return nil
 }
@@ -106,24 +109,28 @@ func (m *Metrics) OnRestart() error {
 	if !m.lnSetup {
 		return nil
 	}
+	uniqAddr.Unset(m.Addr)
+	return m.stopServer()
+}
 
-	uniqAddr.SetTodo(m.Addr)
-
-	m.ln.Close()
+func (m *Metrics) stopServer() error {
+	if !m.lnSetup {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := m.srv.Shutdown(ctx); err != nil {
+		log.Infof("Failed to stop prometheus http server: %s", err)
+		return err
+	}
 	m.lnSetup = false
+	m.ln.Close()
 	return nil
 }
 
 // OnFinalShutdown tears down the metrics listener on shutdown and restart.
 func (m *Metrics) OnFinalShutdown() error {
-	// We allow prometheus statements in multiple Server Blocks, but only the first
-	// will open the listener, for the rest they are all nil; guard against that.
-	if !m.lnSetup {
-		return nil
-	}
-
-	m.lnSetup = false
-	return m.ln.Close()
+	return m.stopServer()
 }
 
 func keys(m map[string]bool) []string {
@@ -137,6 +144,10 @@ func keys(m map[string]bool) []string {
 // ListenAddr is assigned the address of the prometheus listener. Its use is mainly in tests where
 // we listen on "localhost:0" and need to retrieve the actual address.
 var ListenAddr string
+
+// shutdownTimeout is the maximum amount of time the metrics plugin will wait
+// before erroring when it tries to close the metrics server
+var shutdownTimeout time.Duration = time.Second * 1
 
 var buildInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: plugin.Namespace,

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -24,6 +24,7 @@ func (u U) Set(key string, f func() error) {
 	u.u[key] = item{todo, f}
 }
 
+// Unset removes the 'todo' associated with a key
 func (u U) Unset(key string) {
 	if _, ok := u.u[key]; ok {
 		delete(u.u, key)

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -45,11 +45,10 @@ func (u U) SetTodo(key string) {
 func (u U) ForEach() error {
 	for k, v := range u.u {
 		if v.state == todo {
-			if err := v.f(); err == nil {
-				v.state = done
-				u.u[k] = v
-			}
+			v.f()
 		}
+		v.state = done
+		u.u[k] = v
 	}
 	return nil
 }

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -24,6 +24,12 @@ func (u U) Set(key string, f func() error) {
 	u.u[key] = item{todo, f}
 }
 
+func (u U) Unset(key string) {
+	if _, ok := u.u[key]; ok {
+		delete(u.u, key)
+	}
+}
+
 // SetTodo sets key to 'todo' again.
 func (u U) SetTodo(key string) {
 	v, ok := u.u[key]
@@ -38,10 +44,11 @@ func (u U) SetTodo(key string) {
 func (u U) ForEach() error {
 	for k, v := range u.u {
 		if v.state == todo {
-			v.f()
+			if err := v.f(); err == nil {
+				v.state = done
+				u.u[k] = v
+			}
 		}
-		v.state = done
-		u.u[k] = v
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

When the metrics address is changed inside the `Corefile` and a reload is triggered, CoreDNS will continue exporting metrics to the old address. This was reported in #1982, so check out that issue for a more in-depth description and some discussion about the bug itself.

This PR  resolves the issue by modifying the metrics plugin's `OnRestart` behavior. Before CoreDNS reloads, the metrics plugin now stops the existing Prometheus exporter and removes the current metrics address from the `Metrics.uniqAddr.Todo` field. When CoreDNS spins back up, it creates `Metrics.uniqAddr` using the new metrics configuration.

### 2. Which issues (if any) are related?
Resolves #1982.

### 3. Which documentation changes (if any) need to be made?

Other than inline documentation, I don't think any documentation changes are necessary; this is just a bug fix.