### PR TITLE
[plugin/proxy]: Return on WriteMsg err.

### DIFF
--- a/plugin/proxy/dns.go
+++ b/plugin/proxy/dns.go
@@ -95,7 +95,7 @@ func exchange(m *dns.Msg, co net.Conn) (*dns.Msg, error) {
 	dnsco.SetWriteDeadline(writeDeadline)
 	if err := dnsco.WriteMsg(m); err != nil {
 		log.Debugf("Failed to send message: %v", err)
-		return err
+		return nil, err
 	}
 
 	readDeadline := time.Now().Add(defaultTimeout)

--- a/plugin/proxy/dns.go
+++ b/plugin/proxy/dns.go
@@ -93,15 +93,12 @@ func exchange(m *dns.Msg, co net.Conn) (*dns.Msg, error) {
 
 	writeDeadline := time.Now().Add(defaultTimeout)
 	dnsco.SetWriteDeadline(writeDeadline)
-	dnsco.WriteMsg(m)
+	if err := dnsco.WriteMsg(m); err != nil {
+		log.Debugf("Failed to send message: %v", err)
+		return err
+	}
 
 	readDeadline := time.Now().Add(defaultTimeout)
 	co.SetReadDeadline(readDeadline)
-	r, err := dnsco.ReadMsg()
-
-	dnsco.Close()
-	if r == nil {
-		return nil, err
-	}
-	return r, err
+	return dnsco.ReadMsg()
 }


### PR DESCRIPTION
Followup PR on the heels of #2050. Short-circut and log on error from
`WriteMsg`. This will prevent code getting stuck on `ReadMsg` and allow
for easier debugging.

Also simply the `ReadMsg` calling code a little.