### PR TITLE
Add deprecation notice for NO_RELOAD

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -159,6 +159,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 				a.loader.ReloadInterval = d
 
 			case "no_reload":
+				log.Warning("NO_RELOAD of directory is deprecated. Use RELOAD (set to 0) instead. See https://coredns.io/plugins/auto/#syntax")
 				a.loader.ReloadInterval = 0
 
 			case "upstream":

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -113,6 +113,7 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				reload = d
 
 			case "no_reload":
+				log.Warning("NO_RELOAD of directory is deprecated. Use RELOAD (set to 0) instead. See https://coredns.io/plugins/file/#syntax")
 				reload = 0
 
 			case "upstream":


### PR DESCRIPTION
Signed-off-by: Xiao An <hac@zju.edu.cn>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add deprecation notice for NO_RELOAD.

### 2. Which issues (if any) are related?
[#2536](https://github.com/coredns/coredns/issues/2536)

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
Simply warn users of NO_RELOAD's deprecation. 