### PR TITLE
Ensure Re-register of metrics variables after a reload

### DIFF
--- a/plugin/autopath/metrics.go
+++ b/plugin/autopath/metrics.go
@@ -1,8 +1,6 @@
 package autopath
 
 import (
-	"sync"
-
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,5 +14,3 @@ var (
 		Help:      "Counter of requests that did autopath.",
 	}, []string{"server"})
 )
-
-var once sync.Once

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, autoPathCount) })
+		metrics.MustRegister(c, autoPathCount)
 		return nil
 	})
 

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"math"
-	"sync"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -126,5 +125,3 @@ var (
 		Help:      "The number responses that are not cached, because the reply is malformed.",
 	}, []string{"server"})
 )
-
-var once sync.Once

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -34,11 +34,9 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() {
-			metrics.MustRegister(c,
-				cacheSize, cacheHits, cacheMisses,
-				cachePrefetches, cacheDrops)
-		})
+		metrics.MustRegister(c,
+			cacheSize, cacheHits, cacheMisses,
+			cachePrefetches, cacheDrops)
 		return nil
 	})
 

--- a/plugin/dnssec/handler.go
+++ b/plugin/dnssec/handler.go
@@ -2,7 +2,6 @@ package dnssec
 
 import (
 	"context"
-	"sync"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
@@ -81,5 +80,3 @@ var (
 
 // Name implements the Handler interface.
 func (d Dnssec) Name() string { return "dnssec" }
-
-var once sync.Once

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -35,9 +35,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() {
-			metrics.MustRegister(c, cacheSize, cacheHits, cacheMisses)
-		})
+		metrics.MustRegister(c, cacheSize, cacheHits, cacheMisses)
 		return nil
 	})
 

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -1,8 +1,6 @@
 package forward
 
 import (
-	"sync"
-
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -48,5 +46,3 @@ var (
 		Help:      "Gauge of open sockets per upstream.",
 	}, []string{"to"})
 )
-
-var once sync.Once

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -38,9 +38,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() {
-			metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
-		})
+		metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
 		return f.OnStartup()
 	})
 

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -55,7 +55,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, HealthDuration) })
+		metrics.MustRegister(c, HealthDuration)
 		return nil
 	})
 

--- a/plugin/proxy/metrics.go
+++ b/plugin/proxy/metrics.go
@@ -1,8 +1,6 @@
 package proxy
 
 import (
-	"sync"
-
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,5 +34,3 @@ func familyToString(f int) string {
 	}
 	return ""
 }
-
-var once sync.Once

--- a/plugin/proxy/setup.go
+++ b/plugin/proxy/setup.go
@@ -33,7 +33,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, RequestCount, RequestDuration) })
+		metrics.MustRegister(c, RequestCount, RequestDuration)
 		return nil
 	})
 

