### PR TITLE
plugin/federation: handle missing avail-zone/region labels better

### DIFF
--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -54,7 +54,7 @@ func TestFederationKubernetes(t *testing.T) {
 	}
 
 	k := kubernetes.New([]string{"cluster.local."})
-	k.APIConn = &APIConnFederationTest{}
+	k.APIConn = &APIConnFederationTest{zone: "fd-az", region: "fd-r"}
 
 	fed := New()
 	fed.zones = []string{"cluster.local."}
@@ -77,5 +77,41 @@ func TestFederationKubernetes(t *testing.T) {
 
 		resp := rec.Msg
 		test.SortAndCheck(t, resp, tc)
+	}
+}
+
+func TestFederationKubernetesMissingLabels(t *testing.T) {
+	tests := []test.Case{
+		{
+			// service does not exist, do the federation dance.
+			Qname: "svc0.testns.prod.svc.cluster.local.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeSuccess,
+			Answer: []dns.RR{
+				test.CNAME("svc0.testns.prod.svc.cluster.local.  303       IN      CNAME   svc0.testns.prod.svc.fd-az.fd-r.federal.example."),
+			},
+		},
+	}
+
+	k := kubernetes.New([]string{"cluster.local."})
+	k.APIConn = &APIConnFederationTest{zone: "", region: ""}
+
+	fed := New()
+	fed.zones = []string{"cluster.local."}
+	fed.Federations = k.Federations
+	fed.Next = k
+	fed.f = map[string]string{
+		"prod": "federal.example.",
+	}
+
+	ctx := context.TODO()
+	for _, tc := range tests {
+		m := tc.Msg()
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		_, err := fed.ServeDNS(ctx, rec, m)
+		if err == nil {
+			t.Errorf("Expected an error")
+			return
+		}
 	}
 }

--- a/plugin/federation/kubernetes_api_test.go
+++ b/plugin/federation/kubernetes_api_test.go
@@ -8,7 +8,9 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type APIConnFederationTest struct{}
+type APIConnFederationTest struct {
+	zone, region string
+}
 
 func (APIConnFederationTest) HasSynced() bool                        { return true }
 func (APIConnFederationTest) Run()                                   { return }
@@ -176,13 +178,13 @@ func (APIConnFederationTest) EndpointsList() []*api.Endpoints {
 	return eps
 }
 
-func (APIConnFederationTest) GetNodeByName(name string) (*api.Node, error) {
+func (a APIConnFederationTest) GetNodeByName(name string) (*api.Node, error) {
 	return &api.Node{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "test.node.foo.bar",
 			Labels: map[string]string{
-				kubernetes.LabelRegion: "fd-r",
-				kubernetes.LabelZone:   "fd-az",
+				kubernetes.LabelRegion: a.region,
+				kubernetes.LabelZone:   a.zone,
 			},
 		},
 	}, nil

--- a/plugin/kubernetes/federation.go
+++ b/plugin/kubernetes/federation.go
@@ -1,6 +1,8 @@
 package kubernetes
 
 import (
+	"errors"
+
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
@@ -36,6 +38,10 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 
 	lz := node.Labels[LabelZone]
 	lr := node.Labels[LabelRegion]
+
+	if lz == "" || lr == "" {
+		return msg.Service{}, errors.New("local node missing zone/region labels")
+	}
 
 	if r.endpoint == "" {
 		return msg.Service{Host: dnsutil.Join([]string{r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone})}, nil


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

If availability-zone or region labels are missing from a node, `federation` plugin would construct an invalid `CNAME` target domain.  Result was an incorrect "success" written to the log, and no response written to the client and therefore a client timeout. 

This change catches the condition sending a `SERVFAIL` to the client. 

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none