### PR TITLE
plugin/auto: Reload zones every one minute

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -29,11 +29,12 @@ are used.
   used to extract the origin. **ORIGIN_TEMPLATE** will be used as a template for the origin. Strings
   like `{<number>}` are replaced with the respective matches in the file name, e.g. `{1}` is the
   first match, `{2}` is the second. The default is: `db\.(.*)  {1}` i.e. from a file with the
-  name `db.example.com`, the extracted origin will be `example.com`. **TIMEOUT** deprecated. 
-  `reload` will be used, if not defined, and it will be removed in a subsequent version
+  name `db.example.com`, the extracted origin will be `example.com`.
+  **TIMEOUT** is deprecated and will be removed in a subsequent version. 
+  `reload` will be used, if not defined
   (it specifies how often CoreDNS should scan the directory to watch for file removal and addition;
   the default is every 60 seconds. This value is in seconds. The minimum value is 1 second.)
-* `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
+* `reload` interval to perform reloads of zones if SOA version changes and zonefiles. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.
 * `no_reload` deprecated. Sets reload to 0.

--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -29,9 +29,10 @@ are used.
   used to extract the origin. **ORIGIN_TEMPLATE** will be used as a template for the origin. Strings
   like `{<number>}` are replaced with the respective matches in the file name, e.g. `{1}` is the
   first match, `{2}` is the second. The default is: `db\.(.*)  {1}` i.e. from a file with the
-  name `db.example.com`, the extracted origin will be `example.com`. **TIMEOUT** specifies how often
-  CoreDNS should scan the directory; the default is every 60 seconds. This value is in seconds.
-  The minimum value is 1 second.
+  name `db.example.com`, the extracted origin will be `example.com`. **TIMEOUT** deprecated. 
+  `reload` will be used, if not defined, and it will be removed in a subsequent version
+  (it specifies how often CoreDNS should scan the directory to watch for file removal and addition;
+  the default is every 60 seconds. This value is in seconds. The minimum value is 1 second.)
 * `reload` interval to perform reload of zone if SOA version changes. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -78,8 +78,13 @@ func setup(c *caddy.Controller) error {
 
 func autoParse(c *caddy.Controller) (Auto, error) {
 	var a = Auto{
-		loader: loader{template: "${1}", re: regexp.MustCompile(`db\.(.*)`), duration: 60 * time.Second},
-		Zones:  &Zones{},
+		loader: loader{
+			template:       "${1}",
+			re:             regexp.MustCompile(`db\.(.*)`),
+			ReloadInterval: 60 * time.Second,
+			duration:       60 * time.Second,
+		},
+		Zones: &Zones{},
 	}
 
 	config := dnsserver.GetConfig(c)

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -15,6 +15,7 @@ func TestAutoParse(t *testing.T) {
 		expectedTempl          string
 		expectedRe             string
 		expectedReloadInterval time.Duration
+		expectedDuration       time.Duration
 		expectedTo             []string
 	}{
 		{
@@ -22,32 +23,46 @@ func TestAutoParse(t *testing.T) {
 				directory /tmp
 				transfer to 127.0.0.1
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, []string{"127.0.0.1:53"},
+			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, 60 * time.Second, []string{"127.0.0.1:53"},
 		},
 		{
 			`auto 10.0.0.0/24 {
 				directory /tmp
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, nil,
+			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp
 				no_reload
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, 0 * time.Second, nil,
+			false, "/tmp", "${1}", `db\.(.*)`, 0 * time.Second, 0 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp (.*) bliep
 			}`,
-			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, nil,
+			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp (.*) bliep 10
 			}`,
-			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, nil,
+			false, "/tmp", "bliep", `(.*)`, 10 * time.Second, 10 * time.Second, nil,
+		},
+		{
+			`auto {
+				directory /tmp (.*) bliep
+				reload 10s
+			}`,
+			false, "/tmp", "bliep", `(.*)`, 10 * time.Second, 10 * time.Second, nil,
+		},
+		{
+			`auto {
+				directory /tmp (.*) bliep 20
+				reload 10s
+			}`,
+			false, "/tmp", "bliep", `(.*)`, 10 * time.Second, 10 * time.Second, nil,
 		},
 		{
 			`auto {
@@ -56,45 +71,44 @@ func TestAutoParse(t *testing.T) {
 				transfer to 127.0.0.2
 				upstream 8.8.8.8
 			}`,
-			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, []string{"127.0.0.1:53", "127.0.0.2:53"},
+			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, 60 * time.Second, []string{"127.0.0.1:53", "127.0.0.2:53"},
 		},
 		// errors
 		{
 			`auto example.org {
 				directory
 			}`,
-			true, "", "${1}", `db\.(.*)`, 60 * time.Second, nil,
+			true, "", "${1}", `db\.(.*)`, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp * {1}
 			}`,
-			true, "", "${1}", ``, 60 * time.Second, nil,
+			true, "", "${1}", ``, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp * {1} aa
 			}`,
