### PR TITLE
plugin/proxy: add jitter

### DIFF
--- a/plugin/file/secondary.go
+++ b/plugin/file/secondary.go
@@ -1,8 +1,9 @@
 package file
 
 import (
-	"math/rand"
 	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/jitter"
 
 	"github.com/miekg/dns"
 )
@@ -134,7 +135,7 @@ Restart:
 				break
 			}
 
-			time.Sleep(jitter(2000)) // 2s randomize
+			time.Sleep(jitter.DurationMillisecond(2000))
 
 			ok, err := z.shouldTransfer()
 			if err != nil {
@@ -158,7 +159,7 @@ Restart:
 
 		case <-refreshTicker.C:
 
-			time.Sleep(jitter(5000)) // 5s randomize
+			time.Sleep(jitter.DurationMillisecond(5000)) // 5s randomize
 
 			ok, err := z.shouldTransfer()
 			if err != nil {
@@ -184,13 +185,6 @@ Restart:
 
 		}
 	}
-}
-
-// jitter returns a random duration between [0,n) * time.Millisecond
-func jitter(n int) time.Duration {
-	r := rand.Intn(n)
-	return time.Duration(r) * time.Millisecond
-
 }
 
 // MaxSerialIncrement is the maximum difference between two serial numbers. If the difference between

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -68,6 +68,7 @@ func TestCleanupByTimer(t *testing.T) {
 	tr.Yield(c2)
 
 	time.Sleep(120 * time.Millisecond)
+	time.Sleep(30 * time.Millisecond) // jitter we defaults to 25% (impl. leaking through here)
 	c3, cached, _ := tr.Dial("udp")
 	if cached {
 		t.Error("Expected non-cached connection (c3)")
@@ -120,6 +121,8 @@ func TestPartialCleanup(t *testing.T) {
 	if c7 != c4 {
 		t.Errorf("Expected c7 == c4")
 	}
+	time.Sleep(30 * time.Millisecond) // jitter we defaults to 25% (impl. leaking through here
+
 	c8, cached, _ := tr.Dial("udp")
 	if cached {
 		t.Error("Expected non-cached connection (c8)")

--- a/plugin/pkg/jitter/duration.go
+++ b/plugin/pkg/jitter/duration.go
@@ -1,0 +1,19 @@
+// Package jitter contains various function that return a jittered value.
+package jitter
+
+import (
+	"math/rand"
+	"time"
+)
+
+// DurationMillisecond returns a random duration between [0,n) * time.Millisecond
+func DurationMillisecond(n int) time.Duration {
+	r := rand.Intn(n)
+	return time.Duration(r) * time.Millisecond
+}
+
+// Add returns t with a random fraction of d added to it.
+func Add(t time.Time, d time.Duration) time.Time {
+	r := rand.Float64() * float64(d)
+	return t.Add(time.Duration(r))
+}


### PR DESCRIPTION
Add in a bunch of jitter when adding connection back into the map. This
help spread the load and keep some connection open for longer.

This does not implement keep a minimal number of connections open,
but jitter helps in making the expire less dependent on the query load.

Signed-off-by: Miek Gieben <miek@miek.nl>