### PR TITLE
plugins/route53: add AWS credentials file support

### DIFF
--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -16,6 +16,7 @@ The route53 plugin can be used when coredns is deployed on AWS or elsewhere.
 route53 [ZONE:HOSTED_ZONE_ID...] {
     [aws_access_key AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
     upstream [ADDRESS...]
+    [credentials_file PROFILE FILENAME]
 }
 ~~~
 
@@ -29,10 +30,13 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
    to external hosts (eg. used to resolve CNAMEs). If no **ADDRESS** is given, CoreDNS will resolve
    against itself. **ADDRESS** can be an IP, an IP:port or a path to a file structured like
    resolv.conf (**NB**: Currently a bug (#2099) is preventing the use of self-resolver).
+* `credentials_file` used for reading the credential file and setting the profile name for a given zone.
+* **PROFILE** AWS account profile name. Defaults to `default`.
+* **FILENAME** AWS credentials filename. Defaults to `~/.aws/credentials`
 
 ## Examples
 
-Enable route53 with implicit aws credentials and an upstream:
+Enable route53 with implicit AWS credentials and an upstream:
 
 ~~~ txt
 . {
@@ -41,12 +45,22 @@ Enable route53 with implicit aws credentials and an upstream:
 }
 ~~~
 
-Enable route53 with explicit aws credentials:
+Enable route53 with explicit AWS credentials:
 
 ~~~ txt
 . {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
       aws_access_key AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+  }
+}
+~~~
+
+Enable route53 with AWS credentials file:
+
+~~~ txt
+. {
+    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
+      credentials_file some-user
   }
 }
 ~~~

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -16,7 +16,7 @@ The route53 plugin can be used when coredns is deployed on AWS or elsewhere.
 route53 [ZONE:HOSTED_ZONE_ID...] {
     [aws_access_key AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
     upstream [ADDRESS...]
-    [credentials_file PROFILE FILENAME]
+    credentials PROFILE [FILENAME]
 }
 ~~~
 
@@ -30,7 +30,7 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
    to external hosts (eg. used to resolve CNAMEs). If no **ADDRESS** is given, CoreDNS will resolve
    against itself. **ADDRESS** can be an IP, an IP:port or a path to a file structured like
    resolv.conf (**NB**: Currently a bug (#2099) is preventing the use of self-resolver).
-* `credentials_file` used for reading the credential file and setting the profile name for a given zone.
+* `credentials` used for reading the credential file and setting the profile name for a given zone.
 * **PROFILE** AWS account profile name. Defaults to `default`.
 * **FILENAME** AWS credentials filename. Defaults to `~/.aws/credentials`
 

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -36,6 +36,13 @@ func init() {
 
 func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Route53API) error {
 	keys := map[string]string{}
+
+	// Route53 plugin attempts to find AWS credentials by using ChainCredentials.
+	// And the order of that provider chain is as follows:
+	// Static AWS keys -> Environment Variables -> Credentials file -> IAM role
+	// With that said, even though a user doesn't define any credentials in
+	// Corefile, we should still attempt to read the default credentials file,
+	// ~/.aws/credentials with the default profile.
 	sharedProvider := &credentials.SharedCredentialsProvider{}
 	var providers []credentials.Provider
 	var fall fall.F

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -24,11 +24,9 @@ func init() {
 		ServerType: "dns",
 		Action: func(c *caddy.Controller) error {
 			f := func(credential *credentials.Credentials) route53iface.Route53API {
-				r := route53.New(session.Must(session.NewSession(&aws.Config{
+				return route53.New(session.Must(session.NewSession(&aws.Config{
 					Credentials: credential,
 				})))
-
-				return r
 			}
 			return setup(c, f)
 		},

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -82,7 +82,7 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 				if err != nil {
 					return c.Errf("invalid upstream: %v", err)
 				}
-			case "credentials_file":
+			case "credentials":
 				args := c.RemainingArgs()
 				if len(args) > 0 {
 					sharedProvider.Profile = args[0]

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -84,10 +84,10 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 				}
 			case "credentials_file":
 				args := c.RemainingArgs()
-				if len(args) == 1 {
+				if len(args) > 0 {
 					sharedProvider.Profile = args[0]
 				}
-				if len(args) == 2 {
+				if len(args) > 1 {
 					sharedProvider.Filename = args[1]
 				}
 			default:

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -36,7 +36,7 @@ func init() {
 func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Route53API) error {
 	keys := map[string]string{}
 	sharedProvider := &credentials.SharedCredentialsProvider{}
-	providers := []credentials.Provider{}
+	var providers []credentials.Provider
 
 	up, _ := upstream.New(nil)
 	for c.Next() {
@@ -83,12 +83,13 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 					return c.Errf("invalid upstream: %v", err)
 				}
 			case "credentials":
-				args := c.RemainingArgs()
-				if len(args) > 0 {
-					sharedProvider.Profile = args[0]
+				if c.NextArg() {
+					sharedProvider.Profile = c.Val()
+				} else {
+					return c.ArgErr()
 				}
-				if len(args) > 1 {
-					sharedProvider.Filename = args[1]
+				if c.NextArg() {
+					sharedProvider.Filename = c.Val()
 				}
 			default:
 				return c.Errf("unknown property '%s'", c.Val())

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -97,9 +97,7 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 	}
 	providers = append(providers, &credentials.EnvProvider{}, sharedProvider)
 
-	credential := credentials.NewChainCredentials(providers)
-
-	client := f(credential)
+	client := f(credentials.NewChainCredentials(providers))
 	ctx := context.Background()
 	h, err := New(ctx, client, keys, &up)
 	if err != nil {

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -56,4 +56,12 @@ func TestSetupRoute53(t *testing.T) {
 	if err := setup(c, f); err != nil {
 		t.Fatalf("Unexpected errors: %v", err)
 	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
+		credentials_file default credentials
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err != nil {
+		t.Fatalf("Unexpected errors: %v", err)
+	}
 }

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -58,7 +58,7 @@ func TestSetupRoute53(t *testing.T) {
 	}
 
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
-		credentials_file default credentials
+		credentials default credentials
  		upstream 1.2.3.4
 	}`)
 	if err := setup(c, f); err != nil {

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -58,6 +58,22 @@ func TestSetupRoute53(t *testing.T) {
 	}
 
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
+		credentials
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
+		credentials default
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err != nil {
+		t.Fatalf("Unexpected errors: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
 		credentials default credentials
  		upstream 1.2.3.4
 	}`)

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -83,4 +83,12 @@ func TestSetupRoute53(t *testing.T) {
 	if err := setup(c, f); err != nil {
 		t.Fatalf("Unexpected errors: %v", err)
 	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
+		credentials default credentials extra-arg
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
 }


### PR DESCRIPTION
This PR creates AWS credentials file support and enables setting different AWS profile names for each server block
