### PR TITLE
Fix etcd_cache_test to runnable multiple times.

### DIFF
--- a/test/etcd_credentials_test.go
+++ b/test/etcd_credentials_test.go
@@ -37,9 +37,21 @@ func TestEtcdCredentials(t *testing.T) {
 	if _, err := etc.Client.RoleAdd(ctx, "root"); err != nil {
 		t.Errorf("Failed to create root role: %s", err)
 	}
+	defer func() {
+		if _, err := etc.Client.RoleDelete(ctx, "root"); err != nil {
+			t.Errorf("Failed to delete root role: %s", err)
+		}
+	}()
+
 	if _, err := etc.Client.UserAdd(ctx, username, password); err != nil {
 		t.Errorf("Failed to create user: %s", err)
 	}
+	defer func() {
+		if _, err := etc.Client.UserDelete(ctx, username); err != nil {
+			t.Errorf("Failed to delete user: %s", err)
+		}
+	}()
+
 	if _, err := etc.Client.UserGrantRole(ctx, username, "root"); err != nil {
 		t.Errorf("Failed to assign role to root user: %v", err)
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Currently, when you run `TestEtcdCredentials` at etcd_credentials_test.go multiple times without clearing data of etcd, you will get following errors.

```
etcd_credentials_test.go:38: Failed to create root role: etcdserver: role name already exists
etcd_credentials_test.go:41: Failed to create user: etcdserver: user name already exists
```

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
None.
