### PR TITLE
Replace bool map with struct{} map in chaos plugin

### DIFF
--- a/plugin/chaos/chaos.go
+++ b/plugin/chaos/chaos.go
@@ -16,7 +16,7 @@ import (
 type Chaos struct {
 	Next    plugin.Handler
 	Version string
-	Authors map[string]bool
+	Authors map[string]struct{}
 }
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/chaos/chaos_test.go
+++ b/plugin/chaos/chaos_test.go
@@ -14,7 +14,7 @@ import (
 func TestChaos(t *testing.T) {
 	em := Chaos{
 		Version: version,
-		Authors: map[string]bool{"Miek Gieben": true},
+		Authors: map[string]struct{}{"Miek Gieben": struct{}{}},
 	}
 
 	tests := []struct {

--- a/plugin/chaos/setup.go
+++ b/plugin/chaos/setup.go
@@ -28,12 +28,12 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func chaosParse(c *caddy.Controller) (string, map[string]bool, error) {
+func chaosParse(c *caddy.Controller) (string, map[string]struct{}, error) {
 	// Set here so we pick up AppName and AppVersion that get set in coremain's init().
 	chaosVersion = caddy.AppName + "-" + caddy.AppVersion
 
 	version := ""
-	authors := make(map[string]bool)
+	authors := make(map[string]struct{})
 
 	for c.Next() {
 		args := c.RemainingArgs()
@@ -45,7 +45,7 @@ func chaosParse(c *caddy.Controller) (string, map[string]bool, error) {
 		}
 		version = args[0]
 		for _, a := range args[1:] {
-			authors[a] = true
+			authors[a] = struct{}{}
 		}
 		return version, authors, nil
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This fix is the continued effort in using struct{} map whenever applicable,
to help reduce the memory footprint.

### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>