### PR TITLE
Fix some misspells in comment

### DIFF
--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -8,7 +8,7 @@ import (
 // TickTime is clock resolution. By default ticks every second. Handler checks if reloadInterval has been reached on every tick.
 var TickTime = 1 * time.Second
 
-// Reload reloads a zone when it is changed on disk. If z.NoRoload is true, no reloading will be done.
+// Reload reloads a zone when it is changed on disk. If z.NoReload is true, no reloading will be done.
 func (z *Zone) Reload() error {
 	if z.ReloadInterval == 0 {
 		return nil

--- a/plugin/proxy/README.md
+++ b/plugin/proxy/README.md
@@ -69,7 +69,7 @@ There are four load-balancing policies available:
 
 
 All polices implement randomly spraying packets to backend hosts when *no healthy* hosts are
-available. This is to preeempt the case where the healthchecking (as a mechanism) fails.
+available. This is to preempt the case where the healthchecking (as a mechanism) fails.
 
 ## Upstream Protocols
 


### PR DESCRIPTION
1. "NoRoload" to "NoReload" in line 11.
2. "preeempt" to "preempt" in line 72.