### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,4 +219,4 @@ If you find a security vulnerability or any security related issues, please DO N
 issue, instead send your report privately to `security@coredns.io`. Security reports are greatly
 appreciated and we will publicly thank you for it.
 
-Please consult [security vulnerability disclosures and security fix and release process document](https://github.com/coredns/coredns/SECURITY-RELEASE-PROCESS.md)
+Please consult [security vulnerability disclosures and security fix and release process document](https://github.com/coredns/coredns/blob/master/SECURITY-RELEASE-PROCESS.md)


### PR DESCRIPTION
This patch fixes broken link in README.md. Currently [the URL](https://github.com/coredns/coredns/SECURITY-RELEASE-PROCESS.md) returns `Not Found`.
