### PR TITLE
plugin/health: close codeblock

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -57,7 +57,7 @@ com net {
     erratic
     health :8080
 }
-~~~~
+~~~
 
 ## Plugins
 


### PR DESCRIPTION
Codeblock wasn't properly closed in the README.

Signed-off-by: Miek Gieben <miek@miek.nl>