### PR TITLE
Remove redundant words in comments

### DIFF
--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -58,7 +58,7 @@ hosts [FILE [ZONES...]] {
    file path will still be read but entries will be overridden.
 * `ttl` change the DNS TTL of the records generated (forward and reverse). The default is 3600 seconds (1 hour).
 * `reload` change the period between each hostsfile reload. A time of zero seconds disable the feature. Examples of valid durations: "300ms", "1.5h" or "2h45m" are valid duration with units "ns" (nanosecond), "us" (or "µs" for microsecond), "ms" (millisecond), "s" (second), "m" (minute), "h" (hour).
-* `no_reverse` disable the automatic generation of the the `in-addr.arpa` or `ip6.arpa` entries for the hosts
+* `no_reverse` disable the automatic generation of the `in-addr.arpa` or `ip6.arpa` entries for the hosts
 * `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
   If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
   is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only

--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -14,7 +14,7 @@ import (
 // Upstream is used to resolve CNAME or other external targets via CoreDNS itself.
 type Upstream struct{}
 
-// New creates a new Upstream to resolve names using the the coredns process.
+// New creates a new Upstream to resolve names using the coredns process.
 func New() *Upstream { return &Upstream{} }
 
 // Lookup routes lookups to our selves or forward to a remote.


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects
while reading.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
