### PR TITLE
SizeAndDo() + rewrite - do not modify initial query, and do not response OPT if query does not ask to.

### DIFF
--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -38,6 +38,9 @@ type Rewrite struct {
 
 // ServeDNS implements the plugin.Handler interface.
 func (rw Rewrite) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+
+	// ensure r is a copy in order to not pollute the initial request
+	r = r.Copy()
 	wr := NewResponseReverter(w, r)
 	state := request.Request{W: w, Req: r}
 

--- a/request/request.go
+++ b/request/request.go
@@ -196,6 +196,15 @@ func (r *Request) Size() int {
 func (r *Request) SizeAndDo(m *dns.Msg) bool {
 	o := r.Req.IsEdns0()
 	if o == nil {
+		// ensure remove OPT if initial query was not Edns0 - compliance with https://tools.ietf.org/html/rfc6891#page-10
+		for i := len(m.Extra) - 1; i >= 0; i-- {
+			if m.Extra[i].Header().Rrtype == dns.TypeOPT {
+				m.Extra[i] = m.Extra[len(m.Extra)-1]
+				m.Extra[len(m.Extra)-1] = nil
+				m.Extra = m.Extra[:len(m.Extra)-1]
+				break
+			}
+		}
 		return false
 	}
 

--- a/request/request.go
+++ b/request/request.go
@@ -199,10 +199,9 @@ func (r *Request) SizeAndDo(m *dns.Msg) bool {
 		// ensure remove OPT if initial query was not Edns0 - compliance with https://tools.ietf.org/html/rfc6891#page-10
 		for i := len(m.Extra) - 1; i >= 0; i-- {
 			if m.Extra[i].Header().Rrtype == dns.TypeOPT {
-				m.Extra[i] = m.Extra[len(m.Extra)-1]
+				copy(m.Extra[i:], m.Extra[i+1:])
 				m.Extra[len(m.Extra)-1] = nil
 				m.Extra = m.Extra[:len(m.Extra)-1]
-				break
 			}
 		}
 		return false

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -24,9 +24,9 @@ func TestRewrite(t *testing.T) {
 
 	defer i.Stop()
 
-	testMX(t, udp)
+	//testMX(t, udp)
 	testEdns0(t, udp)
-	testNoEdns0(t, udp)
+	//testNoEdns0(t, udp)
 }
 
 func testMX(t *testing.T, server string) {
@@ -55,6 +55,8 @@ func testEdns0(t *testing.T, server string) {
 	m.SetQuestion("example.com.", dns.TypeA)
 	// enable EDNS0 from client : it should come back with all values ??
 	m.SetEdns0(4096, true)
+	o := m.IsEdns0()
+	o.Option = append(o.Option, &dns.EDNS0_LOCAL{Code: 0xffee, Data: []byte("initial-data")})
 
 	r, err := dns.Exchange(m, server)
 	if err != nil {
@@ -71,16 +73,17 @@ func testEdns0(t *testing.T, server string) {
 	if r.Answer[0].(*dns.A).A.String() != "192.0.2.53" {
 		t.Errorf("Expected 192.0.2.53, got: %s", r.Answer[0].(*dns.A).A.String())
 	}
-	o := r.IsEdns0()
-	if o == nil || len(o.Option) == 0 {
+	ro := r.IsEdns0()
+	if ro == nil {
 		t.Error("Expected EDNS0 options but got none")
 	} else {
-		if e, ok := o.Option[0].(*dns.EDNS0_LOCAL); ok {
+		// we should have the options that were sent .. no more unless the response has EDNS0 options
+		if e, ok := ro.Option[0].(*dns.EDNS0_LOCAL); ok {
 			if e.Code != 0xffee {
 				t.Errorf("Expected EDNS_LOCAL code 0xffee but got %x", e.Code)
 			}
-			if !bytes.Equal(e.Data, []byte("hello-world")) {
-				t.Errorf("Expected EDNS_LOCAL data 'hello-world' but got %q", e.Data)
+			if !bytes.Equal(e.Data, []byte("initial-data")) {
+				t.Errorf("Expected EDNS_LOCAL data 'initial-data' but got %q", e.Data)
 			}
 		} else {
 			t.Errorf("Expected EDNS0_LOCAL but got %v", o.Option[0])

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -24,9 +24,9 @@ func TestRewrite(t *testing.T) {
 
 	defer i.Stop()
 
-	//testMX(t, udp)
+	testMX(t, udp)
 	testEdns0(t, udp)
-	//testNoEdns0(t, udp)
+	testNoEdns0(t, udp)
 }
 
 func testMX(t *testing.T, server string) {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. why does it fix and why is it needed
- EDNS0 records are replied to a non EDNS0 client, when it should not
- effect is that the size of the packet can exceed default expectation of UDP client (512)

Explanation of fixe:
- in SizeAndDo() : remove OPT record from response, if the request has no OPT record at all
- in Rewrite ServeDNS() - copy the initial request before modifying it (be sure that you do not modify the OPT record of initial query).


NOTE: During investigation/test, I found that the Msg.Copy() was not complete for OPT records.
This PR requires the merge of this miekg/dns PR https://github.com/miekg/dns/pull/902.
 
### 2. Which issues (if any) are related?
#2484 

### 3. Which documentation changes (if any) need to be made?

NONE - that is a fix of invalid behavior
