### PR TITLE
Fix error string should not be capitalized

### DIFF
--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -26,7 +26,7 @@ const (
 	etcdTimeout = 5 * time.Second
 )
 
-var errKeyNotFound = errors.New("Key not found")
+var errKeyNotFound = errors.New("key not found")
 
 // Etcd is a plugin talks to an etcd cluster.
 type Etcd struct {

--- a/plugin/pkg/singleflight/singleflight_test.go
+++ b/plugin/pkg/singleflight/singleflight_test.go
@@ -40,7 +40,7 @@ func TestDo(t *testing.T) {
 
 func TestDoErr(t *testing.T) {
 	var g Group
-	someErr := errors.New("Some error")
+	someErr := errors.New("some error")
 	v, err := g.Do(1, func() (interface{}, error) {
 		return nil, someErr
 	})

--- a/plugin/proxy/grpc_test.go
+++ b/plugin/proxy/grpc_test.go
@@ -42,7 +42,7 @@ func buildPool(size int) ([]*healthcheck.UpstreamHost, func(), error) {
 		for _, e := range errs {
 			valErr += fmt.Sprintf("%v\n", e)
 		}
-		return nil, nil, fmt.Errorf("Error at allocation of the pool : %v", valErr)
+		return nil, nil, fmt.Errorf("error at allocation of the pool : %v", valErr)
 	}
 	return ups, stopIt, nil
 }

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -300,10 +300,10 @@ func getSubExprUsage(s string) int {
 func isValidRegexPattern(rewriteFrom, rewriteTo string) (*regexp.Regexp, error) {
 	rewriteFromPattern, err := regexp.Compile(rewriteFrom)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid regex matching pattern: %s", rewriteFrom)
+		return nil, fmt.Errorf("invalid regex matching pattern: %s", rewriteFrom)
 	}
 	if getSubExprUsage(rewriteTo) > rewriteFromPattern.NumSubexp() {
-		return nil, fmt.Errorf("The rewrite regex pattern (%s) uses more subexpressions than its corresponding matching regex pattern (%s)", rewriteTo, rewriteFrom)
+		return nil, fmt.Errorf("the rewrite regex pattern (%s) uses more subexpressions than its corresponding matching regex pattern (%s)", rewriteTo, rewriteFrom)
 	}
 	return rewriteFromPattern, nil
 }

--- a/plugin/rewrite/ttl.go
+++ b/plugin/rewrite/ttl.go
@@ -147,7 +147,7 @@ func newTtlRule(nextAction string, args ...string) (Rule, error) {
 		case RegexMatch:
 			regexPattern, err := regexp.Compile(args[1])
 			if err != nil {
-				return nil, fmt.Errorf("Invalid regex pattern in a ttl rule: %s", args[1])
+				return nil, fmt.Errorf("invalid regex pattern in a ttl rule: %s", args[1])
 			}
 			return &regexTtlRule{
 				nextAction,

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -115,17 +115,17 @@ func OPT(bufsize int, do bool) *dns.OPT {
 // Header test if the header in resp matches the header as defined in tc.
 func Header(tc Case, resp *dns.Msg) error {
 	if resp.Rcode != tc.Rcode {
-		return fmt.Errorf("Rcode is %q, expected %q", dns.RcodeToString[resp.Rcode], dns.RcodeToString[tc.Rcode])
+		return fmt.Errorf("rcode is %q, expected %q", dns.RcodeToString[resp.Rcode], dns.RcodeToString[tc.Rcode])
 	}
 
 	if len(resp.Answer) != len(tc.Answer) {
-		return fmt.Errorf("Answer for %q contained %d results, %d expected", tc.Qname, len(resp.Answer), len(tc.Answer))
+		return fmt.Errorf("answer for %q contained %d results, %d expected", tc.Qname, len(resp.Answer), len(tc.Answer))
 	}
 	if len(resp.Ns) != len(tc.Ns) {
-		return fmt.Errorf("Authority for %q contained %d results, %d expected", tc.Qname, len(resp.Ns), len(tc.Ns))
+		return fmt.Errorf("authority for %q contained %d results, %d expected", tc.Qname, len(resp.Ns), len(tc.Ns))
 	}
 	if len(resp.Extra) != len(tc.Extra) {
-		return fmt.Errorf("Additional for %q contained %d results, %d expected", tc.Qname, len(resp.Extra), len(tc.Extra))
+		return fmt.Errorf("additional for %q contained %d results, %d expected", tc.Qname, len(resp.Extra), len(tc.Extra))
 	}
 	return nil
 }

--- a/test/external_test.go
+++ b/test/external_test.go
@@ -44,7 +44,7 @@ func run(t *testing.T, c *exec.Cmd) ([]byte, error) {
 	c.Dir = ".."
 	out, err := c.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Run: failed to run %s %s: %q", c.Args[0], c.Args[1], err)
+		return nil, fmt.Errorf("run: failed to run %s %s: %q", c.Args[0], c.Args[1], err)
 	}
 	return out, nil
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
From [Golang coding convention](https://github.com/golang/go/wiki/CodeReviewComments#error-strings):
> Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context. That is, use fmt.Errorf("something bad") not fmt.Errorf("Something bad"), so that log.Printf("Reading %s: %v", filename, err) formats without a spurious capital letter mid-message. This does not apply to logging, which is implicitly line-oriented and not combined inside other messages.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?

- plugin/errors/errors_test.go
- plugin/etcd/etcd.go
- plugin/pkg/singleflight/singleflight_test.go
- plugin/proxy/grpc_test.go
- plugin/rewrite/name.go
- plugin/rewrite/ttl.go
- plugin/test/helpers.go
- test/external_test.go

### 4. Does this introduce a backward incompatible change or deprecation?
N/A

Co-Authored-By: Nguyen Van Trung [trungnvfet@outlook.com](mailto:trungnvfet@outlook.com)
Signed-off-by: Nguyen Quang Huy [huynq0911@gmail.com](mailto:huynq0911@gmail.com)