### PR TITLE
plugin/kubernetes: Remove multi API endpoint option

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -32,7 +32,7 @@ all the zones the plugin should be authoritative for.
 ```
 kubernetes [ZONES...] {
     resyncperiod DURATION
-    endpoint URL [URL...]
+    endpoint URL
     tls CERT KEY CACERT
     kubeconfig KUBECONFIG CONTEXT
     namespaces NAMESPACE...
@@ -51,9 +51,6 @@ kubernetes [ZONES...] {
 * `resyncperiod` specifies the Kubernetes data API **DURATION** period.
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
-   Multiple k8s API endpoints could be specified:
-   `endpoint http://k8s-endpoint1:8080 http://k8s-endpoint2:8080`. CoreDNS
-   will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -30,7 +30,7 @@ type Kubernetes struct {
 	Next             plugin.Handler
 	Zones            []string
 	Upstream         upstream.Upstream
-	APIServer    string
+	APIServer        string
 	APIProxy         *apiProxy
 	APICertAuth      string
 	APIClientCert    string

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -194,8 +194,8 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			return nil, c.ArgErr()
 		case "endpoint":
 			args := c.RemainingArgs()
-			if len(args) > 0 {
-				k8s.APIServerList = args
+			if len(args) == 1 {
+				k8s.APIServer = args[0]
 				continue
 			}
 			return nil, c.ArgErr()

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -65,20 +65,6 @@ func TestKubernetesParse(t *testing.T) {
 		},
 		{
 			`kubernetes coredns.local {
-	endpoint http://localhost:9090 http://localhost:9091
-}`,
-			false,
-			"",
-			1,
-			0,
-			defaultResyncPeriod,
-			"",
-			podModeDisabled,
-			fall.Zero,
-			nil,
-		},
-		{
-			`kubernetes coredns.local {
 	namespaces demo
 }`,
 			false,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Removing multi k8s api connections option per #1464.

### 2. Which issues (if any) are related?
#1464

### 3. Which documentation changes (if any) need to be made?
included