### PR TITLE
plugin/kubernetes: remove var namespace

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -19,8 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-var namespace = api.NamespaceAll
-
 const (
 	podIPIndex            = "PodIP"
 	svcNameNamespaceIndex = "NameNamespace"
@@ -114,8 +112,8 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 
 	dns.svcLister, dns.svcController = cache.NewIndexerInformer(
 		&cache.ListWatch{
-			ListFunc:  serviceListFunc(dns.client, namespace, dns.selector),
-			WatchFunc: serviceWatchFunc(dns.client, namespace, dns.selector),
+			ListFunc:  serviceListFunc(dns.client, api.NamespaceAll, dns.selector),
+			WatchFunc: serviceWatchFunc(dns.client, api.NamespaceAll, dns.selector),
 		},
 		&api.Service{},
 		opts.resyncPeriod,
@@ -125,8 +123,8 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 	if opts.initPodCache {
 		dns.podLister, dns.podController = cache.NewIndexerInformer(
 			&cache.ListWatch{
-				ListFunc:  podListFunc(dns.client, namespace, dns.selector),
-				WatchFunc: podWatchFunc(dns.client, namespace, dns.selector),
+				ListFunc:  podListFunc(dns.client, api.NamespaceAll, dns.selector),
+				WatchFunc: podWatchFunc(dns.client, api.NamespaceAll, dns.selector),
 			},
 			&api.Pod{},
 			opts.resyncPeriod,
@@ -137,8 +135,8 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 	if opts.initEndpointsCache {
 		dns.epLister, dns.epController = cache.NewIndexerInformer(
 			&cache.ListWatch{
-				ListFunc:  endpointsListFunc(dns.client, namespace, dns.selector),
-				WatchFunc: endpointsWatchFunc(dns.client, namespace, dns.selector),
+				ListFunc:  endpointsListFunc(dns.client, api.NamespaceAll, dns.selector),
+				WatchFunc: endpointsWatchFunc(dns.client, api.NamespaceAll, dns.selector),
 			},
 			&api.Endpoints{},
 			opts.resyncPeriod,

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -177,7 +177,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Service")
 	}
-	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name, ".", s.ObjectMeta.Namespace}, nil
 }
 
 func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -175,7 +175,7 @@ func svcNameNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, errors.New("obj was not an *api.Service")
 	}
-	return []string{s.ObjectMeta.Name, ".", s.ObjectMeta.Namespace}, nil
+	return []string{s.ObjectMeta.Name + "." + s.ObjectMeta.Namespace}, nil
 }
 
 func epNameNamespaceIndexFunc(obj interface{}) ([]string, error) {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -414,7 +414,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 	err = errNoItems
 	if wildcard(r.service) && !wildcard(r.namespace) {
 		// If namespace exist, err should be nil, so that we return nodata instead of NXDOMAIN
-		if k.namespace(namespace) {
+		if k.namespace(r.namespace) {
 			err = nil
 		}
 	}


### PR DESCRIPTION
The removes the var namespace which was not needed.

Also uncovered a bug because of this in the namespace selection or hiding, because namespace as a var existed.