### PR TITLE
plugin/kubernetes: make prefix key in msg.Service a const

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -105,13 +105,13 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		if segs[0] != "dns-version" {
 			return nil, nil
 		}
-		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), "coredns")}
+		svc := msg.Service{Text: DNSSchemaVersion, TTL: 28800, Key: msg.Path(state.QName(), coredns)}
 		return []msg.Service{svc}, nil
 
 	case dns.TypeNS:
 		// We can only get here if the qname equals the zone, see ServeDNS in handler.go.
 		ns := k.nsAddr()
-		svc := msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), "coredns")}
+		svc := msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), coredns)}
 		return []msg.Service{svc}, nil
 	}
 
@@ -119,7 +119,7 @@ func (k *Kubernetes) Services(state request.Request, exact bool, opt plugin.Opti
 		// If this is an A request for "ns.dns", respond with a "fake" record for coredns.
 		// SOA records always use this hardcoded name
 		ns := k.nsAddr()
-		svc := msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), "coredns")}
+		svc := msg.Service{Host: ns.A.String(), Key: msg.Path(state.QName(), coredns)}
 		return []msg.Service{svc}, nil
 	}
 
@@ -349,7 +349,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 
 	namespace := r.namespace
 	podname := r.service
-	zonePath := msg.Path(zone, "coredns")
+	zonePath := msg.Path(zone, coredns)
 	ip := ""
 
 	// handle empty pod name
@@ -414,7 +414,7 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 
 // findServices returns the services matching r from the cache.
 func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.Service, err error) {
-	zonePath := msg.Path(zone, "coredns")
+	zonePath := msg.Path(zone, coredns)
 
 	err = errNoItems
 	if wildcard(r.service) && !wildcard(r.namespace) {
@@ -555,3 +555,5 @@ func match(a, b string) bool {
 func wildcard(s string) bool {
 	return s == "*" || s == "any"
 }
+
+const coredns = "c" // used as a fake key prefix in msg.Service

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -272,12 +272,12 @@ func TestServices(t *testing.T) {
 	}
 	tests := []svcTest{
 		// Cluster IP Services
-		{qname: "svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "10.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1"}},
-		{qname: "_http._tcp.svc1.testns.svc.interwebs.test.", qtype: dns.TypeSRV, answer: svcAns{host: "10.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1"}},
-		{qname: "ep1a.svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "172.0.0.1", key: "/coredns/test/interwebs/svc/testns/svc1/ep1a"}},
+		{qname: "svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "10.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1"}},
+		{qname: "_http._tcp.svc1.testns.svc.interwebs.test.", qtype: dns.TypeSRV, answer: svcAns{host: "10.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1"}},
+		{qname: "ep1a.svc1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "172.0.0.1", key: "/" + coredns + "/test/interwebs/svc/testns/svc1/ep1a"}},
 
 		// External Services
-		{qname: "external.testns.svc.interwebs.test.", qtype: dns.TypeCNAME, answer: svcAns{host: "coredns.io", key: "/coredns/test/interwebs/svc/testns/external"}},
+		{qname: "external.testns.svc.interwebs.test.", qtype: dns.TypeCNAME, answer: svcAns{host: "coredns.io", key: "/" + coredns + "/test/interwebs/svc/testns/external"}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
This is a relic from the etcd integration and only used to remove in the
final answer returned to the client. We do need it. Make it a constant
and only one character wide.