### PR TITLE
Advertize email next to my github username

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,7 @@ approvers:
   - chrisohaver
   - dilyevsky
   - fastest963
-  - fturib (ftur@infoblox.com)
+  - fturib   # ftur@infoblox.com
   - greenpau
   - grobie
   - isolus

--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,7 @@ approvers:
   - chrisohaver
   - dilyevsky
   - fastest963
-  - fturib
+  - fturib (ftur@infoblox.com)
   - greenpau
   - grobie
   - isolus


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Following Governance description, I add my email next to my github handle.

@miekg :
* I guess that will need change in the dreck project that parse this file.
* Do you want me to PR the change on that project (miek/dreck) ?


### 2. Which issues (if any) are related?

I would need for CNCF Graduation to show the different organizations the maintainers are from. Anyone with no email or personal email (like gmail) will be considered under its own organization.

That would also help when vote will come-in, as we restraint votes for people on the same organization.


### 3. Which documentation changes (if any) need to be made?

It is documented in [Governance](governance.md) already
