### PR TITLE
plugin/rewrite - handle properly OPT records 

### DIFF
--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -26,6 +26,7 @@ func TestRewrite(t *testing.T) {
 
 	testMX(t, udp)
 	testEdns0(t, udp)
+	testNoEdns0(t, udp)
 }
 
 func testMX(t *testing.T, server string) {
@@ -52,6 +53,8 @@ func testMX(t *testing.T, server string) {
 func testEdns0(t *testing.T, server string) {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
+	// allow EDNS0
+	m.SetEdns0(4096, true)
 
 	r, err := dns.Exchange(m, server)
 	if err != nil {
@@ -69,9 +72,13 @@ func testEdns0(t *testing.T, server string) {
 		t.Errorf("Expected 192.0.2.53, got: %s", r.Answer[0].(*dns.A).A.String())
 	}
 	o := r.IsEdns0()
-	if o == nil || len(o.Option) == 0 {
-		t.Error("Expected EDNS0 options but got none")
+	if o == nil {
+		t.Error("Expected OPT Record but got none")
 	} else {
+		if len(o.Option) != 1 {
+			t.Errorf("Expected only one EDNS0 options but got %d", len(o.Option))
+			return
+		}
 		if e, ok := o.Option[0].(*dns.EDNS0_LOCAL); ok {
 			if e.Code != 0xffee {
 				t.Errorf("Expected EDNS_LOCAL code 0xffee but got %x", e.Code)
@@ -82,5 +89,30 @@ func testEdns0(t *testing.T, server string) {
 		} else {
 			t.Errorf("Expected EDNS0_LOCAL but got %v", o.Option[0])
 		}
+	}
+}
+
+func testNoEdns0(t *testing.T, server string) {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+
+	r, err := dns.Exchange(m, server)
+	if err != nil {
+		t.Fatalf("Expected to receive reply, but didn't: %s", err)
+	}
+
+	// expect answer section with A record in it
+	if len(r.Answer) == 0 {
+		t.Error("Expected to at least one RR in the answer section, got none")
+	}
+	if r.Answer[0].Header().Rrtype != dns.TypeA {
+		t.Errorf("Expected RR to A, got: %d", r.Answer[0].Header().Rrtype)
+	}
+	if r.Answer[0].(*dns.A).A.String() != "192.0.2.53" {
+		t.Errorf("Expected 192.0.2.53, got: %s", r.Answer[0].(*dns.A).A.String())
+	}
+	o := r.IsEdns0()
+	if o != nil {
+		t.Error("Expected no OPT record but got one")
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. why does it fix and why is it needed
- EDNS0 records are replied to a non EDNS0 client, when it should not
- effect is that the size of the packet can exceed default expectation of UDP client (512)

Explanation of fix:
- REWRITE may modify the OPT of the request : ensure to revert before writing the response
- if the initial request has no OPT, ensure the response has no OPT
- DO NOT fill the response with modified requests's OPT : if no OPT is returned in the response, the initial client will get the OPT from its own initial request (set by SizeAndDo) 

NOTE: During investigation/test, I found that the Msg.Copy() was not complete for OPT records.
This PR requires the merge of this miekg/dns PR https://github.com/miekg/dns/pull/902.
**1/25/2019 - the PR from miekg/dns is not more required**
 
### 2. Which issues (if any) are related?
#2484 

### 3. Which documentation changes (if any) need to be made?

NONE - that is a fix of invalid behavior
enhanced the rewrite_test to show that a request with no OPT will not receive any OPT response.
