### PR TITLE
plugin/log: add test and benchmark

### DIFF
--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -21,7 +21,7 @@ func TestLoggedStatus(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]struct{}{response.All: struct{}{}},
+		Class:     map[response.Class]struct{}{response.All: {}},
 	}
 
 	var f bytes.Buffer
@@ -53,7 +53,7 @@ func TestLoggedClassDenial(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]struct{}{response.Denial: struct{}{}},
+		Class:     map[response.Class]struct{}{response.Denial: {}},
 	}
 
 	var f bytes.Buffer
@@ -82,7 +82,7 @@ func TestLoggedClassError(t *testing.T) {
 	rule := Rule{
 		NameScope: ".",
 		Format:    DefaultLogFormat,
-		Class:     map[response.Class]struct{}{response.Error: struct{}{}},
+		Class:     map[response.Class]struct{}{response.Error: {}},
 	}
 
 	var f bytes.Buffer
@@ -104,5 +104,158 @@ func TestLoggedClassError(t *testing.T) {
 	logged := f.String()
 	if !strings.Contains(logged, "SERVFAIL") {
 		t.Errorf("Expected it to be logged. Logged string: %s", logged)
+	}
+}
+
+func TestLogged(t *testing.T) {
+	tests := []struct {
+		Rules           []Rule
+		Domain          string
+		ShouldLog       bool
+		ShouldString    string
+		ShouldNOTString string // for test format
+	}{
+		// case for NameScope
+		{
+			Rules: []Rule{
+				{
+					NameScope: "example.org.",
+					Format:    DefaultLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:       "example.org.",
+			ShouldLog:    true,
+			ShouldString: "A IN example.org.",
+		},
+		{
+			Rules: []Rule{
+				{
+					NameScope: "example.org.",
+					Format:    DefaultLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:       "example.net.",
+			ShouldLog:    false,
+			ShouldString: "",
+		},
+		{
+			Rules: []Rule{
+				{
+					NameScope: "example.org.",
+					Format:    DefaultLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+				{
+					NameScope: "example.net.",
+					Format:    DefaultLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:       "example.net.",
+			ShouldLog:    true,
+			ShouldString: "A IN example.net.",
+		},
+
+		// case for format
+		{
+			Rules: []Rule{
+				{
+					NameScope: ".",
+					Format:    "{type} {class}",
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:          "example.org.",
+			ShouldLog:       true,
+			ShouldString:    "A IN",
+			ShouldNOTString: "example.org",
+		},
+		{
+			Rules: []Rule{
+				{
+					NameScope: ".",
+					Format:    "{remote}:{port}",
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:          "example.org.",
+			ShouldLog:       true,
+			ShouldString:    "10.240.0.1:40212",
+			ShouldNOTString: "A IN example.org",
+		},
+		{
+			Rules: []Rule{
+				{
+					NameScope: ".",
+					Format:    CombinedLogFormat,
+					Class:     map[response.Class]struct{}{response.All: {}},
+				},
+			},
+			Domain:       "example.org.",
+			ShouldLog:    true,
+			ShouldString: "\"0\"",
+		},
+	}
+
+	for _, tc := range tests {
+		var f bytes.Buffer
+		log.SetOutput(&f)
+
+		logger := Logger{
+			Rules: tc.Rules,
+			Next:  test.ErrorHandler(),
+		}
+
+		ctx := context.TODO()
+		r := new(dns.Msg)
+		r.SetQuestion(tc.Domain, dns.TypeA)
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+		_, err := logger.ServeDNS(ctx, rec, r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		logged := f.String()
+
+		if !tc.ShouldLog && len(logged) != 0 {
+			t.Errorf("Expected it not to be logged, but got string: %s", logged)
+		}
+		if tc.ShouldLog && !strings.Contains(logged, tc.ShouldString) {
+			t.Errorf("Expected it to contains: %s. Logged string: %s", tc.ShouldString, logged)
+		}
+		if tc.ShouldLog && tc.ShouldNOTString != "" && strings.Contains(logged, tc.ShouldNOTString) {
+			t.Errorf("Expected it to NOT contains: %s. Logged string: %s", tc.ShouldNOTString, logged)
+		}
+	}
+}
+
+func BenchmarkLogged(b *testing.B) {
+	var f bytes.Buffer
+	log.SetOutput(&f)
+
+	rule := Rule{
+		NameScope: ".",
+		Format:    DefaultLogFormat,
+		Class:     map[response.Class]struct{}{response.All: {}},
+	}
+
+	logger := Logger{
+		Rules: []Rule{rule},
+		Next:  test.ErrorHandler(),
+	}
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		logger.ServeDNS(ctx, rec, r)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

For now, test in `plugin/log/log_test.go` only consider test case for `class` in `rule`;

this PR makes two contributions:
1. add test for different `NameScopes and format` in `rule`;
2. add `benchmark`;

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None