### PR TITLE
plugin/kubernetes: Note that deprecated style pod records are not transferred 

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -95,6 +95,7 @@ kubernetes [ZONES...] {
   (only `to` is allow). **ADDRESS** must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as
   plain addresses. The special wildcard `*` means: the entire internet.
   Sending DNS notifies is not supported.
+  [Deprecated](https://github.com/kubernetes/dns/blob/master/docs/specification.md#26---deprecated-records) pod records in the sub domain `pod.cluster.local` are not transfered. 
 * `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative
   results in NXDOMAIN, normally that is what the response will be. However, if you specify this option,
   the query will instead be passed on down the plugin chain, which can include another plugin to handle

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -95,7 +95,7 @@ kubernetes [ZONES...] {
   (only `to` is allow). **ADDRESS** must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as
   plain addresses. The special wildcard `*` means: the entire internet.
   Sending DNS notifies is not supported.
-  [Deprecated](https://github.com/kubernetes/dns/blob/master/docs/specification.md#26---deprecated-records) pod records in the sub domain `pod.cluster.local` are not transfered. 
+  [Deprecated](https://github.com/kubernetes/dns/blob/master/docs/specification.md#26---deprecated-records) pod records in the sub domain `pod.cluster.local` are not transferred. 
 * `fallthrough` **[ZONES...]** If a query for a record in the zones for which the plugin is authoritative
   results in NXDOMAIN, normally that is what the response will be. However, if you specify this option,
   the query will instead be passed on down the plugin chain, which can include another plugin to handle


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add a note in the docs that deprecated style pod records (e.g. `1-2-3-4.default.pod.cluster.local`) are not transferred in zone transfers.  These records exist in the zone, but are not transferred.  For "pods insecure" mode, its impractical/impossible to transfer these records (since the set would be all valid IPs 256^4 for ipv4 alone).  But  if using "pods verified", we could transfer them, so one might consider this a bug if we don't document it.

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
included