### PR TITLE
Adding support for explicit no-cache policy for positive/negative dns…

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -203,10 +203,18 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 	// and key is valid
 	switch mt {
 	case response.NoError, response.Delegation:
+		// do not cache if cache disabled
+		if w.pcap < 0 {
+			return
+		}
 		i := newItem(m, w.now(), duration)
 		w.pcache.Add(key, i)
 
 	case response.NameError, response.NoData:
+		// do not cache if cache disabled
+		if w.ncap < 0 {
+			return
+		}
 		i := newItem(m, w.now(), duration)
 		w.ncache.Add(key, i)
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Please see https://github.com/coredns/coredns/issues/2586 for more context.
TLDR; This PR provides a way to disable one of the caches (positive/negative) and not the other. This enables usders to use coredns for positive caching with a ttl, while opting out of negative caching similar to the `no-neg-cache` support in dnsmasq

### 2. Which documentation changes (if any) need to be made?
cache.md should be updated, but will update this PR with the doc changes once I get some feedback.

### 3. Does this introduce a backward incompatible change or deprecation?
No


Also this enables us to have a cache policy like the following:
```
        cache {
          success 5000 5
          denial 0
        }
```
that would enable success cache but disable denial cache. 

fixes #2586