### PR TITLE
Add MINTTL parameter to cache configuration.

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -33,7 +33,7 @@ If you want more control:
 ~~~ txt
 cache [TTL] [ZONES...] {
     success CAPACITY [TTL] [MINTTL]
-    denial CAPACITY [TTL]
+    denial CAPACITY [TTL] [MINTTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
 }
 ~~~
@@ -44,6 +44,7 @@ cache [TTL] [ZONES...] {
   **MINTTL** overrides the cache minimum TTL, which can be useful to limit queries to the backend.
 * `denial`, override the settings for caching denial of existence responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (LRU). **TTL** overrides the cache maximum TTL.
+  **MINTTL** overrides the cache minimum TTL, which can be useful to limit queries to the backend.
   There is a third category (`error`) but those responses are never cached.
 * `prefetch` will prefetch popular items when they are about to be expunged from the cache.
   Popular means **AMOUNT** queries have been seen with no gaps of **DURATION** or more between them.

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -21,6 +21,9 @@ cache [TTL] [ZONES...]
 * **TTL** max TTL in seconds. If not specified, the maximum TTL will be used, which is 3600 for
     noerror responses and 1800 for denial of existence ones.
     Setting a TTL of 300: `cache 300` would cache records up to 300 seconds.
+* **MINTTL** min TTL in seconds for positive responses. If not specified defaults to 0, which means
+    the default TTL from the backend is used.  Specifying a min TTL > 0 can be used to limit queries
+    to the backend by caching longer than the domain owner intended.
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
@@ -32,7 +35,7 @@ If you want more control:
 
 ~~~ txt
 cache [TTL] [ZONES...] {
-    success CAPACITY [TTL]
+    success CAPACITY [TTL] [MINTTL]
     denial CAPACITY [TTL]
     prefetch AMOUNT [[DURATION] [PERCENTAGE%]]
 }

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -21,9 +21,6 @@ cache [TTL] [ZONES...]
 * **TTL** max TTL in seconds. If not specified, the maximum TTL will be used, which is 3600 for
     noerror responses and 1800 for denial of existence ones.
     Setting a TTL of 300: `cache 300` would cache records up to 300 seconds.
-* **MINTTL** min TTL in seconds for positive responses. If not specified defaults to 0, which means
-    the default TTL from the backend is used.  Specifying a min TTL > 0 can be used to limit queries
-    to the backend by caching longer than the domain owner intended.
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
@@ -44,6 +41,7 @@ cache [TTL] [ZONES...] {
 * **TTL**  and **ZONES** as above.
 * `success`, override the settings for caching successful responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (*randomly*). **TTL** overrides the cache maximum TTL.
+  **MINTTL** overrides the cache minimum TTL, which can be useful to limit queries to the backend.
 * `denial`, override the settings for caching denial of existence responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (LRU). **TTL** overrides the cache maximum TTL.
   There is a third category (`error`) but those responses are never cached.

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -112,7 +112,7 @@ func computeTTL(msgTTL time.Duration, minTTL time.Duration, maxTTL time.Duration
 	if ttl > maxTTL {
 		ttl = maxTTL
 	}
-	return ttl
+	return
 }
 
 // ResponseWriter is a response writer that caches the reply message.

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -104,15 +104,15 @@ func hash(qname string, qtype uint16, do bool) uint32 {
 	return h.Sum32()
 }
 
-func computeTTL(msgTTL time.Duration, minTTL time.Duration, maxTTL time.Duration) (ttl time.Duration) {
-	ttl = msgTTL
+func computeTTL(msgTTL, minTTL, maxTTL time.Duration) time.Duration {
+	ttl := msgTTL
 	if ttl < minTTL {
 		ttl = minTTL
 	}
 	if ttl > maxTTL {
 		ttl = maxTTL
 	}
-	return
+	return ttl
 }
 
 // ResponseWriter is a response writer that caches the reply message.
@@ -241,9 +241,9 @@ func (w *ResponseWriter) Write(buf []byte) (int, error) {
 
 const (
 	maxTTL  = dnsutil.MaximumDefaulTTL
-	minTTL  = 0
+	minTTL  = dnsutil.MinimalDefaultTTL
 	maxNTTL = dnsutil.MaximumDefaulTTL / 2
-	minNTTL = 0
+	minNTTL = dnsutil.MinimalDefaultTTL
 
 	defaultCap = 10000 // default capacity of the cache.
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -268,3 +268,23 @@ func zeroTTLBackend() plugin.Handler {
 		return dns.RcodeSuccess, nil
 	})
 }
+
+func TestComputeTTL(t *testing.T) {
+	tests := []struct {
+		msgTTL      time.Duration
+		minTTL      time.Duration
+		maxTTL      time.Duration
+		expectedTTL time.Duration
+	}{
+		{1800 * time.Second, 300 * time.Second, 3600 * time.Second, 1800 * time.Second},
+		{299 * time.Second, 300 * time.Second, 3600 * time.Second, 300 * time.Second},
+		{299 * time.Second, 0 * time.Second, 3600 * time.Second, 299 * time.Second},
+		{3601 * time.Second, 300 * time.Second, 3600 * time.Second, 3600 * time.Second},
+	}
+	for i, test := range tests {
+		ttl := computeTTL(test.msgTTL, test.minTTL, test.maxTTL)
+		if ttl != test.expectedTTL {
+			t.Errorf("Test %v: Expected ttl %v but found: %v", i, test.expectedTTL, ttl)
+		}
+	}
+}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -203,6 +203,8 @@ func TestCache(t *testing.T) {
 
 func TestCacheZeroTTL(t *testing.T) {
 	c := New()
+	c.minpttl = 0
+	c.minnttl = 0
 	c.Next = zeroTTLBackend()
 
 	req := new(dns.Msg)
@@ -210,11 +212,11 @@ func TestCacheZeroTTL(t *testing.T) {
 	ctx := context.TODO()
 
 	c.ServeDNS(ctx, &test.ResponseWriter{}, req)
-	if c.pcache.Len() != 1 {
-		t.Errorf("Msg with 0 TTL should have been cached in pcache")
+	if c.pcache.Len() != 0 {
+		t.Errorf("Msg with 0 TTL should not have been cached")
 	}
 	if c.ncache.Len() != 0 {
-		t.Errorf("Msg with 0 TTL should not have been cached in ncache")
+		t.Errorf("Msg with 0 TTL should not have been cached")
 	}
 }
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -210,11 +210,11 @@ func TestCacheZeroTTL(t *testing.T) {
 	ctx := context.TODO()
 
 	c.ServeDNS(ctx, &test.ResponseWriter{}, req)
-	if c.pcache.Len() != 0 {
-		t.Errorf("Msg with 0 TTL should not have been cached")
+	if c.pcache.Len() != 1 {
+		t.Errorf("Msg with 0 TTL should have been cached in pcache")
 	}
 	if c.ncache.Len() != 0 {
-		t.Errorf("Msg with 0 TTL should not have been cached")
+		t.Errorf("Msg with 0 TTL should not have been cached in ncache")
 	}
 }
 

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -101,6 +101,17 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, fmt.Errorf("cache TTL can not be zero or negative: %d", pttl)
 					}
 					ca.pttl = time.Duration(pttl) * time.Second
+					if len(args) > 2 {
+						minpttl, err := strconv.Atoi(args[2])
+						if err != nil {
+							return nil, err
+						}
+						// Reserve < 0
+						if minpttl < 0 {
+							return nil, fmt.Errorf("cache min TTL can not be negative: %d", minpttl)
+						}
+						ca.minpttl = time.Duration(minpttl) * time.Second
+					}
 				}
 			case Denial:
 				args := c.RemainingArgs()

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -133,6 +133,17 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 						return nil, fmt.Errorf("cache TTL can not be zero or negative: %d", nttl)
 					}
 					ca.nttl = time.Duration(nttl) * time.Second
+					if len(args) > 2 {
+						minnttl, err := strconv.Atoi(args[2])
+						if err != nil {
+							return nil, err
+						}
+						// Reserve < 0
+						if minnttl < 0 {
+							return nil, fmt.Errorf("cache min TTL can not be negative: %d", minnttl)
+						}
+						ca.minnttl = time.Duration(minnttl) * time.Second
+					}
 				}
 			case "prefetch":
 				args := c.RemainingArgs()

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -14,58 +14,67 @@ func TestSetup(t *testing.T) {
 		expectedNcap     int
 		expectedPcap     int
 		expectedNttl     time.Duration
+		expectedMinNttl  time.Duration
 		expectedPttl     time.Duration
 		expectedMinPttl  time.Duration
 		expectedPrefetch int
 	}{
-		{`cache`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
-		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
+		{`cache`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10
-			}`, false, defaultCap, 10, maxNTTL, maxTTL, minTTL, 0},
+			}`, false, defaultCap, 10, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10 1800 30
-			}`, false, defaultCap, 10, maxNTTL, 1800 * time.Second, 30 * time.Second, 0},
+			}`, false, defaultCap, 10, maxNTTL, minNTTL, 1800 * time.Second, 30 * time.Second, 0},
 		{`cache example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, maxTTL, minTTL, 0},
+			}`, false, 10, 10, 15 * time.Second, minNTTL, maxTTL, minTTL, 0},
+		{`cache example.nl {
+				success 10
+				denial 10 15 2
+			}`, false, 10, 10, 15 * time.Second, 2 * time.Second, maxTTL, minTTL, 0},
 		{`cache 25 example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, 25 * time.Second, minTTL, 0},
-		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
+			}`, false, 10, 10, 15 * time.Second, minNTTL, 25 * time.Second, minTTL, 0},
+		{`cache 25 example.nl {
+				success 10
+				denial 10 15 5
+			}`, false, 10, 10, 15 * time.Second, 5 * time.Second, 25 * time.Second, minTTL, 0},
+		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache	{
 				prefetch 10
-			}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 10},
+			}`, false, defaultCap, defaultCap, maxNTTL, minNTTL, maxTTL, minTTL, 10},
 
 		// fails
 		{`cache example.nl {
 				success
 				denial 10 15
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 15
 				denial aaa
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				positive 15
 				negative aaa
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
-		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
-		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
+		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
 				prefetch -1
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				prefetch 0 blurp
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 		{`cache
-		  cache`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+		  cache`, true, defaultCap, defaultCap, maxTTL, minNTTL, maxTTL, minTTL, 0},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
@@ -89,6 +98,9 @@ func TestSetup(t *testing.T) {
 		}
 		if ca.nttl != test.expectedNttl {
 			t.Errorf("Test %v: Expected nttl %v but found: %v", i, test.expectedNttl, ca.nttl)
+		}
+		if ca.minnttl != test.expectedMinNttl {
+			t.Errorf("Test %v: Expected minnttl %v but found: %v", i, test.expectedMinNttl, ca.minnttl)
 		}
 		if ca.pttl != test.expectedPttl {
 			t.Errorf("Test %v: Expected pttl %v but found: %v", i, test.expectedPttl, ca.pttl)

--- a/plugin/cache/setup_test.go
+++ b/plugin/cache/setup_test.go
@@ -15,53 +15,57 @@ func TestSetup(t *testing.T) {
 		expectedPcap     int
 		expectedNttl     time.Duration
 		expectedPttl     time.Duration
+		expectedMinPttl  time.Duration
 		expectedPrefetch int
 	}{
-		{`cache`, false, defaultCap, defaultCap, maxNTTL, maxTTL, 0},
-		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, 0},
+		{`cache`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
+		{`cache {}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 10
-			}`, false, defaultCap, 10, maxNTTL, maxTTL, 0},
+			}`, false, defaultCap, 10, maxNTTL, maxTTL, minTTL, 0},
+		{`cache example.nl {
+				success 10 1800 30
+			}`, false, defaultCap, 10, maxNTTL, 1800 * time.Second, 30 * time.Second, 0},
 		{`cache example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, maxTTL, 0},
+			}`, false, 10, 10, 15 * time.Second, maxTTL, minTTL, 0},
 		{`cache 25 example.nl {
 				success 10
 				denial 10 15
-			}`, false, 10, 10, 15 * time.Second, 25 * time.Second, 0},
-		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, maxTTL, 0},
+			}`, false, 10, 10, 15 * time.Second, 25 * time.Second, minTTL, 0},
+		{`cache aaa example.nl`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 0},
 		{`cache	{
 				prefetch 10
-			}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, 10},
+			}`, false, defaultCap, defaultCap, maxNTTL, maxTTL, minTTL, 10},
 
 		// fails
 		{`cache example.nl {
 				success
 				denial 10 15
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				success 15
 				denial aaa
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache example.nl {
 				positive 15
 				negative aaa
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
-		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
-		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+		{`cache 0 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
+		{`cache -1 example.nl`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				positive 0
 				prefetch -1
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache 1 example.nl {
 				prefetch 0 blurp
-			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+			}`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 		{`cache
-		  cache`, true, defaultCap, defaultCap, maxTTL, maxTTL, 0},
+		  cache`, true, defaultCap, defaultCap, maxTTL, maxTTL, minTTL, 0},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
@@ -88,6 +92,9 @@ func TestSetup(t *testing.T) {
 		}
 		if ca.pttl != test.expectedPttl {
 			t.Errorf("Test %v: Expected pttl %v but found: %v", i, test.expectedPttl, ca.pttl)
+		}
+		if ca.minpttl != test.expectedMinPttl {
+			t.Errorf("Test %v: Expected minpttl %v but found: %v", i, test.expectedMinPttl, ca.minpttl)
 		}
 		if ca.prefetch != test.expectedPrefetch {
 			t.Errorf("Test %v: Expected prefetch %v but found: %v", i, test.expectedPrefetch, ca.prefetch)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Adds a MINTTL parameter to allow specifying a minimum ttl for success and denial responses that can override the ttl for the backend.  This can be useful for limiting queries to the backend.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2054

### 3. Which documentation changes (if any) need to be made?
PR updates cache/plugin/README.md