### PR TITLE
release: split out sha256 upload

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -97,10 +97,17 @@ github-push:
 	@echo Releasing: $(VERSION)
 	@$(eval RELEASE:=$(shell curl -s -d '{"tag_name": "v$(VERSION)", "name": "v$(VERSION)"}' "https://api.github.com/repos/$(GITHUB)/$(NAME)/releases?access_token=${GITHUB_ACCESS_TOKEN}" | grep -m 1 '"id"' | tr -cd '[[:digit:]]'))
 	@echo ReleaseID: $(RELEASE)
-	@for asset in `ls -A release`; do \
+	@for asset in `ls -A release/*tgz`; do \
 	    echo $$asset; \
 	    curl -o /dev/null -X POST \
 	      -H "Content-Type: application/gzip" \
+	      --data-binary "@release/$$asset" \
+	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}&access_token=${GITHUB_ACCESS_TOKEN}" ; \
+	done
+	@for asset in `ls -A release/*sha256`; do \
+	    echo $$asset; \
+	    curl -o /dev/null -X POST \
+	      -H "Content-Type: text/plain" \
 	      --data-binary "@release/$$asset" \
 	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}&access_token=${GITHUB_ACCESS_TOKEN}" ; \
 	done


### PR DESCRIPTION
For the 1.2.1 release we didn't upload the sha256 files. I've added
an echo, but some testing suggests that the files are created, so the
problem lays somewhere else.

Add a new upload section that sets the content type correctly and POST
the files as text/plain.

Signed-off-by: Miek Gieben <miek@miek.nl>