### PR TITLE
K8s remove string ops

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -446,7 +446,7 @@ func checkForApex(b ServiceBackend, zone string, state request.Request, opt Opti
 	// this is equivalent to the NS search code.
 	old := state.QName()
 	state.Clear()
-	state.Req.Question[0].Name = dnsutil.Join([]string{"apex.dns", zone})
+	state.Req.Question[0].Name = dnsutil.Join("apex.dns", zone)
 
 	services, err := b.Services(state, false, opt)
 	if err == nil {

--- a/plugin/etcd/msg/path.go
+++ b/plugin/etcd/msg/path.go
@@ -26,7 +26,7 @@ func Domain(s string) string {
 	for i, j := 1, len(l)-1; i < j; i, j = i+1, j-1 {
 		l[i], l[j] = l[j], l[i]
 	}
-	return dnsutil.Join(l[1 : len(l)-1])
+	return dnsutil.Join(l[1 : len(l)-1]...)
 }
 
 // PathWithWildcard ascts as Path, but if a name contains wildcards (* or any), the name will be

--- a/plugin/etcd/stub.go
+++ b/plugin/etcd/stub.go
@@ -61,7 +61,7 @@ Services:
 			// Chop of left most label, because that is used as the nameserver place holder
 			// and drop the right most labels that belong to zone.
 			// We must *also* chop of dns.stub. which means cutting two more labels.
-			domain = dnsutil.Join(labels[1 : len(labels)-dns.CountLabel(z)-2])
+			domain = dnsutil.Join(labels[1 : len(labels)-dns.CountLabel(z)-2]...)
 			if domain == z {
 				log.Warningf("Skipping nameserver for domain we are authoritative for: %s", domain)
 				continue Services

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -130,7 +130,7 @@ func (f *Federation) isNameFederation(name, zone string) (string, string) {
 	fed := labels[ll-2]
 
 	if _, ok := f.f[fed]; ok {
-		without := dnsutil.Join(labels[:ll-2]) + labels[ll-1] + "." + zone
+		without := dnsutil.Join(labels[:ll-2]...) + labels[ll-1] + "." + zone
 		return without, fed
 	}
 	return "", ""

--- a/plugin/file/dname.go
+++ b/plugin/file/dname.go
@@ -14,7 +14,7 @@ func substituteDNAME(qname, owner, target string) string {
 		labels := dns.SplitDomainName(qname)
 		labels = append(labels[0:len(labels)-dns.CountLabel(owner)], dns.SplitDomainName(target)...)
 
-		return dnsutil.Join(labels)
+		return dnsutil.Join(labels...)
 	}
 
 	return ""

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -177,7 +177,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Service")
 	}
-	return []string{s.ObjectMeta.Name, s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
 }
 
 func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
@@ -185,7 +185,7 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Endpoints")
 	}
-	return []string{s.ObjectMeta.Name, s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
 }
 
 func epIPIndexFunc(obj interface{}) ([]string, error) {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -72,7 +72,7 @@ type dnsControl struct {
 	svcLister cache.Indexer
 	podLister cache.Indexer
 	epLister  cache.Indexer
-	nsLister  storeToNamespaceLister
+	nsLister  cache.Store
 
 	// stopLock is used to enforce only a single call to Stop is active.
 	// Needed because we allow stopping through an http endpoint and
@@ -146,7 +146,7 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 			cache.Indexers{epNameNamespaceIndex: epNameNamespaceIndexFunc, epIPIndex: epIPIndexFunc})
 	}
 
-	dns.nsLister.Store, dns.nsController = cache.NewInformer(
+	dns.nsLister, dns.nsController = cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc:  namespaceListFunc(dns.client, dns.selector),
 			WatchFunc: namespaceWatchFunc(dns.client, dns.selector),
@@ -154,11 +154,6 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 		&api.Namespace{}, opts.resyncPeriod, cache.ResourceEventHandlerFuncs{})
 
 	return &dns
-}
-
-// storeToNamespaceLister makes a Store that lists Namespaces.
-type storeToNamespaceLister struct {
-	cache.Store
 }
 
 func podIPIndexFunc(obj interface{}) ([]string, error) {
@@ -182,7 +177,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Service")
 	}
-	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name, s.ObjectMeta.Namespace}, nil
 }
 
 func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
@@ -190,7 +185,7 @@ func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Endpoints")
 	}
-	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name, s.ObjectMeta.Namespace}, nil
 }
 
 func epIPIndexFunc(obj interface{}) ([]string, error) {
@@ -311,9 +306,8 @@ func namespaceWatchFunc(c *kubernetes.Clientset, s labels.Selector) func(options
 	}
 }
 
