### PR TITLE
disable ra flag for several plugins

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -70,7 +70,7 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 
 	switch result {

--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -70,7 +70,7 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 
 	switch result {

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -422,7 +422,7 @@ func SOA(b ServiceBackend, zone string, state request.Request, opt Options) ([]d
 func BackendError(b ServiceBackend, zone string, rcode int, state request.Request, err error, opt Options) (int, error) {
 	m := new(dns.Msg)
 	m.SetRcode(state.Req, rcode)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	m.Ns, _ = SOA(b, zone, state, opt)
 
 	state.W.WriteMsg(m)

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -422,7 +422,7 @@ func SOA(b ServiceBackend, zone string, state request.Request, opt Options) ([]d
 func BackendError(b ServiceBackend, zone string, rcode int, state request.Request, err error, opt Options) (int, error) {
 	m := new(dns.Msg)
 	m.SetRcode(state.Req, rcode)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	m.Ns, _ = SOA(b, zone, state, opt)
 
 	state.W.WriteMsg(m)

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -82,7 +82,7 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	m.Answer = append(m.Answer, records...)
 	m.Extra = append(m.Extra, extra...)
 

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -82,7 +82,7 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	m.Answer = append(m.Answer, records...)
 	m.Extra = append(m.Extra, extra...)
 

--- a/plugin/etcd/stub_handler.go
+++ b/plugin/etcd/stub_handler.go
@@ -32,7 +32,6 @@ func (s Stub) ServeDNS(ctx context.Context, w dns.ResponseWriter, req *dns.Msg) 
 	if e != nil {
 		return dns.RcodeServerFailure, e
 	}
-	m.RecursionAvailable = false
 	w.WriteMsg(m)
 	return dns.RcodeSuccess, nil
 }

--- a/plugin/etcd/stub_handler.go
+++ b/plugin/etcd/stub_handler.go
@@ -32,7 +32,7 @@ func (s Stub) ServeDNS(ctx context.Context, w dns.ResponseWriter, req *dns.Msg) 
 	if e != nil {
 		return dns.RcodeServerFailure, e
 	}
-	m.RecursionAvailable = true
+	m.RecursionAvailable = false
 	w.WriteMsg(m)
 	return dns.RcodeSuccess, nil
 }

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -104,7 +104,7 @@ func (f *Federation) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 
 	m.Answer = []dns.RR{service.NewCNAME(state.QName(), service.Host)}
 

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -104,7 +104,7 @@ func (f *Federation) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 
 	m.Answer = []dns.RR{service.NewCNAME(state.QName(), service.Host)}
 

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -50,7 +50,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		if z.isNotify(state) {
 			m := new(dns.Msg)
 			m.SetReply(r)
-			m.Authoritative, m.RecursionAvailable = true, false
+			m.Authoritative = true
 			w.WriteMsg(m)
 
 			log.Infof("Notify from %s for %s: checking transfer", state.IP(), zone)
@@ -83,7 +83,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 
 	switch result {

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -50,7 +50,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		if z.isNotify(state) {
 			m := new(dns.Msg)
 			m.SetReply(r)
-			m.Authoritative, m.RecursionAvailable = true, true
+			m.Authoritative, m.RecursionAvailable = true, false
 			w.WriteMsg(m)
 
 			log.Infof("Notify from %s for %s: checking transfer", state.IP(), zone)
@@ -83,7 +83,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	m.Answer, m.Ns, m.Extra = answer, ns, extra
 
 	switch result {

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -63,7 +63,7 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	m.Answer = answers
 
 	w.WriteMsg(m)

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -63,7 +63,7 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	m.Answer = answers
 
 	w.WriteMsg(m)

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -16,7 +16,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 
 	zone := plugin.Zones(k.Zones).Matches(state.Name())
 	if zone == "" {

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -16,7 +16,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 
 	zone := plugin.Zones(k.Zones).Matches(state.Name())
 	if zone == "" {

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -110,7 +110,7 @@ func (h *Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, true
+	m.Authoritative, m.RecursionAvailable = true, false
 	var result file.Result
 	for _, hostedZone := range z {
 		h.zMu.RLock()

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -110,7 +110,7 @@ func (h *Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 
 	m := new(dns.Msg)
 	m.SetReply(r)
-	m.Authoritative, m.RecursionAvailable = true, false
+	m.Authoritative = true
 	var result file.Result
 	for _, hostedZone := range z {
 		h.zMu.RLock()

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -101,7 +101,7 @@ func TestRoute53(t *testing.T) {
 			}
 			m.Answer = []dns.RR{rr}
 
-			m.Authoritative, m.RecursionAvailable = true, true
+			m.Authoritative, m.RecursionAvailable = true, false
 			rcode = dns.RcodeSuccess
 		}
 

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -101,7 +101,7 @@ func TestRoute53(t *testing.T) {
 			}
 			m.Answer = []dns.RR{rr}
 
-			m.Authoritative, m.RecursionAvailable = true, false
+			m.Authoritative = true
 			rcode = dns.RcodeSuccess
 		}
 

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -75,7 +75,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 
 		msg := new(dns.Msg)
 		msg.SetReply(r)
-		msg.Authoritative, msg.RecursionAvailable = true, false
+		msg.Authoritative = true
 		msg.Rcode = template.rcode
 
 		for _, answer := range template.answer {

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -75,7 +75,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 
 		msg := new(dns.Msg)
 		msg.SetReply(r)
-		msg.Authoritative, msg.RecursionAvailable = true, true
+		msg.Authoritative, msg.RecursionAvailable = true, false
 		msg.Rcode = template.rcode
 
 		for _, answer := range template.answer {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This pull request disables the RA flag for several plugins. If CoreDNS is used as forwarder, the flag of forwarded answers of a recursive resolver remains unchanged.
A recursive resolver plugin should be the only case where the flag is set directly. So it shouldn't be set in the template either.
I'm not sure if the change in `plugin/etcd/stub_handler.go` breaks something. The flag does not seem to be used in stub zones in the sense that it advertises the general availability of recursion but rather that recursion is performed for this request and I'm not sure if other software depends on this behaviour.

### 2. Which issues (if any) are related?
#2024 

### 3. Which documentation changes (if any) need to be made?
