### PR TITLE
 Fix t.Error error message

### DIFF
--- a/plugin/etcd/msg/service_test.go
+++ b/plugin/etcd/msg/service_test.go
@@ -100,7 +100,7 @@ func TestGroup(t *testing.T) {
 		},
 	)
 	if len(sx) != 3 {
-		t.Fatalf("Failure to group fith set: %v", sx)
+		t.Fatalf("Failure to group fifth set: %v", sx)
 	}
 
 	// One group.

--- a/plugin/pkg/tls/tls_test.go
+++ b/plugin/pkg/tls/tls_test.go
@@ -76,7 +76,7 @@ func TestNewTLSConfigFromArgs(t *testing.T) {
 		t.Error("RootCAs should not be nil when three args passed")
 	}
 	if len(c.Certificates) != 1 {
-		t.Error("Certificateis should have a single entry when three args passed")
+		t.Error("Certificates should have a single entry when three args passed")
 	}
 }
 


### PR DESCRIPTION
1. "fith" to "fifth" in line 103.
2. "Certificateis" to "Certificates" in line 79.