### PR TITLE
plugin/kubernetes: smaller map

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -348,7 +348,7 @@ func TestServeDNS(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
-	k.Namespaces = map[string]bool{"testns": true}
+	k.Namespaces = map[string]struct{}{"testns": struct{}{}}
 	ctx := context.TODO()
 
 	for i, tc := range dnsTestCases {
@@ -395,7 +395,7 @@ func TestNotSyncedServeDNS(t *testing.T) {
 		notSynced: true,
 	}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
-	k.Namespaces = map[string]bool{"testns": true}
+	k.Namespaces = map[string]struct{}{"testns": struct{}{}}
 	ctx := context.TODO()
 
 	for i, tc := range notSyncedTestCases {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -40,7 +40,7 @@ type Kubernetes struct {
 	APIClientKey     string
 	ClientConfig     clientcmd.ClientConfig
 	APIConn          dnsController
-	Namespaces       map[string]bool
+	Namespaces       map[string]struct{}
 	podMode          string
 	endpointNameMode bool
 	Fall             fall.F
@@ -58,7 +58,7 @@ type Kubernetes struct {
 func New(zones []string) *Kubernetes {
 	k := new(Kubernetes)
 	k.Zones = zones
-	k.Namespaces = make(map[string]bool)
+	k.Namespaces = make(map[string]struct{})
 	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("127.0.0.1") }
 	k.podMode = podModeDisabled
 	k.ttl = defaultTTL

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -187,7 +187,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			args := c.RemainingArgs()
 			if len(args) > 0 {
 				for _, a := range args {
-					k8s.Namespaces[a] = true
+					k8s.Namespaces[a] = struct{}{}
 				}
 				continue
 			}

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -16,7 +16,7 @@ func TestKubernetesXFR(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.TransferTo = []string{"10.240.0.1:53"}
-	k.Namespaces = map[string]bool{"testns": true}
+	k.Namespaces = map[string]struct{}{"testns": struct{}{}}
 
 	ctx := context.TODO()
 	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})
@@ -104,7 +104,7 @@ func TestKubernetesXFRNotAllowed(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.TransferTo = []string{"1.2.3.4:53"}
-	k.Namespaces = map[string]bool{"testns": true}
+	k.Namespaces = map[string]struct{}{"testns": struct{}{}}
 
 	ctx := context.TODO()
 	w := dnstest.NewMultiRecorder(&test.ResponseWriter{})


### PR DESCRIPTION
to continue with a theme: the map[string]bool can be reduced
to map[string]struct{} to reduce a tiny amount of memory.