### PR TITLE
plugin/kubernetes - Option `kubeconfig` is missing in the initial stanza model in the README.md

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -34,6 +34,7 @@ kubernetes [ZONES...] {
     resyncperiod DURATION
     endpoint URL [URL...]
     tls CERT KEY CACERT
+    kubeconfig KUBECONFIG CONTEXT
     namespaces NAMESPACE...
     labels EXPRESSION
     pods POD-MODE


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Just a missing line in the stanza model

### 2. Which issues (if any) are related?
NONE - i did a direct update on the file.

### 3. Which documentation changes (if any) need to be made?
that is the doc.