### PR TITLE
plugin/route53: Add the missed braces for the upstream example in README.md.

### DIFF
--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -49,8 +49,9 @@ Enable route53 with implicit AWS credentials and an upstream:
 
 ~~~ txt
 . {
-    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
-    upstream 10.0.0.1
+	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
+	  upstream 10.0.0.1
+	}
 }
 ~~~
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add the missed braces for the route53 example with upstream.
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
