### PR TITLE
Fix EDNS0 compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ godeps:
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
 	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.11.1)
-	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.1.0)
+	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.1.1)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.9.1)
 
 .PHONY: travis

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -425,7 +425,6 @@ func BackendError(b ServiceBackend, zone string, rcode int, state request.Reques
 	m.Authoritative, m.RecursionAvailable = true, true
 	m.Ns, _ = SOA(b, zone, state, opt)
 
-	state.SizeAndDo(m)
 	state.W.WriteMsg(m)
 	// Return success as the rcode to signal we have written to the client.
 	return dns.RcodeSuccess, err

--- a/plugin/chaos/chaos.go
+++ b/plugin/chaos/chaos.go
@@ -46,7 +46,6 @@ func (c Chaos) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		}
 		m.Answer = []dns.RR{&dns.TXT{Hdr: hdr, Txt: []string{trim(hostname)}}}
 	}
-	state.SizeAndDo(m)
 	w.WriteMsg(m)
 	return 0, nil
 }

--- a/plugin/dnssec/handler.go
+++ b/plugin/dnssec/handler.go
@@ -33,7 +33,6 @@ func (d Dnssec) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 			if qname == z {
 				resp := d.getDNSKEY(state, z, do, server)
 				resp.Authoritative = true
-				state.SizeAndDo(resp)
 				w.WriteMsg(resp)
 				return dns.RcodeSuccess, nil
 			}

--- a/plugin/dnssec/handler_test.go
+++ b/plugin/dnssec/handler_test.go
@@ -26,7 +26,7 @@ var dnssecTestCases = []test.Case{
 			test.DNSKEY("miek.nl.	3600	IN	DNSKEY	257 3 13 0J8u0XJ9GNGFEBXuAmLu04taHG4"),
 			test.RRSIG("miek.nl.	3600	IN	RRSIG	DNSKEY 13 2 3600 20160503150844 20160425120844 18512 miek.nl. Iw/kNOyM"),
 		},
-		Extra: []dns.RR{test.OPT(4096, true)},
+		/* Extra: []dns.RR{test.OPT(4096, true)}, this has moved to the server and can't be test here */
 	},
 }
 

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -97,7 +97,6 @@ func (e *Erratic) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		time.Sleep(e.duration)
 	}
 
-	state.SizeAndDo(m)
 	w.WriteMsg(m)
 
 	return 0, nil

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -51,7 +51,6 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 			m := new(dns.Msg)
 			m.SetReply(r)
 			m.Authoritative, m.RecursionAvailable = true, true
-			state.SizeAndDo(m)
 			w.WriteMsg(m)
 
 			log.Infof("Notify from %s for %s: checking transfer", state.IP(), zone)

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -43,7 +43,6 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 			} else {
 				answer := new(dns.Msg)
 				answer.SetRcode(r, rc)
-				state.SizeAndDo(answer)
 
 				vars.Report(ctx, state, vars.Dropped, rcode.ToString(rc), answer.Len(), time.Now())
 

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -3,9 +3,36 @@ package edns
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/miekg/dns"
 )
+
+var sup = &supported{m: make(map[uint16]struct{})}
+
+type supported struct {
+	m map[uint16]struct{}
+	sync.RWMutex
+}
+
+// SetSupportedOption adds a new supported option the set of EDNS0 options that we supported. Plugins typically call
+// this in their setup code to signal support for a new option.
+// By default we supoort:
+// dns.EDNS0NSID, dns.EDNS0EXPIRE, dns.EDNS0COOKIE, dns.EDNS0TCPKEEPALIVE, dns.EDNS0PADDING. These
+// values are not in this map and checked directly in the server.
+func SetSupportedOption(option uint16) {
+	sup.Lock()
+	sup.m[option] = struct{}{}
+	sup.Unlock()
+}
+
+// SupportedOption returns true if e is supported as an extra EDNS0 option.
+func SupportedOption(option uint16) bool {
+	sup.RLock()
+	_, ok := sup.m[option]
+	sup.RUnlock()
+	return ok
+}
 
 // Version checks the EDNS version in the request. If error
 // is nil everything is OK and we can invoke the plugin. If non-nil, the

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -15,9 +15,9 @@ type supported struct {
 	sync.RWMutex
 }
 
-// SetSupportedOption adds a new supported option the set of EDNS0 options that we supported. Plugins typically call
+// SetSupportedOption adds a new supported option the set of EDNS0 options that we support. Plugins typically call
 // this in their setup code to signal support for a new option.
-// By default we supoort:
+// By default we support:
 // dns.EDNS0NSID, dns.EDNS0EXPIRE, dns.EDNS0COOKIE, dns.EDNS0TCPKEEPALIVE, dns.EDNS0PADDING. These
 // values are not in this map and checked directly in the server.
 func SetSupportedOption(option uint16) {
@@ -26,7 +26,7 @@ func SetSupportedOption(option uint16) {
 	sup.Unlock()
 }
 
-// SupportedOption returns true if e is supported as an extra EDNS0 option.
+// SupportedOption returns true if the option code is supported as an extra EDNS0 option.
 func SupportedOption(option uint16) bool {
 	sup.RLock()
 	_, ok := sup.m[option]

--- a/plugin/rewrite/edns0.go
+++ b/plugin/rewrite/edns0.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/coredns/coredns/plugin/metadata"
+	"github.com/coredns/coredns/plugin/pkg/edns"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -159,6 +160,10 @@ func newEdns0LocalRule(mode, action, code, data string) (*edns0LocalRule, error)
 			return nil, err
 		}
 	}
