### PR TITLE
plugin/kubernetes: handle blank name and namespaces

### DIFF
--- a/plugin/kubernetes/handler_pod_insecure_test.go
+++ b/plugin/kubernetes/handler_pod_insecure_test.go
@@ -55,7 +55,7 @@ var podModeInsecureCases = []test.Case{
 	},
 	{
 		Qname: "podns.pod.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
+		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1515173576 7200 1800 86400 30"),
 		},

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -290,6 +290,13 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
+	{
+		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	303	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
+		},
+	},
 }
 
 func TestServeDNS(t *testing.T) {

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -43,10 +43,10 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 
 	r.port = "*"
 	r.protocol = "*"
-	r.service = "*"
-	r.namespace = "*"
-	// r.endpoint is the odd one out, we need to know if it has been set or not. If it is
-	// empty we should skip the endpoint check in k.get(). Hence we cannot set if to "*".
+	// for r.name, r.namespace and r.endpoint, we need to know if they have been set or not...
+	// For endpoint: if empty we should skip the endpoint check in k.get(). Hence we cannot set if to "*".
+	// For name: myns.svc.cluster.local != *.myns.svc.cluster.local
+	// For namespace: svc.cluster.local != *.svc.cluster.local
 
 	// start at the right and fill out recordRequest with the bits we find, so we look for
 	// pod|svc.namespace.service and then either


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Fixes cases where missing names or namespaces in a query cause k8s plugin to return all services/pods.

### 2. Which issues (if any) are related?
Fixes #2028

### 3. Which documentation changes (if any) need to be made?
none