### PR TITLE
cache: split out items

### DIFF
--- a/plugin/cache/cache_memory_test.go
+++ b/plugin/cache/cache_memory_test.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func BenchmarkCacheMemory(b *testing.B) {
+	c := New()
+	c.Next = BackendMemoryHandler()
+	ctx := context.TODO()
+
+	names := []string{"example1", "example2", "a", "b", "c", "d", "e", "f", "g", "h", "i", "A", "B", "C", "D", "E", "F", "G", "H"}
+
+	reqs := make([]*dns.Msg, len(names))
+	for i, q := range names {
+		reqs[i] = new(dns.Msg)
+		reqs[i].SetQuestion(q+".example.org.", dns.TypeA)
+	}
+
+	b.ReportAllocs()
+	b.StartTimer()
+	j := 0
+	for i := 0; i < b.N; i++ {
+		req := reqs[j]
+		c.ServeDNS(ctx, &test.ResponseWriter{}, req)
+		j = (j + 1) % len(names)
+	}
+}
+
+func BackendMemoryHandler() plugin.Handler {
+	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Response = true
+		m.RecursionAvailable = true
+
+		owner := m.Question[0].Name
+		// uppercase letter return NXDOMAIN
+		if byte(owner[0]) >= 65 && byte(owner[0]) < 90 {
+			m.Ns = []dns.RR{test.SOA("example.org IN SOA 1 2 3 4 5 5")}
+			w.WriteMsg(m)
+			return dns.RcodeSuccess, nil
+		}
+		m.Answer = []dns.RR{test.A(owner + " 303 IN A 127.0.0.53")}
+		w.WriteMsg(m)
+		return dns.RcodeSuccess, nil
+	})
+}

--- a/plugin/cache/cache_memory_test.go
+++ b/plugin/cache/cache_memory_test.go
@@ -44,6 +44,7 @@ func BackendMemoryHandler() plugin.Handler {
 		// uppercase letter return NXDOMAIN
 		if byte(owner[0]) >= 65 && byte(owner[0]) < 90 {
 			m.Ns = []dns.RR{test.SOA("example.org IN SOA 1 2 3 4 5 5")}
+			m.Rcode = dns.RcodeNameError
 			w.WriteMsg(m)
 			return dns.RcodeSuccess, nil
 		}

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -131,6 +131,24 @@ var cacheTestCases = []cacheTestCase{
 		},
 		shouldCache: true,
 	},
+	{
+		RecursionAvailable: true, Authoritative: false,
+		Case: test.Case{
+			Qname: "www.example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{
+				test.NS("example.org.		3600	IN	NS	a.iana-servers.net."),
+				test.NS("example.org.		3600	IN	NS	b.iana-servers.net."),
+			},
+		},
+		in: test.Case{
+			Qname: "www.example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{
+				test.NS("example.org.		3600	IN	NS	a.iana-servers.net."),
+				test.NS("example.org.		3600	IN	NS	b.iana-servers.net."),
+			},
+		},
+		shouldCache: true,
+	},
 }
 
 func cacheMsg(m *dns.Msg, tc cacheTestCase) *dns.Msg {
@@ -185,7 +203,7 @@ func TestCache(t *testing.T) {
 			resp := i.toMsg(m, time.Now().UTC())
 
 			if err := test.Header(tc.Case, resp); err != nil {
-				t.Error(err)
+				t.Errorf("Test %s, %d: %s", tc.Case.Qname, tc.Case.Qtype, err)
 				continue
 			}
 

--- a/plugin/cache/delegation_item.go
+++ b/plugin/cache/delegation_item.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/plugin/cache/freq"
+
+	"github.com/miekg/dns"
+)
+
+type delegationItem struct {
+	Ns    []dns.RR
+	Extra []dns.RR
+
+	meta
+}
+
+func (i *delegationItem) ttl(now time.Time) int { return i.meta.ttl(now) }
+func (i *delegationItem) m() meta               { return i.meta }
+
+func (i *delegationItem) fromMsg(m *dns.Msg, now time.Time, d time.Duration) {
+	i.Ns = m.Ns
+	i.Extra = copyExtra(m.Extra)
+
+	i.origTTL = uint32(d.Seconds())
+	i.stored = now.UTC()
+	i.Freq = new(freq.Freq)
+}
+
+func (i *delegationItem) toMsg(r *dns.Msg, now time.Time) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.RecursionAvailable = true
+	m.Rcode = dns.RcodeSuccess
+	m.Ns = make([]dns.RR, len(i.Ns))
+	m.Extra = make([]dns.RR, len(i.Extra))
+
+	ttl := uint32(i.meta.ttl(now))
+
+	for j, r := range i.Ns {
+		m.Ns[j] = dns.Copy(r)
+		m.Ns[j].Header().Ttl = ttl
+	}
+	for j, r := range i.Extra {
+		m.Extra[j] = dns.Copy(r)
+		m.Extra[j].Header().Ttl = ttl
+	}
+	return m
+}

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -4,85 +4,38 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/cache/freq"
+
 	"github.com/miekg/dns"
 )
 
