### PR TITLE
Change http to https for security links

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,5 +1,5 @@
 * [Infoblox](https://www.infoblox.com) uses CoreDNS in its Active Trust Cloud SaaS service, as well as for Kubernetes cluster DNS.
-* [Sky Betting & Gaming](http://engineering.skybettingandgaming.com) uses CoreDNS for Kubernetes cluster DNS.
+* [Sky Betting & Gaming](https://engineering.skybettingandgaming.com) uses CoreDNS for Kubernetes cluster DNS.
 * [Kismia](https://kismia.com) uses CoreDNS for Kubernetes cluster DNS.
 * [Admiral](https://getadmiral.com) uses CoreDNS to handle geographic DNS requests for our public-facing microservices.
 * [Qunar](https://qunar.com) uses CoreDNS for service discovery of its GPU machine learning cloud with TensorFlow and Kubernetes.
@@ -10,7 +10,7 @@
 * [Serpro/estaleiro](estaleiro.serpro.gov.br) uses CoreDNS as Kubernetes' DNS Server, in production with tuned Kubernetes plugin options
 * [Lumo](https://thinklumo.com) uses CoreDNS as Kubernetes' DNS Server, in production and lab with default configuration
 * [Booming Games](https://booming-games.com) uses CoreDNS in multiple Kubernetes clusters, with Federation plugin. expect going to production soon.
-* [Sodimac](http://www.sodimac.cl) uses CoreDNS with Kubernetes in production with default configuration.
+* [Sodimac](https://www.sodimac.cl) uses CoreDNS with Kubernetes in production with default configuration.
 * [Bose](https://www.bose.com/) uses CoreDNS with Kubernetes in production on very large cluster (over 250 nodes)
 * [farmotive](https://farmotive.io) uses CoreDNS in Kubernetes using default configuration, in its Lab. Expect to be in production soon.
 * [Zalando SE](https://www.zalando.de) uses CoreDNS as Kubernetes' DNS Server, in production.
@@ -24,6 +24,6 @@
 * [Yandex Money](https://money.yandex.ru) uses CoreDNS in Lab and Production, using default configuration for Kubernetes.
 * [AdGuard](https://adguard.com/) uses CoreDNS in [AdGuard Home](https://github.com/AdguardTeam/AdGuardHome) and, therefore, in production public AdGuard DNS servers.
 * [Skyscanner](https://www.skyscanner.net) uses CoreDNS within Kubernetes in production with the configuration tuned to use the Autopath plugin.
-* [Zinza Technology](http://zinza.com.vn) uses CoreDNS within Kubernetes in production, with standard configuration.
-* [Hualala](http://www.hualala.com/home)  uses CoreDNS in Kubernetes using default configuration, in its Lab. Expected to be in production soon.
+* [Zinza Technology](https://zinza.com.vn) uses CoreDNS within Kubernetes in production, with standard configuration.
+* [Hualala](https://www.hualala.com/home)  uses CoreDNS in Kubernetes using default configuration, in its Lab. Expected to be in production soon.
 * [Hellofresh](https://www.hellofresh.com/) uses CoreDNS in multiple Kubernetes clusters, with Forward plugin.

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -35,9 +35,9 @@ when an individual is representing the project or its community.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a CNCF project maintainer, Sarah Novotny <sarahnovotny@google.com>, and/or Dan Kohn <dan@linuxfoundation.org>.
 
 This Code of Conduct is adapted from the Contributor Covenant
-(http://contributor-covenant.org), version 1.2.0, available at
-http://contributor-covenant.org/version/1/2/0/
+(https://contributor-covenant.org), version 1.2.0, available at
+https://contributor-covenant.org/version/1/2/0/
 
 ### CNCF Events Code of Conduct
 
-CNCF events are governed by the Linux Foundation [Code of Conduct](http://events.linuxfoundation.org/events/cloudnativecon/attend/code-of-conduct) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.
+CNCF events are governed by the Linux Foundation [Code of Conduct](https://events.linuxfoundation.org/events/cloudnativecon/attend/code-of-conduct) available on the event page. This is designed to be compatible with the above policy and also includes more details on responding to incidents.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ can understand and reproduce the problematic behavior.
 The burden is on you to convince us that it is actually a bug in CoreDNS. This is easiest to do when
 you write clear, concise instructions so we can reproduce the behavior (even if it seems obvious).
 The more detailed and specific you are, the faster we will be able to help you. Check out [How to
-Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
+Report Bugs Effectively](https://www.chiark.greenend.org.uk/~sgtatham/bugs.html).
 
 Please be kind. :smile: Remember that CoreDNS comes at no cost to you, and you're getting free help.
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -13,7 +13,7 @@ CoreDNS running the kubernetes plugin can be used as a replacement for kube-dns 
 cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how
 to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
 
-[stubDomains and upstreamNameservers](http://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html)
+[stubDomains and upstreamNameservers](https://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html)
 are implemented via the *proxy* plugin and kubernetes *upstream*. See example below.
 
 This plugin can only be used once per Server Block.
@@ -58,7 +58,7 @@ kubernetes [ZONES...] {
    If this option is omitted all namespaces are exposed
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
-   [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that
+   [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that
    only exposes objects labeled as "application=nginx" in the "staging" or "qa" environments, would
    use: `labels environment in (staging, qa),application=nginx`.
 * `pods` **POD-MODE** sets the mode for handling IP-based pod A records, e.g.


### PR DESCRIPTION
Signed-off-by: Nguyen Van Trung <trungnv@vn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
For security, should be change into https links
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
