### PR TITLE
[request] make proto return whether or not connection is using TLS

### DIFF
--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"crypto/tls"
 	"net"
 
 	"github.com/miekg/dns"
@@ -11,6 +12,7 @@ import (
 // port 53.
 type ResponseWriter struct {
 	TCP bool // if TCP is true we return an TCP connection instead of an UDP one.
+	TLS bool // if TLS is true we return a TLS connection instead of UDP one.
 }
 
 // LocalAddr returns the local address, 127.0.0.1:53 (UDP, TCP if t.TCP is true).
@@ -50,6 +52,14 @@ func (t *ResponseWriter) TsigTimersOnly(bool) { return }
 
 // Hijack implement dns.ResponseWriter interface.
 func (t *ResponseWriter) Hijack() { return }
+
+// ConnectionState implement the dns.ConnectionStater interface.
+func (t *ResponseWriter) ConnectionState() *tls.ConnectionState {
+	if t.TLS {
+		return &tls.ConnectionState{}
+	}
+	return nil
+}
 
 // ResponseWriter6 returns fixed client and remote address in IPv6.  The remote
 // address is always fe80::42:ff:feca:4c65 and port 40212. The local address is always ::1 and port 53.

--- a/request/request.go
+++ b/request/request.go
@@ -123,6 +123,9 @@ func Proto(w dns.ResponseWriter) string {
 		return "udp"
 	}
 	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+		if w.(dns.ConnectionStater).ConnectionState() != nil {
+			return "tls"
+		}
 		return "tcp"
 	}
 	return "udp"

--- a/request/request.go
+++ b/request/request.go
@@ -123,7 +123,7 @@ func Proto(w dns.ResponseWriter) string {
 		return "udp"
 	}
 	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
-		if w.(dns.ConnectionStater).ConnectionState() != nil {
+		if i, ok := w.(dns.ConnectionStater); ok && i.ConnectionState() != nil {
 			return "tls"
 		}
 		return "tcp"

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -281,3 +281,48 @@ func TestRequestClear(t *testing.T) {
 		t.Errorf("Expected st.port to be cleared after Clear")
 	}
 }
+
+func TestRequestProtocol(t *testing.T) {
+
+	testCases := []struct {
+		TCP   bool
+		TLS   bool
+		proto string
+	}{
+		{
+			TCP:   false,
+			TLS:   false,
+			proto: "udp",
+		},
+		{
+			TCP:   false,
+			TLS:   true,
+			proto: "udp",
+		},
+		{
+			TCP:   true,
+			TLS:   false,
+			proto: "tcp",
+		},
+		{
+			TCP:   true,
+			TLS:   true,
+			proto: "tls",
+		},
+	}
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetEdns0(4096, true)
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v", tc), func(t *testing.T) {
+
+			r := Request{W: &test.ResponseWriter{TCP: tc.TCP, TLS: tc.TLS}, Req: m}
+			proto := r.Proto()
+			if tc.proto != proto {
+				t.Errorf("Expected protocol %s, got %s", tc.proto, proto)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

this PR makes ResponseWriter.Proto return "tls" when the connection is over a TLS connection.

While technically this is just TCP, this aligns with the use of "tcp-tls" in (albeit I just return "tls" here): https://github.com/miekg/dns/blob/master/server.go#L127

I don't have strong opinions whether this should be in or not. I do find this useful and have something doing this already.... but figured it could be of some use to others if it was provided by request/request.go