### PR TITLE
plugin/kubernetes: fix kubernetes in-cluster CNAME lookup

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -183,6 +183,15 @@ var dnsTestCases = []test.Case{
 			test.CNAME("external.testns.svc.cluster.local.	5	IN	CNAME	ext.interwebs.test."),
 		},
 	},
+	// CNAME External To Internal Service
+	{
+		Qname: "external-to-service.testns.svc.cluster.local", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external-to-service.testns.svc.cluster.local.	5	IN	CNAME	svc1.testns.svc.cluster.local."),
+			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
+		},
+	},
 	// AAAA Service (with an existing A record, but no AAAA record)
 	{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
@@ -412,6 +421,21 @@ var svcIndex = map[string][]*api.Service{
 		},
 		Spec: api.ServiceSpec{
 			ExternalName: "ext.interwebs.test",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
+			Type: api.ServiceTypeExternalName,
+		},
+	}},
+	"external-to-service.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "external-to-service",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ExternalName: "svc1.testns.svc.cluster.local.",
 			Ports: []api.ServicePort{{
 				Name:     "http",
 				Protocol: "tcp",

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -14,17 +14,17 @@ func TestParseRequest(t *testing.T) {
 		expected string // output from r.String()
 	}{
 		// valid SRV request
-		{"_http._tcp.webs.mynamespace.svc.inter.webs.test.", "http.tcp..webs.mynamespace.svc"},
+		{"_http._tcp.webs.mynamespace.svc.inter.webs.tests.", "http.tcp..webs.mynamespace.svc"},
 		// wildcard acceptance
-		{"*.any.*.any.svc.inter.webs.test.", "*.any..*.any.svc"},
+		{"*.any.*.any.svc.inter.webs.tests.", "*.any..*.any.svc"},
 		// A request of endpoint
-		{"1-2-3-4.webs.mynamespace.svc.inter.webs.test.", "*.*.1-2-3-4.webs.mynamespace.svc"},
+		{"1-2-3-4.webs.mynamespace.svc.inter.webs.tests.", "*.*.1-2-3-4.webs.mynamespace.svc"},
 		// bare zone
-		{"inter.webs.test.", "....."},
+		{"inter.webs.tests.", "....."},
 		// bare svc type
-		{"svc.inter.webs.test.", "....."},
+		{"svc.inter.webs.tests.", "....."},
 		// bare pod type
-		{"pod.inter.webs.test.", "....."},
+		{"pod.inter.webs.tests.", "....."},
 	}
 	for i, tc := range tests {
 		m := new(dns.Msg)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

When using kubernetes plugin to do recursive CNAME lookup. If the CNAME target also in kubernetes zone. The kubernetes plugin will fail because of zone is not set, the kubernetes' zone cannot be cutoff from query name, then cannot found from kubernetes service & pod:

So I pass the zone to backend plugin, when state name not belong to the zone passed in. Then the kubernetes plugin will fail to next plugin.


### 2. Which issues (if any) are related?
fix #2038 

### 3. Which documentation changes (if any) need to be made?

none
