### PR TITLE
benchmark are spammy

### DIFF
--- a/.benchmark.sh
+++ b/.benchmark.sh
@@ -2,6 +2,9 @@
 
 set -e +o pipefail
 
+# bit too spammy
+return
+
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     echo -e "NOTE: The CPU benchmarks are performed on Travis VMs and vary widly between runs," > .benchmark.body
     echo -e " you can't trust them. The memory benchmarks are OK\n\n" >> .benchmark.body


### PR DESCRIPTION
This is indeed (as Chris said) too spammy; disable the ping back of the
results for now - and rethink it a bit.

See #2109

Signed-off-by: Miek Gieben <miek@miek.nl>
