### PR TITLE
plugin/kubernetes: dont transfer unexposed namespaces

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -330,6 +330,7 @@ func TestServeDNS(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.Namespaces = map[string]bool{"testns": true}
 	ctx := context.TODO()
 
 	for i, tc := range dnsTestCases {
@@ -476,6 +477,21 @@ var svcIndex = map[string][]*api.Service{
 		Spec: api.ServiceSpec{
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: api.ClusterIPNone,
+		},
+	}},
+	"svc1.unexposedns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "unexposedns",
+		},
+		Spec: api.ServiceSpec{
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: "10.0.0.2",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
 		},
 	}},
 }

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -78,7 +78,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 	zonePath := msg.Path(zone, "coredns")
 	serviceList := k.APIConn.ServiceList()
 	for _, svc := range serviceList {
-		if !k.namespaceExposed(svc.Namespace){
+		if !k.namespaceExposed(svc.Namespace) {
 			continue
 		}
 		svcBase := []string{zonePath, Svc, svc.Namespace, svc.Name}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -78,6 +78,9 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 	zonePath := msg.Path(zone, "coredns")
 	serviceList := k.APIConn.ServiceList()
 	for _, svc := range serviceList {
+		if !k.namespaceExposed(svc.Namespace){
+			continue
+		}
 		svcBase := []string{zonePath, Svc, svc.Namespace, svc.Name}
 		switch svc.Spec.Type {
 		case api.ServiceTypeClusterIP, api.ServiceTypeNodePort, api.ServiceTypeLoadBalancer:

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -17,6 +17,7 @@ func TestKubernetesXFR(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.TransferTo = []string{"127.0.0.1"}
+	k.Namespaces = map[string]bool{"testns": true}
 
 	ctx := context.TODO()
 	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Don't include records in unexposed namespaces in zone transfers.

### 2. Which issues (if any) are related?
fixes #2043

### 3. Which documentation changes (if any) need to be made?
none