### PR TITLE
plugin/template: fixed ret code

### DIFF
--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -105,7 +105,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		}
 
 		w.WriteMsg(msg)
-		return template.rcode, nil
+		return dns.RcodeSuccess, nil
 	}
 
 	return h.Next.ServeDNS(ctx, w, r)

--- a/plugin/template/template_test.go
+++ b/plugin/template/template_test.go
@@ -251,13 +251,16 @@ func TestHandler(t *testing.T) {
 			qclass:       dns.ClassINET,
 			qtype:        dns.TypeMX,
 			qname:        "test.invalid.",
-			expectedCode: dns.RcodeNameError,
+			expectedCode: dns.RcodeSuccess,
 			verifyResponse: func(r *dns.Msg) error {
 				if len(r.Answer) != 1 {
 					return fmt.Errorf("expected 1 answer, got %v", len(r.Answer))
 				}
 				if r.Answer[0].Header().Rrtype != dns.TypeSOA {
 					return fmt.Errorf("expected an SOA record answer, got %v", dns.TypeToString[r.Answer[0].Header().Rrtype])
+				}
+				if r.Rcode != dns.RcodeNameError {
+					return fmt.Errorf("expected an NXDOMAIN code, got %v", r.Rcode)
 				}
 				return nil
 			},
@@ -370,7 +373,7 @@ func TestMultiSection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestMultiSection expected no error resolving some.test. A, got: %v", err)
 	}
-	if code != dns.RcodeRefused {
+	if rec.Rcode != dns.RcodeRefused {
 		t.Fatalf("TestMultiSection expected response code REFUSED got: %v", code)
 	}
 


### PR DESCRIPTION
```
	template IN ANY {
		rcode REFUSED
	}
```
causes write two responses instead one, so any following request fails with FORMERR until connection expired (~ 10 sec).