### PR TITLE
Print test case on UT failure

### DIFF
--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -1,6 +1,7 @@
 package route53
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -68,9 +69,11 @@ func TestSetupRoute53(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := caddy.NewTestController("dns", test.body)
-		if err := setup(c, f); (err == nil) == test.expectedError {
-			t.Errorf("Unexpected errors: %v", err)
-		}
+		t.Run(fmt.Sprintf("Test case: '%s'", test.body), func(t *testing.T) {
+			c := caddy.NewTestController("dns", test.body)
+			if err := setup(c, f); (err == nil) == test.expectedError {
+				t.Errorf("Unexpected errors: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The change introduced by #2602 make it difficult, if not impossible, to identify the offending test case from the output should there be a UT failure. E.g.
```
$ go test
--- FAIL: TestSetupRoute53 (0.00s)
    setup_test.go:73: Unexpected errors: <nil>
FAIL
exit status 1
FAIL	github.com/coredns/coredns/plugin/route53	0.025s
```
Note that the line no. shown above is the line inside the test loop, not the test case itself.

The output of the same test failure with this PR looks like this:

```
go test
--- FAIL: TestSetupRoute53 (0.00s)
    --- FAIL: TestSetupRoute53/Test_case:_'route53_example.org:12345678_{_____upstream_}' (0.00s)
        setup_test.go:75: Unexpected errors: <nil>
FAIL
exit status 1
FAIL	github.com/coredns/coredns/plugin/route53	0.028s
```

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
No.