### PR TITLE
Set klog's logtostderr flag

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -20,6 +20,9 @@ import (
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	// Pull this in for logtostderr flag parsing
+	"k8s.io/klog"
+
 	// Excluding azure because it is failing to compile
 	// pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -38,8 +41,10 @@ func init() {
 	// We also set: os.Stderr = os.Stdout in the setup function below so we output to standard out; as we do for
 	// all CoreDNS logging. We can't do *that* in the init function, because we, when starting, also barf some
 	// things to stderr.
-	flag.Set("logtostderr", "true")
-	flag.Parse()
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	logtostderr := klogFlags.Lookup("logtostderr")
+	logtostderr.Value.Set("true")
 
 	caddy.RegisterPlugin("kubernetes", caddy.Plugin{
 		ServerType: "dns",

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -36,7 +36,7 @@ import (
 var log = clog.NewWithPlugin("kubernetes")
 
 func init() {
-	// Kubernetes plugin uses the kubernetes library, which now uses klog (ugh), we must set and parse this *flag*,
+	// Kubernetes plugin uses the kubernetes library, which now uses klog, we must set and parse this flag
 	// so we don't log to the filesystem, which can fill up and crash CoreDNS indirectly by calling os.Exit().
 	// We also set: os.Stderr = os.Stdout in the setup function below so we output to standard out; as we do for
 	// all CoreDNS logging. We can't do *that* in the init function, because we, when starting, also barf some

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -33,12 +33,13 @@ import (
 var log = clog.NewWithPlugin("kubernetes")
 
 func init() {
-	// Kubernetes plugin uses the kubernetes library, which uses glog (ugh), we must set this *flag*,
+	// Kubernetes plugin uses the kubernetes library, which now uses klog (ugh), we must set and parse this *flag*,
 	// so we don't log to the filesystem, which can fill up and crash CoreDNS indirectly by calling os.Exit().
 	// We also set: os.Stderr = os.Stdout in the setup function below so we output to standard out; as we do for
 	// all CoreDNS logging. We can't do *that* in the init function, because we, when starting, also barf some
 	// things to stderr.
 	flag.Set("logtostderr", "true")
+	flag.Parse()
 
 	caddy.RegisterPlugin("kubernetes", caddy.Plugin{
 		ServerType: "dns",


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The update of client-go to v10.0.0 has moved K8s logging from glog to klog.

This change removes the previous non-obvious flag setting behaviour used for glog and then ensures that `klog`, the replacement for `glog` has the relevant flag set. See klog code for the reason why this has to happen: https://github.com/coredns/coredns/blob/92836cc6f9aaf47a349993271ddae273d8e7d25d/vendor/k8s.io/klog/klog.go

Note that simply updating to the [version of klog updating this flag to default to `true` rather than `false`](https://github.com/kubernetes/klog/commit/dc33890e9278abc368420dc7b2b39d2065db9cb2) was tested and still caused crashes.

Tested locally:

```
kubectl logs -f -n kube-system core-dns-8ff86fc8c-s2hng
.:53
2019-02-05T20:52:29.173Z [INFO] CoreDNS-1.3.1
2019-02-05T20:52:29.173Z [INFO] linux/amd64, go1.11.4, 66623192-dirty
CoreDNS-1.3.1
linux/amd64, go1.11.4, 66623192-dirty
2019-02-05T20:52:29.173Z [INFO] plugin/reload: Running configuration MD5 = a03e157fe14ec2d191bddec59dc496fc
E0205 20:53:15.981439       1 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=15, ErrCode=NO_ERROR, debug=""
E0205 20:53:15.981458       1 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=15, ErrCode=NO_ERROR, debug=""
E0205 20:53:15.981458       1 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=15, ErrCode=NO_ERROR, debug=""
E0205 20:53:15.981470       1 streamwatcher.go:109] Unable to decode an event from the watch stream: http2: server sent GOAWAY and closed the connection; LastStreamID=15, ErrCode=NO_ERROR, debug=""
E0205 20:53:15.981849       1 reflector.go:251] github.com/coredns/coredns/plugin/kubernetes/controller.go:322: Failed to watch *v1.Namespace: Get https://10.254.0.1:443/api/v1/namespaces?resourceVersion=343852&timeout=5m46s&timeoutSeconds=346&watch=true: dial tcp 10.254.0.1:443: connect: connection refused
E0205 20:53:15.981851       1 reflector.go:251] github.com/coredns/coredns/plugin/kubernetes/controller.go:320: Failed to watch *v1.Pod: Get https://10.254.0.1:443/api/v1/pods?resourceVersion=347745&timeout=5m19s&timeoutSeconds=319&watch=true: dial tcp 10.254.0.1:443: connect: connection refused
E0205 20:53:15.981851       1 reflector.go:251] github.com/coredns/coredns/plugin/kubernetes/controller.go:317: Failed to watch *v1.Endpoints: Get https://10.254.0.1:443/api/v1/endpoints?resourceVersion=347877&timeout=5m29s&timeoutSeconds=329&watch=true: dial tcp 10.254.0.1:443: connect: connection refused
E0205 20:53:15.981876       1 reflector.go:251] github.com/coredns/coredns/plugin/kubernetes/controller.go:315: Failed to watch *v1.Service: Get https://10.254.0.1:443/api/v1/services?resourceVersion=343852&timeout=8m26s&timeoutSeconds=506&watch=true: dial tcp 10.254.0.1:443: connect: connection refused
```

No restarts of pods observed.

### 2. Which issues (if any) are related?
#2464 , supersedes the sticking plaster attempted by #2525 

### 3. Which documentation changes (if any) need to be made?
Noted as a bug fix for a regression in v1.3.1 only.
