### PR TITLE
pkg/log: use 000 instead of 999 for the millis

### DIFF
--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -20,7 +20,7 @@ import (
 var D bool
 
 // RFC3339Milli doesn't exist, invent it here.
-func clock() string { return time.Now().Format("2006-01-02T15:04:05.999Z07:00") }
+func clock() string { return time.Now().Format("2006-01-02T15:04:05.000Z07:00") }
 
 // logf calls log.Printf prefixed with level.
 func logf(level, format string, v ...interface{}) {


### PR DESCRIPTION
999 chops of suffix zero, 000 allows for the milliseconds to be always
printed with 3 chars. This makes the log the printed with the same
columns.

(partial logs below)

2018-11-13T21:13:28.249Z [INFO] [::1]
2018-11-13T21:13:48.414Z [INFO] [::1]
2018-11-13T21:13:49.1Z [INFO] [::1]

vs:

2018-11-13T21:20:22.262Z [INFO] [::1]
2018-11-13T21:20:22.436Z [INFO] [::1]
2018-11-13T21:20:22.608Z [INFO] [::1]

Signed-off-by: Miek Gieben <miek@miek.nl>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
