### PR TITLE
plugin/etcd: propagate recursion flag properly

### DIFF
--- a/plugin/etcd/cname_test.go
+++ b/plugin/etcd/cname_test.go
@@ -57,6 +57,7 @@ var servicesCname = []*msg.Service{
 	{Host: "cname5.region2.skydns.test", Key: "cname4.region2.skydns.test."},
 	{Host: "cname6.region2.skydns.test", Key: "cname5.region2.skydns.test."},
 	{Host: "endpoint.region2.skydns.test", Key: "cname6.region2.skydns.test."},
+	{Host: "mainendpoint.region2.skydns.test", Key: "region2.skydns.test."},
 	{Host: "10.240.0.1", Key: "endpoint.region2.skydns.test."},
 }
 
@@ -74,6 +75,12 @@ var dnsTestCasesCname = []test.Case{
 			test.CNAME("cname5.region2.skydns.test.	300	IN	CNAME	cname6.region2.skydns.test."),
 			test.CNAME("cname6.region2.skydns.test.	300	IN	CNAME	endpoint.region2.skydns.test."),
 			test.A("endpoint.region2.skydns.test.	300	IN	A	10.240.0.1"),
+		},
+	},
+	{
+		Qname: "region2.skydns.test.", Qtype: dns.TypeCNAME,
+		Answer: []dns.RR{
+			test.CNAME("region2.skydns.test.	300	IN	CNAME	mainendpoint.region2.skydns.test."),
 		},
 	},
 }

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -75,7 +75,7 @@ func (e *Etcd) Records(state request.Request, exact bool) ([]msg.Service, error)
 	name := state.Name()
 
 	path, star := msg.PathWithWildcard(name, e.PathPrefix)
-	r, err := e.get(path, true)
+	r, err := e.get(path, !exact)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When fetching records via the etcd plugin, the recursion flag was never set properly according to if the caller requested an exact record match or not. This causes problems especially in CNAME lookups, where recursion took place and a random RR was returned instead of the one that was specifically added for this key. Even when there is no service attached on the given path, it is still wrong to return a random one from the recursion.

To fix this issue, the `exact` flag is passed down to the etcd client as the `recursive` parameter to not perform recursive lookups when an exact match is requested by the caller.

A test is included to prove the right CNAME record is now returned (the test fails on the current master).
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None
