### PR TITLE
WIP plugin/kubernetes: use less mem - reduce index size

### DIFF
--- a/plugin/federation/kubernetes_api_test.go
+++ b/plugin/federation/kubernetes_api_test.go
@@ -15,8 +15,8 @@ type APIConnFederationTest struct {
 func (APIConnFederationTest) HasSynced() bool                        { return true }
 func (APIConnFederationTest) Run()                                   { return }
 func (APIConnFederationTest) Stop() error                            { return nil }
-func (APIConnFederationTest) SvcIndexReverse(string) []*api.Service  { return nil }
-func (APIConnFederationTest) EpIndexReverse(string) []*api.Endpoints { return nil }
+func (APIConnFederationTest) SvcIndexReverse(string) *api.Service  { return nil }
+func (APIConnFederationTest) EpIndexReverse(string) *api.Endpoints { return nil }
 func (APIConnFederationTest) Modified() int64                        { return 0 }
 func (APIConnFederationTest) SetWatchChan(watch.Chan)                {}
 func (APIConnFederationTest) Watch(string) error                     { return nil }
@@ -34,9 +34,9 @@ func (APIConnFederationTest) PodIndex(string) []*api.Pod {
 	return a
 }
 
-func (APIConnFederationTest) SvcIndex(string) []*api.Service {
-	svcs := []*api.Service{
-		{
+func (APIConnFederationTest) SvcIndex(key string) *api.Service {
+	svcs := map[string]*api.Service{
+		"testns/svc1": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "svc1",
 				Namespace: "testns",
@@ -50,7 +50,7 @@ func (APIConnFederationTest) SvcIndex(string) []*api.Service {
 				}},
 			},
 		},
-		{
+		"testns/hdls1": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "hdls1",
 				Namespace: "testns",
@@ -59,7 +59,7 @@ func (APIConnFederationTest) SvcIndex(string) []*api.Service {
 				ClusterIP: api.ClusterIPNone,
 			},
 		},
-		{
+		"testns/external": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "external",
 				Namespace: "testns",
@@ -74,7 +74,7 @@ func (APIConnFederationTest) SvcIndex(string) []*api.Service {
 			},
 		},
 	}
-	return svcs
+	return svcs[key]
 }
 
 func (APIConnFederationTest) ServiceList() []*api.Service {
@@ -120,9 +120,9 @@ func (APIConnFederationTest) ServiceList() []*api.Service {
 	return svcs
 }
 
-func (APIConnFederationTest) EpIndex(string) []*api.Endpoints {
-	eps := []*api.Endpoints{
-		{
+func (APIConnFederationTest) EpIndex(key string) *api.Endpoints {
+	eps := map[string]*api.Endpoints{
+		"testns/svc1": {
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -146,7 +146,7 @@ func (APIConnFederationTest) EpIndex(string) []*api.Endpoints {
 			},
 		},
 	}
-	return eps
+	return eps[key]
 }
 
 func (APIConnFederationTest) EndpointsList() []*api.Endpoints {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -419,7 +419,11 @@ func (dns *dnsControl) EpIndex(key string) (*api.Endpoints) {
 
 func (dns *dnsControl) EpIndexReverse(ip string) (ep *api.Endpoints) {
 	if !dns.revIdxAllEndpoints {
-		return dns.EpIndex(*dns.headlessEndpoints.keys[ip])
+		key := dns.headlessEndpoints.keys[ip]
+		if key == nil {
+			return nil
+		}
+		return dns.EpIndex(*key)
 	}
 
 	if dns.epLister == nil {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -367,7 +367,7 @@ func (dns *dnsControl) PodIndex(ip string) (pods []*api.Pod) {
 	return nil
 }
 
-func (dns *dnsControl) SvcIndex(key string) (*api.Service) {
+func (dns *dnsControl) SvcIndex(key string) *api.Service {
 	o, _, err := dns.svcLister.GetByKey(key)
 	if err != nil {
 		return nil
@@ -380,7 +380,7 @@ func (dns *dnsControl) SvcIndex(key string) (*api.Service) {
 	return s
 }
 
-func (dns *dnsControl) SvcIndexReverse(ip string) (*api.Service) {
+func (dns *dnsControl) SvcIndexReverse(ip string) *api.Service {
 	if dns.svcLister == nil {
 		return nil
 	}
@@ -399,7 +399,7 @@ func (dns *dnsControl) SvcIndexReverse(ip string) (*api.Service) {
 	return nil
 }
 
-func (dns *dnsControl) EpIndex(key string) (*api.Endpoints) {
+func (dns *dnsControl) EpIndex(key string) *api.Endpoints {
 	if dns.epLister == nil {
 		return nil
 	}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -554,9 +554,6 @@ func endpointsSubsetDiffs(a, b *api.Endpoints) *api.Endpoints {
 
 // sendUpdates sends a notification to the server if a watch is enabled for the qname.
 func (dns *dnsControl) sendUpdates(oldObj, newObj interface{}) {
-	if len(dns.watched) == 0 {
-		return
-	}
 	// If both objects have the same resource version, they are identical.
 	if newObj != nil && oldObj != nil && (oldObj.(meta.Object).GetResourceVersion() == newObj.(meta.Object).GetResourceVersion()) {
 		return

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -368,9 +368,6 @@ func (dns *dnsControl) PodIndex(ip string) (pods []*api.Pod) {
 }
 
 func (dns *dnsControl) SvcIndex(key string) (*api.Service) {
-	if dns.svcLister == nil {
-		return nil
-	}
 	o, _, err := dns.svcLister.GetByKey(key)
 	if err != nil {
 		return nil

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -735,7 +735,7 @@ func (dns *dnsControl) UpdateEndpoints(oldObj, newObj interface{}) {
 	}
 }
 
-func (dns *dnsControl) addEpToMap(ip string, ep *api.Endpoints){
+func (dns *dnsControl) addEpToMap(ip string, ep *api.Endpoints) {
 	namespace := ep.ObjectMeta.Namespace
 	name := ep.ObjectMeta.Name
 	if dns.headlessEndpoints[ip] == nil {

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -618,7 +618,7 @@ func (dns *dnsControl) AddEndpoints(obj interface{}) {
 	if !ok {
 		return
 	}
-	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.GetNamespace(), ep.GetName()))
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.ObjectMeta.Namespace, ep.ObjectMeta.Name))
 
 	if err != nil {
 		return
@@ -654,7 +654,7 @@ func (dns *dnsControl) DeleteEndpoints(obj interface{}) {
 	if !ok {
 		return
 	}
-	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.GetNamespace(), ep.GetName()))
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.ObjectMeta.Namespace, ep.ObjectMeta.Name))
 	if err != nil {
 		return
 	}
@@ -682,7 +682,7 @@ func (dns *dnsControl) UpdateEndpoints(oldObj, newObj interface{}) {
 	if !(ok && fine) {
 		return
 	}
-	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(oldEp.GetNamespace(), oldEp.GetName()))
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(oldEp.ObjectMeta.Namespace, oldEp.ObjectMeta.Name))
 	if err != nil {
 		return
 	}
@@ -736,8 +736,8 @@ func (dns *dnsControl) UpdateEndpoints(oldObj, newObj interface{}) {
 }
 
 func (dns *dnsControl) addEpToMap(ip string, ep *api.Endpoints){
-	namespace := ep.GetNamespace()
-	name := ep.GetName()
+	namespace := ep.ObjectMeta.Namespace
+	name := ep.ObjectMeta.Name
 	if dns.headlessEndpoints[ip] == nil {
 		dns.headlessEndpoints[ip] = make(endpoints)
 	}

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -117,7 +117,7 @@ func newdnsController(kubeClient *kubernetes.Clientset, opts dnsControlOpts) *dn
 	}
 
 	if !dns.revIdxAllEndpoints {
-		dns.headlessEndpoints = NewEndpointIPs()
+		dns.headlessEndpoints = newEndpointIPs()
 	}
 
 	dns.svcLister, dns.svcController = cache.NewIndexerInformer(

--- a/plugin/kubernetes/epipmap.go
+++ b/plugin/kubernetes/epipmap.go
@@ -12,7 +12,7 @@ type endpointips struct {
 	mutex sync.Mutex
 }
 
-func NewEndpointIPs() *endpointips {
+func newEndpointIPs() *endpointips {
 	epips := new(endpointips)
 	epips.keys = make(map[string]*string)
 	return epips

--- a/plugin/kubernetes/epipmap.go
+++ b/plugin/kubernetes/epipmap.go
@@ -1,0 +1,177 @@
+package kubernetes
+
+import (
+	"sync"
+
+	api "k8s.io/api/core/v1"
+)
+
+type endpointips struct {
+	store map[string]endpoints
+	mutex sync.Mutex
+}
+
+type endpoints map[string]map[string]bool
+
+func NewEndpointIPs() *endpointips {
+	epips := new(endpointips)
+	epips.store = make(map[string]endpoints)
+	return epips
+}
+
+func (dns *dnsControl) AddEndpoints(obj interface{}) {
+	if dns.revIdxAllEndpoints {
+		return
+	}
+
+	ep, ok := obj.(*api.Endpoints)
+	if !ok {
+		svc, isSvc := obj.(*api.Service)
+		if !isSvc {
+			return
+		}
+		if svc.Spec.ClusterIP != api.ClusterIPNone {
+			o, exists, err := dns.epLister.GetByKey(metaNamespaceKey(svc.GetNamespace(), svc.GetName()))
+			if err != nil {
+				return
+			}
+			if !exists {
+				return
+			}
+			ep, ok := o.(*api.Endpoints)
+			if !ok {
+				return
+			}
+			dns.DeleteEndpoints(ep)
+		}
+		return
+	}
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.GetNamespace(), ep.GetName()))
+
+	if err != nil {
+		return
+	}
+	if exists {
+		svc, ok := o.(*api.Service)
+		if !ok {
+			return
+		}
+		if svc.Spec.ClusterIP != api.ClusterIPNone {
+			return
+		}
+	}
+	for _, s := range ep.Subsets {
+		for _, a := range s.Addresses {
+			dns.addEpToMap(a.IP, ep)
+		}
+	}
+}
+
+func (dns *dnsControl) DeleteEndpoints(obj interface{}) {
+	if dns.revIdxAllEndpoints {
+		return
+	}
+	ep, ok := obj.(*api.Endpoints)
+	if !ok {
+		return
+	}
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(ep.GetNamespace(), ep.GetName()))
+	if err != nil {
+		return
+	}
+	if !exists {
+		return
+	}
+	svc, ok := o.(*api.Service)
+	if !ok {
+		return
+	}
+	if svc.Spec.ClusterIP != api.ClusterIPNone {
+		return
+	}
+	for ip := range dns.headlessEndpoints.store {
+		dns.deleteIpFromMap(ip)
+	}
+}
+
+func (dns *dnsControl) UpdateEndpoints(oldObj, newObj interface{}) {
+	if dns.revIdxAllEndpoints {
+		return
+	}
+	oldEp, ok := oldObj.(*api.Endpoints)
+	newEp, fine := newObj.(*api.Endpoints)
+	if !(ok && fine) {
+		return
+	}
+	o, exists, err := dns.svcLister.GetByKey(metaNamespaceKey(oldEp.GetNamespace(), oldEp.GetName()))
+	if err != nil {
+		return
+	}
+	if !exists {
+		return
+	}
+	svc, ok := o.(*api.Service)
+	if !ok {
+		return
+	}
+	if svc.Spec.ClusterIP != api.ClusterIPNone {
+		return
+	}
+	for _, os := range oldEp.Subsets {
+		for _, oa := range os.Addresses {
+			found := false
+		FindDelete:
+			for _, ns := range newEp.Subsets {
+				for _, na := range ns.Addresses {
+					if oa.IP == na.IP {
+						found = true
+						break FindDelete
+					}
+				}
+			}
+			if !found {
+				// remove item from map
+				dns.deleteIpFromMap(oa.IP)
+			}
+		}
+	}
+	// Find new IPs (IPs in newEp, but not in oldEp)
+	for _, ns := range newEp.Subsets {
+		for _, na := range ns.Addresses {
+			found := false
+		FindAdd:
+			for _, os := range oldEp.Subsets {
+				for _, oa := range os.Addresses {
+					if oa.IP == na.IP {
+						found = true
+						break FindAdd
+					}
+				}
+			}
+			if !found {
+				// add item to map
+				dns.addEpToMap(na.IP, newEp)
+			}
+		}
+	}
+}
+
+func (dns *dnsControl) addEpToMap(ip string, ep *api.Endpoints) {
+	namespace := ep.GetNamespace()
+	name := ep.GetName()
+	dns.headlessEndpoints.mutex.Lock()
+	if dns.headlessEndpoints.store[ip] == nil {
+		dns.headlessEndpoints.store[ip] = make(endpoints)
+	}
+	if dns.headlessEndpoints.store[ip][namespace] == nil {
+		dns.headlessEndpoints.store[ip][namespace] = make(map[string]bool)
+	}
+	dns.headlessEndpoints.store[ip][namespace][name] = true
+	dns.headlessEndpoints.mutex.Unlock()
+}
+
+func (dns *dnsControl) deleteIpFromMap(ip string) {
+	dns.headlessEndpoints.mutex.Lock()
+	delete(dns.headlessEndpoints.store, ip)
+	dns.headlessEndpoints.mutex.Unlock()
+}

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -368,15 +368,15 @@ func TestServeDNS(t *testing.T) {
 
 type APIConnServeTest struct{}
 
-func (APIConnServeTest) HasSynced() bool                        { return true }
-func (APIConnServeTest) Run()                                   { return }
-func (APIConnServeTest) Stop() error                            { return nil }
-func (APIConnServeTest) EpIndexReverse(string) []*api.Endpoints { return nil }
-func (APIConnServeTest) SvcIndexReverse(string) []*api.Service  { return nil }
-func (APIConnServeTest) Modified() int64                        { return time.Now().Unix() }
-func (APIConnServeTest) SetWatchChan(watch.Chan)                {}
-func (APIConnServeTest) Watch(string) error                     { return nil }
-func (APIConnServeTest) StopWatching(string)                    {}
+func (APIConnServeTest) HasSynced() bool                      { return true }
+func (APIConnServeTest) Run()                                 { return }
+func (APIConnServeTest) Stop() error                          { return nil }
+func (APIConnServeTest) EpIndexReverse(string) *api.Endpoints { return nil }
+func (APIConnServeTest) SvcIndexReverse(string) *api.Service  { return nil }
+func (APIConnServeTest) Modified() int64                      { return time.Now().Unix() }
+func (APIConnServeTest) SetWatchChan(watch.Chan)              {}
+func (APIConnServeTest) Watch(string) error                   { return nil }
+func (APIConnServeTest) StopWatching(string)                  {}
 
 func (APIConnServeTest) PodIndex(string) []*api.Pod {
 	a := []*api.Pod{{
@@ -390,8 +390,8 @@ func (APIConnServeTest) PodIndex(string) []*api.Pod {
 	return a
 }
 
-var svcIndex = map[string][]*api.Service{
-	"testns/svc1": {{
+var svcIndex = map[string]*api.Service{
+	"testns/svc1": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc1",
 			Namespace: "testns",
@@ -405,8 +405,8 @@ var svcIndex = map[string][]*api.Service{
 				Port:     80,
 			}},
 		},
-	}},
-	"testns/svcempty": {{
+	},
+	"testns/svcempty": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svcempty",
 			Namespace: "testns",
@@ -420,8 +420,8 @@ var svcIndex = map[string][]*api.Service{
 				Port:     80,
 			}},
 		},
-	}},
-	"testns/svc6": {{
+	},
+	"testns/svc6": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc6",
 			Namespace: "testns",
@@ -435,8 +435,8 @@ var svcIndex = map[string][]*api.Service{
 				Port:     80,
 			}},
 		},
-	}},
-	"testns/hdls1": {{
+	},
+	"testns/hdls1": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "hdls1",
 			Namespace: "testns",
@@ -445,8 +445,8 @@ var svcIndex = map[string][]*api.Service{
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: api.ClusterIPNone,
 		},
-	}},
-	"testns/external": {{
+	},
+	"testns/external": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "external",
 			Namespace: "testns",
@@ -460,8 +460,8 @@ var svcIndex = map[string][]*api.Service{
 			}},
 			Type: api.ServiceTypeExternalName,
 		},
-	}},
-	"testns/external-to-service": {{
+	},
+	"testns/external-to-service": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "external-to-service",
 			Namespace: "testns",
@@ -475,8 +475,8 @@ var svcIndex = map[string][]*api.Service{
 			}},
 			Type: api.ServiceTypeExternalName,
 		},
-	}},
-	"testns/hdlsprtls": {{
+	},
+	"testns/hdlsprtls": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "hdlsprtls",
 			Namespace: "testns",
@@ -485,8 +485,8 @@ var svcIndex = map[string][]*api.Service{
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: api.ClusterIPNone,
 		},
-	}},
-	"unexposedns/svc1": {{
+	},
+	"unexposedns/svc1": {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc1",
 			Namespace: "unexposedns",
@@ -500,23 +500,23 @@ var svcIndex = map[string][]*api.Service{
 				Port:     80,
 			}},
 		},
-	}},
+	},
 }
 
-func (APIConnServeTest) SvcIndex(s string) []*api.Service {
+func (APIConnServeTest) SvcIndex(s string) *api.Service {
 	return svcIndex[s]
 }
 
 func (APIConnServeTest) ServiceList() []*api.Service {
 	var svcs []*api.Service
 	for _, svc := range svcIndex {
-		svcs = append(svcs, svc...)
+		svcs = append(svcs, svc)
 	}
 	return svcs
 }
 
-var epsIndex = map[string][]*api.Endpoints{
-	"testns/svc1": {{
+var epsIndex = map[string]*api.Endpoints{
+	"testns/svc1": {
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{
@@ -538,8 +538,8 @@ var epsIndex = map[string][]*api.Endpoints{
 			Name:      "svc1",
 			Namespace: "testns",
 		},
-	}},
-	"testns/svcempty": {{
+	},
+	"testns/svcempty": {
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: nil,
@@ -556,8 +556,8 @@ var epsIndex = map[string][]*api.Endpoints{
 			Name:      "svcempty",
 			Namespace: "testns",
 		},
-	}},
-	"testns/hdls1": {{
+	},
+	"testns/hdls1": {
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{
@@ -595,8 +595,8 @@ var epsIndex = map[string][]*api.Endpoints{
 			Name:      "hdls1",
 			Namespace: "testns",
 		},
-	}},
-	"testns/hdlsprtls": {{
+	},
+	"testns/hdlsprtls": {
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{
@@ -611,17 +611,17 @@ var epsIndex = map[string][]*api.Endpoints{
 			Name:      "hdlsprtls",
 			Namespace: "testns",
 		},
-	}},
+	},
 }
 
-func (APIConnServeTest) EpIndex(s string) []*api.Endpoints {
+func (APIConnServeTest) EpIndex(s string) *api.Endpoints {
 	return epsIndex[s]
 }
 
 func (APIConnServeTest) EndpointsList() []*api.Endpoints {
 	var eps []*api.Endpoints
 	for _, ep := range epsIndex {
-		eps = append(eps, ep...)
+		eps = append(eps, ep)
 	}
 	return eps
 

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -391,7 +391,7 @@ func (APIConnServeTest) PodIndex(string) []*api.Pod {
 }
 
 var svcIndex = map[string][]*api.Service{
-	"svc1.testns": {{
+	"testns/svc1": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc1",
 			Namespace: "testns",
@@ -406,7 +406,7 @@ var svcIndex = map[string][]*api.Service{
 			}},
 		},
 	}},
-	"svcempty.testns": {{
+	"testns/svcempty": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svcempty",
 			Namespace: "testns",
@@ -421,7 +421,7 @@ var svcIndex = map[string][]*api.Service{
 			}},
 		},
 	}},
-	"svc6.testns": {{
+	"testns/svc6": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc6",
 			Namespace: "testns",
@@ -436,7 +436,7 @@ var svcIndex = map[string][]*api.Service{
 			}},
 		},
 	}},
-	"hdls1.testns": {{
+	"testns/hdls1": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "hdls1",
 			Namespace: "testns",
@@ -446,7 +446,7 @@ var svcIndex = map[string][]*api.Service{
 			ClusterIP: api.ClusterIPNone,
 		},
 	}},
-	"external.testns": {{
+	"testns/external": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "external",
 			Namespace: "testns",
@@ -461,7 +461,7 @@ var svcIndex = map[string][]*api.Service{
 			Type: api.ServiceTypeExternalName,
 		},
 	}},
-	"external-to-service.testns": {{
+	"testns/external-to-service": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "external-to-service",
 			Namespace: "testns",
@@ -476,7 +476,7 @@ var svcIndex = map[string][]*api.Service{
 			Type: api.ServiceTypeExternalName,
 		},
 	}},
-	"hdlsprtls.testns": {{
+	"testns/hdlsprtls": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "hdlsprtls",
 			Namespace: "testns",
@@ -486,7 +486,7 @@ var svcIndex = map[string][]*api.Service{
 			ClusterIP: api.ClusterIPNone,
 		},
 	}},
-	"svc1.unexposedns": {{
+	"unexposedns/svc1": {{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "svc1",
 			Namespace: "unexposedns",
@@ -516,7 +516,7 @@ func (APIConnServeTest) ServiceList() []*api.Service {
 }
 
 var epsIndex = map[string][]*api.Endpoints{
-	"svc1.testns": {{
+	"testns/svc1": {{
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{
@@ -539,7 +539,7 @@ var epsIndex = map[string][]*api.Endpoints{
 			Namespace: "testns",
 		},
 	}},
-	"svcempty.testns": {{
+	"testns/svcempty": {{
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: nil,
@@ -557,7 +557,7 @@ var epsIndex = map[string][]*api.Endpoints{
 			Namespace: "testns",
 		},
 	}},
-	"hdls1.testns": {{
+	"testns/hdls1": {{
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{
@@ -596,7 +596,7 @@ var epsIndex = map[string][]*api.Endpoints{
 			Namespace: "testns",
 		},
 	}},
-	"hdlsprtls.testns": {{
+	"testns/hdlsprtls": {{
 		Subsets: []api.EndpointSubset{
 			{
 				Addresses: []api.EndpointAddress{

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -439,9 +439,9 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		serviceList = k.APIConn.ServiceList()
 		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EndpointsList() }
 	} else {
-		idx := r.service + "." + r.namespace
-		serviceList = k.APIConn.SvcIndex(idx)
-		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EpIndex(idx) }
+		key := metaNamespaceKey(r.namespace, r.service)
+		serviceList = k.APIConn.SvcIndex(key)
+		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EpIndex(key) }
 	}
 
 	for _, svc := range serviceList {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -440,8 +440,8 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EndpointsList() }
 	} else {
 		key := metaNamespaceKey(r.namespace, r.service)
-		serviceList = k.APIConn.SvcIndex(key)
-		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EpIndex(key) }
+		serviceList = []*api.Service{k.APIConn.SvcIndex(key)}
+		endpointsListFunc = func() []*api.Endpoints { return []*api.Endpoints{k.APIConn.EpIndex(key)} }
 	}
 
 	for _, svc := range serviceList {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -440,12 +440,15 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 		endpointsListFunc = func() []*api.Endpoints { return k.APIConn.EndpointsList() }
 	} else {
 		key := metaNamespaceKey(r.namespace, r.service)
-		serviceList = []*api.Service{k.APIConn.SvcIndex(key)}
+		s := k.APIConn.SvcIndex(key)
+		if s != nil {
+			serviceList = append(serviceList, s)
+		}
 		endpointsListFunc = func() []*api.Endpoints { return []*api.Endpoints{k.APIConn.EpIndex(key)} }
 	}
 
 	for _, svc := range serviceList {
-		if !(match(r.namespace, svc.Namespace) && match(r.service, svc.Name)) {
+		if !(match(r.namespace, svc.ObjectMeta.Namespace) && match(r.service, svc.ObjectMeta.Name)) {
 			continue
 		}
 

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -62,16 +62,16 @@ func (APIConnServiceTest) HasSynced() bool                        { return true 
 func (APIConnServiceTest) Run()                                   { return }
 func (APIConnServiceTest) Stop() error                            { return nil }
 func (APIConnServiceTest) PodIndex(string) []*api.Pod             { return nil }
-func (APIConnServiceTest) SvcIndexReverse(string) []*api.Service  { return nil }
-func (APIConnServiceTest) EpIndexReverse(string) []*api.Endpoints { return nil }
+func (APIConnServiceTest) SvcIndexReverse(string) *api.Service  { return nil }
+func (APIConnServiceTest) EpIndexReverse(string) *api.Endpoints { return nil }
 func (APIConnServiceTest) Modified() int64                        { return 0 }
 func (APIConnServiceTest) SetWatchChan(watch.Chan)                {}
 func (APIConnServiceTest) Watch(string) error                     { return nil }
 func (APIConnServiceTest) StopWatching(string)                    {}
 
-func (APIConnServiceTest) SvcIndex(string) []*api.Service {
-	svcs := []*api.Service{
-		{
+func (APIConnServiceTest) SvcIndex(key string) *api.Service {
+	svcs := map[string]*api.Service{
+		"testns/svc1": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "svc1",
 				Namespace: "testns",
@@ -85,7 +85,7 @@ func (APIConnServiceTest) SvcIndex(string) []*api.Service {
 				}},
 			},
 		},
-		{
+		"testns/hdls1": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "hdls1",
 				Namespace: "testns",
@@ -94,7 +94,7 @@ func (APIConnServiceTest) SvcIndex(string) []*api.Service {
 				ClusterIP: api.ClusterIPNone,
 			},
 		},
-		{
+		"testns/external": {
 			ObjectMeta: meta.ObjectMeta{
 				Name:      "external",
 				Namespace: "testns",
@@ -110,7 +110,7 @@ func (APIConnServiceTest) SvcIndex(string) []*api.Service {
 			},
 		},
 	}
-	return svcs
+	return svcs[key]
 }
 
 func (APIConnServiceTest) ServiceList() []*api.Service {
@@ -157,11 +157,11 @@ func (APIConnServiceTest) ServiceList() []*api.Service {
 	return svcs
 }
 
-func (APIConnServiceTest) EpIndex(string) []*api.Endpoints {
+func (APIConnServiceTest) EpIndex(key string) *api.Endpoints {
 	n := "test.node.foo.bar"
 
-	eps := []*api.Endpoints{
-		{
+	eps := map[string]*api.Endpoints{
+		"testns/svc1": {
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -184,7 +184,7 @@ func (APIConnServiceTest) EpIndex(string) []*api.Endpoints {
 				Namespace: "testns",
 			},
 		},
-		{
+		"testns/hdls1": {
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -206,7 +206,7 @@ func (APIConnServiceTest) EpIndex(string) []*api.Endpoints {
 				Namespace: "testns",
 			},
 		},
-		{
+		"testns/hdls2": {
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -224,11 +224,11 @@ func (APIConnServiceTest) EpIndex(string) []*api.Endpoints {
 				},
 			},
 			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
+				Name:      "hdls2",
 				Namespace: "testns",
 			},
 		},
-		{
+		"testns/testsvc": {
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -239,9 +239,13 @@ func (APIConnServiceTest) EpIndex(string) []*api.Endpoints {
 					},
 				},
 			},
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "testsvc",
+				Namespace: "testns",
+			},
 		},
 	}
-	return eps
+	return eps[key]
 }
 
 func (APIConnServiceTest) EndpointsList() []*api.Endpoints {
@@ -311,7 +315,7 @@ func (APIConnServiceTest) EndpointsList() []*api.Endpoints {
 				},
 			},
 			ObjectMeta: meta.ObjectMeta{
-				Name:      "hdls1",
+				Name:      "hdls2",
 				Namespace: "testns",
 			},
 		},
@@ -325,6 +329,10 @@ func (APIConnServiceTest) EndpointsList() []*api.Endpoints {
 						},
 					},
 				},
+			},
+			ObjectMeta: meta.ObjectMeta{
+				Name:      "testsvc",
+				Namespace: "testns",
 			},
 		},
 	}

--- a/plugin/kubernetes/local.go
+++ b/plugin/kubernetes/local.go
@@ -28,14 +28,18 @@ func (k *Kubernetes) localNodeName() string {
 	}
 
 	// Find endpoint matching localIP
-	for _, ep := range k.APIConn.EpIndexReverse(localIP.String()) {
-		for _, eps := range ep.Subsets {
-			for _, addr := range eps.Addresses {
-				if localIP.Equal(net.ParseIP(addr.IP)) {
-					return *addr.NodeName
-				}
+	ep := k.APIConn.EpIndexReverse(localIP.String())
+	if ep == nil {
+		return ""
+	}
+
+	for _, eps := range ep.Subsets {
+		for _, addr := range eps.Addresses {
+			if localIP.Equal(net.ParseIP(addr.IP)) {
+				return *addr.NodeName
 			}
 		}
 	}
+
 	return ""
 }

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -22,15 +22,14 @@ func (k *Kubernetes) nsAddr() *dns.A {
 	localIP := k.interfaceAddrsFunc()
 	rr.A = localIP
 
+	ep := k.APIConn.EpIndexReverse(localIP.String())
 FindEndpoint:
-	for _, ep := range k.APIConn.EpIndexReverse(localIP.String()) {
-		for _, eps := range ep.Subsets {
-			for _, addr := range eps.Addresses {
-				if localIP.Equal(net.ParseIP(addr.IP)) {
-					svcNamespace = ep.ObjectMeta.Namespace
-					svcName = ep.ObjectMeta.Name
-					break FindEndpoint
-				}
+	for _, eps := range ep.Subsets {
+		for _, addr := range eps.Addresses {
+			if localIP.Equal(net.ParseIP(addr.IP)) {
+				svcNamespace = ep.ObjectMeta.Namespace
+				svcName = ep.ObjectMeta.Name
+				break FindEndpoint
 			}
 		}
 	}
@@ -41,15 +40,12 @@ FindEndpoint:
 		return rr
 	}
 
-FindService:
-	for _, svc := range k.APIConn.ServiceList() {
-		if svcName == svc.Name && svcNamespace == svc.Namespace {
-			if svc.Spec.ClusterIP == api.ClusterIPNone {
-				rr.A = localIP
-			} else {
-				rr.A = net.ParseIP(svc.Spec.ClusterIP)
-			}
-			break FindService
+	svc := k.APIConn.SvcIndex(metaNamespaceKey(svcNamespace, svcName))
+	if svc != nil {
+		if svc.Spec.ClusterIP == api.ClusterIPNone {
+			rr.A = localIP
+		} else {
+			rr.A = net.ParseIP(svc.Spec.ClusterIP)
 		}
 	}
 

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -23,13 +23,15 @@ func (k *Kubernetes) nsAddr() *dns.A {
 	rr.A = localIP
 
 	ep := k.APIConn.EpIndexReverse(localIP.String())
-FindEndpoint:
-	for _, eps := range ep.Subsets {
-		for _, addr := range eps.Addresses {
-			if localIP.Equal(net.ParseIP(addr.IP)) {
-				svcNamespace = ep.ObjectMeta.Namespace
-				svcName = ep.ObjectMeta.Name
-				break FindEndpoint
+	if ep != nil {
+	FindEndpoint:
+		for _, eps := range ep.Subsets {
+			for _, addr := range eps.Addresses {
+				if localIP.Equal(net.ParseIP(addr.IP)) {
+					svcNamespace = ep.ObjectMeta.Namespace
+					svcName = ep.ObjectMeta.Name
+					break FindEndpoint
+				}
 			}
 		}
 	}

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -11,18 +11,18 @@ import (
 
 type APIConnTest struct{}
 
-func (APIConnTest) HasSynced() bool                       { return true }
-func (APIConnTest) Run()                                  { return }
-func (APIConnTest) Stop() error                           { return nil }
-func (APIConnTest) PodIndex(string) []*api.Pod            { return nil }
-func (APIConnTest) SvcIndex(string) []*api.Service        { return nil }
-func (APIConnTest) SvcIndexReverse(string) []*api.Service { return nil }
-func (APIConnTest) EpIndex(string) []*api.Endpoints       { return nil }
-func (APIConnTest) EndpointsList() []*api.Endpoints       { return nil }
-func (APIConnTest) Modified() int64                       { return 0 }
-func (APIConnTest) SetWatchChan(watch.Chan)               {}
-func (APIConnTest) Watch(string) error                    { return nil }
-func (APIConnTest) StopWatching(string)                   {}
+func (APIConnTest) HasSynced() bool                     { return true }
+func (APIConnTest) Run()                                { return }
+func (APIConnTest) Stop() error                         { return nil }
+func (APIConnTest) PodIndex(string) []*api.Pod          { return nil }
+func (APIConnTest) SvcIndex(string) *api.Service        { return nil }
+func (APIConnTest) SvcIndexReverse(string) *api.Service { return nil }
+func (APIConnTest) EpIndex(string) *api.Endpoints       { return nil }
+func (APIConnTest) EndpointsList() []*api.Endpoints     { return nil }
+func (APIConnTest) Modified() int64                     { return 0 }
+func (APIConnTest) SetWatchChan(watch.Chan)             {}
+func (APIConnTest) Watch(string) error                  { return nil }
+func (APIConnTest) StopWatching(string)                 {}
 
 func (APIConnTest) ServiceList() []*api.Service {
 	svcs := []*api.Service{
@@ -39,25 +39,24 @@ func (APIConnTest) ServiceList() []*api.Service {
 	return svcs
 }
 
-func (APIConnTest) EpIndexReverse(string) []*api.Endpoints {
-	eps := []*api.Endpoints{
-		{
-			Subsets: []api.EndpointSubset{
-				{
-					Addresses: []api.EndpointAddress{
-						{
-							IP: "127.0.0.1",
-						},
+func (APIConnTest) EpIndexReverse(string) *api.Endpoints {
+	eps := api.Endpoints{
+		Subsets: []api.EndpointSubset{
+			{
+				Addresses: []api.EndpointAddress{
+					{
+						IP: "127.0.0.1",
 					},
 				},
 			},
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "dns-service",
-				Namespace: "kube-system",
-			},
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "dns-service",
+			Namespace: "kube-system",
 		},
 	}
-	return eps
+
+	return &eps
 }
 
 func (APIConnTest) GetNodeByName(name string) (*api.Node, error) { return &api.Node{}, nil }

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -15,7 +15,6 @@ func (APIConnTest) HasSynced() bool                     { return true }
 func (APIConnTest) Run()                                { return }
 func (APIConnTest) Stop() error                         { return nil }
 func (APIConnTest) PodIndex(string) []*api.Pod          { return nil }
-func (APIConnTest) SvcIndex(string) *api.Service        { return nil }
 func (APIConnTest) SvcIndexReverse(string) *api.Service { return nil }
 func (APIConnTest) EpIndex(string) *api.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*api.Endpoints     { return nil }
@@ -23,6 +22,10 @@ func (APIConnTest) Modified() int64                     { return 0 }
 func (APIConnTest) SetWatchChan(watch.Chan)             {}
 func (APIConnTest) Watch(string) error                  { return nil }
 func (APIConnTest) StopWatching(string)                 {}
+
+func (a APIConnTest) SvcIndex(string) *api.Service {
+	return a.ServiceList()[0]
+}
 
 func (APIConnTest) ServiceList() []*api.Service {
 	svcs := []*api.Service{

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -32,7 +32,7 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) *msg.Service {
 	service := k.APIConn.SvcIndexReverse(ip)
 	if service != nil {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
-			return &msg.Service{}
+			return nil
 		}
 		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
 		return &msg.Service{Host: domain, TTL: k.ttl}
@@ -50,5 +50,5 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) *msg.Service {
 			}
 		}
 	}
-	return &msg.Service{}
+	return nil
 }

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -18,37 +18,37 @@ func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Optio
 		return nil, e
 	}
 
-	records := k.serviceRecordForIP(ip, state.Name())
-	if len(records) == 0 {
-		return records, errNoItems
+	record := k.serviceRecordForIP(ip, state.Name())
+	if record == nil {
+		return nil, errNoItems
 	}
-	return records, nil
+	return []msg.Service{*record}, nil
 }
 
 // serviceRecordForIP gets a service record with a cluster ip matching the ip argument
 // If a service cluster ip does not match, it checks all endpoints
-func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
+func (k *Kubernetes) serviceRecordForIP(ip, name string) *msg.Service {
 	// First check services with cluster ips
-	for _, service := range k.APIConn.SvcIndexReverse(ip) {
+	service := k.APIConn.SvcIndexReverse(ip)
+	if service != nil {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(service.Namespace) {
-			continue
+			return &msg.Service{}
 		}
 		domain := strings.Join([]string{service.Name, service.Namespace, Svc, k.primaryZone()}, ".")
-		return []msg.Service{{Host: domain, TTL: k.ttl}}
+		return &msg.Service{Host: domain, TTL: k.ttl}
 	}
 	// If no cluster ips match, search endpoints
-	for _, ep := range k.APIConn.EpIndexReverse(ip) {
-		if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.ObjectMeta.Namespace) {
-			continue
-		}
-		for _, eps := range ep.Subsets {
-			for _, addr := range eps.Addresses {
-				if addr.IP == ip {
-					domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.ObjectMeta.Name, ep.ObjectMeta.Namespace, Svc, k.primaryZone()}, ".")
-					return []msg.Service{{Host: domain, TTL: k.ttl}}
-				}
+	ep := k.APIConn.EpIndexReverse(ip)
+	if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.ObjectMeta.Namespace) {
+		return nil
+	}
+	for _, eps := range ep.Subsets {
+		for _, addr := range eps.Addresses {
+			if addr.IP == ip {
+				domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.ObjectMeta.Name, ep.ObjectMeta.Namespace, Svc, k.primaryZone()}, ".")
+				return &msg.Service{Host: domain, TTL: k.ttl}
 			}
 		}
 	}
-	return nil
+	return &msg.Service{}
 }

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -39,7 +39,7 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) *msg.Service {
 	}
 	// If no cluster ips match, search endpoints
 	ep := k.APIConn.EpIndexReverse(ip)
-	if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.ObjectMeta.Namespace) {
+	if ep == nil || len(k.Namespaces) > 0 && !k.namespaceExposed(ep.ObjectMeta.Namespace) {
 		return nil
 	}
 	for _, eps := range ep.Subsets {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -28,7 +28,7 @@ func (APIConnReverseTest) Watch(string) error              { return nil }
 func (APIConnReverseTest) StopWatching(string)             {}
 
 func (APIConnReverseTest) SvcIndex(svc string) []*api.Service {
-	if svc != "svc1.testns" {
+	if svc != "testns/svc1" {
 		return nil
 	}
 	svcs := []*api.Service{

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -19,7 +19,7 @@ func (APIConnReverseTest) HasSynced() bool                 { return true }
 func (APIConnReverseTest) Run()                            { return }
 func (APIConnReverseTest) Stop() error                     { return nil }
 func (APIConnReverseTest) PodIndex(string) []*api.Pod      { return nil }
-func (APIConnReverseTest) EpIndex(string) []*api.Endpoints { return nil }
+func (APIConnReverseTest) EpIndex(string) *api.Endpoints   { return nil }
 func (APIConnReverseTest) EndpointsList() []*api.Endpoints { return nil }
 func (APIConnReverseTest) ServiceList() []*api.Service     { return nil }
 func (APIConnReverseTest) Modified() int64                 { return 0 }
@@ -27,54 +27,52 @@ func (APIConnReverseTest) SetWatchChan(watch.Chan)         {}
 func (APIConnReverseTest) Watch(string) error              { return nil }
 func (APIConnReverseTest) StopWatching(string)             {}
 
-func (APIConnReverseTest) SvcIndex(svc string) []*api.Service {
-	if svc != "testns/svc1" {
+func (APIConnReverseTest) SvcIndex(key string) *api.Service {
+	if key != "testns/svc1" {
 		return nil
 	}
-	svcs := []*api.Service{
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: "192.168.1.100",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
+	svc := api.Service{
+
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ClusterIP: "192.168.1.100",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
 		},
 	}
-	return svcs
+	return &svc
 
 }
 
-func (APIConnReverseTest) SvcIndexReverse(ip string) []*api.Service {
+func (APIConnReverseTest) SvcIndexReverse(ip string) *api.Service {
 	if ip != "192.168.1.100" {
 		return nil
 	}
-	svcs := []*api.Service{
-		{
-			ObjectMeta: meta.ObjectMeta{
-				Name:      "svc1",
-				Namespace: "testns",
-			},
-			Spec: api.ServiceSpec{
-				ClusterIP: "192.168.1.100",
-				Ports: []api.ServicePort{{
-					Name:     "http",
-					Protocol: "tcp",
-					Port:     80,
-				}},
-			},
+	svc := api.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "testns",
+		},
+		Spec: api.ServiceSpec{
+			ClusterIP: "192.168.1.100",
+			Ports: []api.ServicePort{{
+				Name:     "http",
+				Protocol: "tcp",
+				Port:     80,
+			}},
 		},
 	}
-	return svcs
+
+	return &svc
 }
 
-func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
+func (APIConnReverseTest) EpIndexReverse(ip string) *api.Endpoints {
 	switch ip {
 	case "10.0.0.100":
 	case "1234:abcd::1":
@@ -83,8 +81,8 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 	default:
 		return nil
 	}
-	eps := []*api.Endpoints{
-		{
+	ep := api.Endpoints{
+
 			Subsets: []api.EndpointSubset{
 				{
 					Addresses: []api.EndpointAddress{
@@ -118,9 +116,8 @@ func (APIConnReverseTest) EpIndexReverse(ip string) []*api.Endpoints {
 				Name:      "svc1",
 				Namespace: "testns",
 			},
-		},
 	}
-	return eps
+	return &ep
 }
 
 func (APIConnReverseTest) GetNodeByName(name string) (*api.Node, error) {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -117,6 +117,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 		initEndpointsCache: true,
 		ignoreEmptyService: false,
 		resyncPeriod:       defaultResyncPeriod,
+		revIdxAllEndpoints: false,
 	}
 	k8s.opts = opts
 

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/request"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/miekg/dns"
 	api "k8s.io/api/core/v1"
@@ -114,39 +115,36 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 				continue
 			}
 
-			endpointsList := k.APIConn.EpIndex(metaNamespaceKey(svc.Namespace, svc.Name))
+			key, err := cache.MetaNamespaceKeyFunc(svc)
+			if err != nil {
+				return
+			}
+			ep := k.APIConn.EpIndex(key)
+			for _, eps := range ep.Subsets {
+				srvWeight := calcSRVWeight(len(eps.Addresses))
+				for _, addr := range eps.Addresses {
+					s := msg.Service{Host: addr.IP, TTL: k.ttl}
+					s.Key = strings.Join(svcBase, "/")
+					// We don't need to change the msg.Service host from IP to Name yet
+					// so disregard the return value here
+					emitAddressRecord(c, s)
 
-			for _, ep := range endpointsList {
-				if ep.ObjectMeta.Name != svc.Name || ep.ObjectMeta.Namespace != svc.Namespace {
-					continue
-				}
+					s.Key = strings.Join(append(svcBase, endpointHostname(addr, k.endpointNameMode)), "/")
+					// Change host from IP to Name for SRV records
+					host := emitAddressRecord(c, s)
+					s.Host = host
 
-				for _, eps := range ep.Subsets {
-					srvWeight := calcSRVWeight(len(eps.Addresses))
-					for _, addr := range eps.Addresses {
-						s := msg.Service{Host: addr.IP, TTL: k.ttl}
-						s.Key = strings.Join(svcBase, "/")
-						// We don't need to change the msg.Service host from IP to Name yet
-						// so disregard the return value here
-						emitAddressRecord(c, s)
-
-						s.Key = strings.Join(append(svcBase, endpointHostname(addr, k.endpointNameMode)), "/")
-						// Change host from IP to Name for SRV records
-						host := emitAddressRecord(c, s)
-						s.Host = host
-
-						for _, p := range eps.Ports {
-							// As per spec unnamed ports do not have a srv record
-							// https://github.com/kubernetes/dns/blob/master/docs/specification.md#232---srv-records
-							if p.Name == "" {
-								continue
-							}
-
-							s.Port = int(p.Port)
-
-							s.Key = strings.Join(append(svcBase, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
-							c <- s.NewSRV(msg.Domain(s.Key), srvWeight)
+					for _, p := range eps.Ports {
+						// As per spec unnamed ports do not have a srv record
+						// https://github.com/kubernetes/dns/blob/master/docs/specification.md#232---srv-records
+						if p.Name == "" {
+							continue
 						}
+
+						s.Port = int(p.Port)
+
+						s.Key = strings.Join(append(svcBase, strings.ToLower("_"+string(p.Protocol)), strings.ToLower("_"+string(p.Name))), "/")
+						c <- s.NewSRV(msg.Domain(s.Key), srvWeight)
 					}
 				}
 			}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -114,7 +114,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 				continue
 			}
 
-			endpointsList := k.APIConn.EpIndex(svc.Name + "." + svc.Namespace)
+			endpointsList := k.APIConn.EpIndex(metaNamespaceKey(svc.Namespace, svc.Name))
 
 			for _, ep := range endpointsList {
 				if ep.ObjectMeta.Name != svc.Name || ep.ObjectMeta.Namespace != svc.Namespace {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Reduce the amount of memory used for indexes...

- Don't create indexes for headless service endpoints (big): Removes reverse endpoint Index, Replace with a smaller manually maintained map of ip -> endpoint for endpoints of headless services only.
- Remove name.namespace forward index for endpoint and services (small): Use built in namespace/name key and GetByKey() instead of Index.

### 2. Which issues (if any) are related?
#2095 

### 3. Which documentation changes (if any) need to be made?