### PR TITLE
plugin/hosts provide more configuration flexibility

### DIFF
--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -41,6 +41,9 @@ PTR records for reverse lookups are generated automatically by CoreDNS (based on
 ~~~
 hosts [FILE [ZONES...]] {
     [INLINE]
+    ttl SECONDS
+    no_reverse
+    reload DURATION
     fallthrough [ZONES...]
 }
 ~~~
@@ -53,6 +56,9 @@ hosts [FILE [ZONES...]] {
 * **INLINE** the hosts file contents inlined in Corefile. If there are any lines before fallthrough
    then all of them will be treated as the additional content for hosts file. The specified hosts
    file path will still be read but entries will be overrided.
+* `ttl` change the DNS TTL of the records generated (forward and reverse). The default is 3600 seonds (1 hour).
+* `reload` change the period between each hostsfile reload. A time of zero seconds disable the feature. Examples of valid durations: "300ms", "1.5h" or "2h45m" are valid duration with units "ns" (nanosecond), "us" (or "µs" for microsecond), "ms" (millisecond), "s" (second), "m" (minute), "h" (hour).
+* `no_reverse` disable the automatic generation of the the `in-addr.arpa` or `ip6.arpa` entries for the hosts
 * `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
   If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -12,10 +12,20 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (h *Hostsfile) parseReader(r io.Reader) { h.hmap = h.parse(r, h.inline) }
+func (h *Hostsfile) parseReader(r io.Reader) {
+	inline := newHostsMap()
+	h.hmap = h.parse(r, inline, h.options.autoReverse)
+}
 
 func TestLookupA(t *testing.T) {
-	h := Hosts{Next: test.ErrorHandler(), Hostsfile: &Hostsfile{Origins: []string{"."}}}
+	h := Hosts{
+		Next: test.ErrorHandler(),
+		Hostsfile: &Hostsfile{
+			Origins: []string{"."},
+			hmap:    newHostsMap(),
+			options: newOptions(),
+		},
+	}
 	h.parseReader(strings.NewReader(hostsExample))
 
 	ctx := context.TODO()
@@ -90,4 +100,6 @@ const hostsExample = `
 ::1 localhost localhost.domain
 10.0.0.1 example.org
 ::FFFF:10.0.0.2 example.com
+reload 5s
+timeout 3600
 `

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func (h *Hostsfile) parseReader(r io.Reader) {
-	inline := newHostsMap()
-	h.hmap = h.parse(r, inline, h.options.autoReverse)
+	h.hmap = h.parse(r)
 }
 
 func TestLookupA(t *testing.T) {

--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -32,6 +32,26 @@ func absDomainName(b string) string {
 	return plugin.Name(b).Normalize()
 }
 
+type options struct {
+	// automatically generate IP to Hostname PTR entries
+	// for host entries we parse
+	autoReverse bool
+
+	// The TTL of the record we generate
+	ttl uint32
+
+	// The time between two reload of the configuration
+	reload time.Duration
+}
+
+func newOptions() *options {
+	return &options{
+		autoReverse: true,
+		ttl:         3600,
+		reload:      durationOf5s,
+	}
+}
+
 type hostsMap struct {
 	// Key for the list of literal IP addresses must be a host
 	// name. It would be part of DNS labels, a FQDN or an absolute
@@ -45,6 +65,11 @@ type hostsMap struct {
 	// We don't support old-classful IP address notation.
 	byAddr map[string][]string
 }
+
+const (
+	durationOf0s = time.Duration(0)
+	durationOf5s = time.Duration(5 * time.Second)
+)
 
 func newHostsMap() *hostsMap {
 	return &hostsMap{
@@ -90,6 +115,8 @@ type Hostsfile struct {
 	// mtime and size are only read and modified by a single goroutine
 	mtime time.Time
 	size  int64
+
+	options *options
 }
 
 // readHosts determines if the cached data needs to be updated based on the size and modification time of the hostsfile.
@@ -106,7 +133,7 @@ func (h *Hostsfile) readHosts() {
 		return
 	}
 
-	newMap := h.parse(file, h.inline)
+	newMap := h.parse(file, h.hmap, h.options.autoReverse)
 	log.Debugf("Parsed hosts file into %d entries", newMap.Len())
 
 	h.Lock()
@@ -125,12 +152,12 @@ func (h *Hostsfile) initInline(inline []string) {
 	}
 
 	hmap := newHostsMap()
-	h.inline = h.parse(strings.NewReader(strings.Join(inline, "\n")), hmap)
+	h.inline = h.parse(strings.NewReader(strings.Join(inline, "\n")), hmap, h.options.autoReverse)
 	*h.hmap = *h.inline
 }
 
 // Parse reads the hostsfile and populates the byName and byAddr maps.
-func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
+func (h *Hostsfile) parse(r io.Reader, override *hostsMap, autoReverse bool) *hostsMap {
 	hmap := newHostsMap()
 
 	scanner := bufio.NewScanner(r)
@@ -163,6 +190,9 @@ func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
 			default:
 				continue
 			}
+			if !autoReverse {
+				continue
+			}
 			hmap.byAddr[addr.String()] = append(hmap.byAddr[addr.String()], name)
 		}
 	}
@@ -177,6 +207,7 @@ func (h *Hostsfile) parse(r io.Reader, override *hostsMap) *hostsMap {
 	for name := range override.byNameV4 {
 		hmap.byNameV6[name] = append(hmap.byNameV6[name], override.byNameV6[name]...)
 	}
+
 	for addr := range override.byAddr {
 		hmap.byAddr[addr] = append(hmap.byAddr[addr], override.byAddr[addr]...)
 	}
@@ -199,32 +230,34 @@ func ipVersion(s string) int {
 	return 0
 }
 
-// LookupStaticHostV4 looks up the IPv4 addresses for the given host from the hosts file.
-func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
+// LookupStaticHost looks up the IP addresses for the given host from the hosts file.
+func (h *Hostsfile) lookupStaticHost(hmapByName map[string][]net.IP, host string) []net.IP {
+	fqhost := absDomainName(host)
+
 	h.RLock()
 	defer h.RUnlock()
-	if len(h.hmap.byNameV4) != 0 {
-		if ips, ok := h.hmap.byNameV4[absDomainName(host)]; ok {
-			ipsCp := make([]net.IP, len(ips))
-			copy(ipsCp, ips)
-			return ipsCp
-		}
+
+	if len(hmapByName) == 0 {
+		return nil
 	}
-	return nil
+
+	ips, ok := hmapByName[fqhost]
+	if !ok {
+		return nil
+	}
+	ipsCp := make([]net.IP, len(ips))
+	copy(ipsCp, ips)
+	return ipsCp
+}
+
+// LookupStaticHostV4 looks up the IPv4 addresses for the given host from the hosts file.
+func (h *Hostsfile) LookupStaticHostV4(host string) []net.IP {
+	return h.lookupStaticHost(h.hmap.byNameV4, host)
 }
 
 // LookupStaticHostV6 looks up the IPv6 addresses for the given host from the hosts file.
 func (h *Hostsfile) LookupStaticHostV6(host string) []net.IP {
-	h.RLock()
-	defer h.RUnlock()
-	if len(h.hmap.byNameV6) != 0 {
-		if ips, ok := h.hmap.byNameV6[absDomainName(host)]; ok {
-			ipsCp := make([]net.IP, len(ips))
-			copy(ipsCp, ips)
-			return ipsCp
-		}
-	}
-	return nil
+	return h.lookupStaticHost(h.hmap.byNameV6, host)
 }
 
 // LookupStaticAddr looks up the hosts for the given address from the hosts file.
@@ -235,12 +268,14 @@ func (h *Hostsfile) LookupStaticAddr(addr string) []string {
 	if addr == "" {
 		return nil
 	}
-	if len(h.hmap.byAddr) != 0 {
-		if hosts, ok := h.hmap.byAddr[addr]; ok {
-			hostsCp := make([]string, len(hosts))
-			copy(hostsCp, hosts)
-			return hostsCp
-		}
+	if len(h.hmap.byAddr) == 0 {
+		return nil
 	}
-	return nil
+	hosts, ok := h.hmap.byAddr[addr]
+	if !ok {
+		return nil
+	}
+	hostsCp := make([]string, len(hosts))
+	copy(hostsCp, hosts)
+	return hostsCp
 }

--- a/plugin/hosts/hostsfile_test.go
+++ b/plugin/hosts/hostsfile_test.go
@@ -12,7 +12,11 @@ import (
 )
 
 func testHostsfile(file string) *Hostsfile {
-	h := &Hostsfile{Origins: []string{"."}}
+	h := &Hostsfile{
+		Origins: []string{"."},
+		hmap:    newHostsMap(),
+		options: newOptions(),
+	}
 	h.parseReader(strings.NewReader(file))
 	return h
 }

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -3,6 +3,7 @@ package hosts
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,28 +23,37 @@ func init() {
 	})
 }
 
+func periodicHostsUpdate(h *Hosts) chan bool {
+	parseChan := make(chan bool)
+
+	if h.options.reload == durationOf0s {
+		return parseChan
+	}
+
+	go func() {
+		ticker := time.NewTicker(h.options.reload)
+		for {
+			select {
+			case <-parseChan:
+				return
+			case <-ticker.C:
+				h.readHosts()
+			}
+		}
+	}()
+	return parseChan
+}
+
 func setup(c *caddy.Controller) error {
 	h, err := hostsParse(c)
 	if err != nil {
 		return plugin.Error("hosts", err)
 	}
 
-	parseChan := make(chan bool)
+	parseChan := periodicHostsUpdate(&h)
 
 	c.OnStartup(func() error {
 		h.readHosts()
-
-		go func() {
-			ticker := time.NewTicker(5 * time.Second)
-			for {
-				select {
-				case <-parseChan:
-					return
-				case <-ticker.C:
-					h.readHosts()
-				}
-			}
-		}()
 		return nil
 	})
 
@@ -61,14 +71,17 @@ func setup(c *caddy.Controller) error {
 }
 
 func hostsParse(c *caddy.Controller) (Hosts, error) {
-	var h = Hosts{
+	config := dnsserver.GetConfig(c)
+
+	options := newOptions()
+
+	h := Hosts{
 		Hostsfile: &Hostsfile{
-			path: "/etc/hosts",
-			hmap: newHostsMap(),
+			path:    "/etc/hosts",
+			hmap:    newHostsMap(),
+			options: options,
 		},
 	}
-
-	config := dnsserver.GetConfig(c)
 
 	inline := []string{}
 	i := 0
@@ -79,6 +92,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 		i++
 
 		args := c.RemainingArgs()
+
 		if len(args) >= 1 {
 			h.path = args[0]
 			args = args[1:]
@@ -114,6 +128,34 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 			switch c.Val() {
 			case "fallthrough":
 				h.Fall.SetZonesFromArgs(c.RemainingArgs())
+			case "no_reverse":
+				options.autoReverse = false
+			case "ttl":
+				remaining := c.RemainingArgs()
+				if len(remaining) < 1 {
+					return h, c.Errf("ttl needs a time in second")
+				}
+				ttl, err := strconv.Atoi(remaining[0])
+				if err != nil {
+					return h, c.Errf("ttl needs a number of second")
+				}
+				if ttl <= 0 || ttl > 65535 {
+					return h, c.Errf("ttl provided is invalid")
+				}
+				options.ttl = uint32(ttl)
+			case "reload":
+				remaining := c.RemainingArgs()
+				if len(remaining) != 1 {
+					return h, c.Errf("reload needs a duration (zero seconds to disable)")
+				}
+				reload, err := time.ParseDuration(remaining[0])
+				if err != nil {
+					return h, c.Errf("invalid duration for reload '%s'", remaining[0])
+				}
+				if reload < durationOf0s {
+					return h, c.Errf("invalid negative duration for reload '%s'", remaining[0])
+				}
+				options.reload = reload
 			default:
 				if len(h.Fall.Zones) == 0 {
 					line := strings.Join(append([]string{c.Val()}, c.RemainingArgs()...), " ")


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This patch adds few features to the host plugin
 * no-reverse (both as first argument on the plugin line and inline)
   disable the automatic generation of reserve entries for hosts
 * ttl <duration> (inline only atm)
   allows to change the default ttl (default 5 minutes)
 * reload <duration> (inline only atm)
   allows to change the reloading interval (default 5s)

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

README.md updated to reflect the new features