### PR TITLE
plugin/kubernetes: Create records for portless services

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -172,9 +172,9 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 		w[serv.Priority] += weight
 	}
 	for _, serv := range services {
-		// Don't add the entry if the port is 0 (invalid). The kubernetes plugin uses port 0 when a service/endpoint
+		// Don't add the entry if the port is -1 (invalid). The kubernetes plugin uses port -1 when a service/endpoint
 		// does not have any declared ports.
-		if serv.Port == 0 {
+		if serv.Port == -1 {
 			continue
 		}
 		w1 := 100.0 / float64(w[serv.Priority])

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -172,6 +172,11 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 		w[serv.Priority] += weight
 	}
 	for _, serv := range services {
+		// Don't add the entry if the port is 0 (invalid). The kubernetes plugin uses port 0 when a service/endpoint
+		// does not have any declared ports.
+		if serv.Port == 0 {
+			continue
+		}
 		w1 := 100.0 / float64(w[serv.Priority])
 		if serv.Weight == 0 {
 			w1 *= 100

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -124,6 +124,22 @@ var dnsTestCases = []test.Case{
 			test.A("hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
 		},
 	},
+	// A Service (Headless and Portless)
+	{
+		Qname: "hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
+		},
+	},
+	// An Endpoint with no port
+	{
+		Qname: "172-0-0-20.hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("172-0-0-20.hdlsprtls.testns.svc.cluster.local.	5	IN	A	172.0.0.20"),
+		},
+	},
 	// An Endpoint ip
 	{
 		Qname: "172-0-0-2.hdls1.testns.svc.cluster.local.", Qtype: dns.TypeA,
@@ -167,6 +183,14 @@ var dnsTestCases = []test.Case{
 			test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.4"),
 			test.A("dup-name.hdls1.testns.svc.cluster.local.	5	IN	A	172.0.0.5"),
+		},
+	},
+	// SRV Service (Headless and portless)
+	{
+		Qname: "*.*.hdlsprtls.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	300	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 60"),
 		},
 	},
 	// AAAA
@@ -444,6 +468,16 @@ var svcIndex = map[string][]*api.Service{
 			Type: api.ServiceTypeExternalName,
 		},
 	}},
+	"hdlsprtls.testns": {{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "hdlsprtls",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			Type:      api.ServiceTypeClusterIP,
+			ClusterIP: api.ClusterIPNone,
+		},
+	}},
 }
 
 func (APIConnServeTest) SvcIndex(s string) []*api.Service {
@@ -536,6 +570,22 @@ var epsIndex = map[string][]*api.Endpoints{
 		},
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "hdls1",
+			Namespace: "testns",
+		},
+	}},
+	"hdlsprtls.testns": {{
+		Subsets: []api.EndpointSubset{
+			{
+				Addresses: []api.EndpointAddress{
+					{
+						IP: "172.0.0.20",
+					},
+				},
+				Ports: []api.EndpointPort{},
+			},
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "hdlsprtls",
 			Namespace: "testns",
 		},
 	}},

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -466,8 +466,8 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 						}
 
 						if len(eps.Ports) == 0 {
-							// add an empty sentinel port entry so we create records for services without any declared ports
-							eps.Ports = append(eps.Ports, api.EndpointPort{})
+							// add a sentinel port (-1) entry so we create records for services without any declared ports
+							eps.Ports = append(eps.Ports, api.EndpointPort{Port: -1})
 						}
 
 						for _, p := range eps.Ports {
@@ -501,8 +501,8 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 		// ClusterIP service
 		if len(svc.Spec.Ports) == 0 {
-			// add an empty sentinel port entry so we create records for services without any declared ports
-			svc.Spec.Ports = append(svc.Spec.Ports, api.ServicePort{})
+			// add a sentinel port (-1) entry so we create records for services without any declared ports
+			svc.Spec.Ports = append(svc.Spec.Ports, api.ServicePort{Port: -1})
 		}
 		for _, p := range svc.Spec.Ports {
 			if !(match(r.port, p.Name) && match(r.protocol, string(p.Protocol))) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

If a service does not have a port declared, k8s plugin doesn't create an A/AAAA record for it.  K8s documentation says that a port declaration is not needed, hence, this is technically a bug.  

This PR injects sentinel port values for services without an declared ports.
This allows us to create `A`/`AAAA` records for services without any declared ports.
When answering `SRV`, ignore those sentinel ports.

This was recently fixed in kube-dns (see #2046). And upon reviewing the change there, I initially thought this would add significant complexity to the code.  After exploring how it would work in coredns, it turned out to be less ugly than I feared it would be. 

### 2. Which issues (if any) are related?
fixes #2046

### 3. Which documentation changes (if any) need to be made?
none