### PR TITLE
plugin/kubernetes: Error out when multiple https endpoints are specified.

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -52,8 +52,9 @@ kubernetes [ZONES...] {
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
    Multiple k8s API endpoints could be specified:
-   `endpoint http://k8s-endpoint1:8080 http://k8s-endpoint2:8080`. CoreDNS
-   will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
+   `endpoint http://k8s-endpoint1:8080 http://k8s-endpoint2:8080`.
+   CoreDNS will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
+   Note that only http is supported when more than one k8s API endpoints are specified at the moment.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
    This option is ignored if connecting in-cluster (i.e. endpoint is not specified).
 * `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -196,6 +196,15 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			args := c.RemainingArgs()
 			if len(args) > 0 {
 				k8s.APIServerList = args
+				if len(args) > 1 {
+					// If multiple endoints specified, then only http allowed
+					for i := range args {
+						parts := strings.SplitN(args[i], "://", 2)
+						if len(parts) == 2 && parts[0] != "http" {
+							return nil, fmt.Errorf("multiple endpoints can only accept http, found: %v", args[i])
+						}
+					}
+				}
 				continue
 			}
 			return nil, c.ArgErr()

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -439,6 +439,20 @@ kubernetes cluster.local`,
 			fall.Zero,
 			nil,
 		},
+		{
+			`kubernetes coredns.local {
+    endpoint http://localhost:9090 https://localhost:9091
+}`,
+			true,
+			"multiple endpoints can only accept http",
+			-1,
+			-1,
+			defaultResyncPeriod,
+			"",
+			podModeDisabled,
+			fall.Zero,
+			nil,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This fix will error out when multiple https endpoints are specified,
as additional work is needed to support beyond http.

### 2. Which issues (if any) are related?

This fix fixes #1464 and fixes #2429.


### 3. Which documentation changes (if any) need to be made?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>