### PR TITLE
release: kill sum target

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -55,7 +55,7 @@ endif
 all:
 	@echo Use the 'release' target to build a release, 'docker' for docker build.
 
-release: pre build tar sum
+release: pre build tar
 
 docker: docker-build
 
@@ -86,12 +86,6 @@ tar:
 	    tar -zcf release/$(NAME)_$(VERSION)_linux_$$arch.tgz -C build/linux/$$arch $(NAME) ;\
 	done
 
-.PHONY: sum
-sum:
-	for asset in `ls -A release/*tgz`; do \
-	    sha256sum $$asset > $$asset.sha256; \
-	done
-
 .PHONY: github-push
 github-push:
 	@echo Releasing: $(VERSION)
@@ -103,6 +97,9 @@ github-push:
 	      -H "Content-Type: application/gzip" \
 	      --data-binary "@$$asset" \
 	      "https://uploads.github.com/repos/$(GITHUB)/$(NAME)/releases/$(RELEASE)/assets?name=$${asset}&access_token=${GITHUB_ACCESS_TOKEN}" ; \
+	done
+	for asset in `ls -A release/*tgz`; do \
+	    sha256sum $$asset > $$asset.sha256; \
 	done
 	@for asset in `ls -A release/*sha256`; do \
 	    echo $$asset; \
@@ -135,6 +132,10 @@ docker-push:
 	done
 	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):$(VERSION)
 	manifest-tool push from-args --platforms $(PLATFORMS) --template $(DOCKER_IMAGE_NAME):coredns-ARCH --target $(DOCKER_IMAGE_NAME):latest
+
+.PHONY: version
+version:
+	@echo $(VERSION)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Just create the sha256 inline so we know there are there.
Add a 'version' target in Makefile.release that prints the version so we
can double check that easily in the release script.

Signed-off-by: Miek Gieben <miek@miek.nl>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
