### PR TITLE
plugin/route53: add split zone support

### DIFF
--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -21,7 +21,9 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 }
 ~~~
 
-* **ZONE** the name of the domain to be accessed.
+* **ZONE** the name of the domain to be accessed. When there are multiple zones with overlapping domains
+  (private vs. public hosted zone), CoreDNS does the lookup in the given order here. Therefore, for a
+  non-existing resource record, SOA response will be from the rightmost zone.
 * **HOSTED_ZONE_ID** the ID of the hosted zone that contains the resource record sets to be accessed.
 * **AWS_ACCESS_KEY_ID** and **AWS_SECRET_ACCESS_KEY** the AWS access key ID and secret access key
    to be used when query AWS (optional).  If they are not provided, then coredns tries to access
@@ -79,5 +81,13 @@ Enable route53 with AWS credentials file:
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
       credentials_file some-user
     }
+}
+~~~
+
+Enable route53 with multiple hosted zones with the same domain:
+
+~~~ txt
+. {
+    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 example.org.:Z93A52145678156
 }
 ~~~

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -31,19 +31,26 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 	if aws.StringValue(in.HostedZoneId) == "0987654321" {
 		return errors.New("bad. zone is bad")
 	}
-	var rrs []*route53.ResourceRecordSet
+	rrsResponse := map[string][]*route53.ResourceRecordSet{}
 	for _, r := range []struct {
-		rType, name, value string
+		rType, name, value, hostedZoneID string
 	}{
-		{"A", "example.org.", "1.2.3.4"},
-		{"AAAA", "example.org.", "2001:db8:85a3::8a2e:370:7334"},
-		{"CNAME", "sample.example.org.", "example.org"},
-		{"PTR", "example.org.", "ptr.example.org."},
-		{"SOA", "org.", "ns-1536.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"},
-		{"NS", "com.", "ns-1536.awsdns-00.co.uk."},
+		{"A", "example.org.", "1.2.3.4", "1234567890"},
+		{"AAAA", "example.org.", "2001:db8:85a3::8a2e:370:7334", "1234567890"},
+		{"CNAME", "sample.example.org.", "example.org", "1234567890"},
+		{"PTR", "example.org.", "ptr.example.org.", "1234567890"},
+		{"SOA", "org.", "ns-1536.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400", "1234567890"},
+		{"NS", "com.", "ns-1536.awsdns-00.co.uk.", "1234567890"},
 		// Unsupported type should be ignored.
-		{"YOLO", "swag.", "foobar"},
+		{"YOLO", "swag.", "foobar", "1234567890"},
+		// hosted zone with the same name, but a different id
+		{"A", "other-example.org.", "3.5.7.9", "1357986420"},
+		{"SOA", "org.", "ns-15.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400", "1357986420"},
 	} {
+		rrs, ok := rrsResponse[r.hostedZoneID]
+		if !ok {
+			rrs = make([]*route53.ResourceRecordSet, 0)
+		}
 		rrs = append(rrs, &route53.ResourceRecordSet{Type: aws.String(r.rType),
 			Name: aws.String(r.name),
 			ResourceRecords: []*route53.ResourceRecord{
@@ -53,9 +60,11 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 			},
 			TTL: aws.Int64(300),
 		})
+		rrsResponse[r.hostedZoneID] = rrs
 	}
+
 	if ok := fn(&route53.ListResourceRecordSetsOutput{
-		ResourceRecordSets: rrs,
+		ResourceRecordSets: rrsResponse[aws.StringValue(in.HostedZoneId)],
 	}, true); !ok {
 		return errors.New("paging function return false")
 	}
@@ -65,7 +74,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, map[string]string{"bad.": "0987654321"}, &upstream.Upstream{})
+	r, err := New(ctx, fakeRoute53{}, []*zone{{id: "0987654321", dns: "bad."}}, &upstream.Upstream{})
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -73,7 +82,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string]string{"org.": "1234567890", "gov.": "Z098765432"}, &upstream.Upstream{})
+	r, err = New(ctx, fakeRoute53{}, []*zone{{id: "1357986420", dns: "org."}, {id: "1234567890", dns: "org."}, {id: "Z098765432", dns: "gov."}}, &upstream.Upstream{})
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -158,7 +167,7 @@ func TestRoute53(t *testing.T) {
 			qname:        "example.org",
 			qtype:        dns.TypeSOA,
 			expectedCode: dns.RcodeSuccess,
-			wantAnswer: []string{"org.	300	IN	SOA	ns-1536.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"},
+			wantAnswer: []string{"org.	300	IN	SOA	ns-15.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"},
 		},
 		// 6. Explicit SOA query for example.org.
 		{
@@ -186,6 +195,13 @@ func TestRoute53(t *testing.T) {
 			qtype:        dns.TypeA,
 			expectedCode: dns.RcodeSuccess,
 			wantAnswer: []string{"example.gov.	300	IN	A	2.4.6.8"},
+		},
+		// 10. other-zone.example.org is stored in a different hosted zone. success
+		{
+			qname:        "other-example.org",
+			qtype:        dns.TypeA,
+			expectedCode: dns.RcodeSuccess,
+			wantAnswer: []string{"other-example.org.	300	IN	A	3.5.7.9"},
 		},
 	}
 

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -74,7 +74,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, []*zone{{id: "0987654321", dns: "bad."}}, &upstream.Upstream{})
+	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": []string{"0987654321"}}, &upstream.Upstream{})
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -82,7 +82,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, []*zone{{id: "1357986420", dns: "org."}, {id: "1234567890", dns: "org."}, {id: "Z098765432", dns: "gov."}}, &upstream.Upstream{})
+	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": []string{"1357986420", "1234567890"}, "gov": []string{"Z098765432"}}, &upstream.Upstream{})
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -53,6 +53,10 @@ func TestSetupRoute53(t *testing.T) {
     aws_access_key ACCESS_KEY_ID SEKRIT_ACCESS_KEY
     upstream 1.2.3.4
 }`)
+	if err := setup(c, f); err != nil {
+		t.Fatalf("Unexpected errors: %v", err)
+	}
+
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
     fallthrough
 }`)
@@ -86,6 +90,19 @@ func TestSetupRoute53(t *testing.T) {
 
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
 		credentials default credentials extra-arg
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 example.org:12345678 {
+ 		upstream 1.2.3.4
+	}`)
+	if err := setup(c, f); err == nil {
+		t.Fatalf("Expected errors, but got: %v", err)
+	}
+	c = caddy.NewTestController("dns", `route53 example.org {
  		upstream 1.2.3.4
 	}`)
 	if err := setup(c, f); err == nil {


### PR DESCRIPTION
This PR introduces split-zone support for the Route53 plugin. 

When there are multiple hosted zones with overlapping domains (private vs. public hosted zone), previously this plugin was returning a zone conflict error. Now CoreDNS looks up for the queried domain starting from the leftmost hosted zone and moves forward to the next one until it finds a matching resource record. When there's no matching resource record, CoreDNS responds with the rightmost hosted zones SOA record.

Signed-off-by: Can Yucel <jon.yucel@getcruise.com>