### PR TITLE
Check SO_REUSEPORT support

### DIFF
--- a/core/dnsserver/listen_go111.go
+++ b/core/dnsserver/listen_go111.go
@@ -8,19 +8,17 @@ import (
 	"net"
 	"syscall"
 
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"golang.org/x/sys/unix"
 )
 
-const supportsReusePort = true
-
-func reuseportControl(network, address string, c syscall.RawConn) (opErr error) {
-	err := c.Control(func(fd uintptr) {
-		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+func reuseportControl(network, address string, c syscall.RawConn) error {
+	c.Control(func(fd uintptr) {
+		if err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+			log.Warningf("Failed to set SO_REUSEPORT on socket: %s", err)
+		}
 	})
-	if err != nil {
-		return err
-	}
-	return opErr
+	return nil
 }
 
 func listen(network, addr string) (net.Listener, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The code currently assumes that, if compiled with go1.11, the underlying system has SO_REUSEPORT available.

### 2. Which issues (if any) are related?

coredns fails to start on older kernels (pre-3.9) if compiled with go1.11
