### PR TITLE
[plugin/metadata] Add functionality for metadata to provide standard values.

### DIFF
--- a/plugin/metadata/README.md
+++ b/plugin/metadata/README.md
@@ -26,8 +26,28 @@ The value stored is a string. The empty string signals "no meta data". See the d
 ## Syntax
 
 ~~~
-metadata [ZONES... ]
+metadata [ZONES... ] {
+       client_id edns0 0xffed
+       group_id edns0 0xffee hex 16 0 16
+       <label> edns0 <id>
+       <label> ends0 <id> <encoded-format> <params of format ...>
+ }
 ~~~
+
+So far, only 'hex' format is supported with params <length> <start> <end>
+
+
+Currently, supported metadata is based on the variables used in REWRITE plugin. These are:
+
+	queryName  = "qname"
+	queryType  = "qtype"
+	clientIP   = "client_ip"
+	clientPort = "client_port"
+	protocol   = "protocol"
+	serverIP   = "server_ip"
+	serverPort = "server_port"
+	responseIP = "response_ip"
+
 
 * **ZONES** zones metadata should be invoked for.
 

--- a/plugin/metadata/metadata.go
+++ b/plugin/metadata/metadata.go
@@ -15,6 +15,7 @@ type Metadata struct {
 	Zones     []string
 	Providers []Provider
 	Next      plugin.Handler
+	options   map[uint16][]*edns0Map
 }
 
 // Name implements the Handler interface.

