### PR TITLE
text for governance proposal, rev 4

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,18 +4,10 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source. See repository guidelines and CLA, below.
+- Open: CoreDNS is open source. See repository guidelines.
 - Welcoming and respectful: See Code of Conduct, below.
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
-
-## Need to define some concepts
-- Maintainers
-- Organizations
-- Owners
-- Security Team
-- How to we collaborate ? => Ideas, Subjects to talk.
-- How do we vote ?
 
 ## Voting
 
@@ -37,9 +29,22 @@ Maintainers can be removed by a 2/3 majority organization vote.
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub cni-maintainers team, and made a GitHub maintainer of that team.
+Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub maintainers team.
 
 After 6 months a maintainer will be made an "owner" of the GitHub organization.
+
+## Projects
+
+The CoreDNS organization is open to receive new sub-projects under its umbrella. To apply a project as part of the __CoreDNS__ organization, it has to met the following criteria:
+
+- Licensed under the terms of the Apache License v2.0
+- Related to one or more scopes of CoreDNS ecosystem:
+  - CoreDNS project artifacts (website, deployments, CI, etc ...)
+  - External plugin
+  - other DNS processing related
+- Be supported by 2/3 majority of organization
+
+The submission process starts as a Pull Request on CoreDNS repository with the required information mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,25 +13,33 @@ The CoreDNS community adheres to the following principles:
 
 The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
 
-Individuals not associated with or employed by a company or organization are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
+Individuals declare if they contribute as un-affiliated or as associated with or employee of an organization or a company.
+
+Individuals that contribute as un-affiliated are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
 
 In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
 
 Any maintainer from an organization may cast the vote for that organization.
 
-For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+For formal votes, a specific statement of what is being voted on, and in which delay (a suitable amount of time), should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after the delay is expired, the votes will be tallied and the outcome noted.
+
+## Expectations from Maintainers
+
+Maintainers are the bridges between members of the CoreDNS community.
+Maintainers actively participate in PR reviews. Maintainers are expected to respond to assigned PRs in a reasonable time frame,
+either providing insights, or assign the PRs to other maintainers.
 
 ## Changes in Maintainership
 
 New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
 
-Maintainers can be removed by a 2/3 majority organization vote.
+Maintainers who fail to meet the principles of CoreDNS community can be removed by a 2/3 majority organization vote.
+
+The list of Maintainers is available in this [document](/OWNERS) and is synchronized with the receivers of maintainers@coredns.io list
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub project maintainers team.
-
-After 6 months a maintainer will be made an "owner" of the GitHub organization.
+the __coredns__ GitHub project maintainers team reflect the list of Maintainers.
 
 ## Projects
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,48 @@
+# CoreDNS Governance
+
+## Principles
+
+The CoreDNS community adheres to the following principles:
+
+- Open: CoreDNS is open source. See repository guidelines and CLA, below.
+- Welcoming and respectful: See Code of Conduct, below.
+- Transparent and accessible: Work and collaboration are done in public.
+- Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
+
+## Need to define some concepts
+- Maintainers
+- Organizations
+- Owners
+- Security Team
+- How to we collaborate ? => Ideas, Subjects to talk.
+- How do we vote ?
+
+## Voting
+
+The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
+
+Individuals not associated with or employed by a company or organization are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
+
+In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
+
+Any maintainer from an organization may cast the vote for that organization.
+
+For formal votes, a specific statement of what is being voted on should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after a suitable period of time, the votes will be tallied and the outcome noted.
+
+## Changes in Maintainership
+
+New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
+
+Maintainers can be removed by a 2/3 majority organization vote.
+
+## Github Project Administration
+
+Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub cni-maintainers team, and made a GitHub maintainer of that team.
+
+After 6 months a maintainer will be made an "owner" of the GitHub organization.
+
+## Code of Conduct
+
+CoreDNS follows the CNCF Code of Conduct:
+
+https://github.com/cncf/foundation/blob/master/code-of-conduct.md

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source. See repository guidelines.
+- Open: CoreDNS is open source. See repository guidelines, below.
 - Welcoming and respectful: See Code of Conduct, below.
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
@@ -29,22 +29,24 @@ Maintainers can be removed by a 2/3 majority organization vote.
 
 ## Github Project Administration
 
