### PR TITLE
core: edns0 tweaks

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -206,10 +206,7 @@ func (r *Request) SizeAndDo(m *dns.Msg) bool {
 		mo.SetUDPSize(o.UDPSize())
 		mo.Hdr.Ttl &= 0xff00 // clear flags
 
-		// If the request had options set, but we don't support those, we should not echo those back.
-		if len(o.Option) > 0 {
-			mo.Option = supportedOptions(o.Option)
-		}
+		// Assume if the message m has options set, they are OK and represent what an upstream can do.
 
 		if o.Do() {
 			mo.SetDo()

--- a/request/request.go
+++ b/request/request.go
@@ -192,14 +192,12 @@ func (r *Request) Size() int {
 }
 
 // SizeAndDo adds an OPT record that the reflects the intent from request.
-// The returned bool indicated if an record was found and normalised.
+// The returned bool indicates if an record was found and normalised.
 func (r *Request) SizeAndDo(m *dns.Msg) bool {
 	o := r.Req.IsEdns0()
 	if o == nil {
 		return false
 	}
-
-	odo := o.Do()
 
 	if mo := m.IsEdns0(); mo != nil {
 		mo.Hdr.Name = "."
@@ -208,16 +206,18 @@ func (r *Request) SizeAndDo(m *dns.Msg) bool {
 		mo.SetUDPSize(o.UDPSize())
 		mo.Hdr.Ttl &= 0xff00 // clear flags
 
+		// If the request had options set, but we don't support those, we should not echo those back.
 		if len(o.Option) > 0 {
-			o.Option = supportedOptions(o.Option)
+			mo.Option = supportedOptions(o.Option)
 		}
 
-		if odo {
+		if o.Do() {
 			mo.SetDo()
 		}
 		return true
 	}
 
+	// Reuse the request's OPT record and tack it to m.
 	o.Hdr.Name = "."
 	o.Hdr.Rrtype = dns.TypeOPT
 	o.SetVersion(0)
@@ -227,9 +227,6 @@ func (r *Request) SizeAndDo(m *dns.Msg) bool {
 		o.Option = supportedOptions(o.Option)
 	}
 
-	if odo {
-		o.SetDo()
-	}
 	m.Extra = append(m.Extra, o)
 	return true
 }


### PR DESCRIPTION
Per comment thread in https://github.com/coredns/coredns/pull/2357 which
spotted a bug; updated the code and added some comments.

This function should probably be redone as some point or made obsolete.

Signed-off-by: Miek Gieben <miek@miek.nl>
