### PR TITLE
plugin/loop: tweak loop detected msg, add troubleshooting section

### DIFF
--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -45,3 +45,36 @@ This plugin only attempts to find simple static forwarding loops at start up tim
 
 * the loop must be present at start up time.
 * the loop must occur for at least the `HINFO` query type.
+
+## Troubleshooting
+
+When CoreDNS logs contain the message `Forwarding loop detected ...`, this means that
+the `loop` detection plugin has detected an infinite forwarding loop in one of the upstream
+DNS servers.  This is a fatal error because operating with an infinite loop will consume
+memory and CPU until eventual out of memory death by the host.
+
+A forwarding loop is usually caused by:
+* Most commonly, CoreDNS forwarding requests directly to itself. e.g. to `127.0.0.1` or `127.0.0.53`
+* Less commonly, CoreDNS forwarding to an upstream server that in turn, forwards requests back to CoreDNS.
+
+To troubleshoot this problem, look in your Corefile for any `proxy` or `forward` to the zone
+in which the loop was detected.  Make sure that they are not forwarding to a local address or
+to another DNS server that is forwarding requests back to CoreDNS. If `proxy` or `forward` are
+ using a file (e.g. `/etc/resolv.conf`), make sure that file does not contain local addresses.
+
+### Troubleshooting Loops In Kubernetes Clusters
+A common cause of forwarding loops in Kubernetes clusters is an interaction with
+`systemd-resolved` on the host node.  `systemd-resolved` will, in certain configurations,
+put `127.0.0.53` as an upstream into `/etc/resolv.conf`. Kubernetes (`kubelet`) by default
+will pass this `/etc/resolv/conf` file to all Pods using the `default` dnsPolicy (this
+includes CoreDNS Pods). CoreDNS then uses this `/etc/resolv.conf` as a list of upstreams
+to proxy/forward requests to.  Since it contains a local address, CoreDNS ends up forwarding
+requests to itself.
+
+There are many ways to work around this issue, some are listed here:
+* Add the following to `kubelet`: `--resolv-conf /run/systemd/resolve/resolv.conf`.  This flag
+tells `kubelet` to pass an alternate `resolv.conf` to Pods. For `systemd-resolved`,
+`/run/systemd/resolve/resolv.conf` is typically the location of the "original" `/etc/resolv.conf`.
+* Disable `systemd-resolved` on host nodes, and restore `/etc/resolv.conf` to the original.
+* A quick and dirty fix is to edit your Corefile, replacing `proxy . /etc/resolv.conf` with
+the ip address of your upstream DNS, for example `proxy . 8.8.8.8`.

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -63,6 +63,9 @@ to another DNS server that is forwarding requests back to CoreDNS. If `proxy` or
  using a file (e.g. `/etc/resolv.conf`), make sure that file does not contain local addresses.
 
 ### Troubleshooting Loops In Kubernetes Clusters
+When a CoreDNS Pod deployed in Kubernetes detects a loop, the CoreDNS Pod will start to "CrashLoopBackOff".
+This is because Kubernetes will try to restart the Pod every time CoreDNS detects the loop and exits.
+
 A common cause of forwarding loops in Kubernetes clusters is an interaction with
 `systemd-resolved` on the host node.  `systemd-resolved` will, in certain configurations,
 put `127.0.0.53` as an upstream into `/etc/resolv.conf`. Kubernetes (`kubelet`) by default

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-The *loop* plugin will send a random query to ourselves and will then keep track of how many times
+The *loop* plugin will send a random probe query to ourselves and will then keep track of how many times
 we see it. If we see it more than twice, we assume CoreDNS is looping and we halt the process.
 
 The plugin will try to send the query for up to 30 seconds. This is done to give CoreDNS enough time
@@ -36,7 +36,7 @@ forwards to it self.
 After CoreDNS has started it stops the process while logging:
 
 ~~~ txt
-plugin/loop: Forwarding loop detected in "." zone. Probe "HINFO IN 5577006791947779410.8674665223082153551." was seen more than twice.
+plugin/loop: Forwarding loop detected in "." zone. Exiting. See https://coredns.io/plugins/loop#troubleshooting. Probe query: "HINFO 5577006791947779410.8674665223082153551.".
 ~~~
 
 ## Limitations

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -36,7 +36,7 @@ forwards to it self.
 After CoreDNS has started it stops the process while logging:
 
 ~~~ txt
