### PR TITLE
Restore changes in vendor directory

### DIFF
--- a/vendor/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
+++ b/vendor/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
@@ -334,7 +334,7 @@ func (p *TSimpleJSONProtocol) ReadFieldBegin() (string, TType, int16, error) {
 			p.reader.ReadByte()
 			name, err := p.ParseStringBody()
 			// simplejson is not meant to be read back into thrift
-			// - see https://wiki.apache.org/thrift/ThriftUsageJava
+			// - see http://wiki.apache.org/thrift/ThriftUsageJava
 			// - use JSON instead
 			if err != nil {
 				return name, STOP, 0, err


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Part of the changes in #2591 modifies the vendor directory
which should not be modified. `dep ensure` will change it back.


This fix reverts the change of
```
vendor/github.com/apache/thrift/lib/go/thrift/simple_json_protocol.go
```

in #2591.

### 2. Which issues (if any) are related?

#2591 

### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
