### PR TITLE
Upgrade caddy to 0.11.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ godeps:
 	go get -u github.com/miekg/dns
 	go get -u github.com/prometheus/client_golang/prometheus/promhttp
 	go get -u github.com/prometheus/client_golang/prometheus
-	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.11.1)
+	(cd $(GOPATH)/src/github.com/mholt/caddy              && git checkout -q v0.11.2)
 	(cd $(GOPATH)/src/github.com/miekg/dns                && git checkout -q v1.1.3)
 	(cd $(GOPATH)/src/github.com/prometheus/client_golang && git checkout -q v0.9.1)
 

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -142,6 +142,11 @@ func (s *Server) Listen() (net.Listener, error) {
 	return l, nil
 }
 
+// WrapListener Listen implements caddy.GracefulServer interface.
+func (s *Server) WrapListener(ln net.Listener) net.Listener {
+	return ln
+}
+
 // ListenPacket implements caddy.UDPServer interface.
 func (s *Server) ListenPacket() (net.PacketConn, error) {
 	p, err := listenPacket("udp", s.Addr[len(transport.DNS+"://"):])


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Caddy added `WrapListener` method in GracefulServer interface from 0.11.2, which made coredns plugin built failed. This pr fix it.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Nope.