--- a/plugin/template/metrics.go
+++ b/plugin/template/metrics.go
@@ -1,8 +1,6 @@
 package template
 
 import (
-	"sync"
-
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
 
@@ -34,13 +32,9 @@ var (
 // OnStartupMetrics sets up the metrics on startup.
 func setupMetrics(c *caddy.Controller) error {
 	c.OnStartup(func() error {
-		metricsOnce.Do(func() {
-			metrics.MustRegister(c, templateMatchesCount, templateFailureCount, templateRRFailureCount)
-		})
+		metrics.MustRegister(c, templateMatchesCount, templateFailureCount, templateRRFailureCount)
 		return nil
 	})
 
 	return nil
 }
-
-var metricsOnce sync.Once

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -208,9 +208,9 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 	//TODO: add a tool that find an available port because this needs to be a port
 	// that is not used in another test
 	promAddress := "127.0.0.1:53186"
-	proc_metric := "coredns_build_info"
-	proc_cache := "coredns_cache_size"
-	proc_forward := "coredns_dns_request_duration_seconds"
+	procMetric := "coredns_build_info"
+	procCache := "coredns_cache_size"
+	procForward := "coredns_dns_request_duration_seconds"
 	corefileWithMetrics := `
 	.:0 {
 		prometheus ` + promAddress + `
@@ -243,7 +243,7 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 
 	// we should have metrics from forward, cache, and metrics itself
 	time.Sleep(500 * time.Millisecond)
-	if err := collectMetricsInfo(promAddress, proc_metric, proc_cache, proc_forward); err != nil {
+	if err := collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
 		t.Errorf("Could not scrap one of expected stats : %s", err)
 	}
 
@@ -256,7 +256,7 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 	}
 
 	// check the metrics are available still
-	if err := collectMetricsInfo(promAddress, proc_metric, proc_cache, proc_forward); err != nil {
+	if err := collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
 		t.Errorf("Could not scrap one of expected stats : %s", err)
 	}
 

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -261,7 +261,7 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 	//TODO: add a tool that find an available port because this needs to be a port
 	// that is not used in another test
-	promAddress := "127.0.0.1:53186"
+	promAddress := "127.0.0.1:53187"
 	procMetric := "coredns_build_info"
 	procCache := "coredns_cache_size"
 	procForward := "coredns_dns_request_duration_seconds"

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -119,22 +119,24 @@ func TestReloadMetricsHealth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const proc = "process_virtual_memory_bytes"
+	const proc = "coredns_build_info"
 	metrics, _ := ioutil.ReadAll(resp.Body)
 	if !bytes.Contains(metrics, []byte(proc)) {
 		t.Errorf("Failed to see %s in metric output", proc)
 	}
 }
 
-func collectMetricsInfo(addr, proc string) error {
+func collectMetricsInfo(addr string, procs ...string) error {
 	cl := &http.Client{}
 	resp, err := cl.Get(fmt.Sprintf("http://%s/metrics", addr))
 	if err != nil {
 		return err
 	}
 	metrics, _ := ioutil.ReadAll(resp.Body)
-	if !bytes.Contains(metrics, []byte(proc)) {
-		return fmt.Errorf("failed to see %s in metric output", proc)
+	for _, p := range procs {
+		if !bytes.Contains(metrics, []byte(p)) {
+			return fmt.Errorf("failed to see %s in metric output \n%s", p, metrics)
+		}
 	}
 	return nil
 }
@@ -200,6 +202,66 @@ func TestReloadSeveralTimeMetrics(t *testing.T) {
 	if err := collectMetricsInfo(promAddress, proc); err == nil {
 		t.Errorf("Prometheus is still listening")
 	}
+}
+
+func TestMetricsAvailableAfterReload(t *testing.T) {
+	//TODO: add a tool that find an available port because this needs to be a port
+	// that is not used in another test
+	promAddress := "127.0.0.1:53186"
+	proc_metric := "coredns_build_info"
+	proc_cache := "coredns_cache_size"
+	proc_forward := "coredns_dns_request_duration_seconds"
+	corefileWithMetrics := `
+	.:0 {
+		prometheus ` + promAddress + `
+		cache
+		forward . 8.8.8.8 {
+           force_tcp
+		}
+	}`
+	inst, _, tcp, err := CoreDNSServerAndPorts(corefileWithMetrics)
+	if err != nil {
+		if strings.Contains(err.Error(), inUse) {
+			return
+		}
+		t.Errorf("Could not get service instance: %s", err)
+	}
+	// send a query and check we can scrap corresponding metrics
+	cl := dns.Client{Net: "tcp"}
+	m := new(dns.Msg)
+	m.SetQuestion("www.example.org.", dns.TypeA)
+
+	if _, _, err := cl.Exchange(m, tcp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+	if _, _, err := cl.Exchange(m, tcp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+	if _, _, err := cl.Exchange(m, tcp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	// we should have metrics from forward, cache, and metrics itself
+	time.Sleep(500 * time.Millisecond)
+	if err := collectMetricsInfo(promAddress, proc_metric, proc_cache, proc_forward); err != nil {
+		t.Errorf("Could not scrap one of expected stats : %s", err)
+	}
+
+	// now reload
+	instReload, err := inst.Restart(
+		NewInput(corefileWithMetrics),
+	)
+	if err != nil {
+		t.Errorf("Could not restart CoreDNS : %s", err)
+	}
+
+	// check the metrics are available still
+	if err := collectMetricsInfo(promAddress, proc_metric, proc_cache, proc_forward); err != nil {
+		t.Errorf("Could not scrap one of expected stats : %s", err)
+	}
+
+	instReload.Stop()
+	// verify that metrics have not been pushed
 }
 
 const inUse = "address already in use"


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Since the fix of reload issue in Metrics (issue #1982), the metrics plugin create a prom.Reg on each reload.
Therefore each plugin that register metrics variables **MUST** re-register after reload.

Each plugin registering metrics variables was limited to register only once, using a once.Do function.
- At first I proposed to re-trigger that once.Do function on each reload
- Then I found this limitation was useless : by Caddy architecture, each plugin will have its setup called only once per stanza, and the registering happen against the "prometheus" plugin of the SAME stanza. **There cannot be several calls**.
=> Removing the once.Do(..), allow each plugin to re-register after each Reload.

### Added a UT for Metrics / Forward / Cache
Other plugins : DNSSEC, Autopath, Health, Proxy, Template ..use the same mechanism.

### 2. Which issues (if any) are related?
#2079 

### 3. Which documentation changes (if any) need to be made?
No change of documentation this is a fix.


