### PR TITLE
plugin/autopath: document Windows incompatibility

### DIFF
--- a/plugin/autopath/README.md
+++ b/plugin/autopath/README.md
@@ -47,3 +47,7 @@ autopath @kubernetes
 ~~~
 
 Use the search path dynamically retrieved from the *kubernetes* plugin.
+
+## Known Issues
+
+Autopath is not compatible with pods running from Windows nodes.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Pods on Windows nodes don't follow search paths in the same way that linux nodes do.
Pods on Windows nodes act as if they have an ndots=1.

In theory, we could have autopath look up the client pod's node, and determine the OS via the node OS label (beta.kubernetes.io/os), and alter the behavior accordingly.  But for now, just document that we don't support windows nodes with this feature.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?