### PR TITLE
plugin/kubernetes: don't log error for non-existent txt records

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -100,7 +100,7 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 
 		segs := dns.SplitDomainName(t)
 		if len(segs) != 1 {
-			return nil, fmt.Errorf("kubernetes: TXT query can only be for dns-version: %s", state.QName())
+			return nil, nil
 		}
 		if segs[0] != "dns-version" {
 			return nil, nil


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Reduce verbosity in log when a non-existent TXT record is queried.

### 2. Which issues (if any) are related?
#2290 

### 3. Which documentation changes (if any) need to be made?