### PR TITLE
plugin/cache: Document actual cache defaults

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -25,7 +25,7 @@ cache [TTL] [ZONES...]
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
 A cache is divided into 256 shards, each holding up to 39 items by default - for a total size
-of 256*39 = 9984 items.
+of 256 * 39 = 9984 items. 
 
 If you want more control:
 
@@ -53,7 +53,8 @@ cache [TTL] [ZONES...] {
 
 ## Capacity and Eviction
 
-If **CAPACITY** is not specified, the default cache size is 9984 per cache. The minimum allowed cache size is 1024.
+If **CAPACITY** _is not_ specified, the default cache size is 9984 per cache. The minimum allowed cache size is 1024. 
+If **CAPACITY** _is_ specified, the actual cache size used will be rounded down to the nearest number divisible by 256 (so all shards are equal in size).
 
 Eviction is done per shard. In effect, when a shard reaches capacity, items are evicted from that shard.
 Since shards don't fill up perfectly evenly, evictions will occur before the entire cache reaches full capacity.

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -24,8 +24,8 @@ cache [TTL] [ZONES...]
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
-A cache is divided into 256 shards, each holding up to 512 items by default - for a total size
-of 256 * 512 = 131,072 items.
+A cache is divided into 256 shards, each holding up to 19 items by default - for a total size
+of 256 * 19 = 9728 items.
 
 If you want more control:
 
@@ -53,7 +53,7 @@ cache [TTL] [ZONES...] {
 
 ## Capacity and Eviction
 
-If **CAPACITY** is not specified, the default cache size is 10,000 per cache. The minimum allowed cache size is 1024.
+If **CAPACITY** is not specified, the default cache size is 9728 per cache. The minimum allowed cache size is 1024.
 
 Eviction is done per shard. In effect, when a shard reaches capacity, items are evicted from that shard.
 Since shards don't fill up perfectly evenly, evictions will occur before the entire cache reaches full capacity.

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -24,8 +24,8 @@ cache [TTL] [ZONES...]
 * **ZONES** zones it should cache for. If empty, the zones from the configuration block are used.
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
-A cache is divided into 256 shards, each holding up to 19 items by default - for a total size
-of 9984 items.
+A cache is divided into 256 shards, each holding up to 39 items by default - for a total size
+of 256*39 = 9984 items.
 
 If you want more control:
 

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -25,7 +25,7 @@ cache [TTL] [ZONES...]
 
 Each element in the cache is cached according to its TTL (with **TTL** as the max).
 A cache is divided into 256 shards, each holding up to 19 items by default - for a total size
-of 256 * 19 = 9728 items.
+of 9984 items.
 
 If you want more control:
 
@@ -53,7 +53,7 @@ cache [TTL] [ZONES...] {
 
 ## Capacity and Eviction
 
-If **CAPACITY** is not specified, the default cache size is 9728 per cache. The minimum allowed cache size is 1024.
+If **CAPACITY** is not specified, the default cache size is 9984 per cache. The minimum allowed cache size is 1024.
 
 Eviction is done per shard. In effect, when a shard reaches capacity, items are evicted from that shard.
 Since shards don't fill up perfectly evenly, evictions will occur before the entire cache reaches full capacity.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Correct default cache capacity mentions in README:
* there was a stray mention of the old capacity
* Technically, the max capacity is actually 9984 (39*256), not exactly  10000, due to shard size truncation.

### 2. Which issues (if any) are related?
#2248

### 3. Which documentation changes (if any) need to be made?
