### PR TITLE
plugin/kubernetes: Allow 0 TTL

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -92,7 +92,7 @@ kubernetes [ZONES...] {
   will resolve External Services against itself. **ADDRESS** can be an IP, an IP:port, or a path
   to a file structured like resolv.conf.
 * `ttl` allows you to set a custom TTL for responses. The default (and minimum allowed) is
-  5 seconds, while the maximum is capped at 3600 seconds.
+  0 seconds, while the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.
   All endpoint queries and headless service queries will result in an NXDOMAIN.
 * `transfer` enables zone transfers. It may be specified multiples times. `To` signals the direction

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -247,8 +247,8 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			if err != nil {
 				return nil, err
 			}
-			if t < 5 || t > 3600 {
-				return nil, c.Errf("ttl must be in range [5, 3600]: %d", t)
+			if t < 0 || t > 3600 {
+				return nil, c.Errf("ttl must be in range [0, 3600]: %d", t)
 			}
 			k8s.ttl = uint32(t)
 		case "transfer":


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Throwing this out there as a possible solution for disabling cache for just kubernetes plugin created records.  Allowing 0 TTL should prevent kubernetes records from going into the cache.

The idea is that this could be used by folks who don't want any k8s records to persist in cache after they become invalid.  Operating with no cache for k8s plugin is not a big performance hit, since k8s objects are already  "cached" in a sense in the object store.

If a 0 TTL is problematic - we could instead extend _cache_ plugin with an option to exclude a list of domains.

Splitting the config up into two server stanzas, one without cache, is problematic for the reasons outlined in #2327 .

### 2. Which issues (if any) are related?
kubernetes/kubernetes#71308
#2327 


### 3. Which documentation changes (if any) need to be made?