--- a/plugin/metadata/request.go
+++ b/plugin/metadata/request.go
@@ -1,0 +1,211 @@
+package metadata
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+const (
+	typeEDNS0Bytes = iota
+	typeEDNS0Hex
+	typeEDNS0IP
+)
+
+const (
+	QueryName  = "qname"
+	QueryType  = "qtype"
+	ClientIP   = "client_ip"
+	ClientPort = "client_port"
+	Protocol   = "protocol"
+	ServerIP   = "server_ip"
+	ServerPort = "server_port"
+	ResponseIP = "response_ip"
+)
+
+func newMetadata() *Metadata {
+	pol := &Metadata{options: make(map[uint16][]*edns0Map, 0)}
+	return pol
+}
+
+type edns0Map struct {
+	name     string
+	code     uint16
+	dataType uint16
+	size     uint
+	start    uint
+	end      uint
+}
+
+var stringToEDNS0MapType = map[string]uint16{
+	"bytes":   typeEDNS0Bytes,
+	"hex":     typeEDNS0Hex,
+	"address": typeEDNS0IP,
+}
+
+func newEDNS0Map(code, name, dataType, sizeStr, startStr, endStr string) (*edns0Map, error) {
+	c, err := strconv.ParseUint(code, 0, 16)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse EDNS0 code: %s", err)
+	}
+	size, err := strconv.ParseUint(sizeStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse EDNS0 data size: %s", err)
+	}
+	start, err := strconv.ParseUint(startStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse EDNS0 start index: %s", err)
+	}
+	end, err := strconv.ParseUint(endStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse EDNS0 end index: %s", err)
+	}
+	if end <= start && end != 0 {
+		return nil, fmt.Errorf("end index should be > start index (actual %d <= %d)", end, start)
+	}
+	if end > size && size != 0 {
+		return nil, fmt.Errorf("end index should be <= size (actual %d > %d)", end, size)
+	}
+	ednsType, ok := stringToEDNS0MapType[dataType]
+	if !ok {
+		return nil, fmt.Errorf("invalid dataType for EDNS0 map: %s", dataType)
+	}
+	ecode := uint16(c)
+	return &edns0Map{name, ecode, ednsType, uint(size), uint(start), uint(end)}, nil
+}
+
+func (m *Metadata) addEDNS0Map(code, name, dataType, sizeStr, startStr, endStr string) error {
+	meta, err := newEDNS0Map(code, name, dataType, sizeStr, startStr, endStr)
+	if err != nil {
+		return err
+	}
+	m.options[meta.code] = append(m.options[meta.code], meta)
+	return nil
+}
+
+func (m *Metadata) Metadata(ctx context.Context, state request.Request) context.Context {
+	return m.fillMetadata(ctx, state)
+}
+
+func (m *Metadata) fillMetadata(ctx context.Context, state request.Request) context.Context {
+
+	m.declareMetadata(QueryName, state.QName(), ctx)
+	m.declareMetadata(QueryType, dns.Type(state.QType()).String(), ctx)
+	m.declareMetadata(ClientIP, state.IP(), ctx)
+	m.declareMetadata(ServerIP, state.LocalIP(), ctx)
+	m.declareMetadata(ClientPort, state.Port(), ctx)
+	m.declareMetadata(ServerPort, state.LocalPort(), ctx)
+	m.declareMetadata(Protocol, state.Proto(), ctx)
+
+	m.getAttrsFromEDNS0(state.Req, ctx)
+
+	SetValueFunc(ctx, "metadata/"+ResponseIP, func() string {
+		ip := getRespIP(state.Req)
+		if ip != nil {
+			return ip.String()
+		}
+		return ""
+	})
+	return ctx
+
+}
+
+func (m *Metadata) declareMetadata(name string, value string, ctx context.Context) {
+	SetValueFunc(ctx, "metadata/"+name, func() string { return value })
+}
+
+func (m *Metadata) getAttrsFromEDNS0(r *dns.Msg, ctx context.Context) {
+	o := r.IsEdns0()
+	if o == nil {
+		return
+	}
+
+	for _, opt := range o.Option {
+		optLocal, local := opt.(*dns.EDNS0_LOCAL)
+		if !local {
+			continue
+		}
+		opts, ok := m.options[optLocal.Code]
+		if !ok {
+			continue
+		}
+		m.parseOptionGroup(optLocal.Data, opts, ctx)
+	}
+}
+
+func (m *Metadata) parseOptionGroup(data []byte, options []*edns0Map, ctx context.Context) {
+	for _, option := range options {
+		var value string
+		switch option.dataType {
+		case typeEDNS0Bytes:
+			value = string(data)
+		case typeEDNS0Hex:
+			value = parseHex(data, option)
+		case typeEDNS0IP:
+			ip := net.IP(data)
+			value = ip.String()
+		}
+		if value != "" {
+			m.declareMetadata(option.name, value, ctx)
+		}
+	}
+}
+
+func parseHex(data []byte, option *edns0Map) string {
+	size := uint(len(data))
+	// if option.size == 0 - don't check size
+	if option.size > 0 {
+		if size != option.size {
+			// skip parsing option with wrong size
+			return ""
+		}
+	}
+	start := uint(0)
+	if option.start < size {
+		// set start index
+		start = option.start
+	} else {
+		// skip parsing option if start >= data size
+		return ""
+	}
+	end := size
+	// if option.end == 0 - return data[start:]
+	if option.end > 0 {
+		if option.end <= size {
+			// set end index
+			end = option.end
+		} else {
+			// skip parsing option if end > data size
+			return ""
+		}
+	}
+	return hex.EncodeToString(data[start:end])
+}
+
+func getRespIP(r *dns.Msg) net.IP {
+	if r == nil {
+		return nil
+	}
+
+	var ip net.IP
+	for _, rr := range r.Answer {
+		switch rr := rr.(type) {
+		case *dns.A:
+			ip = rr.A
+
+		case *dns.AAAA:
+			ip = rr.AAAA
+		}
+		// If there are several responses, currently
+		// only return the first one and break.
+		if ip != nil {
+			break
+		}
+	}
+	return ip
+}

--- a/plugin/metadata/request_test.go
+++ b/plugin/metadata/request_test.go
@@ -12,7 +12,7 @@ func TestNewEdns0Opt(t *testing.T) {
 		t.Error(err)
 	} else {
 		if o.code != 0xfffe {
-			t.Errorf("expected 0x%x EDNS0 code but got 0x%x", 0xfffe, o.code)
+			t.Errorf("Expected 0x%x EDNS0 code but got 0x%x", 0xfffe, o.code)
 		}
 
 		if o.name != "edns" ||
@@ -20,7 +20,7 @@ func TestNewEdns0Opt(t *testing.T) {
 			o.size != 16 ||
 			o.start != 0 ||
 			o.end != 8 {
-			t.Errorf("unexpected EDNS0 option: %+v", o)
+			t.Errorf("Unexpected EDNS0 option: %+v", o)
 		}
 	}
 
@@ -46,7 +46,7 @@ func TestNewEdns0Opt(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			o, err := newEDNS0Map(test.c, test.n, test.t, test.s, test.b, test.e)
 			if err == nil {
-				t.Errorf("expected error but got EDNS0 0x%x %+v", o.code, o)
+				t.Errorf("Expected error but got EDNS0 0x%x %+v", o.code, o)
 			}
 		})
 	}
