### PR TITLE
plugin/hosts: fix for ipv4-in-ipv6

### DIFF
--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -45,6 +45,12 @@ var hostsTestCases = []test.Case{
 		},
 	},
 	{
+		Qname: "example.com.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			test.A("example.com. 3600	IN	A 10.0.0.2"),
+		},
+	},
+	{
 		Qname: "localhost.", Qtype: dns.TypeAAAA,
 		Answer: []dns.RR{
 			test.AAAA("localhost. 3600	IN	AAAA ::1"),
@@ -54,6 +60,12 @@ var hostsTestCases = []test.Case{
 		Qname: "1.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
 		Answer: []dns.RR{
 			test.PTR("1.0.0.10.in-addr.arpa. 3600 PTR example.org."),
+		},
+	},
+	{
+		Qname: "2.0.0.10.in-addr.arpa.", Qtype: dns.TypePTR,
+		Answer: []dns.RR{
+			test.PTR("2.0.0.10.in-addr.arpa. 3600 PTR example.com."),
 		},
 	},
 	{
@@ -76,4 +88,6 @@ var hostsTestCases = []test.Case{
 const hostsExample = `
 127.0.0.1 localhost localhost.domain
 ::1 localhost localhost.domain
-10.0.0.1 example.org`
+10.0.0.1 example.org
+::FFFF:10.0.0.2 example.com
+`

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -185,9 +185,8 @@ func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
 }
 
 // ipVersion returns what IP version was used textually
-// gomacro> net.ParseIP("::FFFF:127.0.0.1")
-// 127.0.0.1	// net.IP
-// https://tools.ietf.org/html/rfc4291#section-2.5.5
+// For why the string is parsed end to start,
+// see IPv4-Compatible IPv6 addresses - RFC 4291 section 2.5.5
 func ipVersion(s string) int {
 	for i := len(s) - 1; i >= 0; i-- {
 		switch s[i] {

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -185,8 +185,11 @@ func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
 }
 
 // ipVersion returns what IP version was used textually
+// gomacro> net.ParseIP("::FFFF:127.0.0.1")
+// 127.0.0.1	// net.IP
+// https://tools.ietf.org/html/rfc4291#section-2.5.5
 func ipVersion(s string) int {
-	for i := 0; i < len(s); i++ {
+	for i := len(s) - 1; i >= 0; i-- {
 		switch s[i] {
 		case '.':
 			return 4


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This fixes a bug when parsing IPv4 addresses using IPv6 encoding such as `::FFFF:127.0.0.1`

### 2. Which issues (if any) are related?

The work was part of https://github.com/coredns/coredns/pull/2489 but it was requested to have this as a different PR.

### 3. Which documentation changes (if any) need to be made?

N/A