+
+	// Add this code to the ones the server supports.
+	edns.SetSupportedOption(uint16(c))
+
 	return &edns0LocalRule{mode: mode, action: action, code: uint16(c), data: decoded}, nil
 }
 
@@ -172,6 +177,10 @@ func newEdns0VariableRule(mode, action, code, variable string) (*edns0VariableRu
 	if !isValidVariable(variable) {
 		return nil, fmt.Errorf("unsupported variable name %q", variable)
 	}
+
+	// Add this code to the ones the server supports.
+	edns.SetSupportedOption(uint16(c))
+
 	return &edns0VariableRule{mode: mode, action: action, code: uint16(c), variable: variable}, nil
 }
 

--- a/plugin/whoami/whoami.go
+++ b/plugin/whoami/whoami.go
@@ -49,7 +49,6 @@ func (wh Whoami) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 
 	a.Extra = []dns.RR{rr, srv}
 
-	state.SizeAndDo(a)
 	w.WriteMsg(a)
 
 	return 0, nil

--- a/request/edns0.go
+++ b/request/edns0.go
@@ -8,7 +8,7 @@ import (
 
 func supportedOptions(o []dns.EDNS0) []dns.EDNS0 {
 	var supported = make([]dns.EDNS0, 0, 3)
-	// For as long as possible try looking up in the map, because that need an Rlock.
+	// For as long as possible try avoid looking up in the map, because that need an Rlock.
 	for _, opt := range o {
 		switch code := opt.Option(); code {
 		case dns.EDNS0NSID:

--- a/request/edns0.go
+++ b/request/edns0.go
@@ -1,0 +1,31 @@
+package request
+
+import (
+	"github.com/coredns/coredns/plugin/pkg/edns"
+
+	"github.com/miekg/dns"
+)
+
+func supportedOptions(o []dns.EDNS0) []dns.EDNS0 {
+	var supported = make([]dns.EDNS0, 0, 3)
+	// For as long as possible try looking up in the map, because that need an Rlock.
+	for _, opt := range o {
+		switch code := opt.Option(); code {
+		case dns.EDNS0NSID:
+			fallthrough
+		case dns.EDNS0EXPIRE:
+			fallthrough
+		case dns.EDNS0COOKIE:
+			fallthrough
+		case dns.EDNS0TCPKEEPALIVE:
+			fallthrough
+		case dns.EDNS0PADDING:
+			supported = append(supported, opt)
+		default:
+			if edns.SupportedOption(code) {
+				supported = append(supported, opt)
+			}
+		}
+	}
+	return supported
+}

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -123,10 +123,6 @@ func TestRequestScrubExtraEdns0(t *testing.T) {
 	if reply.Truncated {
 		t.Errorf("Want scrub to not set truncated bit")
 	}
-	opt := reply.Extra[len(reply.Extra)-1]
-	if opt.Header().Rrtype != dns.TypeOPT {
-		t.Errorf("Last RR must be OPT record")
-	}
 }
 
 func TestRequestScrubExtraRegression(t *testing.T) {
@@ -152,10 +148,6 @@ func TestRequestScrubExtraRegression(t *testing.T) {
 	}
 	if reply.Truncated {
 		t.Errorf("Want scrub to not set truncated bit")
-	}
-	opt := reply.Extra[len(reply.Extra)-1]
-	if opt.Header().Rrtype != dns.TypeOPT {
-		t.Errorf("Last RR must be OPT record")
 	}
 }
 

--- a/request/writer.go
+++ b/request/writer.go
@@ -15,6 +15,8 @@ func NewScrubWriter(req *dns.Msg, w dns.ResponseWriter) *ScrubWriter { return &S
 // scrub on the message m and will then write it to the client.
 func (s *ScrubWriter) WriteMsg(m *dns.Msg) error {
 	state := Request{Req: s.req, W: s.ResponseWriter}
+
 	n := state.Scrub(m)
+	state.SizeAndDo(n)
 	return s.ResponseWriter.WriteMsg(n)
 }

--- a/test/edns0_test.go
+++ b/test/edns0_test.go
@@ -1,0 +1,33 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestEDNS0(t *testing.T) {
+	corefile := `.:0 {
+		whoami
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeSOA)
+	m.SetEdns0(4096, true)
+
+	resp, err := dns.Exchange(m, udp)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %v", err)
+	}
+	opt := resp.Extra[len(resp.Extra)-1]
+	if opt.Header().Rrtype != dns.TypeOPT {
+		t.Errorf("Last RR must be OPT record")
+	}
+}


### PR DESCRIPTION
Do SizeAndDo in the server and remove all uses of this from the plugins
and do it in the server in the ScrubWiriter. Also *always* do it. This
is to get into compliance  for https://dnsflagday.net/.

The pkg/edns0 now exports the EDNS0 options we understand; this is
exported to allow plugins add things here. This should be documented
still. We don't echo back options we don't understand.

Note I can't test it because of: https://github.com/miekg/dns/issues/857

Running a test instance and pointing the https://ednscomp.isc.org/ednscomp
to it shows the tests are now fixed:

~~~
EDNS Compliance Tester
Checking: 'miek.nl' as at 2018-12-01T17:53:15Z

miek.nl. @147.75.204.203 (drone.coredns.io.): dns=ok edns=ok edns1=ok edns@512=ok ednsopt=ok edns1opt=ok do=ok ednsflags=ok docookie=ok edns512tcp=ok optlist=ok
miek.nl. @2604:1380:2002:a000::1 (drone.coredns.io.): dns=ok edns=ok edns1=ok edns@512=ok ednsopt=ok edns1opt=ok do=ok ednsflags=ok docookie=ok edns512tcp=ok optlist=ok

All Ok
Codes
ok - test passed.
~~~