### PR TITLE
Setting authoritative flag to responses when served from cache.

### DIFF
--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -30,6 +30,8 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	if i != nil && found {
 		resp := i.toMsg(r, now)
 
+		resp.Authoritative = true
+
 		w.WriteMsg(resp)
 
 		if c.prefetch > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This sets the authoritative flag on responses served from cache.

### 2. Which issues (if any) are related?
https://stackoverflow.com/questions/54778160/python-requests-library-not-resolving-dns-non-authoritative-dns-lookups. 

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
No.