### PR TITLE
initiate a project  Governance document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,18 +4,10 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source. See repository guidelines and CLA, below.
+- Open: CoreDNS is open source. See repository guidelines.
 - Welcoming and respectful: See Code of Conduct, below.
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
-
-## Need to define some concepts
-- Maintainers
-- Organizations
-- Owners
-- Security Team
-- How to we collaborate ? => Ideas, Subjects to talk.
-- How do we vote ?
 
 ## Voting
 
@@ -37,9 +29,22 @@ Maintainers can be removed by a 2/3 majority organization vote.
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub cni-maintainers team, and made a GitHub maintainer of that team.
+Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub maintainers team.
 
 After 6 months a maintainer will be made an "owner" of the GitHub organization.
+
+## Projects
+
+The CoreDNS organization is open to receive new sub-projects under its umbrella. To apply a project as part of the __CoreDNS__ organization, it has to met the following criteria:
+
+- Licensed under the terms of the Apache License v2.0
+- Related to one or more scopes of CoreDNS ecosystem:
+  - CoreDNS project artifacts (website, deployments, CI, etc ...)
+  - External plugin
+  - other DNS processing related
+- Be supported by 2/3 majority of organization
+
+The submission process starts as a Pull Request on CoreDNS repository with the required information mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,25 +13,33 @@ The CoreDNS community adheres to the following principles:
 
 The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
 
-Individuals not associated with or employed by a company or organization are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
+Individuals declare if they contribute as un-affiliated or as associated with or employee of an organization or a company.
+
+Individuals that contribute as un-affiliated are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
 
 In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
 
 Any maintainer from an organization may cast the vote for that organization.
 
-For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+For formal votes, a specific statement of what is being voted on, and in which delay (a suitable amount of time), should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after the delay is expired, the votes will be tallied and the outcome noted.
+
+## Expectations from Maintainers
+
+Maintainers are the bridges between members of the CoreDNS community.
+Maintainers actively participate in PR reviews. Maintainers are expected to respond to assigned PRs in a reasonable time frame,
+either providing insights, or assign the PRs to other maintainers.
 
 ## Changes in Maintainership
 
 New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
 
-Maintainers can be removed by a 2/3 majority organization vote.
+Maintainers who fail to meet the principles of CoreDNS community can be removed by a 2/3 majority organization vote.
+
+The list of Maintainers is available in this [document](/OWNERS) and is synchronized with the receivers of maintainers@coredns.io list
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub project maintainers team.
-
-After 6 months a maintainer will be made an "owner" of the GitHub organization.
+the __coredns__ GitHub project maintainers team reflect the list of Maintainers.
 
 ## Projects
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,48 @@
+# CoreDNS Governance
+
+## Principles
+
+The CoreDNS community adheres to the following principles:
+
+- Open: CoreDNS is open source. See repository guidelines and CLA, below.
+- Welcoming and respectful: See Code of Conduct, below.
+- Transparent and accessible: Work and collaboration are done in public.
+- Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
+
+## Need to define some concepts
+- Maintainers
+- Organizations
+- Owners
+- Security Team
+- How to we collaborate ? => Ideas, Subjects to talk.
+- How do we vote ?
+
+## Voting
+
+The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
+
+Individuals not associated with or employed by a company or organization are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
+
+In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
+
+Any maintainer from an organization may cast the vote for that organization.
+
+For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+
+## Changes in Maintainership
+
+New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
+
+Maintainers can be removed by a 2/3 majority organization vote.
+
+## Github Project Administration
+
+Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub cni-maintainers team, and made a GitHub maintainer of that team.
+
+After 6 months a maintainer will be made an "owner" of the GitHub organization.
+
+## Code of Conduct
+
+CoreDNS follows the CNCF Code of Conduct:
+
+https://github.com/cncf/foundation/blob/master/code-of-conduct.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source. See repository guidelines.
+- Open: CoreDNS is open source. See repository guidelines, below.
 - Welcoming and respectful: See Code of Conduct, below.
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
@@ -29,22 +29,24 @@ Maintainers can be removed by a 2/3 majority organization vote.
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub maintainers team.
+Maintainers will be added to the __coredns__ GitHub project maintainers team.
 
 After 6 months a maintainer will be made an "owner" of the GitHub organization.
 
 ## Projects
 
-The CoreDNS organization is open to receive new sub-projects under its umbrella. To apply a project as part of the __CoreDNS__ organization, it has to met the following criteria:
+The CoreDNS organization is open to receive new sub-projects under its umbrella.
+To accept project into the __CoreDNS__ organization, it has to met the following criteria:
 
 - Licensed under the terms of the Apache License v2.0
 - Related to one or more scopes of CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc ...)
   - External plugin
   - other DNS processing related
-- Be supported by 2/3 majority of organization
+- Be supported by 2/3 majority organization vote for acceptance
 
