### PR TITLE
cache: some optimizations

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -167,7 +167,7 @@ func TestCache(t *testing.T) {
 		state := request.Request{W: nil, Req: m}
 
 		mt, _ := response.Typify(m, utc)
-		valid, k := key(m, mt, state.Do())
+		valid, k := key(state.Name(), m, mt, state.Do())
 
 		if valid {
 			crr.set(m, k, mt, c.pttl)
@@ -241,8 +241,7 @@ func BenchmarkCacheResponse(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		req := reqs[j]
 		c.ServeDNS(ctx, &test.ResponseWriter{}, req)
-		j++
-		j = j % 5
+		j = (j + 1) % 5
 	}
 }
 


### PR DESCRIPTION
 Some optimization and lowercasing of the qname (in the end
miekg/dns should provide a fast and OK function for it).

* remove the make([]byte, 2) allocation in the key()
* use already lowercased qname in hash key calculation.

% benchcmp old.txt new.txt
benchmark                    old ns/op     new ns/op     delta
BenchmarkCacheResponse-4     9599          8735          -9.00%

Signed-off-by: Miek Gieben <miek@miek.nl>