### PR TITLE
plugin/kubernetes: set special ttl for clusterIP service

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -40,7 +40,7 @@ kubernetes [ZONES...] {
     pods POD-MODE
     endpoint_pod_names
     upstream [ADDRESS...]
-    ttl TTL
+    ttl TTL [clusterIPTTL]
     noendpoints
     transfer to ADDRESS...
     fallthrough [ZONES...]
@@ -88,7 +88,8 @@ kubernetes [ZONES...] {
   that point to external hosts (aka External Services, aka CNAMEs).  If no **ADDRESS** is given, CoreDNS
   will resolve External Services against itself. **ADDRESS** can be an IP, an IP:port, or a path
   to a file structured like resolv.conf.
-* `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
+* `ttl` allows you to set a custom TTL for responses and a optional clusterIPTTL for clusterIP service
+  which can be a little large. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.
   All endpoint queries and headless service queries will result in an NXDOMAIN.

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -42,6 +42,7 @@ type Kubernetes struct {
 	endpointNameMode bool
 	Fall             fall.F
 	ttl              uint32
+	clusterIPTtl     uint32
 	opts             dnsControlOpts
 
 	primaryZoneIndex   int
@@ -59,6 +60,7 @@ func New(zones []string) *Kubernetes {
 	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("127.0.0.1") }
 	k.podMode = podModeDisabled
 	k.ttl = defaultTTL
+	k.clusterIPTtl = defaultTTL
 
 	return k
 }
@@ -486,7 +488,7 @@ func (k *Kubernetes) findServices(r recordRequest, zone string) (services []msg.
 
 			err = nil
 
-			s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.ttl}
+			s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.clusterIPTtl}
 			s.Key = strings.Join([]string{zonePath, Svc, svc.Namespace, svc.Name}, "/")
 
 			services = append(services, s)

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -252,6 +252,18 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				return nil, c.Errf("ttl must be in range [0, 3600]: %d", t)
 			}
 			k8s.ttl = uint32(t)
+
+			// set clusterIPTtl
+			if len(args) >= 2 {
+				t, err = strconv.Atoi(args[1])
+				if err != nil {
+					return nil, err
+				}
+				if t < 0 || t > 3600 {
+					return nil, c.Errf("ttl must be in range [0, 3600]: %d", t)
+				}
+			}
+			k8s.clusterIPTtl = uint32(t)
 		case "transfer":
 			tos, froms, err := parse.Transfer(c, false)
 			if err != nil {

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -112,7 +112,7 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 			if clusterIP != nil {
 				for _, p := range svc.Ports {
 
-					s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.ttl}
+					s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.clusterIPTtl}
 					s.Key = strings.Join(svcBase, "/")
 
 					// Change host from IP to Name for SRV records


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Unlike other elements, `clusterIP service` is stable and won't change it IP address unless been deleted, so maybe we can set a special ttl for it. So to help the performance and benefit node local dns cache deployments.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2518

### 3. Which documentation changes (if any) need to be made?
plugin/kubernetes/README.md