### PR TITLE
Remove whitespace and pass presubmit

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -32,8 +32,8 @@ are used.
   name `db.example.com`, the extracted origin will be `example.com`. **TIMEOUT** specifies how often
   CoreDNS should scan the directory; the default is every 60 seconds. This value is in seconds.
   The minimum value is 1 second.
-* `reload` interval to perform reload of zone if SOA version changes. Default is one minute. 
-  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds 
+* `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
+  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.
 * `no_reload` deprecated. Sets reload to 0.
 * `upstream` defines upstream resolvers to be used resolve external names found (think CNAMEs)

--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -37,8 +37,8 @@ file DBFILE [ZONES... ] {
   the direction. **ADDRESS** must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as plain
   addresses. The special wildcard `*` means: the entire internet (only valid for 'transfer to').
   When an address is specified a notify message will be send whenever the zone is reloaded.
-* `reload` interval to perform reload of zone if SOA version changes. Default is one minute. 
-  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds 
+* `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
+  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.
 * `no_reload` deprecated. Sets reload to 0.
 * `upstream` defines upstream resolvers to be used resolve external names found (think CNAMEs)


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
While running the following, noticed the whitespace warning from presubmit:
```
ubuntu@ubuntu:~/coredns$ docker run -i -t --rm -v $PWD:/go/src/github.com/coredns/coredns --net=host golang:1.11
root@ubuntu:/go# cd src/github.com/coredns/coredns/
root@ubuntu:/go/src/github.com/coredns/coredns# make
** presubmit/context
** presubmit/filename-hyphen
** presubmit/test-lowercase
** presubmit/trailing-whitespace
plugin/auto/README.md:* `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
plugin/auto/README.md:  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
plugin/file/README.md:* `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
plugin/file/README.md:  Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
** presubmit/trailing-whitespace: please remove any trailing white space
```

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>