### PR TITLE
Disable Proxy Recovery

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -48,6 +48,7 @@ forward FROM TO... {
     except IGNORED_NAMES...
     force_tcp
     prefer_udp
+    disable_proxy_recovery
     expire DURATION
     max_fails INTEGER
     tls CERT KEY CA
@@ -64,6 +65,8 @@ forward FROM TO... {
 * `prefer_udp`, try first using UDP even when the request comes in over TCP. If response is truncated
   (TC flag set in response) then do another attempt over TCP. In case if both `force_tcp` and
   `prefer_udp` options specified the `force_tcp` takes precedence.
+* `disable_proxy_recovery`, allows all upstreams to go down and let other plugins to take over the
+monitoring.
 * `max_fails` is the number of subsequent failed health checks that are needed before considering
   an upstream to be down. If 0, the upstream will never be marked as down (nor health checked).
   Default is 2.

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -220,7 +220,11 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}
-
+	case "disable_proxy_recovery":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.disableProxyRecovery = true
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -12,30 +12,32 @@ import (
 
 func TestSetup(t *testing.T) {
 	tests := []struct {
-		input           string
-		shouldErr       bool
-		expectedFrom    string
-		expectedIgnored []string
-		expectedFails   uint32
-		expectedOpts    options
-		expectedErr     string
+		input                 string
+		shouldErr             bool
+		expectedFrom          string
+		expectedIgnored       []string
+		expectedFails         uint32
+		expectedOpts          options
+		expectedProxyRecovery bool
+		expectedErr           string
 	}{
 		// positive
-		{"forward . 127.0.0.1", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, options{}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true}, ""},
-		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, forceTCP: true}, ""},
-		{"forward . 127.0.0.1:53", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{}, ""},
-		{"forward . [::1]:53", false, ".", nil, 2, options{}, ""},
-		{"forward . [2003::1]:53", false, ".", nil, 2, options{}, ""},
+		{"forward . 127.0.0.1", false, ".", nil, 2, options{}, false, ""},
+		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, options{}, false, ""},
+		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, options{}, false, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true}, false, ""},
+		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true}, false, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, forceTCP: true}, false, ""},
+		{"forward . 127.0.0.1:53", false, ".", nil, 2, options{}, false, ""},
+		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{}, false, ""},
+		{"forward . [::1]:53", false, ".", nil, 2, options{}, false, ""},
+		{"forward . [2003::1]:53", false, ".", nil, 2, options{}, false, ""},
+		{"forward . 127.0.0.1 {\ndisable_proxy_recovery\n}\n", false, ".", nil, 2, options{}, true, ""},
 		// negative
-		{"forward . a27.0.0.1", true, "", nil, 0, options{}, "not an IP"},
-		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{}, "unknown property"},
+		{"forward . a27.0.0.1", true, "", nil, 0, options{}, false, "not an IP"},
+		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{}, false, "unknown property"},
 		{`forward . ::1
-		forward com ::2`, true, "", nil, 0, options{}, "plugin"},
+		forward com ::2`, true, "", nil, 0, options{}, false, "plugin"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR includes new flag (disable_proxy_recovery) that lets all proxies to go down and never go up thus enabling following things:

 1. Other monitoring/healthcheck plugins could take control over health-check and recovery mechanisms reusing proxy.Down functionality. 
2. This also allows alternate plugin to switch faster without random upstream allocation.

### 2. Which issues (if any) are related?

1. Alternate plugin slow-down
2. No control over random upstream allocation [Not an issue, however worth to mention].

### 3. Which documentation changes (if any) need to be made?

New forward flag `disable_proxy_recovery` to be introduced.

### 4. Does this introduce a backward incompatible change or deprecation?

No. By default `disable_proxy_recovery` is set to false.