-The submission process starts as a Pull Request on CoreDNS repository with the required information mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
+The submission process starts as a Pull Request on the [coredns/coredns](https://github.com/coredns/coredns) repository with the required information mentioned above.
+Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -9,55 +9,79 @@ The CoreDNS community adheres to the following principles:
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
 
-## Voting
-
-The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
-
-Individuals declare if they contribute as un-affiliated or as associated with or employee of an organization or a company.
-
-Individuals that contribute as un-affiliated are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
-
-In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
-
-Any maintainer from an organization may cast the vote for that organization.
-
-For formal votes, a specific statement of what is being voted on, and in which delay (a suitable amount of time), should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after the delay is expired, the votes will be tallied and the outcome noted.
 
 ## Expectations from Maintainers
 
-Maintainers are the bridges between members of the CoreDNS community.
-Maintainers actively participate in PR reviews. Maintainers are expected to respond to assigned PRs in a reasonable time frame,
-either providing insights, or assign the PRs to other maintainers.
+"Every one carries water."
+
+Making a community work requires input/effort from every one. Maintainers should actively
+participate in Pull Request reviews. Maintainers are expected to respond to assigned Pull Requests
+in a *reasonable* time frame, either providing insights, or assign the Pull Requests to other
+maintainers.
+
+Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/coredns/OWNERS)
+file, with their Github handle and an (possible obfuscated) email address. Every one in the
+`reviewers` list is a Maintainer.
+
+A Maintainer is also listed in a plugin specific OWNER file.
+
+A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
+A Maintainer that hasn't been active in the CoreDNS repository for 12 months is considered inactive.
+
+## Becoming a Maintainers
+
+On successful completion (it was merged) of a (large) pull request, any current maintainer can reach
+to the person behind the pull request and ask them if they are willing to become a CoreDNS
+maintainer.
 
 ## Changes in Maintainership
 
-New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
+If a Maintainer feels she/he can not fulfill the "Expectations from Maintainers", they are free to
+step down.
 
-Maintainers who fail to meet the principles of CoreDNS community can be removed by a 2/3 majority organization vote.
+The CoreDNS organization will never forcefully remove a current Maintainer, unless a maintainer
+fails to meet the principles of CoreDNS community.
 
-The list of Maintainers is available in this [document](/OWNERS) and is synchronized with the receivers of maintainers@coredns.io list
 
-## Github Project Administration
+## Other Projects
 
-the __coredns__ GitHub project maintainers team reflect the list of Maintainers.
+The CoreDNS organization is open to receive new sub-projects under its umbrella. To accept project
+into the __CoreDNS__ organization, it has to met the following criteria:
 
-## Projects
-
-The CoreDNS organization is open to receive new sub-projects under its umbrella.
-To accept project into the __CoreDNS__ organization, it has to met the following criteria:
-
-- Licensed under the terms of the Apache License v2.0
+- Licensed under the terms of the Apache License v2.0.
 - Related to one or more scopes of CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc ...)
-  - External plugin
+  - External plugins
   - other DNS processing related
-- Be supported by 2/3 majority organization vote for acceptance
+- Be supported by a Maintainer.
 
-The submission process starts as a Pull Request on the [coredns/coredns](https://github.com/coredns/coredns) repository with the required information mentioned above.
-Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
+The submission process starts as a Pull Request or Issue on the
+[coredns/coredns](https://github.com/coredns/coredns) repository with the required information
+mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella
+of CoreDNS__
+
+## Decision making process
+
+Decisions are build on consensus between maintainers.
+Proposal and ideas can either be submitted for agreement via an github issue or by sending an email to `maintainer@coredns.io`
+
+In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
+If a dispute cannot be decided independently, the maintainers can be called in to decide an issue.
+If the maintainers themselves cannot decide an issue, the issue will be resolved by voting.
+
+For formal votes, a specific statement of what is being voted on, and in which delay (a suitable amount of time),
+should be added to the relevant github issue or PR, and a link to that issue
+or PR sent to `maintainer@coredns.io`.
+
+Maintainers should indicate their yes/no vote (or respectively +1/-1) on that issue or PR,
+and after the delay is expired, the votes will be tallied and the outcome noted.
+
+A 2/3 majority vote is needed for the statement to be approved.
+
+Each maintainer weighs one vote.<br>
+Miek Gieben (@miekg), as the historical owner of CoreDNS, weighs two votes.
 
 ## Code of Conduct
 
-CoreDNS follows the CNCF Code of Conduct:
+CoreDNS follows the [CNCF Code of Conduct](https://github.com/coredns/coredns/CODE-OF-CONDUCT.md).
 
-https://github.com/cncf/foundation/blob/master/code-of-conduct.md


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### Why is this pull request needed and what does it do?
In order to graduate on last level inside CNCF organization, we need to clarify our GOVERNANCE rules.

### Description

On advise of @caniszczyk , I started with a copy of the [governance doc from fluentd](https://github.com/fluent/fluentd/blob/master/GOVERNANCE.md), which, itself is extracted from [Kubernetes' governance doc](https://github.com/kubernetes/community/blob/master/governance.md).
Then I tuned the text to adapt to CoreDNS project.

**Please pay attention to these points:**

1- MAINTAINERS are defined as the individuals assigned to the team 'maintainers' (from Github project). It is not the same as Reviewers or Approvers defined into OWNER.md

2- VOTE is defined by Organization + individual maintainers. This vote would be used to agree on a direction to the project. I am not sure, so far, it was used formerly. We may want to be able to have a 2/3 majority when it comes to vote. Which means a limited number of MAINTAINERS that are really focus on CoreDNS project. (as of today we have  2 Orgs + 2 individuals).

3- I made up the content of the paragraph "Projects". We may want to tune that description. 




