### PR TITLE
pkg/Cache adapted to accept string keys

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -64,7 +64,7 @@ func uint16ToWire(data uint16) string {
 }
 
 // hash serializes the RRset and return a signature cache key.
-func RRToWire(rrs []dns.RR) string {
+func optToString(rrs []dns.RR) string {
 	h := bytes.Buffer{}
 	buf := make([]byte, 256)
 	for _, r := range rrs {
@@ -97,7 +97,7 @@ func key(m *dns.Msg, t response.Type, do bool) string {
 	if do {
 		id += "|DO"
 	}
-	id += RRToWire(m.Extra)
+	id += optToString(m.Extra)
 
 	return id
 }

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -63,7 +63,6 @@ func uint16ToWire(data uint16) string {
 	return string(buf)
 }
 
-// hash serializes the RRset and return a signature cache key.
 func optToString(rrs []dns.RR) string {
 	h := bytes.Buffer{}
 	buf := make([]byte, 256)

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -3,7 +3,6 @@ package cache
 
 import (
 	"encoding/binary"
-	"hash/fnv"
 	"net"
 	"time"
 
@@ -57,47 +56,31 @@ func New() *Cache {
 	}
 }
 
+func uint16ToWire(data uint16) string {
+	buf := make([]byte, 2)
+	binary.BigEndian.PutUint16(buf, uint16(data))
+	return string(buf)
+}
+
 // Return key under which we store the item, -1 will be returned if we don't store the
 // message.
 // Currently we do not cache Truncated, errors zone transfers or dynamic update messages.
-func key(m *dns.Msg, t response.Type, do bool) int {
+func key(m *dns.Msg, t response.Type, do bool) string {
 	// We don't store truncated responses.
 	if m.Truncated {
-		return -1
+		return ""
 	}
 	// Nor errors or Meta or Update
 	if t == response.OtherError || t == response.Meta || t == response.Update {
-		return -1
+		return ""
 	}
+	// uint16ToWire writes unit16 to wire/binary format
 
-	return int(hash(m.Question[0].Name, m.Question[0].Qtype, do))
-}
-
-var one = []byte("1")
-var zero = []byte("0")
-
-func hash(qname string, qtype uint16, do bool) uint32 {
-	h := fnv.New32()
-
+	id := m.Question[0].Name + "|" + uint16ToWire(m.Question[0].Qtype)
 	if do {
-		h.Write(one)
-	} else {
-		h.Write(zero)
+		id += "|DO"
 	}
-
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, qtype)
-	h.Write(b)
-
-	for i := range qname {
-		c := qname[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		h.Write([]byte{c})
-	}
-
-	return h.Sum32()
+	return id
 }
 
 // ResponseWriter is a response writer that caches the reply message.
@@ -164,7 +147,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		duration = msgTTL
 	}
 
-	if key != -1 && duration > 0 {
+	if key != "" && duration > 0 {
 		if w.state.Match(res) {
 			w.set(res, key, mt, duration)
 			cacheSize.WithLabelValues(w.server, Success).Set(float64(w.pcache.Len()))
@@ -195,19 +178,19 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	return w.ResponseWriter.WriteMsg(res)
 }
 
-func (w *ResponseWriter) set(m *dns.Msg, key int, mt response.Type, duration time.Duration) {
-	if key == -1 || duration == 0 {
+func (w *ResponseWriter) set(m *dns.Msg, key string, mt response.Type, duration time.Duration) {
+	if key == "" || duration == 0 {
 		return
 	}
 
 	switch mt {
 	case response.NoError, response.Delegation:
 		i := newItem(m, w.now(), duration)
-		w.pcache.Add(uint32(key), i)
+		w.pcache.Add(key, i)
 
 	case response.NameError, response.NoData:
 		i := newItem(m, w.now(), duration)
-		w.ncache.Add(uint32(key), i)
+		w.ncache.Add(key, i)
 
 	case response.OtherError:
 		// don't cache these

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coredns/coredns/plugin/pkg/response"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/request"
@@ -64,7 +66,7 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 func (c *Cache) Name() string { return "cache" }
 
 func (c *Cache) get(now time.Time, state request.Request, server string) (*item, bool) {
-	k := hash(state.Name(), state.QType(), state.Do())
+	k := key(state.Req, response.NoError, state.Do())
 
 	if i, ok := c.ncache.Get(k); ok && i.(*item).ttl(now) > 0 {
 		cacheHits.WithLabelValues(server, Denial).Inc()
@@ -80,7 +82,7 @@ func (c *Cache) get(now time.Time, state request.Request, server string) (*item,
 }
 
 func (c *Cache) exists(state request.Request) *item {
-	k := hash(state.Name(), state.QType(), state.Do())
+	k := key(state.Req, response.NoError, state.Do())
 	if i, ok := c.ncache.Get(k); ok {
 		return i.(*item)
 	}

--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -1,14 +1,14 @@
 package dnssec
 
 import (
-	"hash/fnv"
+	"bytes"
 
 	"github.com/miekg/dns"
 )
 
 // hash serializes the RRset and return a signature cache key.
-func hash(rrs []dns.RR) uint32 {
-	h := fnv.New32()
+func hash(rrs []dns.RR) string {
+	h := bytes.Buffer{}
 	buf := make([]byte, 256)
 	for _, r := range rrs {
 		off, err := dns.PackRR(r, buf, 0, nil, false)
@@ -17,6 +17,5 @@ func hash(rrs []dns.RR) uint32 {
 		}
 	}
 
-	i := h.Sum32()
-	return i
+	return h.String()
 }

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -110,9 +110,9 @@ func (d Dnssec) sign(rrs []dns.RR, signerName string, ttl, incep, expir uint32, 
 	return sigs.([]dns.RR), err
 }
 
-func (d Dnssec) set(key uint32, sigs []dns.RR) { d.cache.Add(key, sigs) }
+func (d Dnssec) set(key string, sigs []dns.RR) { d.cache.Add(key, sigs) }
 
-func (d Dnssec) get(key uint32, server string) ([]dns.RR, bool) {
+func (d Dnssec) get(key string, server string) ([]dns.RR, bool) {
 	if s, ok := d.cache.Get(key); ok {
 		// we sign for 8 days, check if a signature in the cache reached 3/4 of that
 		is75 := time.Now().UTC().Add(sixDays)

--- a/plugin/pkg/cache/cache_test.go
+++ b/plugin/pkg/cache/cache_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestCacheAddAndGet(t *testing.T) {
 	c := New(4)
-	c.Add(1, 1)
+	c.Add("1", 1)
 
-	if _, found := c.Get(1); !found {
+	if _, found := c.Get("1"); !found {
 		t.Fatal("Failed to find inserted record")
 	}
 }
@@ -14,17 +14,17 @@ func TestCacheAddAndGet(t *testing.T) {
 func TestCacheLen(t *testing.T) {
 	c := New(4)
 
-	c.Add(1, 1)
+	c.Add("1", 1)
 	if l := c.Len(); l != 1 {
 		t.Fatalf("Cache size should %d, got %d", 1, l)
 	}
 
-	c.Add(1, 1)
+	c.Add("1", 1)
 	if l := c.Len(); l != 1 {
 		t.Fatalf("Cache size should %d, got %d", 1, l)
 	}
 
-	c.Add(2, 2)
+	c.Add("2", 2)
 	if l := c.Len(); l != 2 {
 		t.Fatalf("Cache size should %d, got %d", 2, l)
 	}
@@ -35,7 +35,7 @@ func BenchmarkCache(b *testing.B) {
 
 	c := New(4)
 	for n := 0; n < b.N; n++ {
-		c.Add(1, 1)
-		c.Get(1)
+		c.Add("1", 1)
+		c.Get("1")
 	}
 }

--- a/plugin/pkg/cache/shard_test.go
+++ b/plugin/pkg/cache/shard_test.go
@@ -4,9 +4,9 @@ import "testing"
 
 func TestShardAddAndGet(t *testing.T) {
 	s := newShard(4)
-	s.Add(1, 1)
+	s.Add("1", 1)
 
-	if _, found := s.Get(1); !found {
+	if _, found := s.Get("1"); !found {
 		t.Fatal("Failed to find inserted record")
 	}
 }
@@ -14,17 +14,17 @@ func TestShardAddAndGet(t *testing.T) {
 func TestShardLen(t *testing.T) {
 	s := newShard(4)
 
-	s.Add(1, 1)
+	s.Add("1", 1)
 	if l := s.Len(); l != 1 {
 		t.Fatalf("Shard size should %d, got %d", 1, l)
 	}
 
-	s.Add(1, 1)
+	s.Add("1", 1)
 	if l := s.Len(); l != 1 {
 		t.Fatalf("Shard size should %d, got %d", 1, l)
 	}
 
-	s.Add(2, 2)
+	s.Add("2", 2)
 	if l := s.Len(); l != 2 {
 		t.Fatalf("Shard size should %d, got %d", 2, l)
 	}
@@ -32,28 +32,28 @@ func TestShardLen(t *testing.T) {
 
 func TestShardEvict(t *testing.T) {
 	s := newShard(1)
-	s.Add(1, 1)
-	s.Add(2, 2)
+	s.Add("1", 1)
+	s.Add("2", 2)
 	// 1 should be gone
 
-	if _, found := s.Get(1); found {
+	if _, found := s.Get("1"); found {
 		t.Fatal("Found item that should have been evicted")
 	}
 }
 
 func TestShardLenEvict(t *testing.T) {
 	s := newShard(4)
-	s.Add(1, 1)
-	s.Add(2, 1)
-	s.Add(3, 1)
-	s.Add(4, 1)
+	s.Add("1", 1)
+	s.Add("2", 1)
+	s.Add("3", 1)
+	s.Add("4", 1)
 
 	if l := s.Len(); l != 4 {
 		t.Fatalf("Shard size should %d, got %d", 4, l)
 	}
 
 	// This should evict one element
-	s.Add(5, 1)
+	s.Add("5", 1)
 	if l := s.Len(); l != 4 {
 		t.Fatalf("Shard size should %d, got %d", 4, l)
 	}

--- a/plugin/pkg/singleflight/singleflight.go
+++ b/plugin/pkg/singleflight/singleflight.go
@@ -31,17 +31,17 @@ type call struct {
 // units of work can be executed with duplicate suppression.
 type Group struct {
 	mu sync.Mutex       // protects m
-	m  map[uint32]*call // lazily initialized
+	m  map[string]*call // lazily initialized
 }
 
 // Do executes and returns the results of the given function, making
 // sure that only one execution is in-flight for a given key at a
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
-func (g *Group) Do(key uint32, fn func() (interface{}, error)) (interface{}, error) {
+func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, error) {
 	g.mu.Lock()
 	if g.m == nil {
-		g.m = make(map[uint32]*call)
+		g.m = make(map[string]*call)
 	}
 	if c, ok := g.m[key]; ok {
 		g.mu.Unlock()

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDo(t *testing.T) {
 	var g Group
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do("1", func() (interface{}, error) {
 		return "bar", nil
 	})
 	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
@@ -41,7 +41,7 @@ func TestDo(t *testing.T) {
 func TestDoErr(t *testing.T) {
 	var g Group
 	someErr := errors.New("Some error")
-	v, err := g.Do(1, func() (interface{}, error) {
+	v, err := g.Do("1", func() (interface{}, error) {
 		return nil, someErr
 	})
 	if err != someErr {
@@ -66,7 +66,7 @@ func TestDoDupSuppress(t *testing.T) {
 	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func() {
-			v, err := g.Do(1, fn)
+			v, err := g.Do("1", fn)
 			if err != nil {
 				t.Errorf("Do error: %v", err)
 			}


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?
- change pkg/cache to accept string key
- compute the shard value of the entry based on an hash on that string key
- change key computation for Cache plugin
- adapt key computation for DNSSEC plugin

**Still some questions :**
1. for CACHE, should we compute the key based on the whole DNS query msg (including edns0 values) ?
2- I update the key computation of DNSSEC based now on full RR values. Need to be validated

### 2. Which issues (if any) are related?
#2072 

### 3. Which documentation changes (if any) need to be made?
I do not think need another documentation.

