### PR TITLE
Scrub: Do more to avoid fragmentation

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -240,6 +240,23 @@ func (r *Request) Scrub(reply *dns.Msg) *dns.Msg {
 	reply.Compress = false
 	rl := reply.Len()
 	if size >= rl {
+		if r.Proto() != "udp" {
+			return reply
+		}
+
+		// Last ditch attempt to avoid fragmentation, if the size is bigger than the v4/v6 UDP fragmentation
+		// limit and sent via UDP compress it (in the hope we go under that limit). Limits taken from NSD:
+		//
+		//    .., 1480 (EDNS/IPv4), 1220 (EDNS/IPv6), or the advertized EDNS buffer size if that is
+		//    smaller than the EDNS default.
+		// See: https://open.nlnetlabs.nl/pipermail/nsd-users/2011-November/001278.html
+		if rl > 1480 && r.Family() == 1 {
+			reply.Compress = true
+		}
+		if rl > 1220 && r.Family() == 2 {
+			reply.Compress = true
+		}
+
 		return reply
 	}
 


### PR DESCRIPTION
Add a check to avoid fragmentation by checking the transport and
protocol and if udp enable compression if the packet is larger than that
limit.



<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?