### PR TITLE
Do not muck with ordering of XFRs in loadbalancer plugin

### DIFF
--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -14,6 +14,10 @@ func (r *RoundRobinResponseWriter) WriteMsg(res *dns.Msg) error {
 		return r.ResponseWriter.WriteMsg(res)
 	}
 
+	if res.Question[0].Qtype == dns.TypeAXFR || res.Question[0].Qtype == dns.TypeIXFR {
+		return r.ResponseWriter.WriteMsg(res)
+	}
+
 	res.Answer = roundRobin(res.Answer)
 	res.Ns = roundRobin(res.Ns)
 	res.Extra = roundRobin(res.Extra)


### PR DESCRIPTION
The loadbalancer plugin reorders records. It was doing this for zone
transfers - if you had a CNAME in the zone then your transfer would
be broken because it would get put before the SOA record.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fixes transfers when using load balancer plugin with CNAMEs.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.
