### PR TITLE
plugin/etcd: Fix CNAME results for empty host fields

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -316,6 +316,9 @@ func CNAME(b ServiceBackend, zone string, state request.Request, opt Options) (r
 
 	if len(services) > 0 {
 		serv := services[0]
+		if len(serv.Host) == 0 {
+			return nil, nil
+		}
 		if ip := net.ParseIP(serv.Host); ip == nil {
 			records = append(records, serv.NewCNAME(state.QName(), serv.Host))
 		}

--- a/plugin/etcd/cname_test.go
+++ b/plugin/etcd/cname_test.go
@@ -58,6 +58,7 @@ var servicesCname = []*msg.Service{
 	{Host: "cname6.region2.skydns.test", Key: "cname5.region2.skydns.test."},
 	{Host: "endpoint.region2.skydns.test", Key: "cname6.region2.skydns.test."},
 	{Host: "mainendpoint.region2.skydns.test", Key: "region2.skydns.test."},
+	{Host: "", Key: "region3.skydns.test.", Text: "SOME-RECORD-TEXT"},
 	{Host: "10.240.0.1", Key: "endpoint.region2.skydns.test."},
 }
 
@@ -81,6 +82,13 @@ var dnsTestCasesCname = []test.Case{
 		Qname: "region2.skydns.test.", Qtype: dns.TypeCNAME,
 		Answer: []dns.RR{
 			test.CNAME("region2.skydns.test.	300	IN	CNAME	mainendpoint.region2.skydns.test."),
+		},
+	},
+	{
+		Qname: "region3.skydns.test.", Qtype: dns.TypeCNAME,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("skydns.test.	303	IN	SOA	ns.dns.skydns.test. hostmaster.skydns.test. 1546424605 7200 1800 86400 30"),
 		},
 	},
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do? 

When a CNAME is requested, and a service with a filled out host field is not present for the exact key, a NODATA result should be returned. If the key exists, and the host field is empty, coredns erroneously returns a NOERROR response with a "." as the result. This would for example manifest when the requested key had a service representing a TXT record (Text field filled, empty Host field).

Fixing by specifically checking for empty Host fields when a CNAME lookup is done, and returning an empty answer, with the NOERROR Rcode.

### 2. Which issues (if any) are related?

N/A?

### 3. Which documentation changes (if any) need to be made?

None
