### PR TITLE
 plugin/etcd: make the address of upstream optional

### DIFF
--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -92,9 +92,6 @@ func etcdParse(c *caddy.Controller) (*Etcd, bool, error) {
 					endpoints = args
 				case "upstream":
 					args := c.RemainingArgs()
-					if len(args) == 0 {
-						return nil, false, c.ArgErr()
-					}
 					u, err := upstream.New(args)
 					if err != nil {
 						return nil, false, err

--- a/plugin/etcd/setup_test.go
+++ b/plugin/etcd/setup_test.go
@@ -31,6 +31,20 @@ func TestSetupEtcd(t *testing.T) {
 }
 `, false, "skydns", []string{"localhost:300"}, "",
 		},
+		//test for upstream
+		{
+			`etcd {
+	endpoint localhost:300
+	upstream 8.8.8.8:53 8.8.4.4:53
+}`, false, "skydns", []string{"localhost:300"}, "",
+		},
+		//test for optional upstream address
+		{
+			`etcd {
+	endpoint localhost:300
+	upstream
+}`, false, "skydns", []string{"localhost:300"}, "",
+		},
 		// negative
 		{
 			`etcd {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
- fix #2099 
- Add 2 tests for upstream in etcd plugin. 
### 2. Which issues (if any) are related?
#2099 
### 3. Which documentation changes (if any) need to be made?
N/A