### PR TITLE
plugin/etcd: Remove unnecessary struct copy

### DIFF
--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -139,13 +139,12 @@ Nodes:
 		if err := json.Unmarshal(n.Value, serv); err != nil {
 			return nil, fmt.Errorf("%s: %s", n.Key, err.Error())
 		}
-		b := msg.Service{Host: serv.Host, Port: serv.Port, Priority: serv.Priority, Weight: serv.Weight, Text: serv.Text, Key: string(n.Key)}
-		if _, ok := bx[b]; ok {
+		serv.Key = string(n.Key)
+		if _, ok := bx[*serv]; ok {
 			continue
 		}
-		bx[b] = struct{}{}
+		bx[*serv] = struct{}{}
 
-		serv.Key = string(n.Key)
 		serv.TTL = e.TTL(n, serv)
 		if serv.Priority == 0 {
 			serv.Priority = priority


### PR DESCRIPTION
The `b` struct is just copying all the fields into a new one, to
check if it already existed in a set. This isn't needed as all the
fields are identical, and a small rearrangement of the code solves the
same problem without the copy.