### PR TITLE
Add benchmark test

### DIFF
--- a/plugin/errors/benchmark_test.go
+++ b/plugin/errors/benchmark_test.go
@@ -1,0 +1,27 @@
+package errors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func BenchmarkServeDNS(b *testing.B) {
+	h := &errorHandler{}
+	h.Next = test.ErrorHandler()
+
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeA)
+	w := &test.ResponseWriter{}
+	ctx := context.TODO()
+
+	for i := 0; i < b.N; i++ {
+		_, err := h.ServeDNS(ctx, w, r)
+		if err != nil {
+			b.Errorf("ServeDNS returned error: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
Add a benchmark for ServeDNS in errors - this can be easily replicated
for all plugins. Can use this as an easy base for benchmark testing each
plugin.