### PR TITLE
 Fix some spelling errors in comment

### DIFF
--- a/plugin/cache/error_test.go
+++ b/plugin/cache/error_test.go
@@ -26,7 +26,7 @@ func TestFormErr(t *testing.T) {
 	}
 }
 
-// formErrHanlder is a fake plugin implementation which returns a FORMERR for a reply.
+// formErrHandler is a fake plugin implementation which returns a FORMERR for a reply.
 func formErrHandler() plugin.Handler {
 	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 		m := new(dns.Msg)

--- a/plugin/etcd/msg/path.go
+++ b/plugin/etcd/msg/path.go
@@ -30,7 +30,7 @@ func Domain(s string) string {
 }
 
 // PathWithWildcard ascts as Path, but if a name contains wildcards (* or any), the name will be
-// chopped of before the (first) wildcard, and we do a highler evel search and
+// chopped of before the (first) wildcard, and we do a higher level search and
 // later find the matching names.  So service.*.skydns.local, will look for all
 // services under skydns.local and will later check for names that match
 // service.*.skydns.local.  If a wildcard is found the returned bool is true.


### PR DESCRIPTION
1. "formErrHanlder" to "formErrHandler" in line 29.
2. "highler evel" to "higher level" in line 33.