### PR TITLE
Add OSX trash to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ coredns.exe~
 kubectl
 go-test-tmpfile*
 coverage.txt
-.idea
+.idea/
+# OSX trash
+.DS_Store


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Add OSX trash to .gitignore
### 2. Which issues (if any) are related?
Add .DS_Store flag to ignore trash file in MAC OSX

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