-type item struct {
-	Rcode              int
-	Authoritative      bool
-	AuthenticatedData  bool
-	RecursionAvailable bool
-	Answer             []dns.RR
-	Ns                 []dns.RR
-	Extra              []dns.RR
+type cacher interface {
+	fromMsg(*dns.Msg, time.Time, time.Duration)
+	toMsg(*dns.Msg, time.Time) *dns.Msg
+	ttl(time.Time) int
+	m() meta
+}
 
+type meta struct {
 	origTTL uint32
 	stored  time.Time
-
 	*freq.Freq
 }
 
-func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
-	i := new(item)
-	i.Rcode = m.Rcode
-	i.Authoritative = m.Authoritative
-	i.AuthenticatedData = m.AuthenticatedData
-	i.RecursionAvailable = m.RecursionAvailable
-	i.Answer = m.Answer
-	i.Ns = m.Ns
-	i.Extra = make([]dns.RR, len(m.Extra))
+func (m meta) ttl(now time.Time) int {
+	ttl := int(m.origTTL) - int(now.UTC().Sub(m.stored).Seconds())
+	return ttl
+}
+
+func copyExtra(extra []dns.RR) []dns.RR {
+	ex := make([]dns.RR, len(extra))
 	// Don't copy OPT records as these are hop-by-hop.
 	j := 0
-	for _, e := range m.Extra {
+	for _, e := range extra {
 		if e.Header().Rrtype == dns.TypeOPT {
 			continue
 		}
-		i.Extra[j] = e
+		ex[j] = e
 		j++
 	}
-	i.Extra = i.Extra[:j]
-
-	i.origTTL = uint32(d.Seconds())
-	i.stored = now.UTC()
-
-	i.Freq = new(freq.Freq)
-
-	return i
-}
-
-// toMsg turns i into a message, it tailors the reply to m.
-// The Authoritative bit is always set to 0, because the answer is from the cache.
-func (i *item) toMsg(m *dns.Msg, now time.Time) *dns.Msg {
-	m1 := new(dns.Msg)
-	m1.SetReply(m)
-
-	m1.Authoritative = false
-	m1.AuthenticatedData = i.AuthenticatedData
-	m1.RecursionAvailable = i.RecursionAvailable
-	m1.Rcode = i.Rcode
-
-	m1.Answer = make([]dns.RR, len(i.Answer))
-	m1.Ns = make([]dns.RR, len(i.Ns))
-	m1.Extra = make([]dns.RR, len(i.Extra))
-
-	ttl := uint32(i.ttl(now))
-	for j, r := range i.Answer {
-		m1.Answer[j] = dns.Copy(r)
-		m1.Answer[j].Header().Ttl = ttl
-	}
-	for j, r := range i.Ns {
-		m1.Ns[j] = dns.Copy(r)
-		m1.Ns[j].Header().Ttl = ttl
-	}
-	// newItem skips OPT records, so we can just use i.Extra as is.
-	for j, r := range i.Extra {
-		m1.Extra[j] = dns.Copy(r)
-		m1.Extra[j].Header().Ttl = ttl
-	}
-	return m1
-}
-
-func (i *item) ttl(now time.Time) int {
-	ttl := int(i.origTTL) - int(now.UTC().Sub(i.stored).Seconds())
-	return ttl
+	return ex[:j]
 }

--- a/plugin/cache/nameerror_item.go
+++ b/plugin/cache/nameerror_item.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/plugin/cache/freq"
+
+	"github.com/miekg/dns"
+)
+
+type nameErrorItem struct {
+	AuthenticatedData bool
+	Ns                []dns.RR
+	Extra             []dns.RR
+
+	meta
+}
+
+func (i *nameErrorItem) ttl(now time.Time) int { return i.meta.ttl(now) }
+func (i *nameErrorItem) m() meta               { return i.meta }
+
+func (i *nameErrorItem) fromMsg(m *dns.Msg, now time.Time, d time.Duration) {
+	i.AuthenticatedData = m.AuthenticatedData
+	i.Ns = m.Ns
+	i.Extra = copyExtra(m.Extra)
+
+	i.origTTL = uint32(d.Seconds())
+	i.stored = now.UTC()
+	i.Freq = new(freq.Freq)
+}
+
+func (i *nameErrorItem) toMsg(r *dns.Msg, now time.Time) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.AuthenticatedData = i.AuthenticatedData
+	m.RecursionAvailable = true
+	m.Rcode = dns.RcodeNameError
+
+	m.Ns = make([]dns.RR, len(i.Ns))
+	m.Extra = make([]dns.RR, len(i.Extra))
+
+	ttl := uint32(i.meta.ttl(now))
+
+	for j, r := range i.Ns {
+		m.Ns[j] = dns.Copy(r)
+		m.Ns[j].Header().Ttl = ttl
+	}
+	for j, r := range i.Extra {
+		m.Extra[j] = dns.Copy(r)
+		m.Extra[j].Header().Ttl = ttl
+	}
+	return m
+}