-Maintainers will be added to the __coredns__ GitHub organization and added to the GitHub maintainers team.
+Maintainers will be added to the __coredns__ GitHub project maintainers team.
 
 After 6 months a maintainer will be made an "owner" of the GitHub organization.
 
 ## Projects
 
-The CoreDNS organization is open to receive new sub-projects under its umbrella. To apply a project as part of the __CoreDNS__ organization, it has to met the following criteria:
+The CoreDNS organization is open to receive new sub-projects under its umbrella.
+To accept project into the __CoreDNS__ organization, it has to met the following criteria:
 
 - Licensed under the terms of the Apache License v2.0
 - Related to one or more scopes of CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc ...)
   - External plugin
   - other DNS processing related
-- Be supported by 2/3 majority of organization
+- Be supported by 2/3 majority organization vote for acceptance
 
-The submission process starts as a Pull Request on CoreDNS repository with the required information mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
+The submission process starts as a Pull Request on the [coredns/coredns](https://github.com/coredns/coredns) repository with the required information mentioned above.
+Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,60 +4,72 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source. See repository guidelines, below.
-- Welcoming and respectful: See Code of Conduct, below.
+- Open: CoreDNS is open source.
+- Welcoming and respectful: See [Code of
+  Conduct](https://github.com/coredns/coredns/CODE-OF-CONDUCT.md).
 - Transparent and accessible: Work and collaboration are done in public.
-- Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
+- Merit: Ideas and contributions are accepted according to their technical merit and alignment with
+  project objectives, scope, and design principles.
 
-## Voting
+## Benevolent Dictator for Life
 
-The CoreDNS project employs "organization voting" to ensure no single organization can dominate the project.
+A [Benevolent dictator for life](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) is
+a single person that has a final say in any decision concerning the CoreDNS project.
 
-Individuals declare if they contribute as un-affiliated or as associated with or employee of an organization or a company.
-
-Individuals that contribute as un-affiliated are allowed one organization vote. Each company or organization (regardless of the number of maintainers associated with or employed by that company/organization) receives one organization vote.
-
-In other words, if two maintainers are employed by Company X, two by Company Y, two by Company Z, and one maintainer is an un-affiliated individual, a total of four "organization votes" are possible; one for X, one for Y, one for Z, and one for the un-affiliated individual.
-
-Any maintainer from an organization may cast the vote for that organization.
-
-For formal votes, a specific statement of what is being voted on, and in which delay (a suitable amount of time), should be added to the relevant github issue or PR, and a link to that issue or PR added to the maintainers meeting agenda document. Maintainers should indicate their yes/no vote on that issue or PR, and after the delay is expired, the votes will be tallied and the outcome noted.
+The benevolent dictator for live can volunteer to step down and appoint a new "dictator for life".
 
 ## Expectations from Maintainers
 
-Maintainers are the bridges between members of the CoreDNS community.
-Maintainers actively participate in PR reviews. Maintainers are expected to respond to assigned PRs in a reasonable time frame,
-either providing insights, or assign the PRs to other maintainers.
+"Every one carries water."
+
+Making a community work requires input/effort from every one. Maintainers should actively
+participate in Pull Request reviews. Maintainers are expected to respond to assigned Pull Requests
+in a *reasonable* time frame, either providing insights, or assign the Pull Requests to other
+maintainers.
+
+Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/coredns/OWNERS)
+file, with their Github handle and an email address. A Maintainer is also listed in a plugin
+specific OWNER file.
+
+A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
+
+A Maintainer that hasn't been active in the CoreDNS repository for 12 months is considered inactive.
+
+## Becoming a Maintainers
+
+On successful completion (it was merged) of a (large) pull request, any current maintainer can reach
+to the person behind the pull request and ask them if they are willing to become a CoreDNS
+maintainer.
 
 ## Changes in Maintainership
 
-New maintainers are proposed by an existing maintainer and are elected by a 2/3 majority organization vote.
+If a Maintainer feels she/he can not fulfill the "Expectations from Maintainers", they are free to
+step down.
 
-Maintainers who fail to meet the principles of CoreDNS community can be removed by a 2/3 majority organization vote.
-
-The list of Maintainers is available in this [document](/OWNERS) and is synchronized with the receivers of maintainers@coredns.io list
+The CoreDNS organization will never forcefully remove a current Maintainer, unless a maintainer
+fails to meet the principles of CoreDNS community.
 
 ## Github Project Administration
 
-the __coredns__ GitHub project maintainers team reflect the list of Maintainers.
+The __coredns__ GitHub project maintainers team reflect the list of Maintainers.
 
-## Projects
+## Other Projects
 
-The CoreDNS organization is open to receive new sub-projects under its umbrella.
-To accept project into the __CoreDNS__ organization, it has to met the following criteria:
+The CoreDNS organization is open to receive new sub-projects under its umbrella. To accept project
+into the __CoreDNS__ organization, it has to met the following criteria:
 
-- Licensed under the terms of the Apache License v2.0
+- Licensed under the terms of the Apache License v2.0.
 - Related to one or more scopes of CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc ...)