-func (dns *dnsControl) SetWatchChan(c dnswatch.Chan) {
-	dns.watchChan = c
-}
+func (dns *dnsControl) SetWatchChan(c dnswatch.Chan) { dns.watchChan = c }
+func (dns *dnsControl) StopWatching(qname string)    { delete(dns.watched, qname) }
 
 func (dns *dnsControl) Watch(qname string) error {
 	if dns.watchChan == nil {
@@ -321,10 +315,6 @@ func (dns *dnsControl) Watch(qname string) error {
 	}
 	dns.watched[qname] = true
 	return nil
-}
-
-func (dns *dnsControl) StopWatching(qname string) {
-	delete(dns.watched, qname)
 }
 
 // Stop stops the  controller.
@@ -621,15 +611,9 @@ func (dns *dnsControl) sendUpdates(oldObj, newObj interface{}) {
 	}
 }
 
-func (dns *dnsControl) Add(obj interface{}) {
-	dns.sendUpdates(nil, obj)
-}
-func (dns *dnsControl) Delete(obj interface{}) {
-	dns.sendUpdates(obj, nil)
-}
-func (dns *dnsControl) Update(oldObj, newObj interface{}) {
-	dns.sendUpdates(oldObj, newObj)
-}
+func (dns *dnsControl) Add(obj interface{})               { dns.sendUpdates(nil, obj) }
+func (dns *dnsControl) Delete(obj interface{})            { dns.sendUpdates(obj, nil) }
+func (dns *dnsControl) Update(oldObj, newObj interface{}) { dns.sendUpdates(oldObj, newObj) }
 
 // subsetsEquivalent checks if two endpoint subsets are significantly equivalent
 // I.e. that they have the same ready addresses, host names, ports (including protocol

--- a/plugin/kubernetes/federation.go
+++ b/plugin/kubernetes/federation.go
@@ -44,8 +44,8 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 	}
 
 	if r.endpoint == "" {
-		return msg.Service{Host: dnsutil.Join([]string{r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone})}, nil
+		return msg.Service{Host: dnsutil.Join(r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone)}, nil
 	}
 
-	return msg.Service{Host: dnsutil.Join([]string{r.endpoint, r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone})}, nil
+	return msg.Service{Host: dnsutil.Join(r.endpoint, r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone)}, nil
 }

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -85,7 +85,7 @@ func qname(zone string) string {
 	l1 := strconv.Itoa(r.Int())
 	l2 := strconv.Itoa(r.Int())
 
-	return dnsutil.Join([]string{l1, l2, zone})
+	return dnsutil.Join(l1, l2, zone)
 }
 
 var r = rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/plugin/pkg/dnsutil/join.go
+++ b/plugin/pkg/dnsutil/join.go
@@ -8,12 +8,10 @@ import (
 
 // Join joins labels to form a fully qualified domain name. If the last label is
 // the root label it is ignored. Not other syntax checks are performed.
-func Join(labels []string) string {
+func Join(labels ...string) string {
 	ll := len(labels)
 	if labels[ll-1] == "." {
-		s := strings.Join(labels[:ll-1], ".")
-		return dns.Fqdn(s)
+		return strings.Join(labels[:ll-1], ".") + "."
 	}
-	s := strings.Join(labels, ".")
-	return dns.Fqdn(s)
+	return dns.Fqdn(strings.Join(labels, "."))
 }

--- a/plugin/pkg/dnsutil/join_test.go
+++ b/plugin/pkg/dnsutil/join_test.go
@@ -9,11 +9,12 @@ func TestJoin(t *testing.T) {
 	}{
 		{[]string{"bla", "bliep", "example", "org"}, "bla.bliep.example.org."},
 		{[]string{"example", "."}, "example."},
+		{[]string{"example", "org."}, "example.org."}, // technically we should not be called like this.
 		{[]string{"."}, "."},
 	}
 
 	for i, tc := range tests {
-		if x := Join(tc.in); x != tc.out {
+		if x := Join(tc.in...); x != tc.out {
 			t.Errorf("Test %d, expected %s, got %s", i, tc.out, x)
 		}
 	}


### PR DESCRIPTION
    plugin/kubernetes: remove bunch a string ops
    
    This removes a bunch of appends to where not needed, makes dnsutil.Join
    take variadic args which removes the need to wrap in a new string slice.
    
    Signed-off-by: Miek Gieben <miek@miek.nl>

