### PR TITLE
plugin/route53: make the upstream address in route53 plugin optional.

### DIFF
--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -32,7 +32,7 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 * `upstream` [**ADDRESS**...] specifies upstream resolver(s) used for resolving services that point
    to external hosts (eg. used to resolve CNAMEs). If no **ADDRESS** is given, CoreDNS will resolve
    against itself. **ADDRESS** can be an IP, an IP:port or a path to a file structured like
-   resolv.conf (**NB**: Currently a bug (#2099) is preventing the use of self-resolver).
+   resolv.conf.
 * `credentials` used for reading the credential file and setting the profile name for a given zone.
 * **PROFILE** AWS account profile name. Defaults to `default`.
 * **FILENAME** AWS credentials filename. Defaults to `~/.aws/credentials`

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -84,11 +84,6 @@ func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Ro
 				})
 			case "upstream":
 				args := c.RemainingArgs()
-				// TODO(dilyevsky): There is a bug that causes coredns to crash
-				// when no upstream endpoint is provided.
-				if len(args) == 0 {
-					return c.Errf("local upstream not supported. please provide upstream endpoint")
-				}
 				var err error
 				up, err = upstream.New(args)
 				if err != nil {

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -36,10 +36,17 @@ func TestSetupRoute53(t *testing.T) {
 	}
 
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
+    upstream 10.0.0.1
+}`)
+	if err := setup(c, f); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `route53 example.org:12345678 {
     upstream
 }`)
-	if err := setup(c, f); err == nil {
-		t.Fatalf("Expected errors, but got: %v", err)
+	if err := setup(c, f); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
 	}
 
 	c = caddy.NewTestController("dns", `route53 example.org:12345678 {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
- Make the upstream address in route53 plugin optional.
- Add tests for upstream.
### 2. Which issues (if any) are related?
#2099 #2262 
### 3. Which documentation changes (if any) need to be made?
[route53 README.md](https://github.com/coredns/coredns/blob/master/plugin/route53/README.md)