### PR TITLE
Insert *~ when using emacs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ go-test-tmpfile*
 coverage.txt
 .idea/
 .DS_Store
+*~


### PR DESCRIPTION
Ignore temporary files *~ when editting source codes with
emacs.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
