### PR TITLE
plugin/rewrite: Add suffix example to docs

### DIFF
--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -221,6 +221,12 @@ Examples:
 rewrite edns0 local set 0xffee {client_ip}
 ~~~
 
+The following example rewrites the `schmoogle.com` suffix to `google.com`.
+
+~~~
+rewrite name suffix .schmoogle.com. .google.com.
+~~~
+
 The following example uses metadata and an imaginary "some-plugin" that would provide "some-label" as metadata information.
 
 ~~~


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Add suffix example to docs.  Suffix rules require leading and trailing dots to work correctly, which isn't obvious.  Example should help.

### 2. Which issues (if any) are related?
#1881

### 3. Which documentation changes (if any) need to be made?
this