### PR TITLE
plugin hosts: seeking feedback on a feature allowing to use hashes instead of FQDN

### DIFF
--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -43,13 +43,13 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 			// If this doesn't match we need to fall through regardless of h.Fallthrough
 			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 		}
-		answers = h.ptr(qname, names)
+		answers = h.ptr(qname, h.hmap.options.ttl, names)
 	case dns.TypeA:
 		ips := h.LookupStaticHostV4(qname)
-		answers = a(qname, ips)
+		answers = a(qname, h.hmap.options.ttl, ips)
 	case dns.TypeAAAA:
 		ips := h.LookupStaticHostV6(qname)
-		answers = aaaa(qname, ips)
+		answers = aaaa(qname, h.hmap.options.ttl, ips)
 	}
 
 	if len(answers) == 0 {
@@ -96,12 +96,12 @@ func (h Hosts) otherRecordsExist(qtype uint16, qname string) bool {
 func (h Hosts) Name() string { return "hosts" }
 
 // a takes a slice of net.IPs and returns a slice of A RRs.
-func a(zone string, ips []net.IP) []dns.RR {
+func a(zone string, ttl uint32, ips []net.IP) []dns.RR {
 	answers := []dns.RR{}
 	for _, ip := range ips {
 		r := new(dns.A)
 		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeA,
-			Class: dns.ClassINET, Ttl: 3600}
+			Class: dns.ClassINET, Ttl: ttl}
 		r.A = ip
 		answers = append(answers, r)
 	}
@@ -109,12 +109,12 @@ func a(zone string, ips []net.IP) []dns.RR {
 }
 
 // aaaa takes a slice of net.IPs and returns a slice of AAAA RRs.
-func aaaa(zone string, ips []net.IP) []dns.RR {
+func aaaa(zone string, ttl uint32, ips []net.IP) []dns.RR {
 	answers := []dns.RR{}
 	for _, ip := range ips {
 		r := new(dns.AAAA)
 		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeAAAA,
-			Class: dns.ClassINET, Ttl: 3600}
+			Class: dns.ClassINET, Ttl: ttl}
 		r.AAAA = ip
 		answers = append(answers, r)
 	}
@@ -122,12 +122,12 @@ func aaaa(zone string, ips []net.IP) []dns.RR {
 }
 
 // ptr takes a slice of host names and filters out the ones that aren't in Origins, if specified, and returns a slice of PTR RRs.
-func (h *Hosts) ptr(zone string, names []string) []dns.RR {
+func (h *Hosts) ptr(zone string, ttl uint32, names []string) []dns.RR {
 	answers := []dns.RR{}
 	for _, n := range names {
 		r := new(dns.PTR)
 		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypePTR,
-			Class: dns.ClassINET, Ttl: 3600}
+			Class: dns.ClassINET, Ttl: ttl}
 		r.Ptr = dns.Fqdn(n)
 		answers = append(answers, r)
 	}

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -43,13 +43,13 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 			// If this doesn't match we need to fall through regardless of h.Fallthrough
 			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 		}
-		answers = h.ptr(qname, h.hmap.options.ttl, names)
+		answers = h.ptr(qname, h.options.ttl, names)
 	case dns.TypeA:
 		ips := h.LookupStaticHostV4(qname)
-		answers = a(qname, h.hmap.options.ttl, ips)
+		answers = a(qname, h.options.ttl, ips)
 	case dns.TypeAAAA:
 		ips := h.LookupStaticHostV6(qname)
-		answers = aaaa(qname, h.hmap.options.ttl, ips)
+		answers = aaaa(qname, h.options.ttl, ips)
 	}
 
 	if len(answers) == 0 {

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -99,6 +99,8 @@ const hostsExample = `
 ::1 localhost localhost.domain
 10.0.0.1 example.org
 ::FFFF:10.0.0.2 example.com
+reload 5s
+timeout 3600
 `
 
 func TestLookupHashed(t *testing.T) {
@@ -137,6 +139,12 @@ var hostsTestCasesHashed = []test.Case{
 }
 
 const hostsExampleHashed = `
+no-reverse
+sha512
+sha256
+ssg224
+md5
 sha1
+reload disabled
 10.0.0.3 e3245ab1c03ed4e3f9e6b858f479d6c00b0055ef
 `

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -50,6 +50,12 @@ var hostsTestCases = []test.Case{
 		},
 	},
 	{
+		Qname: "example.com.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("example.com. 3600	IN	A 10.0.0.2"),
+		},
+	},
+	{
 		Qname: "localhost.", Qtype: dns.TypeAAAA,
 		Answer: []dns.RR{
 			test.AAAA("localhost. 3600	IN	AAAA ::1"),
@@ -59,6 +65,12 @@ var hostsTestCases = []test.Case{
 		Qname: "1.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Answer: []dns.RR{
 			test.PTR("1.0.0.10.in-addr.arpa. 3600 PTR example.org."),
+		},
+	},
+	{
+		Qname: "2.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Answer: []dns.RR{
+			test.PTR("2.0.0.10.in-addr.arpa. 3600 PTR example.com."),
 		},
 	},
 	{
@@ -81,15 +93,10 @@ var hostsTestCases = []test.Case{
 const hostsExample = `
 127.0.0.1 localhost localhost.domain
 ::1 localhost localhost.domain
-10.0.0.1 example.org`
+10.0.0.1 example.org
+::FFFF:10.0.0.2 example.com
+`
 
-// {
-// 	Qname: "localhost.localdomain.", Qtype: dns.TypeA,
-// 	Answer: []dns.RR{
-// 		test.A("localhost. 3600	IN	A 127.0.0.1"),
-// 	},
-// },
-// {
 // 	Qname: "coredns.io.", Qtype: dns.TypeA,
 // 	Answer: []dns.RR{
 // 		test.A("coredns.io. 3600	IN	A 127.0.0.2"),
@@ -97,6 +104,4 @@ const hostsExample = `
 // },
 
 // sha1
-// 127.0.0.1 localhost
-// ::FFFF:127.0.0.1 localhost.domain
 // 10.0.0.2 e3245ab1c03ed4e3f9e6b858f479d6c00b0055ef

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -14,13 +14,8 @@ import (
 )
 
 func (h *Hostsfile) parseReader(r io.Reader) {
-	inline := newHostsMap(&hostsOptions{
-		autoReverse: h.hmap.options.autoReverse,
-		encoding:    h.hmap.options.encoding,
-		ttl:         h.hmap.options.ttl,
-		reload:      h.hmap.options.reload,
-	})
-	h.hmap = h.parse(r, inline)
+	inline := newHostsMap()
+	h.hmap = h.parse(r, inline, h.options.autoReverse)
 }
 
 func TestLookupA(t *testing.T) {
@@ -28,12 +23,8 @@ func TestLookupA(t *testing.T) {
 		Next: test.ErrorHandler(),
 		Hostsfile: &Hostsfile{
 			Origins: []string{"."},
-			hmap: newHostsMap(&hostsOptions{
-				autoReverse: true,
-				encoding:    noEncoding,
-				ttl:         3600,
-				reload:      &durationOf5s,
-			}),
+			hmap:    newHostsMap(),
+			options: newHostsOptions(),
 		},
 	}
 	h.parseReader(strings.NewReader(hostsExample))
@@ -115,12 +106,13 @@ func TestLookupHashed(t *testing.T) {
 		Next: test.ErrorHandler(),
 		Hostsfile: &Hostsfile{
 			Origins: []string{"."},
-			hmap: newHostsMap(&hostsOptions{
+			hmap:    newHostsMap(),
+			options: &hostsOptions{
 				autoReverse: false,
 				encoding:    crypto.SHA1,
 				ttl:         3600,
 				reload:      &durationOf5s,
-			}),
+			},
 		},
 	}
 

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -17,6 +17,7 @@ func (h *Hostsfile) parseReader(r io.Reader) {
 	inline := newHostsMap(&hostsOptions{
 		autoReverse: h.hmap.options.autoReverse,
 		encoding:    h.hmap.options.encoding,
+		ttl:         h.hmap.options.ttl,
 		reload:      h.hmap.options.reload,
 	})
 	h.hmap = h.parse(r, inline)
@@ -30,6 +31,7 @@ func TestLookupA(t *testing.T) {
 			hmap: newHostsMap(&hostsOptions{
 				autoReverse: true,
 				encoding:    noEncoding,
+				ttl:         3600,
 				reload:      &durationOf5s,
 			}),
 		},
@@ -116,6 +118,7 @@ func TestLookupHashed(t *testing.T) {
 			hmap: newHostsMap(&hostsOptions{
 				autoReverse: false,
 				encoding:    crypto.SHA1,
+				ttl:         3600,
 				reload:      &durationOf5s,
 			}),
 		},

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (h *Hostsfile) parseReader(r io.Reader) { h.hmap = h.parse(r, h.inline) }
+func (h *Hostsfile) parseReader(r io.Reader) { h.hmap = h.parse(r, h.inline, h.options) }
 
 func TestLookupA(t *testing.T) {
 	h := Hosts{Next: test.ErrorHandler(), Hostsfile: &Hostsfile{Origins: []string{"."}}}

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -12,7 +12,14 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (h *Hostsfile) parseReader(r io.Reader) { h.hmap = h.parse(r, h.inline, h.options) }
+func (h *Hostsfile) parseReader(r io.Reader) {
+	inline := newHostsMap(&hostsOptions{
+		autoReverse: true,
+		encoding:    noEncoding,
+		reload:      &durationOf5s,
+	})
+	h.hmap = h.parse(r, inline)
+}
 
 func TestLookupA(t *testing.T) {
 	h := Hosts{Next: test.ErrorHandler(), Hostsfile: &Hostsfile{Origins: []string{"."}}}
@@ -75,3 +82,21 @@ const hostsExample = `
 127.0.0.1 localhost localhost.domain
 ::1 localhost localhost.domain
 10.0.0.1 example.org`
+
+// {
+// 	Qname: "localhost.localdomain.", Qtype: dns.TypeA,
+// 	Answer: []dns.RR{
+// 		test.A("localhost. 3600	IN	A 127.0.0.1"),
+// 	},
+// },
+// {
+// 	Qname: "coredns.io.", Qtype: dns.TypeA,
+// 	Answer: []dns.RR{
+// 		test.A("coredns.io. 3600	IN	A 127.0.0.2"),
+// 	},
+// },
+
+// sha1
+// 127.0.0.1 localhost
+// ::FFFF:127.0.0.1 localhost.domain
+// 10.0.0.2 e3245ab1c03ed4e3f9e6b858f479d6c00b0055ef

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -46,20 +46,24 @@ type hostsOptions struct {
 	// for host entries we parse
 	autoReverse bool
 
-	// The time between two reload of the configuration
-	reload *time.Duration
-
 	// Encoding to apply before comparing the hostname with the
 	// data in the hostmap, allowing to use hexencoded hashes
 	// as hostname (so a reader can not reverse engineer what
 	// hosts are being intercepted)
 	encoding crypto.Hash
+
+	// The TTL of the record we generate
+	ttl uint32
+
+	// The time between two reload of the configuration
+	reload *time.Duration
 }
 
 func newHostsOptions() *hostsOptions {
 	return &hostsOptions{
 		autoReverse: true,
 		encoding:    noEncoding,
+		ttl:         3600,
 		reload:      &durationOf5s,
 	}
 }

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -56,6 +56,14 @@ type hostsOptions struct {
 	encoding crypto.Hash
 }
 
+func newHostsOptions() *hostsOptions {
+	return &hostsOptions{
+		autoReverse: true,
+		encoding:    noEncoding,
+		reload:      &durationOf5s,
+	}
+}
+
 type hostsMap struct {
 	// Key for the list of literal IP addresses must be a host
 	// name. It would be part of DNS labels, a FQDN or an absolute

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -231,7 +231,7 @@ func ipVersion(s string) int {
 	return 0
 }
 
-// hostKeys return the hashed hostname to lookup
+// hashed returns the hashed hostname to lookup
 func hashed(encoding crypto.Hash, host string) string {
 	var hashedHost string
 	switch encoding {
@@ -254,7 +254,7 @@ func hashed(encoding crypto.Hash, host string) string {
 }
 
 // LookupStaticHost looks up the IP addresses for the given host from the hosts file.
-func (h *Hostsfile) LookupStaticHost(hmapByName map[string][]net.IP, host string) []net.IP {
+func (h *Hostsfile) lookupStaticHost(hmapByName map[string][]net.IP, host string) []net.IP {
 	fqhost := absDomainName(host)
 
 	h.RLock()
@@ -281,12 +281,12 @@ func (h *Hostsfile) LookupStaticHost(hmapByName map[string][]net.IP, host string
 
 // LookupStaticHostV4 looks up the IPv4 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
-	return h.LookupStaticHost(h.hmap.byNameV4, host)
+	return h.lookupStaticHost(h.hmap.byNameV4, host)
 }
 
 // LookupStaticHostV6 looks up the IPv6 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
-	return h.LookupStaticHost(h.hmap.byNameV6, host)
+	return h.lookupStaticHost(h.hmap.byNameV6, host)
 }
 
 // LookupStaticAddr looks up the hosts for the given address from the hosts file.

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -219,8 +219,11 @@ func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
 }
 
 // ipVersion returns what IP version was used textually
+// gomacro> net.ParseIP("::FFFF:127.0.0.1")
+// 127.0.0.1	// net.IP
+// https://tools.ietf.org/html/rfc4291#section-2.5.5
 func ipVersion(s string) int {
-	for i := 0; i < len(s); i++ {
+	for i := len(s) - 1; i >= 0; i-- {
 		switch s[i] {
 		case '.':
 			return 4

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -47,7 +47,7 @@ type hostsOptions struct {
 	autoReverse bool
 
 	// The time between two reload of the configuration
-	reload time.Duration
+	reload *time.Duration
 
 	// Encoding to apply before comparing the hostname with the
 	// data in the hostmap, allowing to use hexencoded hashes
@@ -69,21 +69,18 @@ type hostsMap struct {
 	// We don't support old-classful IP address notation.
 	byAddr map[string][]string
 
-	options hostsOptions
+	options *hostsOptions
 }
 
+var durationOf0s, _ = time.ParseDuration("0s")
 var durationOf5s, _ = time.ParseDuration("5s")
 
-func newHostsMap(options hostsOptions) *hostsMap {
+func newHostsMap(options *hostsOptions) *hostsMap {
 	return &hostsMap{
 		byNameV4: make(map[string][]net.IP),
 		byNameV6: make(map[string][]net.IP),
 		byAddr:   make(map[string][]string),
-		options: hostsOptions{
-			autoReverse: options.autoReverse,
-			reload:      options.reload,
-			encoding:    options.encoding,
-		},
+		options:  options,
 	}
 }
 
@@ -152,7 +149,7 @@ func (h *Hostsfile) readHosts() {
 	h.Unlock()
 }
 
-func (h *Hostsfile) initInline(options hostsOptions, inline []string) {
+func (h *Hostsfile) initInline(options *hostsOptions, inline []string) {
 	if len(inline) == 0 {
 		return
 	}

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -12,7 +12,10 @@ import (
 )
 
 func testHostsfile(file string) *Hostsfile {
-	h := &Hostsfile{Origins: []string{"."}}
+	h := &Hostsfile{
+		Origins: []string{"."},
+		hmap:    newHostsMap(newHostsOptions()),
+	}
 	h.parseReader(strings.NewReader(file))
 	return h
 }

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -14,7 +14,8 @@ import (
 func testHostsfile(file string) *Hostsfile {
 	h := &Hostsfile{
 		Origins: []string{"."},
-		hmap:    newHostsMap(newHostsOptions()),
+		hmap:    newHostsMap(),
+		options: newHostsOptions(),
 	}
 	h.parseReader(strings.NewReader(file))
 	return h

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,8 +163,25 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 				options.encoding = crypto.SHA512
 			case "no-reverse":
 				options.autoReverse = false
+			case "ttl":
+				remaining := c.RemainingArgs()
+				if len(remaining) < 1 {
+					return h, c.Errf("ttl needs a time in second")
+				}
+				ttl, err := strconv.Atoi(remaining[0])
+				if err != nil {
+					return h, c.Errf("ttl needs a number of second")
+				}
+				if ttl <= 0 || ttl > 65535 {
+					return h, c.Errf("ttl provided is invalid")
+				}
+				options.ttl = uint32(ttl)
 			case "reload":
-				duration := c.RemainingArgs()[0]
+				remaining := c.RemainingArgs()
+				if len(remaining) < 1 {
+					return h, c.Errf("reload needs a duration or the word disabled")
+				}
+				duration := remaining[0]
 				if duration == "disabled" {
 					options.reload = &durationOf0s
 				} else {

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -73,16 +73,12 @@ func setup(c *caddy.Controller) error {
 func hostsParse(c *caddy.Controller) (Hosts, error) {
 	config := dnsserver.GetConfig(c)
 
-	options := hostsOptions{
-		autoReverse: true,
-		encoding:    noEncoding,
-		reload:      &durationOf5s,
-	}
+	options := newHostsOptions()
 
 	h := Hosts{
 		Hostsfile: &Hostsfile{
 			path: "/etc/hosts",
-			hmap: newHostsMap(&options),
+			hmap: newHostsMap(options),
 		},
 	}
 
@@ -188,7 +184,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 		}
 	}
 
-	h.initInline(&options, inline)
+	h.initInline(options, inline)
 
 	return h, nil
 }

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -27,12 +27,12 @@ func init() {
 func periodicHostsUpdate(h *Hosts) chan bool {
 	parseChan := make(chan bool)
 
-	if *h.hmap.options.reload == durationOf0s {
+	if *h.options.reload == durationOf0s {
 		return parseChan
 	}
 
 	go func() {
-		ticker := time.NewTicker(*h.hmap.options.reload)
+		ticker := time.NewTicker(*h.options.reload)
 		for {
 			select {
 			case <-parseChan:
@@ -78,8 +78,9 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 
 	h := Hosts{
 		Hostsfile: &Hostsfile{
-			path: "/etc/hosts",
-			hmap: newHostsMap(options),
+			path:    "/etc/hosts",
+			hmap:    newHostsMap(),
+			options: options,
 		},
 	}
 
@@ -202,7 +203,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 		}
 	}
 
-	h.initInline(options, inline)
+	h.initInline(inline)
 
 	return h, nil
 }

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -90,25 +90,23 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			case "no-reverse":
 				h.options.autoReverse = false
 				args = args[1:]
-				continue
 			case "md5", "MD5":
 				h.options.encoding = crypto.MD5
 				args = args[1:]
-				continue
 			case "sha1", "SHA1":
 				h.options.encoding = crypto.SHA1
 				args = args[1:]
-				continue
 			case "sha224", "SSH224":
 				h.options.encoding = crypto.SHA224
 				args = args[1:]
-				continue
 			case "sha512", "SSH512":
 				h.options.encoding = crypto.SHA512
 				args = args[1:]
 			default:
 				searchForPredended = false
+				continue
 			}
+			searchForPredended = (len(args) >= 1)
 		}
 
 		if len(args) >= 1 {

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -89,23 +89,19 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			switch args[0] {
 			case "no-reverse":
 				h.options.autoReverse = false
-				args = args[1:]
 			case "md5", "MD5":
 				h.options.encoding = crypto.MD5
-				args = args[1:]
 			case "sha1", "SHA1":
 				h.options.encoding = crypto.SHA1
-				args = args[1:]
 			case "sha224", "SSH224":
 				h.options.encoding = crypto.SHA224
-				args = args[1:]
 			case "sha512", "SSH512":
 				h.options.encoding = crypto.SHA512
-				args = args[1:]
 			default:
 				searchForPredended = false
 				continue
 			}
+			args = args[1:]
 			searchForPredended = (len(args) >= 1)
 		}
 

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -84,8 +84,8 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 
 		args := c.RemainingArgs()
 
-	Prepended:
-		for len(args) >= 1 {
+		var searchForPredended = (len(args) >= 1)
+		for searchForPredended {
 			switch args[0] {
 			case "no-reverse":
 				h.options.autoReverse = false
@@ -107,7 +107,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 				h.options.encoding = crypto.SHA512
 				args = args[1:]
 			default:
-				break Prepended
+				searchForPredended = false
 			}
 		}
 


### PR DESCRIPTION
Hello,

As an ISP, we started using CoreDNS as DNS cache for some of our customers. We also provide a content filtering solution to a few thousands of UK schools.

Our solution normally involves explicit and transparent proxies (80 & 443), but when it is not possible, we currently use the host plugin to prevent school children to access some "unsavvy content" - you would be surprised at the wild range of interest teenagers can display :-)

I also want to be able to filter some "sensitive" hosts and point them when a proxy to perform L7 filtering.  For operational reasons, quite a few people have access to the content of CoreDNS.

As the content of the list is quite sensitive (children pornography and terrorist sites), I implemented a quick proof-of-concept allowing to use hashes of the domain names instead of the real name. It seems to work as expected but has not seen operational deployment.

As I never contributed to your projects, I would like your feedback on:
 * if this feature could be considered for upstreaming, so I do not have to maintain the code out-of-tree
 * any test change you would like to see to consider the patch

Should you have no objection with the feature, I would happily update the README.md of the plugin to reflect the new features (asking a native English speaker to do so tho :p).

Also AFACIS the plugin reloads its data every 5 seconds, which is not documented.

Thank you,

Thomas