### PR TITLE
Use TrimPrefix instead of TrimLeft in rewrite prefix plugin (#2364)

### DIFF
--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -71,7 +71,7 @@ func (rule *exactNameRule) Rewrite(ctx context.Context, state request.Request) R
 // Rewrite rewrites the current request when the name begins with the matching string.
 func (rule *prefixNameRule) Rewrite(ctx context.Context, state request.Request) Result {
 	if strings.HasPrefix(state.Name(), rule.Prefix) {
-		state.Req.Question[0].Name = rule.Replacement + strings.TrimLeft(state.Name(), rule.Prefix)
+		state.Req.Question[0].Name = rule.Replacement + strings.TrimPrefix(state.Name(), rule.Prefix)
 		return RewriteDone
 	}
 	return RewriteIgnored


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR fixes a bug where the rewrite plugin trims the prefix incorrectly due to using the TrimLeft function instead of the TrimPrefix function.

### 2. Which issues (if any) are related?
#2364 

### 3. Which documentation changes (if any) need to be made?
None.