### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/plugin/file/tree/less.go
+++ b/plugin/file/tree/less.go
@@ -10,7 +10,7 @@ import (
 // >0 when a is larger than b.
 // The function orders names in DNSSEC canonical order: RFC 4034s section-6.1
 //
-// See http://bert-hubert.blogspot.co.uk/2015/10/how-to-do-fast-canonical-ordering-of.html
+// See https://bert-hubert.blogspot.co.uk/2015/10/how-to-do-fast-canonical-ordering-of.html
 // for a blog article on this implementation, although here we still go label by label.
 //
 // The values of a and b are *not* lowercased before the comparison!

--- a/vendor/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
+++ b/vendor/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
@@ -334,7 +334,7 @@ func (p *TSimpleJSONProtocol) ReadFieldBegin() (string, TType, int16, error) {
 			p.reader.ReadByte()
 			name, err := p.ParseStringBody()
 			// simplejson is not meant to be read back into thrift
-			// - see http://wiki.apache.org/thrift/ThriftUsageJava
+			// - see https://wiki.apache.org/thrift/ThriftUsageJava
 			// - use JSON instead
 			if err != nil {
 				return name, STOP, 0, err


### PR DESCRIPTION
Currently, there are some links that we access with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://...** by **https://...** for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

### 1. Why is this pull request needed and what does it do?
For securing HTTP link
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