@@ -106,7 +106,7 @@ func TestMakeHexString(t *testing.T) {
 	for i, test := range tests {
 		s := test.o.makeHexString(test.b)
 		if s != test.s {
-			t.Errorf("expected string %q for test %d but got %q", test.s, i, s)
+			t.Errorf("Expected string %q for test %d but got %q", test.s, i, s)
 		}
 	}
 }

--- a/plugin/metadata/request_test.go
+++ b/plugin/metadata/request_test.go
@@ -1,0 +1,138 @@
+package metadata
+
+import (
+	"encoding/hex"
+	"strconv"
+	"testing"
+)
+
+func TestNewEdns0Opt(t *testing.T) {
+	o, err := newEDNS0Map("0xfffe", "edns", "hex", "16", "0", "8")
+	if err != nil {
+		t.Error(err)
+	} else {
+		if o.code != 0xfffe {
+			t.Errorf("expected 0x%x EDNS0 code but got 0x%x", 0xfffe, o.code)
+		}
+
+		if o.name != "edns" ||
+			o.dataType != typeEDNS0Hex ||
+			o.size != 16 ||
+			o.start != 0 ||
+			o.end != 8 {
+			t.Errorf("unexpected EDNS0 option: %+v", o)
+		}
+	}
+
+	tests := []struct {
+		c string
+		n string
+		t string
+		s string
+		b string
+		e string
+	}{
+		{c: "0xGGGG", n: "edns", t: "hex", s: "16", b: "0", e: "8"},
+		{c: "0xfffe", n: "edns", t: "xxx", s: "16", b: "0", e: "8"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "0x10", b: "0", e: "8"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "16", b: "0x0", e: "8"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "16", b: "0", e: "0x8"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "16", b: "16", e: "8"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "16", b: "17", e: "1"},
+		{c: "0xfffe", n: "edns", t: "hex", s: "16", b: "0", e: "17"},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			o, err := newEDNS0Map(test.c, test.n, test.t, test.s, test.b, test.e)
+			if err == nil {
+				t.Errorf("expected error but got EDNS0 0x%x %+v", o.code, o)
+			}
+		})
+	}
+}
+
+func TestMakeHexString(t *testing.T) {
+	tests := []struct {
+		o *edns0Map
+		b []byte
+		s string
+	}{
+		{
+			o: &edns0Map{
+				size: 4,
+			},
+			b: []byte{0, 1, 2, 3},
+			s: "00010203",
+		},
+		{
+			o: &edns0Map{
+				size:  4,
+				start: 1,
+				end:   3,
+			},
+			b: []byte{0, 1, 2, 3},
+			s: "0102",
+		},
+		{
+			o: &edns0Map{
+				size:  4,
+				start: 1,
+				end:   3,
+			},
+			b: []byte{0, 1, 2, 3, 4, 5, 6, 7},
+			s: "",
+		},
+		{
+			o: &edns0Map{
+				size:  4,
+				start: 4,
+				end:   3,
+			},
+			b: []byte{0, 1, 2, 3},
+			s: "",
+		},
+		{
+			o: &edns0Map{
+				size:  4,
+				start: 1,
+				end:   5,
+			},
+			b: []byte{0, 1, 2, 3},
+			s: "",
+		},
+	}
+
+	for i, test := range tests {
+		s := test.o.makeHexString(test.b)
+		if s != test.s {
+			t.Errorf("expected string %q for test %d but got %q", test.s, i, s)
+		}
+	}
+}
+
+func (o *edns0Map) makeHexString(b []byte) string {
+	if o.size > 0 && o.size != uint(len(b)) {
+		return ""
+	}
+
+	start := uint(0)
+	if o.start > 0 {
+		if o.start >= uint(len(b)) {
+			return ""
+		}
+
+		start = o.start
+	}
+
+	end := uint(len(b))
+	if o.end > 0 {
+		if o.end > uint(len(b)) {
+			return ""
+		}
+
+		end = o.end
+	}
+
+	return hex.EncodeToString(b[start:end])
+}

