### PR TITLE
plugin/cache: Default min cache TTL to zero

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -238,9 +238,9 @@ func (w *ResponseWriter) Write(buf []byte) (int, error) {
 }
 
 const (
-	maxTTL  = dnsutil.MaximumDefaulTTL
+	maxTTL  = dnsutil.MaximumDefaultTTL
 	minTTL  = dnsutil.MinimalDefaultTTL
-	maxNTTL = dnsutil.MaximumDefaulTTL / 2
+	maxNTTL = dnsutil.MaximumDefaultTTL / 2
 	minNTTL = dnsutil.MinimalDefaultTTL
 
 	defaultCap = 10000 // default capacity of the cache.

--- a/plugin/pkg/dnsutil/ttl.go
+++ b/plugin/pkg/dnsutil/ttl.go
@@ -19,7 +19,7 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 		return MinimalDefaultTTL
 	}
 
-	minTTL := MaximumDefaulTTL
+	minTTL := MaximumDefaultTTL
 	for _, r := range m.Answer {
 		switch mt {
 		case response.NameError, response.NoData:
@@ -65,8 +65,8 @@ func MinimalTTL(m *dns.Msg, mt response.Type) time.Duration {
 }
 
 const (
-	// MinimalDefaultTTL is the absolute lowest TTL we use in CoreDNS.
-	MinimalDefaultTTL = 5 * time.Second
-	// MaximumDefaulTTL is the maximum TTL was use on RRsets in CoreDNS.
-	MaximumDefaulTTL = 1 * time.Hour
+	// MinimalDefaultTTL is the default minimum TTL to use in cache
+	MinimalDefaultTTL = 0
+	// MaximumDefaultTTL is the default maximum TTL to use in cache
+	MaximumDefaultTTL = 1 * time.Hour
 )


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
* Make default minimum TTL be zero, so the default behavior is not to cache entries for longer than the TTL set by authoritative upstream servers.
* Add min TTL default value to readme.

### 2. Which issues (if any) are related?
#2189

### 3. Which documentation changes (if any) need to be made?
included