### PR TITLE
Add failed request counter metric to proxy/forward

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -97,6 +97,7 @@ If monitoring is enabled (via the *prometheus* directive) then the following met
 
 * `coredns_forward_request_duration_seconds{to}` - duration per upstream interaction.
 * `coredns_forward_request_count_total{to}` - query count per upstream.
+* `coredns_forward_request_failure_count_total{to}` - failed queries per upstream.
 * `coredns_forward_response_rcode_total{to, rcode}` - count of RCODEs per upstream.
 * `coredns_forward_healthcheck_failure_count_total{to}` - number of failed health checks per upstream.
 * `coredns_forward_healthcheck_broken_count_total{}` - counter of when all upstreams are unhealthy,

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -16,6 +16,12 @@ var (
 		Name:      "request_count_total",
 		Help:      "Counter of requests made per upstream.",
 	}, []string{"to"})
+	RequestFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "request_failure_count_total",
+		Help:      "Counter of failed requests per upstream.",
+	}, []string{"to"})
 	RcodeCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -39,7 +39,7 @@ func setup(c *caddy.Controller) error {
 
 	c.OnStartup(func() error {
 		once.Do(func() {
-			metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
+			metrics.MustRegister(c, RequestCount, RequestFailureCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
 		})
 		return f.OnStartup()
 	})

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -95,6 +95,8 @@ If monitoring is enabled (via the *prometheus* directive) then the following met
   upstream interaction.
 * `coredns_proxy_request_count_total{server, proto, proto_proxy, family, to}` - query count per
   upstream.
+* `coredns_proxy_request_failure_count_total{server, proto, proto_proxy, family, to}` - failed queries
+  per upstream.
 
 Where `proxy_proto` is the protocol used (`dns` or `grpc`) and `to` is **TO**
 specified in the config, `proto` is the protocol used by the incoming query ("tcp" or "udp"), family

--- a/plugin/proxy/metrics.go
+++ b/plugin/proxy/metrics.go
@@ -16,6 +16,12 @@ var (
 		Name:      "request_count_total",
 		Help:      "Counter of requests made per protocol, proxy protocol, family and upstream.",
 	}, []string{"server", "proto", "proxy_proto", "family", "to"})
+	RequestFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "proxy",
+		Name:      "request_failure_count_total",
+		Help:      "Counter of failed requests per protocol, proxy protocol, family and upstream.",
+	}, []string{"server", "proto", "proxy_proto", "family", "to"})
 	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "proxy",

--- a/plugin/proxy/setup.go
+++ b/plugin/proxy/setup.go
@@ -33,7 +33,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		once.Do(func() { metrics.MustRegister(c, RequestCount, RequestDuration) })
+		once.Do(func() { metrics.MustRegister(c, RequestCount, RequestFailureCount, RequestDuration) })
 		return nil
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Metrics exported by proxy and forward plugins should provide visibility into failed upstream requests allowing operators to detect and troubleshoot service degradation that may result from dropped packets or other i/o errors in the upstream path.
This PR adds metric counters that get incremented when a request to an upstream server yields an error instead of a valid query response.
- `coredns_proxy_request_failure_count_total{server, proto, proto_proxy, family, to}` - failed queries per upstream.
- `coredns_forward_request_failure_count_total{to}` - failed queries per upstream.

### 2. Which issues (if any) are related?
NA
### 3. Which documentation changes (if any) need to be made?
Included