--- a/plugin/metadata/setup.go
+++ b/plugin/metadata/setup.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"fmt"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 
@@ -38,24 +39,70 @@ func setup(c *caddy.Controller) error {
 }
 
 func metadataParse(c *caddy.Controller) (*Metadata, error) {
-	m := &Metadata{}
-	c.Next()
-	zones := c.RemainingArgs()
+	m := newMetadata()
+	for c.Next() {
+		zones := c.RemainingArgs()
 
-	if len(zones) != 0 {
-		m.Zones = zones
-		for i := 0; i < len(m.Zones); i++ {
-			m.Zones[i] = plugin.Host(m.Zones[i]).Normalize()
+		if len(zones) != 0 {
+			m.Zones = zones
+			for i := 0; i < len(m.Zones); i++ {
+				m.Zones[i] = plugin.Host(m.Zones[i]).Normalize()
+			}
+		} else {
+			m.Zones = make([]string, len(c.ServerBlockKeys))
+			for i := 0; i < len(c.ServerBlockKeys); i++ {
+				m.Zones[i] = plugin.Host(c.ServerBlockKeys[i]).Normalize()
+			}
 		}
-	} else {
-		m.Zones = make([]string, len(c.ServerBlockKeys))
-		for i := 0; i < len(c.ServerBlockKeys); i++ {
-			m.Zones[i] = plugin.Host(c.ServerBlockKeys[i]).Normalize()
+
+		for c.NextBlock() {
+			err := m.parseEDNS0(c)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if c.Next() {
+			return nil, plugin.Error("metadata", c.ArgErr())
 		}
 	}
 
-	if c.NextBlock() || c.Next() {
-		return nil, plugin.Error("metadata", c.ArgErr())
-	}
 	return m, nil
+}
+
+func (m *Metadata) parseEDNS0(c *caddy.Controller) error {
+	name := c.Val()
+	args := c.RemainingArgs()
+	// <label> <definition>
+	// <label> edns0 <id>
+	// <label> ends0 <id> <encoded-format> <params of format ...>
+	// Valid encoded-format are hex (default), bytes, ip.
+
+	argsLen := len(args)
+	if argsLen != 2 && argsLen != 3 && argsLen != 6 {
+		return fmt.Errorf("invalid edns0 directive")
+	}
+	code := args[1]
+
+	dataType := "hex"
+	size := "0"
+	start := "0"
+	end := "0"
+
+	if argsLen > 2 {
+		dataType = args[2]
+	}
+
+	if argsLen == 6 && dataType == "hex" {
+		size = args[3]
+		start = args[4]
+		end = args[5]
+	}
+
+	err := m.addEDNS0Map(code, name, dataType, size, start, end)
+	if err != nil {
+		return fmt.Errorf("could not add EDNS0 map for %s: %s", name, err)
+	}
+
+	return nil
 }

--- a/test/metadata_test.go
+++ b/test/metadata_test.go
@@ -1,0 +1,55 @@
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestMetadata(t *testing.T) {
+	t.Parallel()
+	corefile := `.:0 {
+       metadata
+  	   rewrite edns0 local set 0xffee {metadata/qname}
+       erratic . {
+	drop 0
+	}
+}`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+
+	defer i.Stop()
+
+	testMeta(t, udp)
+
+}
+
+func testMeta(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	o := r.IsEdns0()
+	if o == nil || len(o.Option) == 0 {
+		t.Error("Expected EDNS0 options but got none")
+	} else {
+		if e, ok := o.Option[0].(*dns.EDNS0_LOCAL); ok {
+			if e.Code != 0xffee {
+				t.Errorf("Expected EDNS_LOCAL code 0xffee but got %x", e.Code)
+			}
+			if !bytes.Equal(e.Data, []byte("example.com.")) {
+				t.Errorf("Expected EDNS_LOCAL data 'example.com.' but got %q", e.Data)
+			}
+		} else {
+			t.Errorf("Expected EDNS0_LOCAL but got %v", o.Option[0])
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Extend Metadata functionality to include the basic 'standard' request values from the Metadata plugin.
The standard values extended currently are the edns0 values from the `rewrite` plugin.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
Document changes are made in the metadata Readme file.
