### PR TITLE
Move cache Keys to 64bit for a better dispersion and lower collision frequency 

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -167,9 +167,11 @@ func TestCache(t *testing.T) {
 		state := request.Request{W: nil, Req: m}
 
 		mt, _ := response.Typify(m, utc)
-		k := key(m, mt, state.Do())
+		valid, k := key(m, mt, state.Do())
 
-		crr.set(m, k, mt, c.pttl)
+		if valid {
+			crr.set(m, k, mt, c.pttl)
+		}
 
 		i, _ := c.get(time.Now().UTC(), state, "dns://:53")
 		ok := i != nil

--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -7,8 +7,8 @@ import (
 )
 
 // hash serializes the RRset and return a signature cache key.
-func hash(rrs []dns.RR) uint32 {
-	h := fnv.New32()
+func hash(rrs []dns.RR) uint64 {
+	h := fnv.New64()
 	buf := make([]byte, 256)
 	for _, r := range rrs {
 		off, err := dns.PackRR(r, buf, 0, nil, false)
@@ -17,6 +17,6 @@ func hash(rrs []dns.RR) uint32 {
 		}
 	}
 
-	i := h.Sum32()
+	i := h.Sum64()
 	return i
 }

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -110,9 +110,9 @@ func (d Dnssec) sign(rrs []dns.RR, signerName string, ttl, incep, expir uint32, 
 	return sigs.([]dns.RR), err
 }
 
-func (d Dnssec) set(key uint32, sigs []dns.RR) { d.cache.Add(key, sigs) }
+func (d Dnssec) set(key uint64, sigs []dns.RR) { d.cache.Add(key, sigs) }
 
-func (d Dnssec) get(key uint32, server string) ([]dns.RR, bool) {
+func (d Dnssec) get(key uint64, server string) ([]dns.RR, bool) {
 	if s, ok := d.cache.Get(key); ok {
 		// we sign for 8 days, check if a signature in the cache reached 3/4 of that
 		is75 := time.Now().UTC().Add(sixDays)

--- a/plugin/pkg/singleflight/singleflight.go
+++ b/plugin/pkg/singleflight/singleflight.go
@@ -31,17 +31,17 @@ type call struct {
 // units of work can be executed with duplicate suppression.
 type Group struct {
 	mu sync.Mutex       // protects m
-	m  map[uint32]*call // lazily initialized
+	m  map[uint64]*call // lazily initialized
 }
 
 // Do executes and returns the results of the given function, making
 // sure that only one execution is in-flight for a given key at a
 // time. If a duplicate comes in, the duplicate caller waits for the
 // original to complete and receives the same results.
-func (g *Group) Do(key uint32, fn func() (interface{}, error)) (interface{}, error) {
+func (g *Group) Do(key uint64, fn func() (interface{}, error)) (interface{}, error) {
 	g.mu.Lock()
 	if g.m == nil {
-		g.m = make(map[uint32]*call)
+		g.m = make(map[uint64]*call)
 	}
 	if c, ok := g.m[key]; ok {
 		g.mu.Unlock()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Lowering the risk of collision in the keys of the cache.
That collision is managed, but generate global efficiency

### 2. Which issues (if any) are related?
#2072 


### 3. Which documentation changes (if any) need to be made?
No change 