### PR TITLE
Metrics registered on wrong prometheus registry

### DIFF
--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -89,6 +89,15 @@ func (c *Cache) exists(state request.Request) *item {
 	return nil
 }
 
+// CacheResetMetrics - ensure all metrics for cache re-start from 0
+func CacheResetMetrics() {
+	cacheSize.Reset()
+	cacheHits.Reset()
+	cacheMisses.Reset()
+	cachePrefetches.Reset()
+	cacheDrops.Reset()
+}
+
 var (
 	cacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -89,15 +89,6 @@ func (c *Cache) exists(state request.Request) *item {
 	return nil
 }
 
-// CacheResetMetrics - ensure all metrics for cache re-start from 0
-func CacheResetMetrics() {
-	cacheSize.Reset()
-	cacheHits.Reset()
-	cacheMisses.Reset()
-	cachePrefetches.Reset()
-	cacheDrops.Reset()
-}
-
 var (
 	cacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -57,7 +57,15 @@ func New(addr string) *Metrics {
 }
 
 // MustRegister wraps m.Reg.MustRegister.
-func (m *Metrics) MustRegister(c prometheus.Collector) { m.Reg.MustRegister(c) }
+func (m *Metrics) MustRegister(c prometheus.Collector) {
+	err := m.Reg.Register(c)
+	if err != nil {
+		// ignore any duplicate error, but fatal on any other kind of error
+		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+			log.Fatalf("cannot register metrics collector : %s", err)
+		}
+	}
+}
 
 // AddZone adds zone z to m.
 func (m *Metrics) AddZone(z string) {

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -62,7 +62,7 @@ func (m *Metrics) MustRegister(c prometheus.Collector) {
 	if err != nil {
 		// ignore any duplicate error, but fatal on any other kind of error
 		if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
-			log.Fatalf("cannot register metrics collector : %s", err)
+			log.Fatalf("Cannot register metrics collector: %s", err)
 		}
 	}
 }

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -10,6 +10,7 @@ type U struct {
 type item struct {
 	state int          // either todo or done
 	f     func() error // function to be executed.
+	obj   interface{}  // any object to return when needed
 }
 
 // New returns a new initialized U.
@@ -17,28 +18,19 @@ func New() U { return U{u: make(map[string]item)} }
 
 // Set sets function f in U under key. If the key already exists
 // it is not overwritten.
-func (u U) Set(key string, f func() error) {
-	if _, ok := u.u[key]; ok {
-		return
+func (u U) Set(key string, f func() error, o interface{}) interface{} {
+	if item, ok := u.u[key]; ok {
+		return item.obj
 	}
-	u.u[key] = item{todo, f}
+	u.u[key] = item{todo, f, o}
+	return o
 }
 
-// Unset removes the 'todo' associated with a key
+// Unset removes the key
 func (u U) Unset(key string) {
 	if _, ok := u.u[key]; ok {
 		delete(u.u, key)
 	}
-}
-
-// SetTodo sets key to 'todo' again.
-func (u U) SetTodo(key string) {
-	v, ok := u.u[key]
-	if !ok {
-		return
-	}
-	v.state = todo
-	u.u[key] = v
 }
 
 // ForEach iterates for u executes f for each element that is 'todo' and sets it to 'done'.

--- a/plugin/pkg/uniq/uniq.go
+++ b/plugin/pkg/uniq/uniq.go
@@ -26,7 +26,7 @@ func (u U) Set(key string, f func() error, o interface{}) interface{} {
 	return o
 }
 
-// Unset removes the key
+// Unset removes the key.
 func (u U) Unset(key string) {
 	if _, ok := u.u[key]; ok {
 		delete(u.u, key)

--- a/plugin/pkg/uniq/uniq_test.go
+++ b/plugin/pkg/uniq/uniq_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestForEach(t *testing.T) {
 	u, i := New(), 0
-	u.Set("test", func() error { i++; return nil })
+	u.Set("test", func() error { i++; return nil }, nil)
 
 	u.ForEach()
 	if i != 1 {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/miekg/dns"
 )
 
-// fail when done in parallel
-
 // Start test server that has metrics enabled. Then tear it down again.
 func TestMetricsServer(t *testing.T) {
 	corefile := `example.org:0 {
@@ -206,6 +204,8 @@ google.com:0 {
 }
 `, addrMetrics, addrMetrics)
 
+	// ensure the metrics are reset (from other Test that were running before)
+	cache.CacheResetMetrics()
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -99,7 +99,6 @@ func TestMetricsCache(t *testing.T) {
 
 	beginCacheSizeSuccess := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheSizeMetricName, cache.Success, 0)
 	beginCacheHitSuccess := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheHitMetricName, cache.Success, 0)
-	t.Logf("metrics at begining : %s = %d %s = %d", cacheSizeMetricName, beginCacheSizeSuccess, cacheHitMetricName, beginCacheHitSuccess)
 
 	m = new(dns.Msg)
 	m.SetQuestion("www.example.net.", dns.TypeA)
@@ -110,7 +109,6 @@ func TestMetricsCache(t *testing.T) {
 
 	// Get the value for the cache size metric where the one of the labels values matches "success".
 	got := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheSizeMetricName, cache.Success, 0)
-	t.Logf("metrics collected : %s = %d", cacheSizeMetricName, got)
 
 	if got-beginCacheSizeSuccess != 1 {
 		t.Errorf("Expected value %d for %s, but got %d", 1, cacheSizeMetricName, got-beginCacheSizeSuccess)

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -75,14 +75,12 @@ func TestMetricsCache(t *testing.T) {
 	cacheSizeMetricName := "coredns_cache_size"
 	cacheHitMetricName := "coredns_cache_hits_total"
 
-	corefile := `www.example.net:0 {
+	corefile := `example.net:0 {
 	proxy . 8.8.8.8:53
 	prometheus localhost:0
 	cache
 }
-` // ensure the metrics are reset (from other Test that were running before)
-	cache.CacheResetMetrics()
-
+`
 	srv, err := CoreDNSServer(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -91,19 +89,31 @@ func TestMetricsCache(t *testing.T) {
 
 	udp, _ := CoreDNSServerPorts(srv, 0)
 
+	// send an initial query to set properly the cache size metric
 	m := new(dns.Msg)
+	m.SetQuestion("example.net.", dns.TypeA)
+
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	beginCacheSizeSuccess := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheSizeMetricName, cache.Success, 0)
+	beginCacheHitSuccess := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheHitMetricName, cache.Success, 0)
+	t.Logf("metrics at begining : %s = %d %s = %d", cacheSizeMetricName, beginCacheSizeSuccess, cacheHitMetricName, beginCacheHitSuccess)
+
+	m = new(dns.Msg)
 	m.SetQuestion("www.example.net.", dns.TypeA)
 
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
-	data := mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
 	// Get the value for the cache size metric where the one of the labels values matches "success".
-	got, _ := mtest.MetricValueLabel(cacheSizeMetricName, cache.Success, data)
+	got := mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheSizeMetricName, cache.Success, 0)
+	t.Logf("metrics collected : %s = %d", cacheSizeMetricName, got)
 
-	if got != "1" {
-		t.Errorf("Expected value %s for %s, but got %s", "1", cacheSizeMetricName, got)
+	if got-beginCacheSizeSuccess != 1 {
+		t.Errorf("Expected value %d for %s, but got %d", 1, cacheSizeMetricName, got-beginCacheSizeSuccess)
 	}
 
 	// Second request for the same response to test hit counter
@@ -115,12 +125,11 @@ func TestMetricsCache(t *testing.T) {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
-	data = mtest.Scrape(t, "http://"+metrics.ListenAddr+"/metrics")
 	// Get the value for the cache hit counter where the one of the labels values matches "success".
-	got, _ = mtest.MetricValueLabel(cacheHitMetricName, cache.Success, data)
+	got = mtest.ScrapeMetricAsInt(t, metrics.ListenAddr, cacheHitMetricName, cache.Success, 0)
 
-	if got != "2" {
-		t.Errorf("Expected value %s for %s, but got %s", "2", cacheHitMetricName, got)
+	if got-beginCacheHitSuccess != 2 {
+		t.Errorf("Expected value %d for %s, but got %d", 2, cacheHitMetricName, got-beginCacheHitSuccess)
 	}
 }
 
@@ -210,30 +219,34 @@ google.com:0 {
 }
 `, addrMetrics, addrMetrics)
 
-	// ensure the metrics are reset (from other Test that were running before)
-	cache.CacheResetMetrics()
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
 
-	// it is expected to have no info on cache yet
-	err = collectMetricsInfo(addrMetrics, cacheSizeMetricName)
-	if err == nil {
-		t.Errorf("Unexpected metric data retrieved for %s", cacheSizeMetricName)
-	}
-
+	// send an inital query to setup properly the cache size
 	m := new(dns.Msg)
 	m.SetQuestion("google.com.", dns.TypeA)
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+
+	beginCacheSize := mtest.ScrapeMetricAsInt(t, addrMetrics, cacheSizeMetricName, "", 0)
+
+	// send an query, different from initial to ensure we have another add to the cache
+	m = new(dns.Msg)
+	m.SetQuestion("www.google.com.", dns.TypeA)
 
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
-	// it is expected to have no info on cache yet
-	err = collectMetricsInfo(addrMetrics, cacheSizeMetricName)
+	endCacheSize := mtest.ScrapeMetricAsInt(t, addrMetrics, cacheSizeMetricName, "", 0)
 	if err != nil {
-		t.Errorf("Expected metric data retrieved for %s, but got an error : %s", cacheSizeMetricName, err)
+		t.Errorf("Unexpected metric data retrieved for %s : %s", cacheSizeMetricName, err)
+	}
+	if endCacheSize-beginCacheSize != 1 {
+		t.Errorf("Expected metric data retrieved for %s, expected %d, got %d", cacheSizeMetricName, 1, endCacheSize-beginCacheSize)
 	}
 }

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -215,7 +215,7 @@ google.com:0 {
 	// it is expected to have no info on cache yet
 	err = collectMetricsInfo(addrMetrics, cacheSizeMetricName)
 	if err == nil {
-		t.Errorf("unexpected metric data retrieved for %s", cacheSizeMetricName)
+		t.Errorf("Unexpected metric data retrieved for %s", cacheSizeMetricName)
 	}
 
 	m := new(dns.Msg)
@@ -228,6 +228,6 @@ google.com:0 {
 	// it is expected to have no info on cache yet
 	err = collectMetricsInfo(addrMetrics, cacheSizeMetricName)
 	if err != nil {
-		t.Errorf("expected metric data retrieved for %s, but got an error : %s", cacheSizeMetricName, err)
+		t.Errorf("Expected metric data retrieved for %s, but got an error : %s", cacheSizeMetricName, err)
 	}
 }

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -71,7 +71,7 @@ func TestMetricsRefused(t *testing.T) {
 }
 
 // TODO(miek): disabled for now - fails in weird ways in travis.
-func testMetricsCache(t *testing.T) {
+func TestMetricsCache(t *testing.T) {
 	cacheSizeMetricName := "coredns_cache_size"
 	cacheHitMetricName := "coredns_cache_hits_total"
 
@@ -80,7 +80,9 @@ func testMetricsCache(t *testing.T) {
 	prometheus localhost:0
 	cache
 }
-`
+` // ensure the metrics are reset (from other Test that were running before)
+	cache.CacheResetMetrics()
+
 	srv, err := CoreDNSServer(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -104,7 +106,11 @@ func testMetricsCache(t *testing.T) {
 		t.Errorf("Expected value %s for %s, but got %s", "1", cacheSizeMetricName, got)
 	}
 
-	// Second request for the same response to test hit counter.
+	// Second request for the same response to test hit counter
+	if _, err = dns.Exchange(m, udp); err != nil {
+		t.Fatalf("Could not send message: %s", err)
+	}
+	// Third request for the same response to test hit counter for the second time
 	if _, err = dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When metrics of 2 different blocs are available on the SAME tcp address, 
all the plugins of both blocs should register that collectors for Prometheus on the Registry that is associated with the listener.

### 2. Which issues (if any) are related?
#2241

### 3. Which documentation changes (if any) need to be made?
NONE.
It is fixing a wrong behavior.

