### PR TITLE
Adjust docs for [ADDRESS] in metrics plugin

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -47,12 +47,12 @@ prometheus [ADDRESS]
 
 For each zone that you want to see metrics for.
 
-It optionally takes an address to which the metrics are exported; the default
-is `localhost:9153`. The metrics path is fixed to `/metrics`.
+It optionally takes a bind address to which the metrics are exported; the default
+listens on `localhost:9153`. The metrics path is fixed to `/metrics`.
 
 ## Examples
 
-Use an alternative address:
+Use an alternative listening address:
 
 ~~~ corefile
 . {


### PR DESCRIPTION
The `[ADDRESS]` field in the metrics plugin is not explained in a manner that makes it immediately obvious, that what we are talking about here is a listening address.

Hopefully this change can save other newbies some time when initially setting this up. I debugged for 2 hours, thinking I messed up my k8s networking once again, only to find out that listening on 127.0.0.1 really doesn't help much when you are exposing the metrics via a service.