### PR TITLE
Make every one an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-reviewers:
+approvers:
   - bradbeam
   - chrisohaver
   - dilyevsky
@@ -14,12 +14,6 @@ reviewers:
   - stp-ip
   - superq
   - varyoo
-  - yongtang
-
-approvers:
-  - chrisohaver
-  - johnbelamaric
-  - miekg
   - yongtang
 
 features:


### PR DESCRIPTION
This is already true; as everyone listed here can 'click merge', extend
this functionally to the bot as well.

Code from dreck:
~~~
	if len(config.Reviewers) == 0 && len(config.Approvers) > 0 {
		config.Reviewers = config.Approvers
	}

~~~
This is why @dilyevsky couldn't use `/merge` (most likely; didn't check the logs)

Signed-off-by: Miek Gieben <miek@miek.nl>