-			true, "", "${1}", ``, 60 * time.Second, nil,
+			true, "", "${1}", ``, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
 			}`,
-			true, "", "${1}", ``, 60 * time.Second, nil,
+			true, "", "${1}", ``, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
 			}`,
-			true, "", "${1}", ``, 60 * time.Second, nil,
+			true, "", "${1}", ``, 60 * time.Second, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
-				reload 10s
 			}`,
-			true, "", "${1}", ``, 10 * time.Second, nil,
+			true, "", "${1}", ``, 60 * time.Second, 60 * time.Second, nil,
 		},
 	}
 
@@ -118,6 +132,9 @@ func TestAutoParse(t *testing.T) {
 			}
 			if a.loader.ReloadInterval != test.expectedReloadInterval {
 				t.Fatalf("Test %d expected %v, got %v", i, test.expectedReloadInterval, a.loader.ReloadInterval)
+			}
+			if a.loader.duration != test.expectedDuration {
+				t.Fatalf("Test %d expected %v, got %v", i, test.expectedDuration, a.loader.duration)
 			}
 			if test.expectedTo != nil {
 				for j, got := range a.loader.transferTo {

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -62,7 +62,7 @@ func TestAutoParse(t *testing.T) {
 				directory /tmp (.*) bliep 20
 				reload 10s
 			}`,
-			false, "/tmp", "bliep", `(.*)`, 10 * time.Second, 10 * time.Second, nil,
+			false, "/tmp", "bliep", `(.*)`, 10 * time.Second, 20 * time.Second, nil,
 		},
 		{
 			`auto {

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -2,50 +2,52 @@ package auto
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mholt/caddy"
 )
 
 func TestAutoParse(t *testing.T) {
 	tests := []struct {
-		inputFileRules    string
-		shouldErr         bool
-		expectedDirectory string
-		expectedTempl     string
-		expectedRe        string
-		expectedTo        []string
+		inputFileRules         string
+		shouldErr              bool
+		expectedDirectory      string
+		expectedTempl          string
+		expectedRe             string
+		expectedReloadInterval time.Duration
+		expectedTo             []string
 	}{
 		{
 			`auto example.org {
 				directory /tmp
 				transfer to 127.0.0.1
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, []string{"127.0.0.1:53"},
+			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, []string{"127.0.0.1:53"},
 		},
 		{
 			`auto 10.0.0.0/24 {
 				directory /tmp
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, nil,
+			false, "/tmp", "${1}", `db\.(.*)`, 60 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp
 				no_reload
 			}`,
-			false, "/tmp", "${1}", `db\.(.*)`, nil,
+			false, "/tmp", "${1}", `db\.(.*)`, 0 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp (.*) bliep
 			}`,
-			false, "/tmp", "bliep", `(.*)`, nil,
+			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, nil,
 		},
 		{
 			`auto {
 				directory /tmp (.*) bliep 10
 			}`,
-			false, "/tmp", "bliep", `(.*)`, nil,
+			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, nil,
 		},
 		{
 			`auto {
@@ -54,44 +56,45 @@ func TestAutoParse(t *testing.T) {
 				transfer to 127.0.0.2
 				upstream 8.8.8.8
 			}`,
-			false, "/tmp", "bliep", `(.*)`, []string{"127.0.0.1:53", "127.0.0.2:53"},
+			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, []string{"127.0.0.1:53", "127.0.0.2:53"},
 		},
 		// errors
 		{
 			`auto example.org {
 				directory
 			}`,
-			true, "", "${1}", `db\.(.*)`, nil,
+			true, "", "${1}", `db\.(.*)`, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp * {1}
 			}`,
-			true, "", "${1}", ``, nil,
+			true, "", "${1}", ``, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp * {1} aa
 			}`,
-			true, "", "${1}", ``, nil,
+			true, "", "${1}", ``, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
 			}`,
-			true, "", "${1}", ``, nil,
+			true, "", "${1}", ``, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
 			}`,
-			true, "", "${1}", ``, nil,
+			true, "", "${1}", ``, 60 * time.Second, nil,
 		},
 		{
 			`auto example.org {
 				directory /tmp .* {1}
+				reload 10s
 			}`,
-			true, "", "${1}", ``, nil,
+			true, "", "${1}", ``, 10 * time.Second, nil,
 		},
 	}
 
@@ -112,6 +115,9 @@ func TestAutoParse(t *testing.T) {
 			}
 			if a.loader.re.String() != test.expectedRe {
 				t.Fatalf("Test %d expected %v, got %v", i, test.expectedRe, a.loader.re)
+			}
+			if a.loader.ReloadInterval != test.expectedReloadInterval {
+				t.Fatalf("Test %d expected %v, got %v", i, test.expectedReloadInterval, a.loader.ReloadInterval)
 			}
 			if test.expectedTo != nil {
 				for j, got := range a.loader.transferTo {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
However README says "Default is one minute.", zone data is not reloaded without declaring `reload` option explicitly.
By this change, data is reloaded every one minute by default.

### 2. Which issues (if any) are related?
#2471 

### 3. Which documentation changes (if any) need to be made?
None