### PR TITLE
plugin/hosts: fix data race on h.size

### DIFF
--- a/plugin/hosts/hostsfile.go
+++ b/plugin/hosts/hostsfile.go
@@ -129,7 +129,10 @@ func (h *Hostsfile) readHosts() {
 	defer file.Close()
 
 	stat, err := file.Stat()
-	if err == nil && h.mtime.Equal(stat.ModTime()) && h.size == stat.Size() {
+	h.RLock()
+	size := h.size
+	h.RUnlock()
+	if err == nil && h.mtime.Equal(stat.ModTime()) && size == stat.Size() {
 		return
 	}
 


### PR DESCRIPTION
Guard the access of h.size as this is now a data race.

Fixes #2571