### PR TITLE
plugin/file: Fix memory leak in Parse

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -121,6 +121,12 @@ func (s *serialErr) Error() string {
 // it returns an error indicating nothing was read.
 func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 	tokens := dns.ParseZone(f, dns.Fqdn(origin), fileName)
+	defer func() {
+		// Drain the tokens chan so that large zone files won't
+		// leak goroutines and memory.
+		for range tokens {
+		}
+	}()
 	z := NewZone(origin, fileName)
 	seenSOA := false
 	for x := range tokens {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

For zone files with more than 10,000 records, the goroutines and memory pinned by dns.ParseZone won't be released unless the tokens chan is drained. As Parse is called by (*Zone).Reload very frequently, this causes memory leaks and OOM conditions.

### 2. Which issues (if any) are related?

miekg/dns#786

### 3. Which documentation changes (if any) need to be made?

N/A