### PR TITLE
Project lead

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ approvers:
   - grobie
   - isolus
   - johnbelamaric
-  - miekg
+  - miekg (project lead: - 11/12/2019)
   - pmoroney
   - rajansandeep
   - stp-ip

--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ approvers:
   - grobie
   - isolus
   - johnbelamaric
-  - miekg (project lead: - 11/12/2019)
+  - miekg (project lead: - 11/11/2019)
   - pmoroney
   - rajansandeep
   - stp-ip

--- a/OWNERS
+++ b/OWNERS
@@ -8,7 +8,7 @@ approvers:
   - grobie
   - isolus
   - johnbelamaric
-  - miekg (project lead: - 11/11/2019)
+  - miekg          # miek@miek.nl | project lead: - 11/11/2019
   - pmoroney
   - rajansandeep
   - stp-ip


### PR DESCRIPTION
This change is considered as part of the GOVERNANCE.md update (11/12/2018)
to add the project lead in OWNERS file. The term (11/11/2019) aligns
with GOVERNANCE.md update time (11/12/2018).

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
