### PR TITLE
Fix schema for federated services

### DIFF
--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -124,7 +124,7 @@ func (f *Federation) Name() string { return "federation" }
 
 // IsNameFederation checks the qname to see if it is a potential federation. The federation
 // label is always the 2nd to last once the zone is chopped of. For instance
-// "nginx.mynamespace.myfederation.svc.example.com" has "myfederation" as the federation label.
+// "nginx.mynamespace.myfederation.fsvc.example.com" has "myfederation" as the federation label.
 // IsNameFederation returns a new qname with the federation label and the label itself or two
 // empty strings if there wasn't a hit.
 func (f *Federation) isNameFederation(name, zone string) (string, string) {

--- a/plugin/federation/federation_test.go
+++ b/plugin/federation/federation_test.go
@@ -37,18 +37,18 @@ func TestFederationKubernetes(t *testing.T) {
 	tests := []test.Case{
 		{
 			// service exists so we return the IP address associated with it.
-			Qname: "svc1.testns.prod.svc.cluster.local.", Qtype: dns.TypeA,
+			Qname: "svc1.testns.prod.fsvc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.A("svc1.testns.prod.svc.cluster.local.      303       IN      A       10.0.0.1"),
+				test.A("svc1.testns.prod.fsvc.cluster.local.      303       IN      A       10.0.0.1"),
 			},
 		},
 		{
 			// service does not exist, do the federation dance.
-			Qname: "svc0.testns.prod.svc.cluster.local.", Qtype: dns.TypeA,
+			Qname: "svc0.testns.prod.fsvc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.CNAME("svc0.testns.prod.svc.cluster.local.  303       IN      CNAME   svc0.testns.prod.svc.fd-az.fd-r.federal.example."),
+				test.CNAME("svc0.testns.prod.fsvc.cluster.local.  303       IN      CNAME   svc0.testns.prod.fsvc.fd-az.fd-r.federal.example."),
 			},
 		},
 	}
@@ -84,10 +84,10 @@ func TestFederationKubernetesMissingLabels(t *testing.T) {
 	tests := []test.Case{
 		{
 			// service does not exist, do the federation dance.
-			Qname: "svc0.testns.prod.svc.cluster.local.", Qtype: dns.TypeA,
+			Qname: "svc0.testns.prod.fsvc.cluster.local.", Qtype: dns.TypeA,
 			Rcode: dns.RcodeSuccess,
 			Answer: []dns.RR{
-				test.CNAME("svc0.testns.prod.svc.cluster.local.  303       IN      CNAME   svc0.testns.prod.svc.fd-az.fd-r.federal.example."),
+				test.CNAME("svc0.testns.prod.fsvc.cluster.local.  303       IN      CNAME   svc0.testns.prod.fsvc.fd-az.fd-r.federal.example."),
 			},
 		},
 	}

--- a/plugin/kubernetes/federation.go
+++ b/plugin/kubernetes/federation.go
@@ -44,8 +44,8 @@ func (k *Kubernetes) Federations(state request.Request, fname, fzone string) (ms
 	}
 
 	if r.endpoint == "" {
-		return msg.Service{Host: dnsutil.Join(r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone)}, nil
+		return msg.Service{Host: dnsutil.Join(r.service, r.namespace, fname, Fsvc, lz, lr, fzone)}, nil
 	}
 
-	return msg.Service{Host: dnsutil.Join(r.endpoint, r.service, r.namespace, fname, r.podOrSvc, lz, lr, fzone)}, nil
+	return msg.Service{Host: dnsutil.Join(r.endpoint, r.service, r.namespace, fname, Fsvc, lz, lr, fzone)}, nil
 }

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -79,6 +79,8 @@ const (
 	Svc = "svc"
 	// Pod is the DNS schema for kubernetes pods
 	Pod = "pod"
+	// Fsvc is the DNS schema for Federated services
+	Fsvc = "fsvc"
 	// defaultTTL to apply to all answers.
 	defaultTTL = 5
 )

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -58,7 +58,7 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 		return r, nil
 	}
 	r.podOrSvc = segs[last]
-	if r.podOrSvc != Pod && r.podOrSvc != Svc {
+	if r.podOrSvc != Pod && r.podOrSvc != Svc && r.podOrSvc != Fsvc {
 		return r, errInvalidRequest
 	}
 	last--


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix an outstanding issue when using federation plugin. Refer to this [issue](https://github.com/kubernetes/dns/issues/29). Federation service will use `fsvc` keyword instead of `svc` keyword in the kubernetes service schema. This will allow the controllers to clearly disambiguate the requests.
This PR also allow the federation service redirection to work when there are missing zone/region labels. This would help in some `on-prem` environments which does not have these labels.

### 2. Which issues (if any) are related?
https://github.com/kubernetes/dns/issues/29

### 3. Which documentation changes (if any) need to be made?
Need to update `DNS spec for kubernetes` and `kubernetes documentation`. No updates required in this repo.

/cc @johnbelamaric @chrisohaver 