-plugin/loop: Seen "HINFO IN 5577006791947779410.8674665223082153551." more than twice, loop detected
+plugin/loop: Forwarding loop detected in "." zone. Probe "HINFO IN 5577006791947779410.8674665223082153551." was seen more than twice.
 ~~~
 
 ## Limitations

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
@@ -49,7 +50,8 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		log.Fatalf("Forwarding loop detected in \".\" zone. Probe \"HINFO IN %s\" was seen more than twice.", l.qname)
+		zone := dnsutil.Join(dns.SplitDomainName(l.qname)[2:]...) + "."
+		log.Fatalf("Forwarding loop detected in \"%s\" zone. Probe \"HINFO IN %s\" was seen more than twice.", zone, l.qname)
 	}
 
 	return plugin.NextOrFailure(l.Name(), l.Next, ctx, w, r)

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/coredns/coredns/plugin"
-	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/request"
 
@@ -50,11 +49,7 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		zone := "."
-		if len(dns.SplitDomainName(l.qname)) > 2 {
-			zone = dnsutil.Join(dns.SplitDomainName(l.qname)[2:]...)
-		}
-		log.Fatalf("Forwarding loop detected in \"%s\" zone. Probe \"HINFO IN %s\" was seen more than twice.", zone, l.qname)
+		log.Fatalf("Forwarding loop detected in \"%s\" zone. Exiting. See https://coredns.io/plugins/loop#troubleshooting.", l.zone, l.qname)
 	}
 
 	return plugin.NextOrFailure(l.Name(), l.Next, ctx, w, r)

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -50,7 +50,10 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		zone := dnsutil.Join(dns.SplitDomainName(l.qname)[2:]...) + "."
+		zone:= "."
+		if len(dns.SplitDomainName(l.qname)) > 2 {
+			zone = dnsutil.Join(dns.SplitDomainName(l.qname)[2:]...)
+		}
 		log.Fatalf("Forwarding loop detected in \"%s\" zone. Probe \"HINFO IN %s\" was seen more than twice.", zone, l.qname)
 	}
 

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -50,7 +50,7 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		zone:= "."
+		zone := "."
 		if len(dns.SplitDomainName(l.qname)) > 2 {
 			zone = dnsutil.Join(dns.SplitDomainName(l.qname)[2:]...)
 		}

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -49,7 +49,7 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		log.Fatalf("Seen \"HINFO IN %s\" more than twice, loop detected", l.qname)
+		log.Fatalf("Forwarding loop detected in \".\" zone. Probe \"HINFO IN %s\" was seen more than twice.", l.qname)
 	}
 
 	return plugin.NextOrFailure(l.Name(), l.Next, ctx, w, r)

--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -49,7 +49,7 @@ func (l *Loop) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	if l.seen() > 2 {
-		log.Fatalf("Forwarding loop detected in \"%s\" zone. Exiting. See https://coredns.io/plugins/loop#troubleshooting.", l.zone, l.qname)
+		log.Fatalf("Forwarding loop detected in \"%s\" zone. Exiting. See https://coredns.io/plugins/loop#troubleshooting. Probe query: \"HINFO %s\".", l.zone, l.qname)
 	}
 
 	return plugin.NextOrFailure(l.Name(), l.Next, ctx, w, r)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Feedback from the field, the current message is confusing some people. This PR tweaks the message a bit, moving the long "confusing" HINFO probe detail to the end of the message.

In the context of kubernetes, the exit on detection behavior manifests as a "crashloop" on the pod, since k8s detects the container exit as a "crash", and will try to start it up again ad infinitum.  I think people also find this confusing. But, there isn't anything practical we could do to change that.  If for example, we didn't exit, and disabled all forwards/proxys to the offending zone (hard to do), it would leave CoreDNS in a "silently" semi-functional state, which is IMO worse.  The presence of the coredns pod "crashloop" is a breadcrumb of sorts, to go check out the coredns log.  So, I think the best we can do is to improve the message a little.

### 2. Which issues (if any) are related?

it has come up in slack many times, and in various github repos... 
e.g. kubernetes/kubeadm#1162

### 3. Which documentation changes (if any) need to be made?
Included