### PR TITLE
OWNERS: add aliases

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -33,4 +33,8 @@ aliases:
   - |
     /plugin: (.*) -> /label add: plugin/$1
   - |
+    /approve -> /lgtm
+  - |
+    /wai -> /label add: works as intended
+  - |
     /release: (.*) -> /exec: /opt/bin/release-coredns $1


### PR DESCRIPTION
add /approve and /wai as aliases.

Signed-off-by: Miek Gieben <miek@miek.nl>

[skip ci]