### PR TITLE
Use filepath when manipulating file paths

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -2,7 +2,7 @@ package auto
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
@@ -104,8 +104,8 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 					return a, c.ArgErr()
 				}
 				a.loader.directory = c.Val()
-				if !path.IsAbs(a.loader.directory) && config.Root != "" {
-					a.loader.directory = path.Join(config.Root, a.loader.directory)
+				if !filepath.IsAbs(a.loader.directory) && config.Root != "" {
+					a.loader.directory = filepath.Join(config.Root, a.loader.directory)
 				}
 				_, err := os.Stat(a.loader.directory)
 				if err != nil {

--- a/plugin/auto/walk.go
+++ b/plugin/auto/walk.go
@@ -2,7 +2,6 @@ package auto
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 
@@ -91,7 +90,7 @@ func (a Auto) Walk() error {
 // matches matches re to filename, if is is a match, the subexpression will be used to expand
 // template to an origin. When match is true that origin is returned. Origin is fully qualified.
 func matches(re *regexp.Regexp, filename, template string) (match bool, origin string) {
-	base := path.Base(filename)
+	base := filepath.Base(filename)
 
 	matches := re.FindStringSubmatchIndex(base)
 	if matches == nil {

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -3,7 +3,7 @@ package auto
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 )
@@ -73,15 +73,15 @@ func createFiles() (string, error) {
 	}
 
 	for _, name := range dbFiles {
-		if err := ioutil.WriteFile(path.Join(dir, name), []byte(zoneContent), 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
 			return dir, err
 		}
 	}
 	// symlinks
-	if err = os.Symlink(path.Join(dir, "db.example.org"), path.Join(dir, "db.example.com")); err != nil {
+	if err = os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "db.example.com")); err != nil {
 		return dir, err
 	}
-	if err = os.Symlink(path.Join(dir, "db.example.org"), path.Join(dir, "aa.example.com")); err != nil {
+	if err = os.Symlink(filepath.Join(dir, "db.example.org"), filepath.Join(dir, "aa.example.com")); err != nil {
 		return dir, err
 	}
 

--- a/plugin/auto/watcher_test.go
+++ b/plugin/auto/watcher_test.go
@@ -2,7 +2,7 @@ package auto
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 )
@@ -39,7 +39,7 @@ func TestWatcher(t *testing.T) {
 	}
 
 	// Now remove one file, rescan and see if it's gone.
-	if err := os.Remove(path.Join(tempdir, "db.example.com")); err != nil {
+	if err := os.Remove(filepath.Join(tempdir, "db.example.com")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -78,15 +78,15 @@ func TestSymlinks(t *testing.T) {
 	a.Walk()
 
 	// Now create a duplicate file in a subdirectory and repoint the symlink
-	if err := os.Remove(path.Join(tempdir, "db.example.com")); err != nil {
+	if err := os.Remove(filepath.Join(tempdir, "db.example.com")); err != nil {
 		t.Fatal(err)
 	}
-	dataDir := path.Join(tempdir, "..data")
+	dataDir := filepath.Join(tempdir, "..data")
 	if err = os.Mkdir(dataDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	newFile := path.Join(dataDir, "db.example.com")
-	if err = os.Symlink(path.Join(tempdir, "db.example.org"), newFile); err != nil {
+	newFile := filepath.Join(dataDir, "db.example.com")
+	if err = os.Symlink(filepath.Join(tempdir, "db.example.org"), newFile); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -2,7 +2,7 @@ package dnssec
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -146,8 +146,8 @@ func keyParse(c *caddy.Controller) ([]*DNSKEY, error) {
 			if strings.HasSuffix(k, ".private") {
 				base = k[:len(k)-8]
 			}
-			if !path.IsAbs(base) && config.Root != "" {
-				base = path.Join(config.Root, base)
+			if !filepath.IsAbs(base) && config.Root != "" {
+				base = filepath.Join(config.Root, base)
 			}
 			k, err := ParseKeyFile(base+".key", base+".private")
 			if err != nil {

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -2,7 +2,7 @@ package file
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/coredns/coredns/core/dnsserver"
@@ -71,8 +71,8 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 			origins = args
 		}
 
-		if !path.IsAbs(fileName) && config.Root != "" {
-			fileName = path.Join(config.Root, fileName)
+		if !filepath.IsAbs(fileName) && config.Root != "" {
+			fileName = filepath.Join(config.Root, fileName)
 		}
 
 		reader, err := os.Open(fileName)

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -3,7 +3,7 @@ package file
 import (
 	"fmt"
 	"net"
-	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -48,7 +48,7 @@ func NewZone(name, file string) *Zone {
 	z := &Zone{
 		origin:         dns.Fqdn(name),
 		origLen:        dns.CountLabel(dns.Fqdn(name)),
-		file:           path.Clean(file),
+		file:           filepath.Clean(file),
 		Tree:           &tree.Tree{},
 		Expired:        new(bool),
 		reloadShutdown: make(chan bool),

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -2,7 +2,7 @@ package hosts
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -83,8 +83,8 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			h.path = args[0]
 			args = args[1:]
 
-			if !path.IsAbs(h.path) && config.Root != "" {
-				h.path = path.Join(config.Root, h.path)
+			if !filepath.IsAbs(h.path) && config.Root != "" {
+				h.path = filepath.Join(config.Root, h.path)
 			}
 			s, err := os.Stat(h.path)
 			if err != nil {

--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -46,7 +46,7 @@ func TestAuto(t *testing.T) {
 	}
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +61,7 @@ func TestAuto(t *testing.T) {
 	}
 
 	// Remove db.example.org again.
-	os.Remove(path.Join(tmpdir, "db.example.org"))
+	os.Remove(filepath.Join(tmpdir, "db.example.org"))
 
 	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
 	resp, err = p.Lookup(state, "www.example.org.", dns.TypeA)
@@ -139,7 +139,7 @@ func TestAutoAXFR(t *testing.T) {
 	defer i.Stop()
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -3,7 +3,7 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -145,7 +145,7 @@ func TestMetricsAuto(t *testing.T) {
 	defer i.Stop()
 
 	// Write db.example.org to get example.org.
-	if err = ioutil.WriteFile(path.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
+	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 	// TODO(miek): make the auto sleep even less.
@@ -169,7 +169,7 @@ func TestMetricsAuto(t *testing.T) {
 	}
 
 	// Remove db.example.org again. And see if the metric stops increasing.
-	os.Remove(path.Join(tmpdir, "db.example.org"))
+	os.Remove(filepath.Join(tmpdir, "db.example.org"))
 	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
 	if _, err := dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It switches to the filepath module when interacting with OS filenames. This is necessary for manipulating Windows paths.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
