### PR TITLE
map bool -> map struct{}

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -70,7 +70,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		if site.registry != nil {
 			// this config is already computed with the chain of plugin
 			// set classChaos in accordance with previously registered plugins
-			for name := range enableChaos {
+			for name := range EnableChaos {
 				if _, ok := site.registry[name]; ok {
 					s.classChaos = true
 					break
@@ -97,7 +97,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 				}
 			}
 			// Unblock CH class queries when any of these plugins are loaded.
-			if _, ok := enableChaos[stack.Name()]; ok {
+			if _, ok := EnableChaos[stack.Name()]; ok {
 				s.classChaos = true
 			}
 		}
@@ -381,12 +381,11 @@ type (
 	loopKey struct{} // loopKey is the context key for counting self loops
 )
 
-// enableChaos is a map with plugin names for which we should open CH class queries as
-// we block these by default.
-var enableChaos = map[string]bool{
-	"chaos":   true,
-	"forward": true,
-	"proxy":   true,
+// EnableChaos is a map with plugin names for which we should open CH class queries as we block these by default.
+var EnableChaos = map[string]struct{}{
+	"chaos":   struct{}{},
+	"forward": struct{}{},
+	"proxy":   struct{}{},
 }
 
 // Quiet mode will not show any informative output on initialization.

--- a/coremain/run.go
+++ b/coremain/run.go
@@ -257,14 +257,14 @@ var (
 )
 
 // flagsBlacklist removes flags with these names from our flagset.
-var flagsBlacklist = map[string]bool{
-	"logtostderr":      true,
-	"alsologtostderr":  true,
-	"v":                true,
-	"stderrthreshold":  true,
-	"vmodule":          true,
-	"log_backtrace_at": true,
-	"log_dir":          true,
+var flagsBlacklist = map[string]struct{}{
+	"logtostderr":      struct{}{},
+	"alsologtostderr":  struct{}{},
+	"v":                struct{}{},
+	"stderrthreshold":  struct{}{},
+	"vmodule":          struct{}{},
+	"log_backtrace_at": struct{}{},
+	"log_dir":          struct{}{},
 }
 
 var flagsToKeep []*flag.Flag

--- a/plugin/kubernetes/xfr_test.go
+++ b/plugin/kubernetes/xfr_test.go
@@ -129,9 +129,9 @@ func TestKubernetesXFRNotAllowed(t *testing.T) {
 
 // difference shows what we're missing when comparing two RR slices
 func difference(testRRs []dns.RR, gotRRs []dns.RR) []dns.RR {
-	expectedRRs := map[string]bool{}
+	expectedRRs := map[string]struct{}{}
 	for _, rr := range testRRs {
-		expectedRRs[rr.String()] = true
+		expectedRRs[rr.String()] = struct{}{}
 	}
 
 	foundRRs := []dns.RR{}

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -55,7 +55,9 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		class := response.Classify(tpe)
 		// If we don't set up a class in config, the default "all" will be added
 		// and we shouldn't have an empty rule.Class.
-		if rule.Class[response.All] || rule.Class[class] {
+		_, ok := rule.Class[response.All]
+		_, ok1 := rule.Class[class]
+		if ok || ok1 {
 			rep := replacer.New(ctx, r, rrw, CommonLogEmptyValue)
 			clog.Infof(rep.Replace(rule.Format))
 		}
@@ -72,7 +74,7 @@ func (l Logger) Name() string { return "log" }
 // Rule configures the logging plugin.
 type Rule struct {
 	NameScope string
-	Class     map[response.Class]bool
+	Class     map[response.Class]struct{}
 	Format    string
 }
 

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -21,7 +21,7 @@ func TestLoggedStatus(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]bool{response.All: true},
+		Class:     map[response.Class]struct{}{response.All: struct{}{}},
 	}
 
 	var f bytes.Buffer
@@ -53,7 +53,7 @@ func TestLoggedClassDenial(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]bool{response.Denial: true},
+		Class:     map[response.Class]struct{}{response.Denial: struct{}{}},
 	}
 
 	var f bytes.Buffer
@@ -82,7 +82,7 @@ func TestLoggedClassError(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]bool{response.Error: true},
+		Class:     map[response.Class]struct{}{response.Error: struct{}{}},
 	}
 
 	var f bytes.Buffer

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -40,13 +40,13 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			rules = append(rules, Rule{
 				NameScope: ".",
 				Format:    DefaultLogFormat,
-				Class:     make(map[response.Class]bool),
+				Class:     make(map[response.Class]struct{}),
 			})
 		} else if len(args) == 1 {
 			rules = append(rules, Rule{
 				NameScope: dns.Fqdn(args[0]),
 				Format:    DefaultLogFormat,
-				Class:     make(map[response.Class]bool),
+				Class:     make(map[response.Class]struct{}),
 			})
 		} else {
 			// Name scope, and maybe a format specified
@@ -64,7 +64,7 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 			rules = append(rules, Rule{
 				NameScope: dns.Fqdn(args[0]),
 				Format:    format,
-				Class:     make(map[response.Class]bool),
+				Class:     make(map[response.Class]struct{}),
 			})
 		}
 
@@ -82,14 +82,14 @@ func logParse(c *caddy.Controller) ([]Rule, error) {
 					if err != nil {
 						return nil, err
 					}
-					rules[len(rules)-1].Class[cls] = true
+					rules[len(rules)-1].Class[cls] = struct{}{}
 				}
 			default:
 				return nil, c.ArgErr()
 			}
 		}
 		if len(rules[len(rules)-1].Class) == 0 {
-			rules[len(rules)-1].Class[response.All] = true
+			rules[len(rules)-1].Class[response.All] = struct{}{}
 		}
 	}
 

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -18,42 +18,42 @@ func TestLogParse(t *testing.T) {
 		{`log`, false, []Rule{{
 			NameScope: ".",
 			Format:    DefaultLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    DefaultLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org. {common}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org {combined}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CombinedLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org.
 		log example.net {combined}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    DefaultLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}, {
 			NameScope: "example.net.",
 			Format:    CombinedLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org {host}
 			  log example.org {when}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    "{host}",
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}, {
 			NameScope: "example.org.",
 			Format:    "{when}",
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 
 		{`log example.org {
@@ -61,28 +61,28 @@ func TestLogParse(t *testing.T) {
 			}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.All: true},
+			Class:     map[response.Class]struct{}{response.All: struct{}{}},
 		}}},
 		{`log example.org {
 			class denial
 		}`, false, []Rule{{
 			NameScope: "example.org.",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.Denial: true},
+			Class:     map[response.Class]struct{}{response.Denial: struct{}{}},
 		}}},
 		{`log {
 			class denial
 		}`, false, []Rule{{
 			NameScope: ".",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.Denial: true},
+			Class:     map[response.Class]struct{}{response.Denial: struct{}{}},
 		}}},
 		{`log {
 			class denial error
 		}`, false, []Rule{{
 			NameScope: ".",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.Denial: true, response.Error: true},
+			Class:     map[response.Class]struct{}{response.Denial: struct{}{}, response.Error: struct{}{}},
 		}}},
 		{`log {
 			class denial
@@ -90,7 +90,7 @@ func TestLogParse(t *testing.T) {
 		}`, false, []Rule{{
 			NameScope: ".",
 			Format:    CommonLogFormat,
-			Class:     map[response.Class]bool{response.Denial: true, response.Error: true},
+			Class:     map[response.Class]struct{}{response.Denial: struct{}{}, response.Error: struct{}{}},
 		}}},
 		{`log {
 			class abracadabra

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -26,7 +26,7 @@ type Metrics struct {
 	srv     *http.Server
 
 	zoneNames []string
-	zoneMap   map[string]bool
+	zoneMap   map[string]struct{}
 	zoneMu    sync.RWMutex
 }
 
@@ -35,7 +35,7 @@ func New(addr string) *Metrics {
 	met := &Metrics{
 		Addr:    addr,
 		Reg:     prometheus.NewRegistry(),
-		zoneMap: make(map[string]bool),
+		zoneMap: make(map[string]struct{}),
 	}
 	// Add the default collectors
 	met.MustRegister(prometheus.NewGoCollector())
@@ -69,7 +69,7 @@ func (m *Metrics) MustRegister(c prometheus.Collector) {
 // AddZone adds zone z to m.
 func (m *Metrics) AddZone(z string) {
 	m.zoneMu.Lock()
-	m.zoneMap[z] = true
+	m.zoneMap[z] = struct{}{}
 	m.zoneNames = keys(m.zoneMap)
 	m.zoneMu.Unlock()
 }
@@ -140,7 +140,7 @@ func (m *Metrics) OnFinalShutdown() error {
 	return m.stopServer()
 }
 
-func keys(m map[string]bool) []string {
+func keys(m map[string]struct{}) []string {
 	sx := []string{}
 	for k := range m {
 		sx = append(sx, k)

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -50,25 +50,25 @@ func WithServer(ctx context.Context) string {
 	return srv.(string)
 }
 
-var monitorType = map[uint16]bool{
-	dns.TypeAAAA:   true,
-	dns.TypeA:      true,
-	dns.TypeCNAME:  true,
-	dns.TypeDNSKEY: true,
-	dns.TypeDS:     true,
-	dns.TypeMX:     true,
-	dns.TypeNSEC3:  true,
-	dns.TypeNSEC:   true,
-	dns.TypeNS:     true,
-	dns.TypePTR:    true,
-	dns.TypeRRSIG:  true,
-	dns.TypeSOA:    true,
-	dns.TypeSRV:    true,
-	dns.TypeTXT:    true,
+var monitorType = map[uint16]struct{}{
+	dns.TypeAAAA:   struct{}{},
+	dns.TypeA:      struct{}{},
+	dns.TypeCNAME:  struct{}{},
+	dns.TypeDNSKEY: struct{}{},
+	dns.TypeDS:     struct{}{},
+	dns.TypeMX:     struct{}{},
+	dns.TypeNSEC3:  struct{}{},
+	dns.TypeNSEC:   struct{}{},
+	dns.TypeNS:     struct{}{},
+	dns.TypePTR:    struct{}{},
+	dns.TypeRRSIG:  struct{}{},
+	dns.TypeSOA:    struct{}{},
+	dns.TypeSRV:    struct{}{},
+	dns.TypeTXT:    struct{}{},
 	// Meta Qtypes
-	dns.TypeIXFR: true,
-	dns.TypeAXFR: true,
-	dns.TypeANY:  true,
+	dns.TypeIXFR: struct{}{},
+	dns.TypeAXFR: struct{}{},
+	dns.TypeANY:  struct{}{},
 }
 
 const other = "other"


### PR DESCRIPTION
This clears out the remaining map[x]bool usage and moves the bool to an
empty struct.

Nothing really in the serving path, so the saving are minimal, but good form to not use more than you need.

Two note worthy other changes:

* EnableChaos in the server is now also exported to make it show up in
  the documentation.
* The auto plugin is left as is, because there the boolean is
  explicitaly set to false to signal 'to-be-deleted' and the key is left
  as-is.

Signed-off-by: Miek Gieben <miek@miek.nl>