### PR TITLE
Add Error log output after lookup failure

### DIFF
--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -59,6 +59,7 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		return plugin.BackendError(e, zone, dns.RcodeNameError, state, nil /* err */, opt)
 	}
 	if err != nil {
+		log.Errorf("error: %s in lookup %s\n", err.Error(), state.Name())
 		return plugin.BackendError(e, zone, dns.RcodeServerFailure, state, err, opt)
 	}
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
    for example, error like "etcdserver: user name is empty" should be sent to warning administrator.
### 2. Which issues (if any) are related?
  nothing to be worried
### 3. Which documentation changes (if any) need to be made?
  nothing to be worried
### 4. Does this introduce a backward incompatible change or deprecation?
  no