### PR TITLE
plugin/loop: add ipv6 loopback address to example

### DIFF
--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -55,7 +55,7 @@ memory and CPU until eventual out of memory death by the host.
 
 A forwarding loop is usually caused by:
 
-* Most commonly, CoreDNS forwarding requests directly to itself. e.g. to `127.0.0.1` or `127.0.0.53`
+* Most commonly, CoreDNS forwarding requests directly to itself. e.g. via a loopback address such as `127.0.0.1`, `::1` or `127.0.0.53`
 * Less commonly, CoreDNS forwarding to an upstream server that in turn, forwards requests back to CoreDNS.
 
 To troubleshoot this problem, look in your Corefile for any `proxy` or `forward` to the zone


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds an IPv6 loopback to the list of example loopback addresses in the troubleshooting section.
https://github.com/coredns/coredns/issues/2087#issuecomment-427723951

### 2. Which issues (if any) are related?
#2087

### 3. Which documentation changes (if any) need to be made?