--- a/plugin/cache/noerror_item.go
+++ b/plugin/cache/noerror_item.go
@@ -1,0 +1,53 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/coredns/coredns/plugin/cache/freq"
+
+	"github.com/miekg/dns"
+)
+
+type noErrorItem struct {
+	AuthenticatedData bool
+	Answer            []dns.RR
+	Extra             []dns.RR
+
+	meta
+}
+
+func (i *noErrorItem) ttl(now time.Time) int { return i.meta.ttl(now) }
+func (i *noErrorItem) m() meta               { return i.meta }
+
+func (i *noErrorItem) fromMsg(m *dns.Msg, now time.Time, d time.Duration) {
+	i.AuthenticatedData = m.AuthenticatedData
+	i.Answer = m.Answer
+	i.Extra = copyExtra(m.Extra)
+
+	i.origTTL = uint32(d.Seconds())
+	i.stored = now.UTC()
+	i.Freq = new(freq.Freq)
+}
+
+func (i *noErrorItem) toMsg(r *dns.Msg, now time.Time) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.AuthenticatedData = i.AuthenticatedData
+	m.RecursionAvailable = true
+	m.Rcode = dns.RcodeSuccess
+
+	m.Answer = make([]dns.RR, len(i.Answer))
+	m.Extra = make([]dns.RR, len(i.Extra))
+
+	ttl := uint32(i.meta.ttl(now))
+
+	for j, r := range i.Answer {
+		m.Answer[j] = dns.Copy(r)
+		m.Answer[j].Header().Ttl = ttl
+	}
+	for j, r := range i.Extra {
+		m.Extra[j] = dns.Copy(r)
+		m.Extra[j].Header().Ttl = ttl
+	}
+	return m
+}

--- a/plugin/cache/prefech_test.go
+++ b/plugin/cache/prefech_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
-
 	"github.com/coredns/coredns/plugin/test"
+
 	"github.com/miekg/dns"
 )
 


### PR DESCRIPTION
Make each of the structs we store smaller, this should cut back on
memory use. The included benchmark shows same *number* of allocations,
but those allocation are smaller (still need to get that data out of the
test).

Cache was already using interface{} so this slit in nicely.
### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?