### PR TITLE
plugin/loop: fix loop detection when an upstream DNS server is not reachable

### DIFF
--- a/plugin/loop/loop.go
+++ b/plugin/loop/loop.go
@@ -77,6 +77,12 @@ func (l *Loop) inc() {
 	l.i++
 }
 
+func (l *Loop) reset() {
+	l.Lock()
+	defer l.Unlock()
+	l.i = 0
+}
+
 func (l *Loop) setDisabled() {
 	l.Lock()
 	defer l.Unlock()

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -42,6 +42,7 @@ func setup(c *caddy.Controller) error {
 
 			for time.Now().Before(deadline) {
 				if _, err := l.exchange(addr); err != nil {
+					l.reset()
 					time.Sleep(1 * time.Second)
 					continue
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The loop plugin erroneously detects a loop (and causes the server startup to fail) when the server is configured with an upstream DNS server that is unavailable during startup. The issue can be reproduced with the following minimal configuration file (choose any IP address that is unavailable for you):
```
.:53 {
	proxy . 10.20.30.40
	loop
}
```
Running the server with this configuration file yields the following output:
```
[FATAL] plugin/loop: Forwarding loop detected in "." zone. Exiting. See https://coredns.io/plugins/loop#troubleshooting. Probe query: "HINFO 1132263262137561571.8670159584435333845.".
```

The loop detection fails for the following reason: when the server receives the HINFO query, the query first passes the loop plugin which registers an occurence of the query by calling inc(). When the query is passed to the proxy plugin, the plugin tries to forward the request to the (unavailable) upstream server which ultimately causes the HINFO query request to fail. In its current implementation, the loop plugin retries the query several times over a total time span of 30 seconds. With each retry the loop plugin registers another occurrence of the HINFO query request. When loop plugin receives the second retry (i.e. when seen() returns 3) , the plugin erroneously believes to have detected a loop.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None