### PR TITLE
plugin/kubernetes: Expose Load Balancer/External IPs as records

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -442,7 +442,7 @@ func newAddress(s msg.Service, name string, ip net.IP, what uint16) dns.RR {
 	return &dns.AAAA{Hdr: hdr, AAAA: ip}
 }
 
-// checkForApex checks the spcecial apex.dns directory for records that will be returned as A or AAAA.
+// checkForApex checks the special apex.dns directory for records that will be returned as A or AAAA.
 func checkForApex(b ServiceBackend, zone string, state request.Request, opt Options) ([]msg.Service, error) {
 	if state.Name() != zone {
 		return b.Services(state, false, opt)

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -374,6 +374,7 @@ func NS(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 	// ... and reset
 	state.Req.Question[0].Name = old
 
+	hostSeen := make(map[string]bool)
 	for _, serv := range services {
 		what, ip := serv.HostType()
 		switch what {
@@ -382,7 +383,10 @@ func NS(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 
 		case dns.TypeA, dns.TypeAAAA:
 			serv.Host = msg.Domain(serv.Key)
-			records = append(records, serv.NewNS(state.QName()))
+			if !hostSeen[serv.Host] {
+				records = append(records, serv.NewNS(state.QName()))
+				hostSeen[serv.Host] = true
+			}
 			extra = append(extra, newAddress(serv, serv.Host, ip, what))
 		}
 	}

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -45,6 +45,7 @@ kubernetes [ZONES...] {
     transfer to ADDRESS...
     fallthrough [ZONES...]
     ignore empty_service
+    external ZONES...
 }
 ```
 
@@ -109,6 +110,10 @@ kubernetes [ZONES...] {
 * `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
+* `external` will synthesize records in the listed **[ZONES...]** for all Kubernetes services with Load Balancer IPs.
+  All **[ZONES...]** must exist in the plugin's zones or server block.  If all non-reverse zones in the
+  plugin's zones or server block are listed, then no internal service records will be synthesized. Records are in the
+  form of `service-name.namespace.zone.`
 
 ## Health
 
@@ -149,6 +154,27 @@ Connect to Kubernetes with CoreDNS running outside the cluster:
 kubernetes cluster.local {
     endpoint https://k8s-endpoint:8443
     tls cert key cacert
+}
+~~~
+
+## Exposing Load Balancer IPs
+
+Expose internal service cluster ips in the `cluster.local` zone, and external load
+balancer ips in the `my.zone.com. zone.
+
+~~~ txt
+kubernetes cluster.local my.zone.com {
+    external my.zone.com
+}
+~~~
+
+Connect to Kubernetes with CoreDNS running outside the cluster, and only expose external IPs in the zone `my.zone.com`:
+
+~~~ txt
+kubernetes my.zone.com {
+    endpoint https://k8s-endpoint:8443
+    tls cert key cacert
+    external my.zone.com
 }
 ~~~
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -110,8 +110,8 @@ kubernetes [ZONES...] {
 * `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
-* `external` will synthesize records in the listed **[ZONES...]** for all Kubernetes services with Load Balancer IPs.
-  All **[ZONES...]** must exist in the plugin's zones or server block.  If all non-reverse zones in the
+* `external` **ZONES...** will synthesize records in the listed **ZONES...** for all Kubernetes services with Load Balancer IPs.
+  All **ZONES...** listed here must also exist in the plugin's zones or server block.  If all non-reverse zones in the
   plugin's zones or server block are listed, then no internal service records will be synthesized. Records are in the
   form of `service-name.namespace.zone.`
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -159,8 +159,8 @@ kubernetes cluster.local {
 
 ## Exposing Load Balancer IPs
 
-Expose internal service cluster ips in the `cluster.local` zone, and external load
-balancer ips in the `my.zone.com. zone.
+Expose internal service cluster IPs in the `cluster.local` zone, and external load
+balancer IPs in the `my.zone.com. zone.
 
 ~~~ txt
 kubernetes cluster.local my.zone.com {

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -110,7 +110,7 @@ kubernetes [ZONES...] {
 * `ignore empty_service` return NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
-* `external` **ZONES...** will synthesize records in the listed **ZONES...** for all Kubernetes services with Load Balancer IPs.
+* `external` **ZONES...** will synthesize records in the listed **ZONES...** for all Kubernetes services with Load Balancer IPs and External IPs.
   All **ZONES...** listed here must also exist in the plugin's zones or server block.  If all non-reverse zones in the
   plugin's zones or server block are listed, then no internal service records will be synthesized. Records are in the
   form of `service-name.namespace.zone.`
@@ -157,10 +157,9 @@ kubernetes cluster.local {
 }
 ~~~
 
-## Exposing Load Balancer IPs
+## Exposing Load Balancer and External IPs
 
-Expose internal service cluster IPs in the `cluster.local` zone, and external load
-balancer IPs in the `my.zone.com. zone.
+Expose internal service cluster IPs in the `cluster.local` zone, and external IPs in the `my.zone.com. zone.
 
 ~~~ txt
 kubernetes cluster.local my.zone.com {

--- a/plugin/kubernetes/federation.go
+++ b/plugin/kubernetes/federation.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"errors"
 
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	"github.com/coredns/coredns/request"
@@ -31,7 +32,8 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 	if err != nil {
 		return msg.Service{}, err
 	}
-	r, err := parseRequest(state)
+
+	r, err := parseRequest(state, "" != plugin.Zones(k.externalZones).Matches(state.Name()))
 	if err != nil {
 		return msg.Service{}, err
 	}

--- a/plugin/kubernetes/handler_external_test.go
+++ b/plugin/kubernetes/handler_external_test.go
@@ -1,0 +1,256 @@
+package kubernetes
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
+	"github.com/coredns/coredns/plugin/pkg/watch"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+	api "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var dnsTestCasesExternal = []test.Case{
+	// A Service
+	{
+		Qname: "svc1.testns.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "svc1.testns.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
+		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+	},
+	// A Service (wildcard)
+	{
+		Qname: "svc1.*.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc1.*.example.com.  5       IN      A       1.2.3.4"),
+		},
+	},
+	// SRV Service (wildcard)
+	{
+		Qname: "svc1.*.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("svc1.*.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
+		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+	},
+	// SRV Service (>1 wildcards)
+	{
+		Qname: "*.any.svc1.*.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{test.SRV("*.any.svc1.*.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com.")},
+		Extra: []dns.RR{test.A("svc1.testns.example.com.  5       IN      A       1.2.3.4")},
+	},
+	// A Service (>1 wildcards)
+	{
+		Qname: "*.any.svc1.*.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("*.any.svc1.*.example.com.  5       IN      A       1.2.3.4"),
+		},
+	},
+	// SRV Service Not udp/tcp
+	{
+		Qname: "*._not-udp-or-tcp.svc1.testns.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("example.com.	30	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// SRV Service
+	{
+		Qname: "_http._tcp.svc1.testns.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc1.testns.example.com.	5	IN	SRV	0 100 80 svc1.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.A("svc1.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	// AAAA Service (with an existing A record, but no AAAA record)
+	{
+		Qname: "svc1.testns.example.com.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("example.com.	30	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// AAAA Service (non-existing service)
+	{
+		Qname: "svc0.testns.example.com.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("example.com.	30	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// A Service (non-existing service)
+	{
+		Qname: "svc0.testns.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("example.com.	30	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// A Service (non-existing namespace)
+	{
+		Qname: "svc0.svc-nons.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("example.com.	30	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+	// AAAA Service
+	{
+		Qname: "svc6.testns.example.com.", Qtype: dns.TypeAAAA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
+		},
+	},
+	// SRV
+	{
+		Qname: "_http._tcp.svc6.testns.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("_http._tcp.svc6.testns.example.com.	5	IN	SRV	0 100 80 svc6.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
+		},
+	},
+	// SRV
+	{
+		Qname: "svc6.testns.example.com.", Qtype: dns.TypeSRV,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.SRV("svc6.testns.example.com.	5	IN	SRV	0 100 80 svc6.testns.example.com."),
+		},
+		Extra: []dns.RR{
+			test.AAAA("svc6.testns.example.com.	5	IN	AAAA	1:2::5"),
+		},
+	},
+	{
+		Qname: "testns.example.com.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("example.com.	303	IN	SOA	ns.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 60"),
+		},
+	},
+}
+
+func TestServeDNSExternal(t *testing.T) {
+	k := New([]string{"example.com."})
+	k.APIConn = &APIConnServeTestExternal{}
+	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.Namespaces = map[string]bool{"testns": true}
+	k.externalZones = []string{"example.com."}
+	k.opts.expose = exposeExternal
+
+	ctx := context.TODO()
+
+	for i, tc := range dnsTestCasesExternal {
+		r := tc.Msg()
+
+		w := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := k.ServeDNS(ctx, w, r)
+		if err != tc.Error {
+			t.Errorf("Test %d expected no error, got %v", i, err)
+			return
+		}
+		if tc.Error != nil {
+			continue
+		}
+
+		resp := w.Msg
+		if resp == nil {
+			t.Fatalf("Test %d, got nil message and no error for %q", i, r.Question[0].Name)
+		}
+
+		// Before sorting, make sure that CNAMES do not appear after their target records
+		test.CNAMEOrder(t, resp)
+
+		test.SortAndCheck(t, resp, tc)
+	}
+}
+
+type APIConnServeTestExternal struct{}
+
+func (APIConnServeTestExternal) HasSynced() bool                              { return true }
+func (APIConnServeTestExternal) Run()                                         { return }
+func (APIConnServeTestExternal) Stop() error                                  { return nil }
+func (APIConnServeTestExternal) EpIndexReverse(string) []*object.Endpoints    { return nil }
+func (APIConnServeTestExternal) SvcIndexReverse(string) []*object.Service     { return nil }
+func (APIConnServeTestExternal) Modified() int64                              { return time.Now().Unix() }
+func (APIConnServeTestExternal) SetWatchChan(watch.Chan)                      {}
+func (APIConnServeTestExternal) Watch(string) error                           { return nil }
+func (APIConnServeTestExternal) StopWatching(string)                          {}
+func (APIConnServeTestExternal) EpIndex(s string) []*object.Endpoints         { return nil }
+func (APIConnServeTestExternal) EndpointsList() []*object.Endpoints           { return nil }
+func (APIConnServeTestExternal) GetNodeByName(name string) (*api.Node, error) { return nil, nil }
+func (APIConnServeTestExternal) SvcIndex(s string) []*object.Service          { return svcIndexExternal[s] }
+
+func (APIConnServeTestExternal) GetNamespaceByName(name string) (*api.Namespace, error) {
+	if name == "pod-nons" { // handler_pod_verified_test.go uses this for non-existent namespace.
+		return &api.Namespace{}, nil
+	}
+	return &api.Namespace{
+		ObjectMeta: meta.ObjectMeta{
+			Name: name,
+		},
+	}, nil
+}
+
+func (APIConnServeTestExternal) PodIndex(string) []*object.Pod {
+	a := []*object.Pod{
+		{Namespace: "podns", PodIP: "10.240.0.1"}, // Remote IP set in test.ResponseWriter
+	}
+	return a
+}
+
+var svcIndexExternal = map[string][]*object.Service{
+	"svc1.testns": {
+		{
+			Name:        "svc1",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeClusterIP,
+			ClusterIP:   "10.0.0.1",
+			ExternalIPs: []string{"1.2.3.4"},
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"svc6.testns": {
+		{
+			Name:        "svc6",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeClusterIP,
+			ClusterIP:   "10.0.0.3",
+			ExternalIPs: []string{"1:2::5"},
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+}
+
+func (APIConnServeTestExternal) ServiceList() []*object.Service {
+	var svcs []*object.Service
+	for _, svc := range svcIndexExternal {
+		svcs = append(svcs, svc...)
+	}
+	return svcs
+}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -52,7 +52,6 @@ type Kubernetes struct {
 	autoPathSearch     []string // Local search path from /etc/resolv.conf. Needed for autopath.
 	TransferTo         []string
 	externalZones      []string
-	exposeExternalIPs  bool
 }
 
 // New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -563,17 +563,16 @@ func (k *Kubernetes) findServices(r recordRequest, zone string, external bool) (
 
 			err = nil
 
-			if !external {
+			if external {
+				for _, ip := range svc.ExternalIPs {
+					s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
+					s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
+					services = append(services, s)
+				}
+			} else {
 				s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.ttl}
 				s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
 				services = append(services, s)
-				return services, err
-			}
-			for _, ip := range svc.ExternalIPs {
-				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
-				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
-				services = append(services, s)
-				return services, err
 			}
 		}
 	}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -564,7 +564,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 	return services, err
 }
 
-// findServices returns the services matching r from the cache.
+// findServicesExternal returns the services with external IPs matching r from the cache.
 func (k *Kubernetes) findServicesExternal(r recordRequest, zone string) (services []msg.Service, err error) {
 	zonePath := msg.Path(zone, "coredns")
 
@@ -593,12 +593,12 @@ func (k *Kubernetes) findServicesExternal(r recordRequest, zone string) (service
 			continue
 		}
 
-		for _, p := range svc.Ports {
+		for _, ip := range svc.ExternalIPs {
+			for _, p := range svc.Ports {
 			if !(match(r.port, p.Name) && match(r.protocol, string(p.Protocol))) {
 				continue
 			}
 			err = nil
-			for _, ip := range svc.ExternalIPs {
 				s := msg.Service{Host: ip, Port: int(p.Port), TTL: k.ttl}
 				s.Key = strings.Join([]string{zonePath, svc.Namespace, svc.Name}, "/")
 				services = append(services, s)

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -127,7 +127,8 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		nss := k.nsAddr(external)
 		var svcs []msg.Service
 		for _, ns := range nss {
-			if ns.A.String() == "0.0.0.0" {
+			if ns.A == nil {
+				// the IP is not known, don't create an A record
 				continue
 			}
 			svcs = append(svcs, msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), "coredns")})

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -58,11 +58,13 @@ FindEndpoint:
 	}
 
 	var nsARecs []*dns.A
+	name := strings.Join([]string{svcName, "." , svcNamespace , "."}, "")
+
 	for _, svc := range k.APIConn.SvcIndex(object.ServiceKey(svcName, svcNamespace)) {
 		for _, ip := range svc.ExternalIPs {
 			rr := new(dns.A)
 			rr.A = net.ParseIP(ip)
-			rr.Hdr.Name = svcName + "." + svcNamespace + "."
+			rr.Hdr.Name = name
 			nsARecs = append(nsARecs, rr)
 		}
 		break
@@ -70,13 +72,11 @@ FindEndpoint:
 
 	if len(nsARecs) == 0 {
 		rr := new(dns.A)
-		rr.A = net.ParseIP("0.0.0.0")
-		rr.Hdr.Name = svcName + "." + svcNamespace + "."
+		rr.A = nil
+		rr.Hdr.Name = name
 		return []*dns.A{rr}
 	}
-
 	return nsARecs
-
 }
 
 const defaultNSName = "ns.dns."

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -15,7 +15,7 @@ func (APIConnTest) HasSynced() bool                          { return true }
 func (APIConnTest) Run()                                     { return }
 func (APIConnTest) Stop() error                              { return nil }
 func (APIConnTest) PodIndex(string) []*object.Pod            { return nil }
-func (APIConnTest) SvcIndex(string) []*object.Service        { return nil }
+func (APIConnTest) ServiceList() []*object.Service        { return nil }
 func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
 func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
@@ -24,7 +24,7 @@ func (APIConnTest) SetWatchChan(watch.Chan)                  {}
 func (APIConnTest) Watch(string) error                       { return nil }
 func (APIConnTest) StopWatching(string)                      {}
 
-func (APIConnTest) ServiceList() []*object.Service {
+func (APIConnTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{
 		{
 			Name:      "dns-service",
@@ -64,14 +64,14 @@ func TestNsAddr(t *testing.T) {
 	k := New([]string{"inter.webs.test."})
 	k.APIConn = &APIConnTest{}
 
-	cdr := k.nsAddr()
+	cdr := k.nsAddr(false)
 	expected := "10.0.0.111"
 
-	if cdr.A.String() != expected {
-		t.Errorf("Expected A to be %q, got %q", expected, cdr.A.String())
+	if cdr[0].A.String() != expected {
+		t.Errorf("Expected A to be %q, got %q", expected, cdr[0].A.String())
 	}
 	expected = "dns-service.kube-system.svc."
-	if cdr.Hdr.Name != expected {
-		t.Errorf("Expected Hdr.Name to be %q, got %q", expected, cdr.Hdr.Name)
+	if cdr[0].Hdr.Name != expected {
+		t.Errorf("Expected Hdr.Name to be %q, got %q", expected, cdr[0].Hdr.Name)
 	}
 }

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -30,6 +30,7 @@ func (APIConnTest) SvcIndex(string) []*object.Service {
 			Name:      "dns-service",
 			Namespace: "kube-system",
 			ClusterIP: "10.0.0.111",
+			ExternalIPs: []string{"1.2.3.4"},
 		},
 	}
 	return svcs
@@ -71,6 +72,23 @@ func TestNsAddr(t *testing.T) {
 		t.Errorf("Expected A to be %q, got %q", expected, cdr[0].A.String())
 	}
 	expected = "dns-service.kube-system.svc."
+	if cdr[0].Hdr.Name != expected {
+		t.Errorf("Expected Hdr.Name to be %q, got %q", expected, cdr[0].Hdr.Name)
+	}
+}
+
+func TestNsAddrExternal(t *testing.T) {
+
+	k := New([]string{"inter.webs.test."})
+	k.APIConn = &APIConnTest{}
+
+	cdr := k.nsAddr(true)
+	expected := "1.2.3.4"
+
+	if cdr[0].A.String() != expected {
+		t.Errorf("Expected A to be %q, got %q", expected, cdr[0].A.String())
+	}
+	expected = "dns-service.kube-system."
 	if cdr[0].Hdr.Name != expected {
 		t.Errorf("Expected Hdr.Name to be %q, got %q", expected, cdr[0].Hdr.Name)
 	}

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -36,7 +36,7 @@ func ToService(obj interface{}) interface{} {
 		Namespace:    svc.GetNamespace(),
 		Index:        ServiceKey(svc.GetName(), svc.GetNamespace()),
 		ClusterIP:    svc.Spec.ClusterIP,
-		ExternalIPs:  make([]string, len(svc.Status.LoadBalancer.Ingress)),
+		ExternalIPs:  make([]string, len(svc.Status.LoadBalancer.Ingress)+len(svc.Spec.ExternalIPs)),
 		Type:         svc.Spec.Type,
 		ExternalName: svc.Spec.ExternalName,
 	}
@@ -51,6 +51,12 @@ func ToService(obj interface{}) interface{} {
 
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
 		s.ExternalIPs[i] = lb.IP
+	}
+
+	ipCount := len(svc.Status.LoadBalancer.Ingress)
+
+	for i, ip := range svc.Spec.ExternalIPs {
+		s.ExternalIPs[i+ipCount] = ip
 	}
 
 	*svc = api.Service{}

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -12,6 +12,7 @@ type Service struct {
 	Namespace    string
 	Index        string
 	ClusterIP    string
+	ExternalIPs  []string
 	Type         api.ServiceType
 	ExternalName string
 	Ports        []api.ServicePort
@@ -35,6 +36,7 @@ func ToService(obj interface{}) interface{} {
 		Namespace:    svc.GetNamespace(),
 		Index:        ServiceKey(svc.GetName(), svc.GetNamespace()),
 		ClusterIP:    svc.Spec.ClusterIP,
+		ExternalIPs:  make([]string, len(svc.Status.LoadBalancer.Ingress)),
 		Type:         svc.Spec.Type,
 		ExternalName: svc.Spec.ExternalName,
 	}
@@ -45,6 +47,10 @@ func ToService(obj interface{}) interface{} {
 	} else {
 		s.Ports = make([]api.ServicePort, len(svc.Spec.Ports))
 		copy(s.Ports, svc.Spec.Ports)
+	}
+
+	for i, lb := range svc.Status.LoadBalancer.Ingress {
+		s.ExternalIPs[i] = lb.IP
 	}
 
 	*svc = api.Service{}
@@ -62,11 +68,13 @@ func (s *Service) DeepCopyObject() runtime.Object {
 		Namespace:    s.Namespace,
 		Index:        s.Index,
 		ClusterIP:    s.ClusterIP,
+		ExternalIPs:  make([]string, len(s.ExternalIPs)),
 		Type:         s.Type,
 		ExternalName: s.ExternalName,
 		Ports:        make([]api.ServicePort, len(s.Ports)),
 	}
 	copy(s1.Ports, s.Ports)
+	copy(s1.ExternalIPs, s.ExternalIPs)
 	return s1
 }
 

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -26,7 +26,7 @@ type recordRequest struct {
 // parseRequest parses the qname to find all the elements we need for querying k8s. Anything
 // that is not parsed will have the wildcard "*" value (except r.endpoint).
 // Potential underscores are stripped from _port and _protocol.
-func parseRequest(state request.Request) (r recordRequest, err error) {
+func parseRequest(state request.Request, external bool) (r recordRequest, err error) {
 	// for internal cluster records 3 Possible cases:
 	// 1. _port._protocol.service.namespace.pod|svc.zone
 	// 2. (endpoint): endpoint.service.namespace.pod|svc.zone
@@ -58,13 +58,16 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 	if last < 0 {
 		return r, nil
 	}
-	r.podOrSvc = segs[last]
-	if r.podOrSvc != Pod && r.podOrSvc != Svc {
-		return r, errInvalidRequest
-	}
-	last--
-	if last < 0 {
-		return r, nil
+
+	if !external {
+		r.podOrSvc = segs[last]
+		if r.podOrSvc != Pod && r.podOrSvc != Svc {
+			return r, errInvalidRequest
+		}
+		last--
+		if last < 0 {
+			return r, nil
+		}
 	}
 
 	r.namespace = segs[last]
@@ -79,7 +82,13 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 		return r, nil
 	}
 
-	// Because of ambiquity we check the labels left: 1: an endpoint. 2: port and protocol.
+	if external {
+		r.protocol = stripUnderscore(segs[last])
+		r.port = stripUnderscore(segs[last-1])
+		return r, nil
+	}
+
+	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol.
 	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
 	switch last {
 
@@ -92,55 +101,6 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 	default: // too long
 		return r, errInvalidRequest
 	}
-
-	return r, nil
-}
-
-// parseRequestExternal parses the qname to find all the elements we need for querying k8s services from an external context.
-func parseRequestExternal(state request.Request) (r recordRequest, err error) {
-	// 2 Possible cases:
-	//   * _port._protocol.service.namespace.zone
-	//   * (service): service.namespace.zone
-	//
-
-	base, _ := dnsutil.TrimZone(state.Name(), state.Zone)
-
-	// return NODATA for apex queries
-	if base == "" {
-		return r, nil
-	}
-	segs := dns.SplitDomainName(base)
-
-	// port and protocol default to wildcard behavior
-	r.port = "*"
-	r.protocol = "*"
-
-	// start at the right and fill out recordRequest with the bits we find, so we look for
-	// namespace.service and then _protocol._port
-
-	last := len(segs) - 1
-	if last < 0 {
-		return r, nil
-	}
-
-	r.namespace = segs[last]
-	last--
-	if last < 0 {
-		return r, nil
-	}
-
-	r.service = segs[last]
-	last--
-	if last < 0 {
-		return r, nil
-	}
-
-	if last != 1 {
-		return r, errInvalidRequest
-	}
-
-	r.protocol = stripUnderscore(segs[last])
-	r.port = stripUnderscore(segs[last-1])
 
 	return r, nil
 }

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -59,6 +59,8 @@ func parseRequest(state request.Request, external bool) (r recordRequest, err er
 		return r, nil
 	}
 
+	// The local cluster naming scheme requires an object type (svc|pod).
+	// The external naming scheme does not contain this segment.
 	if !external {
 		r.podOrSvc = segs[last]
 		if r.podOrSvc != Pod && r.podOrSvc != Svc {
@@ -82,12 +84,15 @@ func parseRequest(state request.Request, external bool) (r recordRequest, err er
 		return r, nil
 	}
 
+	// The external naming scheme does not contain an endpoint name segment,
+	// so grab SRV port/protocol
 	if external {
 		r.protocol = stripUnderscore(segs[last])
 		r.port = stripUnderscore(segs[last-1])
 		return r, nil
 	}
 
+	// The local cluster naming scheme may contain an endpoint name segment.
 	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol.
 	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
 	switch last {

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -87,6 +87,9 @@ func parseRequest(state request.Request, external bool) (r recordRequest, err er
 	// The external naming scheme does not contain an endpoint name segment,
 	// so grab SRV port/protocol
 	if external {
+		if last != 1 {
+			return r, errInvalidRequest
+		}
 		r.protocol = stripUnderscore(segs[last])
 		r.port = stripUnderscore(segs[last-1])
 		return r, nil
@@ -96,7 +99,6 @@ func parseRequest(state request.Request, external bool) (r recordRequest, err er
 	// Because of ambiguity we check the labels left: 1: an endpoint. 2: port and protocol.
 	// Anything else is a query that is too long to answer and can safely be delegated to return an nxdomain.
 	switch last {
-
 	case 0: // endpoint only
 		r.endpoint = segs[last]
 	case 1: // service and port

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -31,7 +31,7 @@ func TestParseRequest(t *testing.T) {
 		m.SetQuestion(tc.query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		r, e := parseRequest(state)
+		r, e := parseRequest(state, false)
 		if e != nil {
 			t.Errorf("Test %d, expected no error, got '%v'.", i, e)
 		}
@@ -53,7 +53,7 @@ func TestParseInvalidRequest(t *testing.T) {
 		m.SetQuestion(query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		if _, e := parseRequest(state); e == nil {
+		if _, e := parseRequest(state, false); e == nil {
 			t.Errorf("Test %d: expected error from %s, got none", i, query)
 		}
 	}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -294,7 +294,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 	// determine if all zones are external
 	fwdZoneCount := 0
 	for _, z := range k8s.Zones {
-		if dnsutil.IsReverse(z) > 0 {
+		if dnsutil.IsReverse(z) > 0 || dnsutil.IsReverseDomain(z) > 0{
 			continue
 		}
 		fwdZoneCount++
@@ -311,7 +311,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 	// determine primary zone index
 	k8s.primaryZoneIndex = -1
 	for i, z := range k8s.Zones {
-		if dnsutil.IsReverse(z) > 0 {
+		if dnsutil.IsReverse(z) > 0 || dnsutil.IsReverseDomain(z) > 0{
 			continue
 		}
 		if "" != plugin.Zones(k8s.externalZones).Matches(z) {

--- a/plugin/kubernetes/setup_external_test.go
+++ b/plugin/kubernetes/setup_external_test.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestKubernetesParseExternal(t *testing.T) {
+	tests := []struct {
+		input            string   // Corefile data as string
+		expectedExternal []string // expected count of defined zones.
+		shouldErr        bool
+	}{
+		{`kubernetes example.com cluster.local {
+			external example.com
+		}`, []string{"example.com."}, false},
+		{`kubernetes example.com another.domain.com cluster.local {
+			external example.com another.domain.com
+		}`, []string{"example.com.", "another.domain.com."}, false},
+		{`kubernetes example.com cluster.local {
+			external
+		}`, []string{}, true},
+	}
+
+	for i, tc := range tests {
+		c := caddy.NewTestController("dns", tc.input)
+		k, err := kubernetesParse(c)
+		if err != nil && !tc.shouldErr {
+			t.Fatalf("Test %d: Expected no error, got %q", i, err)
+		}
+		if err == nil && tc.shouldErr {
+			t.Fatalf("Test %d: Expected error, got none", i)
+		}
+		if err != nil && tc.shouldErr {
+			// input should error
+			continue
+		}
+		if len(k.externalZones) != len(tc.expectedExternal) {
+			t.Errorf("Test %d: Expected external zones to be %v, got %v", i, tc.expectedExternal, k.externalZones)
+		}
+		for i := range k.externalZones {
+			if k.externalZones[i] != tc.expectedExternal[i] {
+				t.Errorf("Test %d: Expected external zones to be %v, got %v", i, tc.expectedExternal, k.externalZones)
+			}
+		}
+	}
+}

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -120,7 +120,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 			if !externalZone {
 				clusterIP := net.ParseIP(svc.ClusterIP)
 				if clusterIP != nil {
-					ips = append(ips, svc.ClusterIP)
+					ips = []string{svc.ClusterIP}
 				}
 			} else {
 				ips = svc.ExternalIPs

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -99,7 +99,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 
 	defer close(c)
 
-	externalZone := k.externalZone(zone)
+	externalZone := "" != plugin.Zones(k.externalZones).Matches(zone)
 	zonePath := msg.Path(zone, "coredns")
 	serviceList := k.APIConn.ServiceList()
 

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -13,8 +13,25 @@ import (
 )
 
 func TestKubernetesXFR(t *testing.T) {
-	k := New([]string{"cluster.local."})
-	k.APIConn = &APIConnServeTest{}
+	testk8sXFR(t,
+		[]string{"cluster.local."},
+		[]string{},
+		&APIConnServeTest{},
+		dnsTestCases)
+}
+
+func TestKubernetesXFRExternal(t *testing.T) {
+	testk8sXFR(t,
+		[]string{"example.com.", "cluster.local."},
+		[]string{"example.com."},
+		&APIConnServeTestExternal{},
+		dnsTestCasesExternal)
+}
+
+func testk8sXFR(t *testing.T, zones, externalZones []string, apiConn dnsController, testCases []test.Case) {
+	k := New(zones)
+	k.externalZones = externalZones
+	k.APIConn = apiConn
 	k.TransferTo = []string{"10.240.0.1:53"}
 	k.Namespaces = map[string]bool{"testns": true}
 
@@ -50,7 +67,7 @@ func TestKubernetesXFR(t *testing.T) {
 	}
 
 	testRRs := []dns.RR{}
-	for _, tc := range dnsTestCases {
+	for _, tc := range testCases {
 		if tc.Rcode != dns.RcodeSuccess {
 			continue
 		}

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -33,18 +33,13 @@ func ExtractAddressFromReverse(reverseName string) string {
 // name is in a reverse zone. The returned integer will be 1 for in-addr.arpa. (IPv4)
 // and 2 for ip6.arpa. (IPv6).
 func IsReverse(name string) int {
-	if strings.HasSuffix(name, IP4arpa) {
+	if strings.HasSuffix(name, IP4arpa) || name == IP4arpaDom {
 		return 1
 	}
-	if strings.HasSuffix(name, IP6arpa) {
+	if strings.HasSuffix(name, IP6arpa) || name == IP6arpaDom {
 		return 2
 	}
-	if "."+name == IP4arpa {
-		return 1
-	}
-	if "."+name == IP6arpa {
-		return 2
-	}
+
 	return 0
 }
 
@@ -84,4 +79,8 @@ const (
 	IP4arpa = ".in-addr.arpa."
 	// IP6arpa is the reverse tree suffix for v6 IP addresses.
 	IP6arpa = ".ip6.arpa."
+	// IP4arpa is the reverse tree suffix for v4 IP addresses.
+	IP4arpaDom = "in-addr.arpa."
+	// IP6arpa is the reverse tree suffix for v6 IP addresses.
+	IP6arpaDom = "ip6.arpa."
 )

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -39,6 +39,12 @@ func IsReverse(name string) int {
 	if strings.HasSuffix(name, IP6arpa) {
 		return 2
 	}
+	if "."+name == IP4arpa {
+		return 1
+	}
+	if "."+name == IP6arpa {
+		return 2
+	}
 	return 0
 }
 

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -29,14 +29,28 @@ func ExtractAddressFromReverse(reverseName string) string {
 	return f(strings.Split(search, "."))
 }
 
-// IsReverse returns 0 is name is not in a reverse zone. Anything > 0 indicates
+// IsReverse returns 0 if name is not in a reverse zone. Anything > 0 indicates
 // name is in a reverse zone. The returned integer will be 1 for in-addr.arpa. (IPv4)
 // and 2 for ip6.arpa. (IPv6).
 func IsReverse(name string) int {
-	if strings.HasSuffix(name, IP4arpa) || name == IP4arpaDom {
+	if strings.HasSuffix(name, IP4arpa) {
 		return 1
 	}
-	if strings.HasSuffix(name, IP6arpa) || name == IP6arpaDom {
+	if strings.HasSuffix(name, IP6arpa) {
+		return 2
+	}
+
+	return 0
+}
+
+// IsReverseDomain returns 0 if name is not equal to reverse domain. Anything > 0 indicates
+// name is a reverse domain. The returned integer will be 1 for in-addr.arpa. (IPv4)
+// and 2 for ip6.arpa. (IPv6).
+func IsReverseDomain(name string) int {
+	if name == IP4arpaDom {
+		return 1
+	}
+	if name == IP6arpaDom {
 		return 2
 	}
 

--- a/plugin/pkg/dnsutil/reverse.go
+++ b/plugin/pkg/dnsutil/reverse.go
@@ -79,8 +79,8 @@ const (
 	IP4arpa = ".in-addr.arpa."
 	// IP6arpa is the reverse tree suffix for v6 IP addresses.
 	IP6arpa = ".ip6.arpa."
-	// IP4arpa is the reverse tree suffix for v4 IP addresses.
+	// IP4arpaDom is the reverse tree domain for v4 IP addresses.
 	IP4arpaDom = "in-addr.arpa."
-	// IP6arpa is the reverse tree suffix for v6 IP addresses.
+	// IP6arpaDom is the reverse tree domain for v6 IP addresses.
 	IP6arpaDom = "ip6.arpa."
 )

--- a/plugin/pkg/dnsutil/reverse_test.go
+++ b/plugin/pkg/dnsutil/reverse_test.go
@@ -69,3 +69,23 @@ func TestIsReverse(t *testing.T) {
 
 	}
 }
+
+func TestIsReverseDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected int
+	}{
+		{"ip6.arpa.", 2},
+		{"in-addr.arpa.", 1},
+		{"example.com.", 0},
+		{"", 0},
+		{"in-addr.arpa.example.com.", 0},
+	}
+	for i, tc := range tests {
+		got := IsReverseDomain(tc.name)
+		if got != tc.expected {
+			t.Errorf("Test %d, got %d, expected %d for %s", i, got, tc.expected, tc.name)
+		}
+
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds option to expose Services with external Load Balancer IPs (and External IPs) in the form:

`service-name.namespace.zone`

where zone is a zone defined as an external zone in the options.  e.g.

```
kubernetes cluster.local myzone.com in-addr.arpa ip6.arpa {
    external myzone.com
}
```

### 2. Which issues (if any) are related?
#1851
kubernetes/dns#242
#2349

### 3. Which documentation changes (if any) need to be made?