### PR TITLE
plugin/backend: CNAMEs to non-existing targets in same domain

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -47,7 +47,6 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 				state1.Zone = zone
 				nextRecords, err := A(b, zone, state1, append(previousRecords, newRecord), opt)
 				if err == nil {
-					// Not only have we found something we should add the CNAME and the IP addresses.
 					if len(nextRecords) > 0 {
 						records = append(records, nextRecords...)
 					}
@@ -109,14 +108,13 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 				continue
 			}
 			if dns.IsSubDomain(zone, dns.Fqdn(serv.Host)) {
+				records = append(records, newRecord)
+
 				state1 := state.NewWithQuestion(serv.Host, state.QType())
 				state1.Zone = zone
 				nextRecords, err := AAAA(b, zone, state1, append(previousRecords, newRecord), opt)
-
 				if err == nil {
-					// Not only have we found something we should add the CNAME and the IP addresses.
 					if len(nextRecords) > 0 {
-						records = append(records, newRecord)
 						records = append(records, nextRecords...)
 					}
 				}

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -41,14 +41,14 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 				continue
 			}
 			if dns.IsSubDomain(zone, dns.Fqdn(serv.Host)) {
+				records = append(records, newRecord)
+
 				state1 := state.NewWithQuestion(serv.Host, state.QType())
 				state1.Zone = zone
 				nextRecords, err := A(b, zone, state1, append(previousRecords, newRecord), opt)
-
 				if err == nil {
 					// Not only have we found something we should add the CNAME and the IP addresses.
 					if len(nextRecords) > 0 {
-						records = append(records, newRecord)
 						records = append(records, nextRecords...)
 					}
 				}

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -125,7 +125,9 @@ var dnsTestCases = []test.Case{
 	// CNAME (unresolvable internal name)
 	{
 		Qname: "cname.prod.region1.skydns.test.", Qtype: dns.TypeA,
-		Ns: []dns.RR{test.SOA("skydns.test. 30 SOA ns.dns.skydns.test. hostmaster.skydns.test. 0 0 0 0 0")},
+		Answer: []dns.RR{
+			test.CNAME("cname.prod.region1.skydns.test. 300 CNAME unresolvable.skydns.test."),
+		},
 	},
 	// Wildcard Test
 	{
@@ -181,7 +183,10 @@ var dnsTestCases = []test.Case{
 	// CNAME loop detection
 	{
 		Qname: "a.cname.skydns.test.", Qtype: dns.TypeA,
-		Ns: []dns.RR{test.SOA("skydns.test. 30 SOA ns.dns.skydns.test. hostmaster.skydns.test. 1407441600 28800 7200 604800 60")},
+		Answer: []dns.RR{
+			test.CNAME("a.cname.skydns.test. 300 CNAME b.cname.skydns.test."),
+			test.CNAME("b.cname.skydns.test. 300 CNAME a.cname.skydns.test."),
+		},
 	},
 	// NODATA Test
 	{

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -227,6 +227,14 @@ var dnsTestCases = []test.Case{
 			test.A("svc1.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
 	},
+	// CNAME External To Internal Non-Existent Service
+	{
+		Qname: "external-to-not-a-service.testns.svc.cluster.local", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("external-to-not-a-service.testns.svc.cluster.local.	5	IN	CNAME	not-here.testns.svc.cluster.local."),
+		},
+	},
 	// AAAA Service (with an existing A record, but no AAAA record)
 	{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeAAAA,
@@ -510,6 +518,17 @@ var svcIndex = map[string][]*object.Service{
 			Name:         "external-to-service",
 			Namespace:    "testns",
 			ExternalName: "svc1.testns.svc.cluster.local.",
+			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"external-to-not-a-service.testns": {
+		{
+			Name:         "external-to-not-a-service",
+			Namespace:    "testns",
+			ExternalName: "not-here.testns.svc.cluster.local.",
 			Type:         api.ServiceTypeExternalName,
 			Ports: []api.ServicePort{
 				{Name: "http", Protocol: "tcp", Port: 80},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Include CNAME record in a response where the CNAME target is in the same domain (or handled by same plugin), and the CNAME target does not exist. Prior to this change, we would reply NXDOMAIN for this case.

### 2. Which issues (if any) are related?
#2492 

### 3. Which documentation changes (if any) need to be made?
none