### PR TITLE
Remove unused test case

### DIFF
--- a/plugin/dnssec/dnssec_test.go
+++ b/plugin/dnssec/dnssec_test.go
@@ -95,37 +95,6 @@ func TestSigningCname(t *testing.T) {
 	}
 }
 
-// Disabled for now, see #1211.
-func testZoneSigningDelegation(t *testing.T) {
-	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
-	defer rm1()
-	defer rm2()
-
-	m := testDelegationMsg()
-	state := request.Request{Req: m, Zone: "miek.nl."}
-	m = d.Sign(state, time.Now().UTC(), server)
-	if !section(m.Ns, 1) {
-		t.Errorf("Authority section should have 1 RRSIG")
-		t.Logf("%v\n", m)
-	}
-
-	ds := 0
-	for i := range m.Ns {
-		if _, ok := m.Ns[i].(*dns.DS); ok {
-			ds++
-		}
-	}
-	if ds != 1 {
-		t.Errorf("Authority section should have 1 DS")
-		t.Logf("%v\n", m)
-
-	}
-	if !section(m.Extra, 0) {
-		t.Errorf("Answer section should have 0 RRSIGs")
-		t.Logf("%v\n", m)
-	}
-}
-
 func TestSigningDname(t *testing.T) {
 	d, rm1, rm2 := newDnssec(t, []string{"miek.nl."})
 	defer rm1()


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR remove unused test case for dnssec_test.go by issue [#1211](https://github.com/coredns/coredns/issues/1211)

### 2. Which issues (if any) are related?
issue [#1211](https://github.com/coredns/coredns/issues/1211)

### 3. Which documentation changes (if any) need to be made?
N/A

### 4. Does this introduce a backward incompatible change or deprecation?
N/A
