### PR TITLE
pprof plugin -- survive coredns reload

### DIFF
--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -47,10 +47,8 @@ func setup(c *caddy.Controller) error {
 		}
 	}
 
-	pprofOnce.Do(func() {
-		c.OnStartup(h.Startup)
-		c.OnShutdown(h.Shutdown)
-	})
+	c.OnStartup(h.Startup)
+	c.OnRestart(h.Shutdown)
 
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
`pprof` plugin does not survive CoreDNS reload when asked to via SIGUSR1 or when `reload` plugin does it automatically.

### 2. Which issues (if any) are related?
Couldn't find any.

### 3. Which documentation changes (if any) need to be made?
None, it was expected behaviour to survive CoreDNS reload.