### PR TITLE
DoH: Fixing panic in case if there's no response

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -119,6 +119,11 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We should expect a packet to be returned that we can send to the client.
 	s.ServeDNS(context.Background(), dw, msg)
 
+	if dw.Msg == nil {
+		http.Error(w, "No response", http.StatusInternalServerError)
+		return
+	}
+
 	buf, _ := dw.Msg.Pack()
 
 	mt, _ := response.Typify(dw.Msg, time.Now().UTC())

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -119,6 +119,9 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We should expect a packet to be returned that we can send to the client.
 	s.ServeDNS(context.Background(), dw, msg)
 
+	// See section 4.2.1 of RFC 8484.
+	// We are using code 500 to indicate an unexpected situation when the chain
+	// handler has not provided any response message.
 	if dw.Msg == nil {
 		http.Error(w, "No response", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

There could be a situation when there's no response after ServeDNS call. With the current implementation, this leads to panic.

### 2. Which issues (if any) are related?

I've not filed a bug report, went to the pull request right away:)

### 3. Which documentation changes (if any) need to be made?

Nothing

### 4. Does this introduce a backward incompatible change or deprecation?

No