### PR TITLE
plugin/file: Use new zone parser API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ godeps:
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.10.13)
-	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.12)
+	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.0.14)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.8.0)
 	@ # for travis only, if this fails we don't care, but don't see benchmarks
 	 go get -u golang.org/x/tools/cmd/benchcmp || true

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -120,22 +120,17 @@ func (s *serialErr) Error() string {
 // If serial >= 0 it will reload the zone, if the SOA hasn't changed
 // it returns an error indicating nothing was read.
 func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
-	tokens := dns.ParseZone(f, dns.Fqdn(origin), fileName)
-	defer func() {
-		// Drain the tokens chan so that large zone files won't
-		// leak goroutines and memory.
-		for range tokens {
-		}
-	}()
+
+	zp := dns.NewZoneParser(f, dns.Fqdn(origin), fileName)
 	z := NewZone(origin, fileName)
 	seenSOA := false
-	for x := range tokens {
-		if x.Error != nil {
-			return nil, x.Error
+	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
+		if err := zp.Err(); err != nil {
+			return nil, err
 		}
 
 		if !seenSOA && serial >= 0 {
-			if s, ok := x.RR.(*dns.SOA); ok {
+			if s, ok := rr.(*dns.SOA); ok {
 				if s.Serial == uint32(serial) { // same serial
 					return nil, &serialErr{err: "no change in SOA serial", origin: origin, zone: fileName, serial: serial}
 				}
@@ -143,7 +138,7 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 			}
 		}
 
-		if err := z.Insert(x.RR); err != nil {
+		if err := z.Insert(rr); err != nil {
 			return nil, err
 		}
 	}

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -122,6 +122,7 @@ func (s *serialErr) Error() string {
 func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 
 	zp := dns.NewZoneParser(f, dns.Fqdn(origin), fileName)
+	zp.SetIncludeAllowed(true)
 	z := NewZone(origin, fileName)
 	seenSOA := false
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {


### PR DESCRIPTION
Use new dns lib 1.0.14 and default to using the new zone parser that
does not leak go-routines.

Signed-off-by: Miek Gieben <miek@miek.nl>