-  - External plugin
+  - External plugins
   - other DNS processing related
-- Be supported by 2/3 majority organization vote for acceptance
+- Be supported by a Maintainer.
 
-The submission process starts as a Pull Request on the [coredns/coredns](https://github.com/coredns/coredns) repository with the required information mentioned above.
-Once a project is accepted, it's considered a __CNCF sub-project under the umbrella of CoreDNS__
+The submission process starts as a Pull Request or Issue on the
+[coredns/coredns](https://github.com/coredns/coredns) repository with the required information
+mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella
+of CoreDNS__
 
 ## Code of Conduct
 
-CoreDNS follows the CNCF Code of Conduct:
-
-https://github.com/cncf/foundation/blob/master/code-of-conduct.md
+CoreDNS follows the [CNCF Code of Conduct](https://github.com/coredns/coredns/CODE-OF-CONDUCT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,9 +4,9 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source.
+- Open: CoreDNS is open source, advertised on [our website](https://coredns.io/community)
 - Welcoming and respectful: See [Code of
-  Conduct](https://github.com/coredns/coredns/CODE-OF-CONDUCT.md).
+  Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with
   project objectives, scope, and design principles.
@@ -26,26 +26,25 @@ behind the name.
 
 ## Expectations from Maintainers
 
-"Every one carries water."
+Every one carries water....
 
-Making a community work requires input/effort from every one. Maintainers should actively
+Making a community work requires input/effort from everyone. Maintainers should actively
 participate in Pull Request reviews. Maintainers are expected to respond to assigned Pull Requests
 in a *reasonable* time frame, either providing insights, or assign the Pull Requests to other
 maintainers.
 
-Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/coredns/OWNERS)
-file, with their Github handle and an (possible obfuscated) email address. Every one in the
-`reviewers` list is a Maintainer.
+Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/coredns/blob/master/OWNERS)
+file, with their Github handle and a possibly obfuscated email address. Everyone in the
+`approvers` list is a Maintainer.
 
 A Maintainer is also listed in a plugin specific OWNER file.
 
 A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
-A Maintainer that hasn't been active in the CoreDNS repository for 12 months is considered inactive.
 
 ## Becoming a Maintainers
 
-On successful completion (it was merged) of a (large) pull request, any current maintainer can reach
-to the person behind the pull request and ask them if they are willing to become a CoreDNS
+On successful merge of a significant pull request, any current maintainer can reach
+to the author behind the pull request and ask them if they are willing to become a CoreDNS
 maintainer.
 
 ## Changes in Maintainership
@@ -54,7 +53,8 @@ If a Maintainer feels she/he can not fulfill the "Expectations from Maintainers"
 step down.
 
 The CoreDNS organization will never forcefully remove a current Maintainer, unless a maintainer
-fails to meet the principles of CoreDNS community.
+fails to meet the principles of CoreDNS community,
+or adhere to the [Code of Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
 
 ## Github Project Administration
 
@@ -62,15 +62,15 @@ The __coredns__ GitHub project maintainers team reflects the list of Maintainers
 
 ## Other Projects
 
-The CoreDNS organization is open to receive new sub-projects under its umbrella. To accept project
-into the __CoreDNS__ organization, it has to met the following criteria:
+The CoreDNS organization is open to receive new sub-projects under its umbrella. To accept a project
+into the __CoreDNS__ organization, it has to meet the following criteria:
 
-- Licensed under the terms of the Apache License v2.0.
-- Related to one or more scopes of CoreDNS ecosystem:
+- Must be licensed under the terms of the Apache License v2.0.
+- Must be related to one or more scopes of the CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc ...)
   - External plugins
-  - other DNS processing related
-- Be supported by a Maintainer.
+  - Other DNS related processing
+- Must be supported by a Maintainer.
 
 The submission process starts as a Pull Request or Issue on the
 [coredns/coredns](https://github.com/coredns/coredns) repository with the required information
@@ -79,4 +79,8 @@ of CoreDNS__
 
 ## Code of Conduct
 
-CoreDNS follows the [CNCF Code of Conduct](https://github.com/coredns/coredns/CODE-OF-CONDUCT.md).
+The [CoreDNS Code of Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md) is aligned with the CNCF Code of Conduct.
+
+## Credits
+
+Sections of this documents have been borrowed from [Fluentd](https://github.com/fluent/fluentd/blob/master/GOVERNANCE.md) and [Envoy](https://github.com/envoyproxy/envoy/blob/master/GOVERNANCE.md) projects.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,25 +4,29 @@
 
 The CoreDNS community adheres to the following principles:
 
-- Open: CoreDNS is open source, advertised on [our website](https://coredns.io/community)
+- Open: CoreDNS is open source, advertised on [our website](https://coredns.io/community).
 - Welcoming and respectful: See [Code of
   Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with
   project objectives, scope, and design principles.
 
-## Benevolent Dictator for Life
+## Project Lead
 
-The CoreDNS project has a benevolent dictator for life.
+The CoreDNS project has a project lead.
 
-A [Benevolent dictator for life](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) is
+A project lead in CoreDNS is
 a single person that has a final say in any decision concerning the CoreDNS project.
 
-The benevolent dictator for life can volunteer to step down and appoint a new "dictator for life".
+The term of the project lead is two years, with no term limit restriction.
 
-The current "benevolent dictator for life" is identified in the [top level OWNERS
-file](https://github.com/coredns/coredns/OWNERS) with the string `benevolent dictator for life`
-behind the name.
+The project lead is elected by CoreDNS maintainers
+according to an individual's technical merit to CoreDNS project.
+
+The current "project lead" is identified in the top level [OWNERS]
+(https://github.com/coredns/coredns/blob/master/OWNERS) file with the string
+`project lead` and the term behind the name.
+
 
 ## Expectations from Maintainers
 
@@ -56,6 +60,39 @@ The CoreDNS organization will never forcefully remove a current Maintainer, unle
 fails to meet the principles of CoreDNS community,
 or adhere to the [Code of Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
 
+## Changes in Project Lead
+
+Changes in project lead or term is initiated by opening a github PR.
+
+Anyone from CoreDNS community can vote on the PR with either +1 or -1.
+
+Only the following votes are binding:
+1) Any maintainer that has been listed in the top-level [OWNERS](OWNERS) file before the PR is opened.
+2) Any maintainer from an organization may cast the vote for that organization. However, no organization
+should have more binding votes than 1/5 of the total number of maintainers defined in 1).
+
+The PR should be kept open for no less than 4 weeks. The PR can only be merged after the end of the
+last project lead's term, with more +1 than -1 in the binding votes.
+
+When there are conflicting PRs about changes in project lead, the PR with the most binding +1 votes is merged.
+
+The project lead can volunteer to step down.
+
+## Decision making process
+
+Decisions are build on consensus between maintainers.
+Proposals and ideas can either be submitted for agreement via a github issue or PR,
+or by sending an email to `maintainer@coredns.io`.
+
+In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
+If a dispute cannot be decided independently, the project lead has the final say to decide an issue.
+
+Decision making process should be transparent and accessible to adhere to
+the principles of CoreDNS project.
+
+All proposals, ideas, and decisions, by maintainers or the project lead,
+should either be part of a github issue or PR, or be sent to `maintainer@coredns.io`.
+
 ## Github Project Administration
 
 The __coredns__ GitHub project maintainers team reflects the list of Maintainers.
@@ -75,7 +112,7 @@ into the __CoreDNS__ organization, it has to meet the following criteria:
 The submission process starts as a Pull Request or Issue on the
 [coredns/coredns](https://github.com/coredns/coredns) repository with the required information
 mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella
-of CoreDNS__
+of CoreDNS__.
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -13,10 +13,16 @@ The CoreDNS community adheres to the following principles:
 
 ## Benevolent Dictator for Life
 
+The CoreDNS project has a benevolent dictator for life.
+
 A [Benevolent dictator for life](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) is
 a single person that has a final say in any decision concerning the CoreDNS project.
 
-The benevolent dictator for live can volunteer to step down and appoint a new "dictator for life".
+The benevolent dictator for life can volunteer to step down and appoint a new "dictator for life".
+
+The current "benevolent dictator for life" is identified in the [top level OWNERS
+file](https://github.com/coredns/coredns/OWNERS) with the string `benevolent dictator for life`
+behind the name.
 
 ## Expectations from Maintainers
 
@@ -28,11 +34,12 @@ in a *reasonable* time frame, either providing insights, or assign the Pull Requ
 maintainers.
 
 Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/coredns/OWNERS)
-file, with their Github handle and an email address. A Maintainer is also listed in a plugin
-specific OWNER file.
+file, with their Github handle and an (possible obfuscated) email address. Every one in the
+`reviewers` list is a Maintainer.
+
+A Maintainer is also listed in a plugin specific OWNER file.
 
 A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
-
 A Maintainer that hasn't been active in the CoreDNS repository for 12 months is considered inactive.
 
 ## Becoming a Maintainers
@@ -51,7 +58,7 @@ fails to meet the principles of CoreDNS community.
 
 ## Github Project Administration
 
-The __coredns__ GitHub project maintainers team reflect the list of Maintainers.
+The __coredns__ GitHub project maintainers team reflects the list of Maintainers.
 
 ## Other Projects
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -107,7 +107,7 @@ into the __CoreDNS__ organization, it has to meet the following criteria:
   - CoreDNS project artifacts (website, deployments, CI, etc)
   - External plugins
   - Other DNS related processing
-- Must be supported by a Maintainer
+- Must be supported by a Maintainer not associated or affiliated with the author(s) of the sub-projects
 
 The submission process starts as a Pull Request or Issue on the
 [coredns/coredns](https://github.com/coredns/coredns) repository with the required information

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -116,7 +116,7 @@ of CoreDNS__.
 
 ## Code of Conduct
 
-The [CoreDNS Code of Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md) is aligned with the CNCF Code of Conduct.
+The [CoreDNS Code of Conduct](CODE-OF-CONDUCT.md) is aligned with the CNCF Code of Conduct.
 
 ## Credits
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,7 +47,8 @@ A Maintainer should be a member of `maintainers@coredns.io`, although this is no
 
 On successful merge of a significant pull request any current maintainer can reach
 to the author behind the pull request and ask them if they are willing to become a CoreDNS
-maintainer.
+maintainer. The email of the new maintainer invitation should be cc'ed to `maintainers@coredns.io`
+as part of the process.
 
 ## Changes in Maintainership
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -84,7 +84,9 @@ Proposals and ideas can either be submitted for agreement via a github issue or 
 or by sending an email to `maintainers@coredns.io`.
 
 In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
-If a dispute cannot be decided independently, the project lead has the final say to decide an issue.
+If a dispute cannot be decided independently, get a third-party maintainer (e.g. a mutual contact with some background
+on the issue, but not involved in the conflict) to intercede.
+If a dispute still cannot be decided, the project lead has the final say to decide an issue.
 
 Decision making process should be transparent to adhere to
 the principles of CoreDNS project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -47,7 +47,7 @@ A Maintainer should be a member of `maintainers@coredns.io`, although this is no
 
 ## Becoming a Maintainers
 
-On successful merge of a significant pull request, any current maintainer can reach
+On successful merge of a significant pull request any current maintainer can reach
 to the author behind the pull request and ask them if they are willing to become a CoreDNS
 maintainer.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -90,7 +90,7 @@ If a dispute cannot be decided independently, the project lead has the final say
 Decision making process should be transparent and accessible to adhere to
 the principles of CoreDNS project.
 
-All proposals, ideas, and decisions, by maintainers or the project lead,
+All proposals, ideas, and decisions by maintainers or the project lead
 should either be part of a github issue or PR, or be sent to `maintainer@coredns.io`.
 
 ## Github Project Administration

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -58,7 +58,7 @@ step down.
 
 The CoreDNS organization will never forcefully remove a current Maintainer, unless a maintainer
 fails to meet the principles of CoreDNS community,
-or adhere to the [Code of Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
+or adhere to the [Code of Conduct](CODE-OF-CONDUCT.md).
 
 ## Changes in Project Lead
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -114,6 +114,13 @@ The submission process starts as a Pull Request or Issue on the
 mentioned above. Once a project is accepted, it's considered a __CNCF sub-project under the umbrella
 of CoreDNS__.
 
+## New Plugins
+
+The CoreDNS is open to receive new plugins as part of the CoreDNS repo. The submission process
+is the same as a Pull Request submission. Unlike small Pull Requests though, a new plugin submission
+should only be approved by a maintainer not associated or affiliated with the author(s) of the
+plugin.
+
 ## Code of Conduct
 
 The [CoreDNS Code of Conduct](CODE-OF-CONDUCT.md) is aligned with the CNCF Code of Conduct.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -23,7 +23,7 @@ The term of the project lead is two years, with no term limit restriction.
 The project lead is elected by CoreDNS maintainers
 according to an individual's technical merit to CoreDNS project.
 
-The current "project lead" is identified in the top level [OWNERS]
+The current project lead is identified in the top level [OWNERS](OWNERS) file with the string
 (https://github.com/coredns/coredns/blob/master/OWNERS) file with the string
 `project lead` and the term behind the name.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -127,7 +127,8 @@ plugin.
 CoreDNS is a CNCF project. As such, CoreDNS might be involved in CNCF (or other CNCF projects) related
 marketing, events, or activities. Any maintainer could help driving the CoreDNS involvement, as long as
 she/he sends email to `maintainers@coredns.io` (or create a GitHub Pull Request) to call for participation
-from other maintainers.
+from other maintainers. The `Call for Participation` should be kept open for no less than a week if time
+permits, or a _reasonable_ time frame to allow maintainers to have a chance to volunteer.
 
 ## Code of Conduct
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -43,7 +43,7 @@ A Maintainer is also listed in a plugin specific OWNERS file.
 
 A Maintainer should be a member of `maintainers@coredns.io`, although this is not a hard requirement.
 
-## Becoming a Maintainers
+## Becoming a Maintainer
 
 On successful merge of a significant pull request any current maintainer can reach
 to the author behind the pull request and ask them if they are willing to become a CoreDNS

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,7 +82,7 @@ The project lead can volunteer to step down.
 
 Decisions are build on consensus between maintainers.
 Proposals and ideas can either be submitted for agreement via a github issue or PR,
-or by sending an email to `maintainer@coredns.io`.
+or by sending an email to `maintainers@coredns.io`.
 
 In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
 If a dispute cannot be decided independently, the project lead has the final say to decide an issue.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -41,7 +41,7 @@ Every Maintainer is listed in the top-level [OWNERS](https://github.com/coredns/
 file, with their Github handle and a possibly obfuscated email address. Everyone in the
 `approvers` list is a Maintainer.
 
-A Maintainer is also listed in a plugin specific OWNER file.
+A Maintainer is also listed in a plugin specific OWNERS file.
 
 A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -77,6 +77,13 @@ When there are conflicting PRs about changes in project lead, the PR with the mo
 
 The project lead can volunteer to step down.
 
+## Changes in Project Governance
+
+Changes in project governance (GOVERNANCE.md) could be initiated by opening a github PR.
+The PR should only be opened no earlier than 6 weeks before the end of the project lead's term.
+The PR should be kept open for no less than 4 weeks. The PR can only be merged follow the same
+voting process as in `Changes in Project Lead`.
+
 ## Decision making process
 
 Decisions are build on consensus between maintainers.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -70,6 +70,7 @@ Only the following votes are binding:
 2) Any maintainer from an organization may cast the vote for that organization. However, no organization
 should have more binding votes than 1/5 of the total number of maintainers defined in 1).
 
+The PR should only be opened no earlier than 6 weeks before the end of the project lead's term.
 The PR should be kept open for no less than 4 weeks. The PR can only be merged after the end of the
 last project lead's term, with more +1 than -1 in the binding votes.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -104,7 +104,7 @@ into the __CoreDNS__ organization, it has to meet the following criteria:
 
 - Must be licensed under the terms of the Apache License v2.0.
 - Must be related to one or more scopes of the CoreDNS ecosystem:
-  - CoreDNS project artifacts (website, deployments, CI, etc ...)
+  - CoreDNS project artifacts (website, deployments, CI, etc)
   - External plugins
   - Other DNS related processing
 - Must be supported by a Maintainer.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -17,7 +17,7 @@ The CoreDNS project has a project lead.
 A project lead in CoreDNS is
 a single person that has a final say in any decision concerning the CoreDNS project.
 
-The term of the project lead is two years, with no term limit restriction.
+The term of the project lead is one year, with no term limit restriction.
 
 The project lead is elected by CoreDNS maintainers
 according to an individual's technical merit to CoreDNS project.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -122,6 +122,13 @@ is the same as a Pull Request submission. Unlike small Pull Requests though, a n
 should only be approved by a maintainer not associated or affiliated with the author(s) of the
 plugin.
 
+## CoreDNS and CNCF
+
+CoreDNS is a CNCF project. As such, CoreDNS might be involved in CNCF (or other CNCF projects) related
+marketing, events, or activities. Any maintainer could help driving the CoreDNS involvement, as long as
+she/he sends email to `maintainers@coredns.io` (or create a GitHub Pull Request) to call for participation
+from other maintainers.
+
 ## Code of Conduct
 
 The [CoreDNS Code of Conduct](CODE-OF-CONDUCT.md) is aligned with the CNCF Code of Conduct.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ The CoreDNS community adheres to the following principles:
 
 - Open: CoreDNS is open source, advertised on [our website](https://coredns.io/community).
 - Welcoming and respectful: See [Code of
-  Conduct](https://github.com/coredns/coredns/blob/master/CODE-OF-CONDUCT.md).
+  Conduct](CODE-OF-CONDUCT.md).
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with
   project objectives, scope, and design principles.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,8 +5,7 @@
 The CoreDNS community adheres to the following principles:
 
 - Open: CoreDNS is open source, advertised on [our website](https://coredns.io/community).
-- Welcoming and respectful: See [Code of
-  Conduct](CODE-OF-CONDUCT.md).
+- Welcoming and respectful: See [Code of Conduct](CODE-OF-CONDUCT.md).
 - Transparent and accessible: Work and collaboration are done in public.
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with
   project objectives, scope, and design principles.
@@ -29,7 +28,7 @@ The current project lead is identified in the top level [OWNERS](OWNERS) file wi
 
 ## Expectations from Maintainers
 
-Every one carries water....
+Every one carries water...
 
 Making a community work requires input/effort from everyone. Maintainers should actively
 participate in Pull Request reviews. Maintainers are expected to respond to assigned Pull Requests

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -43,7 +43,7 @@ file, with their Github handle and a possibly obfuscated email address. Everyone
 
 A Maintainer is also listed in a plugin specific OWNERS file.
 
-A Maintainer should be a member of `maintainer@coredns.io`, although this is not a hard requirement.
+A Maintainer should be a member of `maintainers@coredns.io`, although this is not a hard requirement.
 
 ## Becoming a Maintainers
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -24,7 +24,6 @@ The project lead is elected by CoreDNS maintainers
 according to an individual's technical merit to CoreDNS project.
 
 The current project lead is identified in the top level [OWNERS](OWNERS) file with the string
-(https://github.com/coredns/coredns/blob/master/OWNERS) file with the string
 `project lead` and the term behind the name.
 
 
@@ -87,7 +86,7 @@ or by sending an email to `maintainers@coredns.io`.
 In general, we prefer that technical issues and maintainer membership are amicably worked out between the persons involved.
 If a dispute cannot be decided independently, the project lead has the final say to decide an issue.
 
-Decision making process should be transparent and accessible to adhere to
+Decision making process should be transparent to adhere to
 the principles of CoreDNS project.
 
 All proposals, ideas, and decisions by maintainers or the project lead

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -107,7 +107,7 @@ into the __CoreDNS__ organization, it has to meet the following criteria:
   - CoreDNS project artifacts (website, deployments, CI, etc)
   - External plugins
   - Other DNS related processing
-- Must be supported by a Maintainer.
+- Must be supported by a Maintainer
 
 The submission process starts as a Pull Request or Issue on the
 [coredns/coredns](https://github.com/coredns/coredns) repository with the required information

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -102,7 +102,7 @@ The __coredns__ GitHub project maintainers team reflects the list of Maintainers
 The CoreDNS organization is open to receive new sub-projects under its umbrella. To accept a project
 into the __CoreDNS__ organization, it has to meet the following criteria:
 
-- Must be licensed under the terms of the Apache License v2.0.
+- Must be licensed under the terms of the Apache License v2.0
 - Must be related to one or more scopes of the CoreDNS ecosystem:
   - CoreDNS project artifacts (website, deployments, CI, etc)
   - External plugins

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -91,7 +91,7 @@ Decision making process should be transparent and accessible to adhere to
 the principles of CoreDNS project.
 
 All proposals, ideas, and decisions by maintainers or the project lead
-should either be part of a github issue or PR, or be sent to `maintainer@coredns.io`.
+should either be part of a github issue or PR, or be sent to `maintainers@coredns.io`.
 
 ## Github Project Administration
 


### PR DESCRIPTION
This proposal is based on conversations in #2112, #2152, #2203.

Maintainers vote for project lead. Project lead has the final say on anything else. The process should always be transparent and accessible to public.

A maintainer has to be listed before the PR is opened, to have a binding vote for project lead.

There are restrictions on affiliated maintainer votes for a company. If a company has more than 1/5 of the total maintainers, only no more than 1/5 of the total maintainers count are considered as binding.

A company certainly could recruit more non-affiliated maintainers to allow more votes for this company. That has to happen before the PR is open. Adding maintainers should also adhere to the policy about new maintainers.

Example: Since there are 16 maintainers in total now, any company can cast `16 / 5 = 3` votes for the project lead. If, in the future, a company adds one affiliated maintainer and recruits 3 more non-affiliated maintainers, then this company could cast `(16 + 1 + 3) / 5 = 4` votes.

It is not clear to me if there is an immediately need to have a governance document now (or soon). But since this is a proposal, I guess it does not hurt to open a PR for discussion.