### PR TITLE
use local server if no upstream in template

### DIFF
--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -7,6 +7,7 @@ import (
 	"github.com/miekg/dns"
 
 	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/nonwriter"
 	"github.com/coredns/coredns/request"
 )
@@ -19,15 +20,20 @@ func New() *Upstream { return &Upstream{} }
 
 // Lookup routes lookups to our selves or forward to a remote.
 func (u *Upstream) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
-	server, ok := state.Context.Value(dnsserver.Key{}).(*dnsserver.Server)
-	if !ok {
-		return nil, fmt.Errorf("no full server is running")
-	}
-
 	req := new(dns.Msg)
 	req.SetQuestion(name, typ)
 
 	nw := nonwriter.New(state.W)
+	server, ok := state.Context.Value(dnsserver.Key{}).(*dnsserver.Server)
+	if !ok {
+		// this is so it can be used in template_test unittest
+		handler, handlerOk := state.Context.Value(dnsserver.Key{}).(plugin.Handler)
+		if !handlerOk {
+			return nil, fmt.Errorf("no full server is running")
+		}
+		handler.ServeDNS(state.Context, nw, req)
+		return nw.Msg, nil
+	}
 
 	server.ServeDNS(state.Context, nw, req)
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

When no upstream resolvers are defined in a template, make CoreDNS resolve CNAME targets against itself..

### 2. Which issues (if any) are related?

#2600

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No