### PR TITLE
[WIP] plugin/k8s_external implement transfer zone for k8s_external

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -29,9 +29,8 @@ ns1.dns.example.org.  5 IN  A    ....
 ns1.dns.example.org.  5 IN  AAAA ....
 ~~~
 
-Note we use the `dns` subdomain to place the records the DNS needs (see the `apex` directive). Also
-note the SOA's serial number is static. The IP addresses of the nameserver records are those of the
-CoreDNS service.
+Note we use the `dns` subdomain to place the records the DNS needs (see the `apex` directive).
+The IP addresses of the nameserver records are those of the CoreDNS service.
 
 The *k8s_external* plugin handles the subdomain `dns` and the apex of the zone by itself, all other
 queries are resolved to addresses in the cluster.
@@ -51,11 +50,17 @@ this extended syntax.
 k8s_external [ZONE...] {
     apex APEX
     ttl TTL
+    transfer to ADDRESS...
 }
 ~~~
 
 * **APEX** is the name (DNS label) to use the apex records, defaults to `dns`.
 * `ttl` allows you to set a custom **TTL** for responses. The default is 5 (seconds).
+* `transfer` enables zone transfers. It may be specified multiples times. `To` signals the direction
+  (only `to` is allow). **ADDRESS** must be denoted in CIDR notation (127.0.0.1/32 etc.) or just as
+  plain addresses. The special wildcard `*` means: the entire internet.
+  Sending DNS notifies is not supported.
+
 
 # Examples
 

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -38,6 +38,7 @@ type External struct {
 	hostmaster string
 	apex       string
 	ttl        uint32
+	transferTo []string
 
 	externalFunc     func(request.Request) ([]msg.Service, int)
 	externalAddrFunc func(request.Request) []dns.RR

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -3,6 +3,8 @@ package external
 import (
 	"strconv"
 
+	prs "github.com/coredns/coredns/plugin/pkg/parse"
+
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 
@@ -77,6 +79,15 @@ func parse(c *caddy.Controller) (*External, error) {
 					return nil, c.ArgErr()
 				}
 				e.apex = args[0]
+			case "transfer":
+				tos, froms, err := prs.Transfer(c, false)
+				if err != nil {
+					return nil, err
+				}
+				if len(froms) != 0 {
+					return nil, c.Errf("transfer from is not supported with this plugin")
+				}
+				e.transferTo = tos
 			default:
 				return nil, c.Errf("unknown property '%s'", c.Val())
 			}

--- a/plugin/k8s_external/xfr.go
+++ b/plugin/k8s_external/xfr.go
@@ -1,0 +1,94 @@
+package external
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/request"
+
+	"github.com/miekg/dns"
+)
+
+const transferLength = 2000
+
+// Serial implements the Transferer interface.
+func (e *External) Serial(state request.Request) uint32 { return uint32(time.Now().Unix()) }
+
+// MinTTL implements the Transferer interface.
+func (e *External) MinTTL(state request.Request) uint32 { return e.ttl }
+
+// Transfer implements the Transferer interface.
+func (e *External) Transfer(ctx context.Context, state request.Request) (int, error) {
+
+	if !e.transferAllowed(state) {
+		return dns.RcodeRefused, nil
+	}
+
+	svc, rcode := e.externalFunc(state)
+
+	m := new(dns.Msg)
+	m.SetReply(state.Req)
+
+	if len(svc) == 0 {
+		m.Rcode = rcode
+		m.Ns = []dns.RR{e.soa(state)}
+		state.W.WriteMsg(m)
+		return 0, nil
+	}
+
+	records := e.axfr(svc, state)
+
+	ch := make(chan *dns.Envelope)
+	tr := new(dns.Transfer)
+
+	soa := []dns.RR{e.soa(state)}
+	ns := []dns.RR{e.ns(state)}
+
+	records = append(ns, records...)
+	records = append(soa, records...)
+	records = append(records, soa...)
+
+	go func(ch chan *dns.Envelope) {
+		j, l := 0, 0
+		log.Infof("Outgoing transfer of %d records of zone %s to %s started", len(records), state.Zone, state.IP())
+		for i, r := range records {
+			l += dns.Len(r)
+			if l > transferLength {
+				ch <- &dns.Envelope{RR: records[j:i]}
+				l = 0
+				j = i
+			}
+		}
+		if j < len(records) {
+			ch <- &dns.Envelope{RR: records[j:]}
+		}
+		close(ch)
+	}(ch)
+
+	tr.Out(state.W, state.Req, ch)
+	// Defer closing to the client
+	state.W.Hijack()
+	return dns.RcodeSuccess, nil
+}
+
+// transferAllowed checks if incoming request for transferring the zone is allowed according to the ACLs.
+// Note: This is copied from zone.transferAllowed, but should eventually be factored into a common transfer pkg.
+func (e *External) transferAllowed(state request.Request) bool {
+	for _, t := range e.transferTo {
+		if t == "*" {
+			return true
+		}
+		// If remote IP matches we accept.
+		remote := state.IP()
+		to, _, err := net.SplitHostPort(t)
+		if err != nil {
+			continue
+		}
+		if to == remote {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -23,6 +23,8 @@ func (k *Kubernetes) nsAddr() *dns.A {
 	)
 
 	rr := new(dns.A)
+	rr.Hdr.Class = dns.ClassINET
+	rr.Hdr.Rrtype = dns.TypeA
 	localIP := k.interfaceAddrsFunc()
 	rr.A = localIP
 
@@ -41,7 +43,6 @@ FindEndpoint:
 
 	if len(svcName) == 0 {
 		rr.Hdr.Name = defaultNSName
-		rr.A = localIP
 		return rr
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
I need to be able to serve a secondary server from the Authoritative server of the public side of the Cluster.
In other word, I need AXFR to be implemented in `k8s_external` plugin

### 2. Which issues (if any) are related?
#2526 

### 3. Which documentation changes (if any) need to be made?
oops .. will update on next commit

WIP, still todo:
- Update the README with 'tranferTo' and the support for AXFR/IXFR
- Implement a smart SERIAL for k8s_external
- add UT for Transfer support
