### PR TITLE
msg.Service: optimize a bit

### DIFF
--- a/plugin/etcd/msg/service_test.go
+++ b/plugin/etcd/msg/service_test.go
@@ -123,3 +123,11 @@ func TestGroup(t *testing.T) {
 		t.Fatalf("Failure to group seventh set: %v", sx)
 	}
 }
+
+func BenchmarkNewSRV(b *testing.B) {
+	s := &Service{Host: "www,example.org", Port: 8080}
+	for n := 0; n < b.N; n++ {
+		srv := s.NewSRV("www.example.org.", 16)
+		srv = srv
+	}
+}


### PR DESCRIPTION
Make the NewSRV and friends slightly smarter. Optimize the calling of
targetStrip which is almost certainly not used.

Added benchmark show a modest improvement:

benchmark             old ns/op     new ns/op     delta
BenchmarkNewSRV-4     300           283           -5.67%