### PR TITLE
Fix a flaky test by not depending on Google

### DIFF
--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -1,80 +1,120 @@
 package test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/miekg/dns"
 )
 
-func TestLookupAutoPathErratic(t *testing.T) {
+func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "coredns")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpdir)
+
+	content := `
+example.org. IN	SOA sns.dns.icann.org. noc.dns.icann.org. 1 3600 3600 3600 3600
+
+google.com. IN SOA ns1.google.com. dns-admin.google.com. 1 3600 3600 3600 3600
+google.com. IN A 172.217.25.110
+`
+
+	path := filepath.Join(tmpdir, "file")
+	if err = ioutil.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Could not write to temp file: %s", err)
+	}
+	defer os.Remove(path)
+
 	corefile := `.:0 {
-	erratic
-	autopath @erratic
-	proxy . 8.8.8.8:53
-	debug
-    }
+	file ` + path + `
+}
 `
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
-		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+		t.Fatalf("Could not get proxy target CoreDNS serving instance: %s", err)
 	}
 	defer i.Stop()
 
-	tests := []struct {
-		qname          string
-		expectedAnswer string
-		expectedType   uint16
-	}{
-		{"google.com.a.example.org.", "google.com.a.example.org.", dns.TypeCNAME},
-		{"google.com.", "google.com.", dns.TypeA},
-	}
+	fn(udp)
+}
 
-	for i, tc := range tests {
-		m := new(dns.Msg)
-		// erratic always returns this search path: "a.example.org.", "b.example.org.", "".
-		m.SetQuestion(tc.qname, dns.TypeA)
-
-		r, err := dns.Exchange(m, udp)
+func TestLookupAutoPathErratic(t *testing.T) {
+	setupProxyTargetCoreDNS(t, func(proxyPath string) {
+		corefile := `.:0 {
+		erratic
+		autopath @erratic
+		proxy . ` + proxyPath + `
+		debug
+		}
+`
+		i, udp, _, err := CoreDNSServerAndPorts(corefile)
 		if err != nil {
-			t.Fatalf("Test %d, failed to sent query: %q", i, err)
+			t.Fatalf("Could not get CoreDNS serving instance: %s", err)
 		}
-		if len(r.Answer) == 0 {
-			t.Fatalf("Test %d, answer section should have RRs", i)
+		defer i.Stop()
+
+		tests := []struct {
+			qname          string
+			expectedAnswer string
+			expectedType   uint16
+		}{
+			{"google.com.a.example.org.", "google.com.a.example.org.", dns.TypeCNAME},
+			{"google.com.", "google.com.", dns.TypeA},
 		}
-		if x := r.Answer[0].Header().Name; x != tc.expectedAnswer {
-			t.Fatalf("Test %d, expected answer %s, got %s", i, tc.expectedAnswer, x)
+
+		for i, tc := range tests {
+			m := new(dns.Msg)
+			// erratic always returns this search path: "a.example.org.", "b.example.org.", "".
+			m.SetQuestion(tc.qname, dns.TypeA)
+
+			r, err := dns.Exchange(m, udp)
+			if err != nil {
+				t.Fatalf("Test %d, failed to sent query: %q", i, err)
+			}
+			if len(r.Answer) == 0 {
+				t.Fatalf("Test %d, answer section should have RRs", i)
+			}
+			if x := r.Answer[0].Header().Name; x != tc.expectedAnswer {
+				t.Fatalf("Test %d, expected answer %s, got %s", i, tc.expectedAnswer, x)
+			}
+			if x := r.Answer[0].Header().Rrtype; x != tc.expectedType {
+				t.Fatalf("Test %d, expected answer type %d, got %d", i, tc.expectedType, x)
+			}
 		}
-		if x := r.Answer[0].Header().Rrtype; x != tc.expectedType {
-			t.Fatalf("Test %d, expected answer type %d, got %d", i, tc.expectedType, x)
-		}
-	}
+	})
 }
 
 func TestAutoPathErraticNotLoaded(t *testing.T) {
-	corefile := `.:0 {
+	setupProxyTargetCoreDNS(t, func(proxyPath string) {
+		corefile := `.:0 {
 	autopath @erratic
-	proxy . 8.8.8.8:53
+	proxy . ` + proxyPath + `
 	debug
     }
 `
-	i, err := CoreDNSServer(corefile)
-	if err != nil {
-		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
-	}
+		i, err := CoreDNSServer(corefile)
+		if err != nil {
+			t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+		}
 
-	udp, _ := CoreDNSServerPorts(i, 0)
-	if udp == "" {
-		t.Fatalf("Could not get UDP listening port")
-	}
-	defer i.Stop()
+		udp, _ := CoreDNSServerPorts(i, 0)
+		if udp == "" {
+			t.Fatalf("Could not get UDP listening port")
+		}
+		defer i.Stop()
 
-	m := new(dns.Msg)
-	m.SetQuestion("google.com.a.example.org.", dns.TypeA)
-	r, err := dns.Exchange(m, udp)
-	if err != nil {
-		t.Fatalf("Failed to sent query: %q", err)
-	}
-	if r.Rcode != dns.RcodeNameError {
-		t.Fatalf("Expected NXDOMAIN, got %d", r.Rcode)
-	}
+		m := new(dns.Msg)
+		m.SetQuestion("google.com.a.example.org.", dns.TypeA)
+		r, err := dns.Exchange(m, udp)
+		if err != nil {
+			t.Fatalf("Failed to sent query: %q", err)
+		}
+		if r.Rcode != dns.RcodeNameError {
+			t.Fatalf("Expected NXDOMAIN, got %d", r.Rcode)
+		}
+	})
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
TestLookupAutoPathErratic sometimes fail on TravisCI saying below

```
=== RUN   TestLookupAutoPathErratic
--- FAIL: TestLookupAutoPathErratic (8.30s)
    erratic_autopath_test.go:39: Test 0, failed to sent query: "read udp [::1]:39758->[::1]:56643: i/o timeout"
FAIL
```

The failure happens when Google replies slowly.
This PR changes to not use Google but run CoreDNS locally and proxy to the server.

---

Because the failure depends on Google, sometimes it happens frequently but sometimes it doesn't happen.
I hope following test help you reproduce it.

```
func TestLookupAutoPathErratic2(t *testing.T) {
	for i := 0; i < 200; i++ {
		TestLookupAutoPathErratic(t)
	}
}
```

or I can reproduce it by changing proxy to other DNS like 1.1.1.1 instead of 8.8.8.8 too

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
