### PR TITLE
plugin/cache: Make default min TTL 5

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -40,10 +40,10 @@ cache [TTL] [ZONES...] {
 * **TTL**  and **ZONES** as above.
 * `success`, override the settings for caching successful responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (*randomly*). **TTL** overrides the cache maximum TTL.
-  **MINTTL** overrides the cache minimum TTL (default 0), which can be useful to limit queries to the backend.
+  **MINTTL** overrides the cache minimum TTL (default 5), which can be useful to limit queries to the backend.
 * `denial`, override the settings for caching denial of existence responses. **CAPACITY** indicates the maximum
   number of packets we cache before we start evicting (LRU). **TTL** overrides the cache maximum TTL.
-  **MINTTL** overrides the cache minimum TTL (default 0), which can be useful to limit queries to the backend.
+  **MINTTL** overrides the cache minimum TTL (default 5), which can be useful to limit queries to the backend.
   There is a third category (`error`) but those responses are never cached.
 * `prefetch` will prefetch popular items when they are about to be expunged from the cache.
   Popular means **AMOUNT** queries have been seen with no gaps of **DURATION** or more between them.

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -239,9 +239,9 @@ func (w *ResponseWriter) Write(buf []byte) (int, error) {
 
 const (
 	maxTTL  = dnsutil.MaximumDefaulTTL
-	minTTL  = 0
+	minTTL  = dnsutil.MinimalDefaultTTL
 	maxNTTL = dnsutil.MaximumDefaulTTL / 2
-	minNTTL = 0
+	minNTTL = dnsutil.MinimalDefaultTTL
 
 	defaultCap = 10000 // default capacity of the cache.
 

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -48,7 +48,7 @@ func TestLookupCache(t *testing.T) {
 	})
 
 	t.Run("Short TTL", func(t *testing.T) {
-		testCase(t, state, p, "short.example.org.", 1, 1)
+		testCase(t, state, p, "short.example.org.", 1, 5)
 	})
 
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

#2055 contained an _intentional_ (but undocumented) change in default behavior that I incorrectly identified as an unintentional regression.  This PR reverts #2199,  but leaves (adjusted) documentation in place so the behavior is documented somewhere and also leaves (adjusted) unit tests in place so the behavior is tested.

### 2. Which issues (if any) are related?
#2055 #2189
partly reverts #2199

### 3. Which documentation changes (if any) need to be made?