### PR TITLE
Adding '/usr/bin/env bash'

### DIFF
--- a/.presubmit/context
+++ b/.presubmit/context
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/filename-hyphen
+++ b/.presubmit/filename-hyphen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/import-testing
+++ b/.presubmit/import-testing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/test-lowercase
+++ b/.presubmit/test-lowercase
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 

--- a/.presubmit/trailing-whitespace
+++ b/.presubmit/trailing-whitespace
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "** presubmit/$(basename $0)"
 


### PR DESCRIPTION
This commit aims to add '/usr/bin/env bash' as a shebang line
to indicates scripts use bash shell for interpreting.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
