### PR TITLE
plugin/log: explain the {size} better

### DIFF
--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -65,9 +65,9 @@ The following place holders are supported:
 * `{port}`: client's port
 * `{duration}`: response duration
 * `{rcode}`: response RCODE
-* `{rsize}`: response size
+* `{rsize}`: raw (uncompressed), response size (a client may receive a smaller response)
 * `{>rflags}`: response flags, each set flag will be displayed, e.g. "aa, tc". This includes the qr
-  bit as well.
+  bit as well
 * `{>bufsize}`: the EDNS0 buffer size advertised in the query
 * `{>do}`: is the EDNS0 DO (DNSSEC OK) bit set in the query
 * `{>id}`: query ID


### PR DESCRIPTION
This is now the raw size which may be larger than what a particular
client actually sees.

Clarify this a bit.

Fixes #2258

Signed-off-by: Miek Gieben <miek@miek.nl>