### PR TITLE
Update deprecated link in doc

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -13,7 +13,7 @@ CoreDNS running the kubernetes plugin can be used as a replacement for kube-dns 
 cluster.  See the [deployment](https://github.com/coredns/deployment) repository for details on [how
 to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
 
-[stubDomains and upstreamNameservers](https://blog.kubernetes.io/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes.html)
+[stubDomains and upstreamNameservers](https://kubernetes.io/blog/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes/)
 are implemented via the *proxy* plugin and kubernetes *upstream*. See example below.
 
 This plugin can only be used once per Server Block.


### PR DESCRIPTION
Currently, the modified link is out of date. This patch aims to update
this link to the working one that user can access.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

### 1. Why is this pull request needed and what does it do?
To update the deprecated link in README.md

### 2. Which issues (if any) are related?
The link to k8s site is dead.

### 3. Which documentation changes (if any) need to be made?
README.md

### 4. Does this introduce a backward incompatible change or deprecation?
No