### PR TITLE
Add release notes into coredns repo

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -4,9 +4,10 @@
 # used to tag the git repo and to build the assets that are uploaded to github
 # (after some sanity checks).
 #
-# The release should be accompanied by release notes published on coredns.io.
-# For example: https://coredns.io/2016/09/18/coredns-001-release/ Also send an
-# email to coredns-discuss@ to announce the new version.
+# The release should be accompanied by release notes in the notes/ subdirectory.
+# These are published on coredns.io.
+#
+# For example: https://coredns.io/2016/09/18/coredns-001-release/ .
 #
 # Getting the authors for this release is done with the following command line
 # git log --pretty=format:'%an' v$(VERSION)..master | sort -u

--- a/notes/coredns-0.9.10.md
+++ b/notes/coredns-0.9.10.md
@@ -1,0 +1,50 @@
++++
+title = "CoreDNS-0.9.10 Release"
+description = "CoreDNS-0.9.10 Release Notes."
+tags = ["Release", "0.9.10", "Notes"]
+draft = false
+release = "0.9.10"
+date = "2017-11-03T20:45:43-00:00"
+author = "coredns"
++++
+
+CoreDNS-0.9.10 has been [released](https://github.com/coredns/coredns/releases/tag/v0.9.10)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release 0.9.10 is a minor release, with some fixes.
+
+## Core
+
+* The reverse zone syntax was extended to allow non-octet boundaries:
+
+   ~~~
+   192.168.1.0/17 {
+       ...
+   }
+   ~~~
+
+   Will behave correctly.
+
+* Lots of documentation clean ups.
+* More platforms have binaries for each release.
+
+## Plugins
+
+* *dnssec* will now insert DS records (and sign them) when it signs a delegation response.
+* *host* now checks for /etc/hosts updates in a separate go-routine.
+
+## Contributors
+
+The following people helped with getting this release done:
+Chris O'Haver,
+Miek Gieben,
+Pat Moroney,
+Paul Hoffman,
+Sandeep Rajan,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-0.9.9.md
+++ b/notes/coredns-0.9.9.md
@@ -1,0 +1,70 @@
++++
+title = "CoreDNS-0.9.9 Release"
+description = "CoreDNS-0.9.9 Release Notes."
+tags = ["Release", "0.9.9", "Notes"]
+draft = false
+release = "0.9.9"
+date = "2017-10-18T11:37:43-04:00"
+author = "coredns"
++++
+
+CoreDNS-0.9.9 has been [released](https://github.com/coredns/coredns/releases/tag/v0.9.9)!
+(yes, we've moved to [semver](https://coredns.io/2017/09/16/semantic-versioning/))
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release 0.9.9 is a major release, with lots of fixes.
+
+## Core
+
+* We've renamed `middleware.Middleware` to `plugin.Plugin`. This is backwards incompatible for external ~~middleware~~ plugins, but you can update your plugin by just replacing `[Mm]iddleware` with `[Pp]lugin`:
+   ~~~
+    sed 's/Middleware/Plugin/'g -i *.go
+    sed 's/middleware/plugin/'g -i *.go
+   ~~~
+From now on we'll use the term *plugin* in our documentation and code.
+
+* We've sent a proposal to make CoreDNS the default in Kubernetes: https://github.com/kubernetes/community/pull/1100
+
+## Plugins
+
+* *etcd*'s debug queries are removed.
+* *hosts* gets inline host definitions that add or overwrite those from `/etc/hosts`.
+* *auto*, *file* now poll every minute for on disk changes (inotify wasn't working).
+* *rewrite* can chain rules and perform multiple changes on a message.
+* *kubernetes* uses `protobuf` to communicate with the kubernetes API and
+performance improvements when there are a large number of services.
+* *dnstap* saw several fixes, including sending tap messages out-of-band.
+* *cache* apply configured TTL to first answer returned.
+   * Don't cache TTL=0 messages.
+* *proxy* smaller timeouts and the health check GET was given a timeout.
+  * Better metrics: add a request counter metrics and change the 'from' label to 'to' so we count/duration per upstream.
+* *dnssec* now signs NODATA responses.
+
+## External Plugins
+
+Two new [external plugins](/explugins) were added:
+
+* *ipecho* parses the IP out of a subdomain and echos it back as an record.
+* *forward* facilitates proxying DNS messages to upstream resolvers.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+antonkyrylenko,
+Chris O'Haver,
+Chris West,
+Damian Myerscough,
+Isolus,
+John Belamaric,
+Miek Gieben,
+Sandeep Rajan,
+Thong Huynh,
+varyoo,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-001.md
+++ b/notes/coredns-001.md
@@ -1,0 +1,57 @@
++++
+date = "2016-09-18T11:40:37+01:00"
+description = "CoreDNS-001 Release Notes."
+release = "001"
+tags = ["Release", "001", "Notes"]
+title = "CoreDNS-001 Release"
+author = "coredns"
++++
+
+CoreDNS-001 has been [released](https://github.com/coredns/coredns/releases). This is the first
+release! It provides a complete DNS server, that also does DNSSEC and is useful for service
+discovery in cloud setups.
+
+# What is CoreDNS?
+
+[CoreDNS](https://coredns.io) is a DNS server that started its life as a fork of the [Caddy
+web(!)server](https://caddyserver.com).
+
+It chains [plugin](https://github.com/coredns/coredns/tree/master/plugin),
+where each plugin implements some DNS feature. CoreDNS is a complete replacement
+(with more features, and maybe less bugs) for [SkyDNS](https://github.com/skynetservices/skydns).
+
+It is also useful as a normal DNS server, featuring DNSSEC, on-the-fly signing and zone transfers.
+
+# What is New
+
+CoreDNS is now a (the first!) server type plugin in Caddy - this means we can leverage a lot of code
+from Caddy without having to fork (and maintain) it all. By doing so we were able to remove 9000
+lines of code from CoreDNS.
+
+The core (ghe!) of CoreDNS is now in a good shape. Future work will focus on making the
+plugin better, e.g. the proxy implementation is slow and needs to be
+[faster](https://github.com/coredns/coredns/issues/184).
+
+## New Plugins
+
+* There is now a [specific
+  plugin](https://github.com/coredns/coredns/tree/master/plugin/kubernetes) to deal with [Kubernetes](https://kubernetes.io).
+* The *bind* [plugin](https://github.com/coredns/coredns/tree/master/plugin/bind)  allows you to bind to a specific IP address, instead of using the wildcard
+  address.
+* A *whoami* [plugin](https://github.com/coredns/coredns/tree/master/plugin/whoami) reports
+  back your address and port.
+* All other plugins are reworked to fit in the new plugin framework from Caddy version 0.9 (and
+  up).
+
+The *whoami* plugin is also used when CoreDNS starts up and can't find a Corefile.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Cricket Liu, elcore, Félix Cantournet, Ilya Dmitrichenko, Joe Blow, Lee, Matt Layher,
+Michael Richmond, Miek Gieben, pixelbender, Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/) and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-002.md
+++ b/notes/coredns-002.md
@@ -1,0 +1,108 @@
++++
+date = "2016-10-19T19:09:32Z"
+description = "CoreDNS-002 Release Notes."
+release = "002"
+tags = ["Release", "002", "Notes"]
+title = "CoreDNS-002 Release"
+author = "coredns"
++++
+
+CoreDNS-002 has been [released](https://github.com/coredns/coredns/releases)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+## What is New
+
+* `-port` was renamed to `-dns.port` to avoid clashing with Caddy's `-port` (which was renamed to
+  `http.port`).
+* Lumberjack logger was removed, this means no built in log rotation; use an external tool for that.
+* Brushed up GoDoc for all packages.
+* Brushed up all READMEs to be more standard and look like manual page.
+* Golint-ed and go vet-ed the code - these can now (somewhat) useful tools before submitting PRs.
+* Add more tests and show test coverage on submitting/PRs.
+* Various Corefile parsing bugs fixed, better syntax error detection.
+
+## Plugin improvements:
+
+* plugin/root: a root plugin, same usage as in [Caddy](https://caddyserver.com/docs/root).
+  See plugin/root/README.md for its use in CoreDNS.
+  This makes stanzas like this shorter:
+
+    ~~~ txt
+    .:53 {
+        file /etc/coredns/zones/db.example.net example.net
+        file /etc/coredns/zones/db.example.org example.org
+        file /etc/coredns/zones/db.example.com example.com
+    }
+    ~~~
+
+    Can be written as:
+
+    ~~~ txt
+    .:53 {
+        root /etc/coredns/zones
+        file db.example.net example.net
+        file db.example.org example.org
+        file db.example.com example.com
+    }
+    ~~~
+
+* plugin/auto: similar to the *file* plugin, but automatically picks up new zones.
+  The following Corefile will load all zones found under `/etc/coredns/org` and be authoritative
+  for `.org.`:
+
+    ~~~ corefile
+    . {
+        auto org {
+            directory /etc/coredns/org
+        }
+    }
+    ~~~
+* plugin/file: handle wildcards better.
+* plugin/kubernetes: TLS support for kubernetes and other improvements.
+* plugin/cache: use an LRU cache to make it memory bounded. Added more option to have more
+  control on what is cached and for how long. The cache stanza was extended:
+
+    ~~~ txt
+    . {
+        cache {
+            success CAPACITY [TTL]
+            denial CAPACITY [TTL]
+        }
+    }
+    ~~~
+
+  See plugin/cache/README.md for more details.
+
+* plugin/dnssec: replaced go-cache with golang-lru in dnssec. Also adds a `cache_capacity`.
+  option in dnssec plugin so that the capacity of the LRU cache could be specified in the config
+  file.
+* plugin/logging: allow a response classs to be specified on log on responses matching the name *and*
+  the response class. For instance only log denials for example.com:
+
+    ~~~ corefile
+    . {
+        log example.com {
+            class denial
+        }
+    }
+    ~~~
+
+* plugin/proxy: performance improvements.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Manuel de Brito Fontes,
+Miek Gieben,
+Shawn Smith,
+Silas Baronda,
+Yong Tang,
+Zhipeng Jiang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-003.md
+++ b/notes/coredns-003.md
@@ -1,0 +1,50 @@
++++
+date = "2016-11-11T16:38:32Z"
+description = "CoreDNS-003 Release Notes."
+release = "003"
+tags = ["Release", "003", "Notes"]
+title = "CoreDNS-003 Release"
+author = "coredns"
++++
+
+CoreDNS-003 has been [released](https://github.com/coredns/coredns/releases)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+# What is New
+
+## Core
+
+Refused queries are properly logged and exported if metrics are enabled.
+
+## Plugin improvements
+
+* *proxy*: allow  `/etc/resolv.conf` to be used in the configuration.
+* *metrics*: add tests and normalize some of the metrics. Removed the AXFR size metrics.
+* *cache*: Added size and capacity of the cache (for both `denial` and `success` cache types).
+  Don't cache meta data records and zone transfers.
+* *dnssec*: metrics were unused, hooked them up: export size and capacity of the signature cache.
+* *loadbalance*: balance MX records as well.
+* *auto*: numerous bugfixes.
+* *file*: fix data race in reload process and also reload a zone when it is `mv`ed (newly created) into place.
+  Also rewrite the zone lookup algorithm and be more standards compliant, esp. in the area of DNSSEC, wildcards and empty-non-terminals; handle secure delegations.
+* *kubernetes*: vender the k8s dependency and updates to be compatible with Kubernetes 1.4 and 1.5.
+   Multiple cleanups and fixes. Kubernetes services can now be resolved.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Ben Kochie,
+Chris O'Haver,
+John Belamaric,
+Jonathan Dickinson,
+Manuel Alejandro de Brito Fontes,
+Michael Grosser,
+Miek Gieben,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-004.md
+++ b/notes/coredns-004.md
@@ -1,0 +1,45 @@
++++
+date = "2017-01-01T10:30:31Z"
+description = "CoreDNS-004 Release Notes."
+release = "004"
+tags = ["Release", "004", "Notes"]
+title = "CoreDNS-004 Release"
+author = "coredns"
++++
+
+CoreDNS-004 has been [released](https://github.com/coredns/coredns/releases/tag/v004)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+# What is New
+
+## Core
+
+We are now also releasing an ARM build that can run on Raspberry Pi.
+
+## Plugin improvements
+
+* *file|auto*: resolve external CNAME when an upstream (new option) is specified.
+* *file|auto*: allow port numbers for transfer from/to to be specified.
+* *file|auto*: include zone's NSset in positive responses.
+* *auto*: close files and don't leak file descriptors.
+* *httpproxy*: new plugin that proxies to <https://dns.google.com> and resolves your requests over an encrypted connection. This plugin will probably be morphed into proxy at some point in the feature. Consider it experimental for the time being.
+* *metrics*: `reponse_size_bytes` and `request_size_bytes` export the actual length of the packet, not the advertised bufsize.
+* *log*: `{size}` is now the length in bytes of the request, `{rsize}` for the reply. Default logging is changed to show both.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Dmytro Kislov,
+John Belamaric,
+Mark Nevill,
+Michael Grosser,
+Miek Gieben,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-005.md
+++ b/notes/coredns-005.md
@@ -1,0 +1,65 @@
++++
+date = "2017-02-09T18:50:31Z"
+description = "CoreDNS-005 Release Notes."
+tags = ["Release", "005", "Notes"]
+release = "005"
+title = "CoreDNS-005 Release"
+author = "coredns"
++++
+
+CoreDNS-005 has been [released](https://github.com/coredns/coredns/releases/tag/v005)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+# What is New
+
+# Core
+
+A way to configure (external) plugin was added. Edit `plugin.cfg` and do a `go generate && go
+build` and your plugin has been added. This allows for out-of-tree plugin to be easily
+added. Documentation can be found in
+[plugin.cfg](https://github.com/coredns/coredns/blob/master/plugin.cfg).
+
+## Plugin improvements
+
+### New
+
+* *erratic*: a new plugin that can drop queries, limited in the current functionality, but useful for testing.
+* *trace*: a new plugin that implements OpenTracing-based tracing using Zipkin.
+
+### Improvements/changes
+
+* *proxy*: fix a bug when a connection hangs and never gets release (#467)
+* *proxy*: Fold *httpproxy* into it, which is now a normal proxy with a special `protocol`. For
+  Monitoring an extra label was added: `proxy_proto` that shows the protocol used (`dns` or `https_google`). 
+  See the [proxy README.md](https://github.com/coredns/coredns/blob/master/plugin/proxy/README.md) for details.
+* *httpproxy*: removed because functionality is moved to *proxy*.
+* *kubernetes*: Now implements the full
+  [Kubernetes DNS Specification](https://github.com/kubernetes/dns/blob/master/docs/specification.md),
+  including regular and headless services, endpoint hostnames, A, SRV, and PTR records.
+* *kubernetes*: Implements the `pod` type for requests in both a Kube-DNS compatible mode
+  (`insecure`) and a mode which validates that the IP in question belongs to a pod in the specified
+  namespace (`verified`)
+* *kubernetes*: Simplified the configuration of reverse zones. Instead of listing the zones in the
+  zone list, you can just add a list of CIDRs using the `cidrs` option.
+* *rewrite*: allow rewriting more bits of the incoming packet. This required some backward
+  *incompatible* changes, e.g. a new **FIELD** keyword is now required. See the 
+  [rewrite README.md](https://github.com/coredns/coredns/blob/master/plugin/rewrite/README.md) for details.
+
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Bob Wasniak,
+Chris O'Haver,
+devnev,
+Dmytro Kislov,
+John Belamaric,
+Miek Gieben,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-006.md
+++ b/notes/coredns-006.md
@@ -1,0 +1,55 @@
++++
+date = "2017-02-22T21:26:11Z"
+description = "CoreDNS-006 Release Notes."
+tags = ["Release", "006", "Notes"]
+release = "006"
+title = "CoreDNS-006 Release"
+author = "coredns"
++++
+
+CoreDNS-006 has been [released](https://github.com/coredns/coredns/releases/tag/v006)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+# What is New
+
+# Core
+
+Move CoreDNS to <https://github.com/coredns/coredns> together with several other repos. This will be
+the new home for CoreDNS development.
+
+Fixed:
+
+* Fix hot-reloading. This would fail with `[ERROR] SIGUSR1: listen tcp :53: bind: address already in
+  use`.
+* Allow removal of core plugin, see comments in
+  [plugin.cfg](https://github.com/miekg/coredns/blob/master/plugin.cfg).
+
+## Plugin improvements
+
+### New
+
+* *reverse* plugin: allows CoreDNS to respond dynamicly to an PTR request and the related
+  A/AAAA request.
+
+### Improvements/changes
+
+* *proxy* a new `protocol`: `grpc`: speak DNS over gRPC. Server side impl. resides [in this out of
+  tree plugin](https://github.com/coredns/grpc).
+* *file* additional section processing for MX and SRV queries.
+* *prometheus* fix hot reloading
+* *trace* various improvements
+
+# Contributors
+
+The following people helped with getting this release done:
+
+John Belamaric,
+Miek Gieben,
+Richard Hillmann,
+Yong Tang,
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-007.md
+++ b/notes/coredns-007.md
@@ -1,0 +1,69 @@
++++
+date = "2017-05-03T19:26:11Z"
+description = "CoreDNS-007 Release Notes."
+release = "007"
+tags = ["Release", "007", "Notes"]
+title = "CoreDNS-007 Release"
+author = "coredns"
++++
+
+CoreDNS-007 has been [released](https://github.com/coredns/coredns/releases/tag/v007)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+# News
+
+CoreDNS is accepted as an inception project by the [CNCF](https://cncf.io)! Which means a lot to us.
+See [this blog post](/2017/03/02/why-cncf-for-coredns/) on why we wanted/did this.
+
+Because of this we moved repos: <https://github.com/coredns> is the main overarching repo. There is
+an automatic redirect in place from the old repo.
+
+And... We have a new logo! We're also discussion a website redesign for <https://coredns.io> and
+this blog.
+
+Back to the release.
+
+# Core
+
+* `ServeDNS` is extended to take a context. This allows (for instance) tracing to start at an earlier entrypoint.
+* gRPC and TLS are made first class citizens. See [the zone
+  specification](https://github.com/coredns/coredns/blob/master/README.md#zone-specification) on how
+  to use it. TL;DR using `grpc://` makes the server talk gRPC. The `tls` directive is used to
+  specify TLS certifcates.
+* Zipkin tracing can be enabled for all plugin.
+
+# Plugins
+
+* *rewrite* now allows you to add or modify EDNS0 local or NSID options. The framework is in place to add additional EDNS0 types in the future.
+* *etcd* when no upstreams are defined won't default to using 8.8.8.8, 8.8.4.4; it just does not resolve external names in that case.
+* *erratic* now can also delay queries and send queries with Truncated set.
+* *metrics* will happily start as many (different) listeners as you want (if you really need that).
+* *startup* and *shutdown* allow for command to be run during startup or shutdown. These directly use the code from Caddy, see [Caddy's docs](https://caddyserver.com/docs/startup).
+* *kubernetes* now implements a `fallthrough` option to pass queries that would result in NXDOMAIN
+  to the next plugin, even if the query is in the cluster domain. This enables custom DNS
+  entries in the cluster domain (as long as they do not overlap with a normal Kubernetes record). To
+  facilitate this the plugin ordering is also altered to put *kubernetes* in the chain before
+  other backends.
+* *cache* will no longer cache RRSIGs that will expire while cached.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Chris Aniszczyk,
+Chris O'Haver,
+Christoph Görn,
+Dominic,
+John Belamaric,
+Jonathan Boulle,
+Michael,
+Michael S. Fischer,
+Miek Gieben,
+Yong Tang,
+Yue Ko.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-008.md
+++ b/notes/coredns-008.md
@@ -1,0 +1,66 @@
++++
+date = "2017-06-14T22:52:11Z"
+description = "CoreDNS-008 Release Notes."
+release = "008"
+tags = ["Release", "008", "Notes"]
+title = "CoreDNS-008 Release"
+author = "coredns"
++++
+
+CoreDNS-008 has been [released](https://github.com/coredns/coredns/releases/tag/v008)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release v008 has a lot of content, with new plugin and major features added to existing plugin.
+
+Please note there is an *incompatible* change to the `log` directive - it now only logs to `stdout` and so
+only allows `stdout` as the file name (which of course may be omitted).
+
+# Core
+
+* `-log` flag was changed into a boolean as all logging will be written to standard output.
+
+# Plugins
+
+## New
+
+* *hosts* allows CoreDNS to read a `/etc/hosts` styled file and generate responses from that.
+* *debug* can disable the `panic/recover` that is enabled by default. Mostly useful for testing/non-prod use cases to generate stack traces.
+
+## Updates
+
+* *chaos* now returns the correct `version.bind` `TXT` record.
+* *kubernetes*
+   * Now returns a proper NS record for the cluster domain
+   * Supports `ExternalName` services, which was an oversight in the 1.0.0 version of the [Kubernetes dns spec](https://github.com/kubernetes/dns/blob/master/docs/specification.md)
+   * Now supports federation records
+   * Has had some other bug fixes.
+* *file*
+   * Now supports DNAME [RFC 6672](https://tools.ietf.org/html/rfc6672)
+   * Refuse to load a zone without a SOA record.
+* *file, auto* don't reload a zone when the SOA's serial hasn't changed.
+* *secondary* now behaves properly if queried before the zone has been transferred
+* *log, errors* output everything to *stdout* and let `journald` or `docker` (or whatever) that care of further handling. This is backwards **incompatible** change wrt to the Corefile: `log query.log` will return an error.
+* *cache* got a new cache implementation to be more scalable and  a new `prefetch` option for fetching records before the TTL expires.
+* *proxy* does not use `singleinflight` anymore, removing a potential bottleneck on the single mutex in that implementation; it now forwards *all* queries it get to the upstream nameserver.
+
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Chris Aniszczyk,
+Chris O'Haver,
+cricketliu,
+Eric Yan,
+John Belamaric,
+Jonas Östanbäck,
+Manuel Alejandro de Brito Fontes,
+Miek Gieben,
+Pat Moroney,
+Yong Tang
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-009.md
+++ b/notes/coredns-009.md
@@ -1,0 +1,47 @@
++++
+date = "2017-07-13T22:52:11Z"
+release = "009"
+description = "CoreDNS-009 Release Notes."
+tags = ["Release", "009", "Notes"]
+title = "CoreDNS-009 Release"
+author = "coredns"
++++
+
+CoreDNS-009 has been [released](https://github.com/coredns/coredns/releases/tag/v009)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release v009 is mostly a bugfix release, with a few new features in the plugin.
+
+# Core
+
+No changes.
+
+# Plugins
+
+* *secondary*: fix functionality and improve matching of notify queries.
+* *cache*: fix data race.
+* *proxy*: async healthchecks.
+* *reverse*: new option `wildcard` that also catches all subdomains of a template.
+* *kubernetes*: experimental new option `autopath` that optimizes the search path and ndots
+  combinatorial explosion, so clients with a large search path and high ndots will get a reply on
+  the first query.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Athir Nuaimi,
+Chris O'Haver,
+ghostflame,
+jremond,
+Mia Boulay,
+Miek Gieben,
+Ning Xie,
+Roman Mazur,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-010.md
+++ b/notes/coredns-010.md
@@ -1,0 +1,51 @@
++++
+title = "CoreDNS-010 Release"
+description = "CoreDNS-010 Release Notes."
+tags = ["Release", "010", "Notes"]
+draft = false
+release = "010"
+date = "2017-07-25T11:24:43-04:00"
+author = "coredns"
++++
+
+CoreDNS-010 has been [released](https://github.com/coredns/coredns/releases/tag/v010)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release v010 is mostly a bugfix release, with one new plugin - *dnstap*.
+
+# Core
+
+No changes.
+
+# Plugins
+
+## New
+
+* *dnstap* is a new plugin that allows you to get dnstap information from CoreDNS.
+
+## Updates
+
+* *file* now handles multiple wildcard below each other correctly, and handles wildcards at the apex.
+* *hosts*, and *kubernetes* have been fixed to return success with no data in cases where records exist
+but not of the requested type. This fixes an issue with getting NXDOMAIN for the AAAA record even when the
+A record exists confusing some resolvers.
+
+# Documentation
+
+* Many updates to README files.
+
+# Contributors
+
+The following people helped with getting this release done:
+
+Antoine Debuisson,
+Chris O'Haver,
+John Belamaric,
+Miek Gieben,
+Pat Moroney
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-011.md
+++ b/notes/coredns-011.md
@@ -1,0 +1,75 @@
++++
+title = "CoreDNS-011 Release"
+description = "CoreDNS-011 Release Notes."
+tags = ["Release", "011", "Notes"]
+draft = false
+release = "011"
+date = "2017-09-10T20:24:43-04:00"
+author = "coredns"
++++
+
+CoreDNS-011 has been [released](https://github.com/coredns/coredns/releases/tag/v011)!
+
+CoreDNS is a DNS server that chains plugins, where each plugin implements a DNS feature.
+
+Release v011 is a major release, with backwards incompatible changes in the *kubernetes* plugin.
+
+## Core
+
+**This release has backwards incompatible changes** for the *kubernetes* plugin.
+
+* Stop vendoring `github.com/miekg/dns` and `golang.org/x/net/context`. This enables external plugin to compile without tripping over vendored types that mismatch.
+* Allow an easy way to specify reverse zones in the Corefile, just use (e.g) `10.0.0.0/24` as the zone name,
+  CoreDNS translates this to 0.0.10.in-addr.arpa. This is only done when the netmask is a multiple of 8 and for both IPv4 and IPv6.
+* Bug and stability fixes.
+
+## Plugins
+
+Make *kubernetes*, *file*, *secondary*, *hosts*, *erratic* and *metrics* now fail on unknown properties in the Corefile.
+
+### New
+
+* *federation*: enables federation via kubernetes.
+* *autopath*: enables autopath-ing. Can be used standalone, but its main use is with kubernetes.
+
+### Updates
+
+* *log* adds an `>rflags` replacer that shows the flags from the response - this has been enabled by default.
+* *kubernetes* deprecates:
+   * `cidr`: use the reverse syntax in the Corefile
+   * `federation`: use the new *federation* plugin
+   * `autopath`: use the new *autopath* plugin
+* *kubernetes*:
+   * add TTL option allowing to set minimal TTL for responses.
+   * Multiple k8s API endpoints could be specified, separated by `","`s, e.g. `endpoint http://k8s-endpoint1:8080,http://k8s-endpoint2:8080`. CoreDNS will automatically perform a healthcheck and proxy to the healthy k8s API endpoint.
+* *rewrite*:
+   * allow for *dynamic* properties to be used, like client IP address in rewrite rules, i.e.
+`rewrite edns0 local set 0xffee {client_ip}`
+   * add support for EDNS0 Client Subnet
+* *dnstap* now reports messages proxied by *proxy*, and support remote IP endpoints by specifying `tcp://`.
+* *dnssec* now warns if keys can't be used to sign the configured zones.
+* *health* now allows for per plugin health status; no plugin makes use of this yet, though.
+* *secondary* parses a secondary with a zone (`secondary example.org {...}`) correctly.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Brad Beam,
+Chris O'Haver,
+insomniac,
+James Mills,
+John Belamaric,
+Markus Sommer,
+Miek Gieben
+Mohammed Naser,
+Sandeep Rajan,
+Thong Huynh,
+varyoo,
+Yong Tang,
+张勋.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.0.md
+++ b/notes/coredns-1.0.0.md
@@ -1,0 +1,75 @@
++++
+title = "CoreDNS-1.0.0 Release"
+description = "CoreDNS-1.0.0 Release Notes."
+tags = ["Release", "1.0.0", "Notes"]
+draft = false
+release = "1.0.0"
+date = "2017-12-01T22:43:43-00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.0) of CoreDNS-1.0.0!
+
+Release 1.0.0 and other recent releases have focused on improving the performance and
+functionality of the *kubernetes* plugin, since CoreDNS is now on track to eventually
+[replace kube-dns](https://github.com/kubernetes/features/issues/427) as the default
+cluster DNS in Kubernetes.
+
+As part of the [Kubernetes proposal](https://github.com/kubernetes/community/pull/1100), we have shown that CoreDNS
+not only provides more functionality than kube-dns, but performs much better while using less memory. In our tests,
+[CoreDNS](https://github.com/kubernetes/community/pull/1100#issuecomment-337747482) running against a cluster with 5000
+services was able to process 18,000 queries per second using 73MB of RAM, while
+[kube-dns](https://github.com/kubernetes/community/pull/1100#issuecomment-338329100) achieved 7,000qps using 97MB of RAM.
+This can be partial ascribed to CoreDNS simpler runtime - a single process instead of a combination of several processes.
+
+CoreDNS also implements a number of Kubernetes-related features that are not part of kube-dns, including:
+
+* Filtering of records by namespace
+* Filtering of records by label selector
+* `pods verified` mode, which ensures that a Pod exists before returning an answer for a `pod.cluster.local` query
+* `endpoint_pod_names` which uses [Pod names](https://github.com/kubernetes/kubernetes/issues/47992) for service endpoint records if the hostname is not set
+* `autopath` which provides a server-side implementation of the namespace-specific search path. This can cut down the query latency from pods dramatically.
+
+As a general-purpose DNS server, CoreDNS also enables many other use cases that would be difficult or impossible to
+achieve with kube-dns, such as the ability to create [custom DNS entries](https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/).
+
+We are excited to continue our contributions to the Kubernetes community, and CoreDNS is being incorporated as a 1.9 alpha feature into a variety
+of Kubernetes deployment mechanisms, including upcoming versions of [kubeadm](https://github.com/kubernetes/kubeadm), [kops](https://github.com/kubernetes/kops), [minikube](https://github.com/kubernetes/minikube), and [kubespray](https://github.com/kubernetes-incubator/kubespray).
+
+Of course, there is more to 1.0.0 than just the Kubernetes work. See below for the details on all the changes.
+
+## Core
+
+* Fixed a bug in the gRPC server that prevented *dnstap* from working with it.
+* Additional fuzz testing to ferret out obscure bugs.
+* Documentation and configuration cleanups.
+
+## Plugins
+* *log* no longer accepts `stdout` in the configuration (use of a file was removed in a previous release). All logging is always to STDOUT. This is a backwards **incompatible** change, so be sure to check your Corefile for this.
+* *health* now checks plugins that support it for health and reflects that in the server health.
+* *kubernetes* now shows healthy only after the initial API sync is complete.
+* *kubernetes* has bug fixes and performance improvements.
+* *kubernetes* now has an option to use pod names instead of IPs in service endpoint records when the `hostname` is not set.
+* *metrics* have been revised to provide better histograms. You will need to change your Prometheus queries as metric names have changed to comply with Prometheus best practices.
+* *erratic* now supports the health check.
+
+## Contributors
+
+The following people helped with getting this release done:
+Andy Goldstein,
+Ben Kochie,
+Brian Akins,
+Chris O'Haver,
+Christian Nilsson,
+John Belamaric,
+Max Schmitt,
+Michael Grosser,
+Miek Gieben,
+Ruslan Drozhdzh,
+Uladzimir Trehubenka,
+Yong Tang.
+
+If you want to help, please check out one of the [issues](https://github.com/coredns/coredns/issues/)
+and start coding!
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.1.md
+++ b/notes/coredns-1.0.1.md
@@ -1,0 +1,34 @@
++++
+title = "CoreDNS-1.0.1 Release"
+description = "CoreDNS-1.0.1 Release Notes."
+tags = ["Release", "1.0.1", "Notes"]
+draft = false
+release = "1.0.1"
+date = "2017-12-11T14:43:43-00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.1) of CoreDNS-1.0.1!
+
+This release fixes a crash in the *file* plugin and has some minor bug fixes for other plugins.
+One new plugin was added: *nsid*, that implements [RFC 5001](https://tools.ietf.org/html/rfc5001).
+
+## Plugins
+* *file* fixes a crash when an request with a DO bit (pretty much the default) hits an unsigned zone. The default configuration should recover the go-routine, but this is nonetheless serious. *file* received some other fixes when returning (secure) delegations.
+* *dnstap* plugin is now 50% faster.
+* *metrics* fixed the start time bucket for duration.
+
+## Contributors
+
+The following people helped with getting this release done:
+Brad Beam,
+James Hartig,
+Miek Gieben,
+Rene Treffer,
+Ruslan Drozhdzh,
+Seansean2,
+Yong Tang.
+
+If you want to help, please check out one of the
+[issues](https://github.com/coredns/coredns/issues/) and start coding! For documentation and help,
+see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.2.md
+++ b/notes/coredns-1.0.2.md
@@ -1,0 +1,44 @@
++++
+title = "CoreDNS-1.0.2 Release"
+description = "CoreDNS-1.0.2 Release Notes."
+tags = ["Release", "1.0.2", "Notes"]
+draft = false
+release = "1.0.2"
+date = "2017-12-31T09:06:29+00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.2) of CoreDNS-1.0.2!
+This release can be summerized as "help external plugin developers" as most changes are geared
+towards exposing CoreDNS functionality to make this as easy as possible. Is also a fairly small
+release.
+
+## Core
+
+Expose the directives list, so that external plugins can be easily added without mucking with
+CoreDNS code, see the [pull request](https://github.com/coredns/coredns/pull/1315) for details.
+
+Fix crash when there are no handlers that can actually serve queries, i.e. a Corefile with only
+*debug* and *pprof* for instance.
+
+## Plugins
+
+* [*metrics*](/plugins/metrics) has a New function to help external plugin developers.
+* [*health*](/plugins/health) plugin now checks all plugins for a `health.Healther` implementation and will export health for those plugins that do. Again helps external plugin developers.
+* [*rewrite*](/plugins/rewrite) gained regular expression and substring-matching support.
+
+## Contributors
+
+The following people helped with getting this release done:
+Brad Beam,
+Francois Tur,
+Frederic Hemberger,
+James Hartig,
+Max Schmitt,
+Miek Gieben,
+Paul Greenberg,
+Yong Tang.
+
+If you want to help, please check out one of the
+[issues](https://github.com/coredns/coredns/issues/) and start coding! For documentation and help,
+see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.3.md
+++ b/notes/coredns-1.0.3.md
@@ -1,0 +1,43 @@
++++
+title = "CoreDNS-1.0.3 Release"
+description = "CoreDNS-1.0.3 Release Notes."
+tags = ["Release", "1.0.3", "Notes"]
+draft = false
+release = "1.0.3"
+date = "2018-01-10T19:38:29+00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.3) of CoreDNS-1.0.3!
+This is a small bugfix release, but we also have a new plugin:
+[*template*](https://coredns.io/plugins/template).
+
+## Core
+
+Manual pages are now generated from the READMEs, you can find them in the man/ directory.
+A coredns(1) and corefile(5) one where also added.
+
+## Plugins
+
+The `fallthrough` directive was overhauled and now allows a list of zones to be specified. It will
+then only fallthrough for those zones, see `plugin/plugin.md`.
+
+A new plugin *template* was added. It allows you to use Go (text) templates to craft a response, see
+<https://coredns.io/plugins/template> for docs.
+
+* *dnssec* implements Cloudflares's NSEC blacklies better.
+* *kubernetes*, adds a fix for `pod insecure` look ups for non-IP addresses.
+* *health* adds a metrics for the duration it takes to GET /health. Useful for getting a sense of
+  overloadedness of the process.
+
+## Contributors
+
+The following people helped with getting this release done:
+John Belamaric,
+Miek Gieben,
+Rene Treffer,
+Yong Tang.
+
+If you want to help, please check out one of the
+[issues](https://github.com/coredns/coredns/issues/) and start coding! For documentation and help,
+see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.4.md
+++ b/notes/coredns-1.0.4.md
@@ -1,0 +1,17 @@
++++
+title = "CoreDNS-1.0.4 Release"
+description = "CoreDNS-1.0.4 Release Notes."
+tags = ["Release", "1.0.4", "Notes"]
+draft = false
+release = "1.0.4"
+date = "2018-01-18T15:54:29+00:00"
+author = "coredns"
++++
+
+We are announcing the [release](https://github.com/coredns/coredns/releases/tag/v1.0.4) of CoreDNS-1.0.4!
+
+This is a release that fixes a vulnerability in the underlying DNS library.
+See <https://github.com/miekg/dns/issues/627> and the (still embargoed) CVE-2017-15133.
+Thanks to Tom Thorogood for bringing this issue to our attention.
+
+CoreDNS-1.0.4 is [CoreDNS-1.0.3](https://coredns.io/2018/01/10/coredns-1.0.3-release/) recompiled with a patched DNS library.

--- a/notes/coredns-1.0.5.md
+++ b/notes/coredns-1.0.5.md
@@ -1,0 +1,48 @@
++++
+title = "CoreDNS-1.0.5 Release"
+description = "CoreDNS-1.0.5 Release Notes."
+tags = ["Release", "1.0.5", "Notes"]
+draft = false
+release = "1.0.5"
+date = "2018-01-25T11:10:29+00:00"
+author = "coredns"
+enabled = "default"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.5) of CoreDNS-1.0.5!
+This release has bug fixes, documentation fixes, polish and new plugins.
+
+## Core
+
+Add ability to *really* compile out the default plugins.
+
+## Plugins
+
+* A new plugin *route53* was added that enables serving zone data from AWS route53, see the [documentation](https://coredns.io/plugins/route53).
+* A new plugin *on* was added. This is an external Caddy [plugin](https://caddyserver.com/docs/on), that is now also available (by default) for CoreDNS; it allows you to run commands when an event is generated.
+
+* *cache* doesn't apply a 5s minimum TTL anymore. It fixes prefetching *and* correctly sets the metrics for cache hits and misses.
+* *dnssec* fixes handing out *expired* signatures after 8 days and properly filters out the qtype in the NSEC bitmap for NXDOMAIN responses.
+* *log* adds message ID `{>id}` to the default logging.
+* *health* has gotten a lameduck option that will nack health, but will keep the server running for a configurable duration when CoreDNS is being shut down. If metrics are enabled *health* exports a metric that curls the local endpoint and exports the duration. Useful for getting a sense of overloadedness of the process.
+* *rewrite* can now rewrite answers for `name regex` matches. This prevents DNS clients from ignoring the answers due to a mismatch with the original question.
+* *secondary* saw a bunch of fixes.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Christian Nilsson,
+cricketliu,
+Francois Tur,
+Ilya Galimyanov,
+Miek Gieben,
+Paul Greenberg,
+Ruslan Drozhdzh,
+Tobias Schmidt,
+Yong Tang,
+Yue Ko.
+
+If you want to help, please check out one of the
+[issues](https://github.com/coredns/coredns/issues/) and start coding! For documentation and help,
+see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.0.6.md
+++ b/notes/coredns-1.0.6.md
@@ -1,0 +1,51 @@
++++
+title = "CoreDNS-1.0.6 Release"
+description = "CoreDNS-1.0.6 Release Notes."
+tags = ["Release", "1.0.6", "Notes"]
+draft = false
+release = "1.0.6"
+date = "2018-02-21T11:10:29+00:00"
+author = "coredns"
+enabled = "default"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.0.6) of CoreDNS-1.0.6!
+This release has bug fixes, documentation fixes, polish and new plugins.
+
+## Core
+
+We've moved to a OWNERS model, where each plugin (and CoreDNS itself) now has an OWNERS file listing
+people involved with this code.
+
+## Plugins
+
+* The *startup* and *shutdown* plugin are **deprecated** (but working and included) in this release in favor of the *on*
+  plugin. If you use them, this is the moment to move to [*on*](/explugins/on).
+* A plugin called [*forward*](https://coredns.io/plugins/forward) has been included in CoreDNS, this
+  was, up until now, an external plugin. Supports DNS-over-TLS and has different way of health
+  checking an upstream.
+* The [*proxy*](https://coredns.io/plugins/proxy) plugin has a new policy, *first* which always
+  chooses the first healthy upstream host. It also contains an important fix where
+  a non-health checked target could be mark unhealthy forever.
+* We now support zone transfers in the [*kubernetes*](https://coredns.io/plugins/kubernetes) plugin.
+* The [*bind*](https://coredns.io/plugins/bind) now supports multiple listening addresses.
+* Bugfixes, improvements and documentation fixes in various other plugins.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Francois Tur,
+Freddy,
+Harshavardhana,
+John Belamaric,
+Miek Gieben,
+Pat Moroney,
+Paul Greenberg,
+Sandeep Rajan,
+Tobias Schmidt,
+Uladzimir Trehubenka,
+Yong Tang.
+
+For documentation and help, see our [community page](https://coredns.io/community/).

--- a/notes/coredns-1.1.0.md
+++ b/notes/coredns-1.1.0.md
@@ -1,0 +1,79 @@
++++
+title = "CoreDNS-1.1.0 Release"
+description = "CoreDNS-1.1.0 Release Notes."
+tags = ["Release", "1.1.0", "Notes"]
+draft = false
+release = "1.1.0"
+date = "2018-03-12T09:33:29+00:00"
+author = "coredns"
+enabled = "default"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.0) of
+CoreDNS-1.1.0!
+
+CoreDNS has been promoted to the [incubating](https://www.cncf.io/projects/graduation-criteria/)
+level in the [CNCF](https://www.cncf.io/projects/)!
+This has been made possible by the work done by contributors, users and adopters.
+
+**Thank you all!**
+
+## Core
+
+Bump the version to 1.1.0, as we deprecate two plugins (*shutdown* and *startup*).
+
+In CoreDNS 1.0.6 the [*bind*](/plugins/bind) plugin was extended to allow binding to multiple
+interfaces. This release adds the ability serve the same zone on different interfaces (we used to
+block this for no good reason). I.e. this now works:
+
+```
+. {
+    bind 127.0.0.1
+    # ..
+}
+
+. {
+    bind 127.0.0.2
+    # ...
+}
+```
+
+## Plugins
+
+* The plugins *shutdown* and *startup* where marked deprecated in 1.0.6. This release removes them. You should use [*on*](/explugins/on) instead.
+* A new plugin was added: *reload*, which watches for changes in your Corefile and then automatically will reload the process. This is not yet bullet proof, some plugins can fail to setup during a reload. See the discussion in [issue 1445](https://github.com/coredns/coredns/issues/1455).
+* A number of plugins can only be used once in a server block, but didn't make this explicit. I.e. [*dnssec*](/plugins/dnssec) would silently overwrite earlier config. The following plugins now return an error when used multiple times **in a single Server Block**:
+*cache*,
+*dnssec*,
+*errors*,
+*forward*,
+*hosts*,
+*nsid*,
+*metrics*,
+*kubernetes*,
+*pprof*,
+*reload*,
+*root*.
+* [*Trace*](/plugins/trace) adds support for a Datadog endpoint.
+* Some changes went into [*dnstap*](/plugins/dnstap), make it easier to use from other plugins.
+* Small change in the [*log*](/plugin/log) plugin, the log default will now also log the client's
+  port number and IPv6 addresses are printed with brackets: `[::1]`.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Francois Tur,
+John Belamaric,
+Miek Gieben,
+nogoegst,
+Ricardo Katz,
+Tobias Schmidt,
+Uladzimir Trehubenka,
+varyoo,
+Yamil Asusta,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.1.1.md
+++ b/notes/coredns-1.1.1.md
@@ -1,0 +1,40 @@
++++
+title = "CoreDNS-1.1.1 Release"
+description = "CoreDNS-1.1.1 Release Notes."
+tags = ["Release", "1.1.1", "Notes"]
+release = "1.1.1"
+date = "2018-03-25T18:04:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.1) of
+CoreDNS-1.1.1!
+
+This release fixes a **critical bug** in the *cache* plugin found by [Cure53](/2018/03/15/cure53-security-assessment/).
+
+All users are encouraged to upgrade.
+
+## Core
+
+Fix a bug when scrubbing the reply to fit the request's buffer consumes 100% CPU and does not return
+the reply.
+
+## Plugins
+
+* [*cache*](/plugins/cache) fixes the critical spoof vulnerability.
+* [*route53*](/plugins/route53) adds support for PTR records.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Mario Kleinsasser,
+Miek Gieben,
+Yong Tang.
+
+And of course the people in [Cure53](https://cure53.de). Also special shout out to Mario Kleinsasser
+for helping to debug the [scrubbing issue](https://github.com/coredns/coredns/issues/1625).
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.1.2.md
+++ b/notes/coredns-1.1.2.md
@@ -1,0 +1,40 @@
++++
+title = "CoreDNS-1.1.2 Release"
+description = "CoreDNS-1.1.2 Release Notes."
+tags = ["Release", "1.1.2", "Notes"]
+release = "1.1.2"
+date = "2018-04-23T09:21:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.2) of
+CoreDNS-1.1.2!
+
+This release has some fixes in the plugins and no core updates.
+
+# Plugins
+
+* [*forward*](/plugins/forward) has received a large pile of fixes and improvements.
+* [*reload*](/plugins/reload): the *metrics* and *health* plugin saw fixes for this reload issue, still not 100% perfect, but a whole lot better than it was.
+* [*log*](/plugins/log) now allows `OR`ing of log classes.
+* [*metrics*](/plugins/metrics): add a server label to make each metric unique to the server handling it.
+  This impacts all plugins, currently *proxy* and *forward* have been updated to include a server label.
+* [*debug*](/plugins/debug): when enabled plugins show their `log.Debug` output (none of the included plugins use this yet).
+* [*kubernetes*](/plugins/kubernetes) has a small fix for apex queries.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Francois Tur,
+Maksim Paramonau,
+Miek Gieben,
+Moto Ishizawa,
+Ruslan Drozhdzh,
+Scott Donovan,
+Tobias Schmidt,
+Uladzimir Trehubenka.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.1.3.md
+++ b/notes/coredns-1.1.3.md
@@ -1,0 +1,57 @@
++++
+title = "CoreDNS-1.1.3 Release"
+description = "CoreDNS-1.1.3 Release Notes."
+tags = ["Release", "1.1.3", "Notes"]
+release = "1.1.3"
+date = "2018-05-24T09:43:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.3) of
+CoreDNS-1.1.3!
+
+This release has fixes in the plugins, small core updates and experimental DNS over HTTPs support.
+We also announce the deprecation of a few things.
+
+# Core
+
+*Experimental* DNS-over-HTTPS support was added in the server. Use `https://` as the server's scheme
+ in the configuration.
+
+The `-log` flag actually doesn't do anything, so this is a deprecation notice that this flag will be
+removed in the next release.
+
+# Plugins
+
+* [*metrics*](/plugin/metrics) All in-tree plugins serve metrics with a `server` label.
+   * *cache* and *dnssec* drop the capacity metrics
+   * add a panic counter: `coredns_panic_count_total`
+* [*etcd*](/plugins/etcd) supports A and AAAA record under the zone's apex.
+* [*rewrite*](/plugins/rewrite) now handles `continue` in response rewrites.
+* [*forward*](/plugin/forward) clean ups, esp when shutting it down.
+* [*cache*](/plugin/cache) adds some optimization.
+* [*kubernetes*](/plugin/kubernetes) adds option to `ignore` services without ready endpoints.
+* Deprecation notice for the *reverse* plugin.
+* Deprecation notice for the `https_google` protocol in *proxy*.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Ahmet Alp Balkan,
+Anton Antonov,
+Cem Türker,
+Chris O'Haver,
+darkweaver87,
+Eugen Kleiner,
+Francois Tur,
+John Belamaric,
+Mario Kleinsasser,
+Miek Gieben,
+Ruslan Drozhdzh,
+Silver,
+Tobias Schmidt,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.1.4.md
+++ b/notes/coredns-1.1.4.md
@@ -1,0 +1,54 @@
++++
+title = "CoreDNS-1.1.4 Release"
+description = "CoreDNS-1.1.4 Release Notes."
+tags = ["Release", "1.1.4", "Notes"]
+release = "1.1.4"
+date = "2018-06-19T09:39:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.1.4) of
+CoreDNS-1.1.4!
+
+This release has a few enhancements in the plugins, and a few (Docker) improvements.
+
+# Core
+
+As said in the [1.1.3 Release Notes](/2018/05/24/coredns-1.1.3-release/), we are making the `-log`
+command line flag a noop.
+
+This is also a heads up that in the next release - 1.2.0 - the current *etcd* plugin will be
+replaced by a new plugin that supports etcd3, see this [pull
+request](https://github.com/coredns/coredns/pull/1702).
+
+The Docker image is now built using a multistage build. This means the final image is based on
+`scratch` *and* all architectures now have certificates in the image (not just the amd64 one).
+
+# Plugins
+
+We are also deprecating:
+
+* the *reverse* plugin has been removed, but we allow it still in the configuration.
+* the `google_https` protocol has been a noop in the *proxy* plugin.
+
+In the next release (1.2.0) this code will removed completely.
+
+Further more:
+
+* *file* now always queries local zones when trying to find a CNAME target.
+* *log* will now always log in seconds (not micro, or milliseconds).
+* *forward* erases expired connection after some time.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Francois Tur,
+Malcolm Akinje,
+Mario Kleinsasser,
+Miek Gieben,
+Ruslan Drozhdzh,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.0.md
+++ b/notes/coredns-1.2.0.md
@@ -1,0 +1,50 @@
++++
+title = "CoreDNS-1.2.0 Release"
+description = "CoreDNS-1.2.0 Release Notes."
+tags = ["Release", "1.2.0", "Notes"]
+release = "1.2.0"
+date = "2018-07-11T11:13:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.0) of
+CoreDNS-1.2.0!
+
+In this release we have a new plugin, bump etcd to version 3 and bugfixes.
+
+# Core
+
+Enable watch functionality when CoreDNS is used as a gRPC server (documented in the code - for now).
+
+# Plugins
+
+* A new plugin called [*metadata*](/plugins/metadata) was added. It adds metadata to a query, via the context.
+* The [*etcd*](/plugins/etcd) plugin now supports etcd version 3 (only!). It was impossible to support v2 *and* v3 at
+  the same time (even as separate plugins); so we decided to drop v2 support.
+* Fix a race/crash in the [*cache*](/plugins/cache) plugin when `prefetch` is enabled.
+* The [*forward*](/plugins/forward) plugin has a `prefer_udp` option, that even when the incoming query is over TCP, the
+  outgoing one will be tried over UDP first.
+* [*secondary*](/plugins/secondary) plugin has a bug fix for zone expiration: don't expire zones if we can reach the
+  primary, but see no zone changes.
+* The [*auto*](/plugins/auto) plugin now works better with Kubernetes Configmaps.
+
+## Contributors
+
+The following people helped with getting this release done:
+Chris O'Haver,
+Eren Güven,
+Eugen Kleiner,
+Francois Tur,
+Isolus,
+Joey Espinosa,
+John Belamaric,
+Jun Li,
+Marcus André,
+Miek Gieben,
+Nitish Tiwari,
+Ruslan Drozhdzh,
+Tobias Schmidt,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.1.md
+++ b/notes/coredns-1.2.1.md
@@ -1,0 +1,41 @@
++++
+title = "CoreDNS-1.2.1 Release"
+description = "CoreDNS-1.2.1 Release Notes."
+tags = ["Release", "1.2.1", "Notes"]
+release = "1.2.1"
+date = "2018-08-28T07:10:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.1) of
+CoreDNS-1.2.1!
+
+This release features bugfixes (mostly in the [*kubernetes*](/plugins/kubernetes) plugin),
+documentation improvements and one new plugin: [*loop*](/plugins/loop).
+
+# Plugins
+
+* A new plugin called [*loop*](/plugins/loop) was added. When starting up it detects resolver loops
+  and stops the process if one is detected.
+
+## Contributors
+
+The following people helped with getting this release done. Good to see a whole bunch of new names,
+as well as the usual suspects:
+
+Bingshen Wang,
+Chris O'Haver,
+Eugen Kleiner,
+Francois Tur,
+Jiacheng Xu,
+Karsten Weiss,
+Lorenzo Fontana,
+Miek Gieben,
+Nitish Tiwari,
+Stanislav Zapolsky,
+varyoo,
+Yong Tang,
+Zach Eddy.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.2.md
+++ b/notes/coredns-1.2.2.md
@@ -1,0 +1,24 @@
++++
+title = "CoreDNS-1.2.2 Release"
+description = "CoreDNS-1.2.2 Release Notes."
+tags = ["Release", "1.2.2", "Notes"]
+release = "1.2.2"
+date = "2018-08-29T07:10:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.2) of
+CoreDNS-1.2.2!
+
+This is a (small) release that helps out our friends at
+[kops](https://github.com/kubernetes/kops/issues/5652): make the default cache size smaller.
+
+## Contributors
+
+The following people helped with getting this release done:
+
+Chris O'Haver,
+Miek Gieben.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.3.md
+++ b/notes/coredns-1.2.3.md
@@ -1,0 +1,61 @@
++++
+title = "CoreDNS-1.2.3 Release"
+description = "CoreDNS-1.2.3 Release Notes."
+tags = ["Release", "1.2.3", "Notes"]
+release = "1.2.3"
+date = "2018-10-16T11:37:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.3) of
+CoreDNS-1.2.3!
+
+## Core
+
+This is a big release that spans almost 6 weeks of development, slightly longer than normal. You may
+also have noticed that CoreDNS *wasn't* made the default in Kubernetes 1.12 due to increased memory
+used compared to kube-dns. This release contains a fix for that.
+
+The underlying DNS library has seen multiple updates to improve throughput and memory and we have
+enabled REUSE_PORT on the ports CoreDNS opens on \*nix.
+
+## Plugins
+
+* [*federation*](/plugins/federation) return a correct answer (SERVFAIL) if availability-zone or region labels are missing from a node.
+* [*route53*](/plugins/route53)
+    * Refactor add-on to support batch querying of Route 53 along with all AWS record types (including `CNAME`).
+    * Add support for zones with overlapping domains (split config)
+    * Minor improvements (`fallthrough`, `upstream` options, AWS credentials file support)
+* [*cache*](/plugin/cache) add a minttl option to set the minimal TTL for records being cached. The cache key moved to hash/fnv64.
+* [*rewrite*](/plugin/rewrite) can now also rewrite TTLs
+* [*kubernetes*](/plugin/kubernetes)
+    * Uses less memory (~30% less).
+    * Do not block on startup when connecting to the API server; returns SERVFAIL in the mean time.
+    * Support for using a `kubeconfig` file, including various auth providers (Azure not supported due to a compilation issue with that code).
+* [*reload*](/plugin/reload) allows the reload interval to be configured.
+* [*forward*](/plugin/forward) fix a crash when health checking is enabled in some circumstances.
+
+## Brought to you by:
+
+Aaron Riekenberg,
+Billie Cleek,
+Brad Beam,
+Can Yucel,
+Chris O'Haver,
+dilyevsky,
+Eugen Kleiner,
+Francois Tur,
+John Belamaric,
+Manuel Alejandro de Brito Fontes,
+Manuel Stocker,
+marqc,
+Miek Gieben,
+Nic Cope,
+Paul G,
+Ruslan Drozhdzh,
+Tom Thorogood,
+Yong Tang,
+Zach Eddy.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.4.md
+++ b/notes/coredns-1.2.4.md
@@ -1,0 +1,31 @@
++++
+title = "CoreDNS-1.2.4 Release"
+description = "CoreDNS-1.2.4 Release Notes."
+tags = ["Release", "1.2.4", "Notes"]
+release = "1.2.4"
+date = "2018-10-17T20:01:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.4) of
+CoreDNS-1.2.4!
+
+Remember we [said the 1.2.3 release](/2018/10/16/coredns-1.2.3-release/) was a big release and took
+quite a while? Well, we've fixed that glitch; as 1.2.4 is here now.
+
+CoreDNS v1.2.3's *kubernetes* plugin **DOES NOT WORK IN KUBERNETES** and our testing that didn't catch
+that regression, nor the Kubernetes scale testing which doesn't really exercise the *whole* API.
+
+## Plugins
+
+* [*cache*](/plugins/cache) use zero of the minimal negative TTL (if no suitable TTL was found in
+  the packet).
+* [*kubernetes*](/plugins/kubernetes) fix a grave bug that made plugin **unusable** in Kubernetes.
+
+## Brought to you by:
+
+Chris O'Haver,
+Miek Gieben.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.5.md
+++ b/notes/coredns-1.2.5.md
@@ -1,0 +1,40 @@
++++
+title = "CoreDNS-1.2.5 Release"
+description = "CoreDNS-1.2.5 Release Notes."
+tags = ["Release", "1.2.5", "Notes"]
+release = "1.2.5"
+date = "2018-10-24T20:40:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.5) of
+CoreDNS-1.2.5!
+
+## Core
+
+Correctly make a reply fit in the client's buffer, *especially* when EDNS0 is not used.
+This used to be the responsibility of a plugin, now the server will handle it.
+
+## Plugins
+
+Documentation and smaller updates for various plugins, as well as:
+
+* [*cache*](/plugins/cache) - resets min TTL default back to 5 second (instead of 0).
+* [*dnssec*](/plugins/dnssec) - now allows aZSK/KSK split as well as a CSK setup.
+* [*rewrite*](/plugins/rewrite) - answer rewrite is now automatic for _exact_ name rewrites.
+
+## Brought to you by
+
+Andrey Meshkov,
+Chris O'Haver,
+Francois Tur,
+Kevin Nisbet,
+Manuel Stocker,
+Miek Gieben,
+Paul G,
+Ruslan Drozhdzh,
+Sandeep Rajan,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.2.6.md
+++ b/notes/coredns-1.2.6.md
@@ -1,0 +1,49 @@
++++
+title = "CoreDNS-1.2.6 Release"
+description = "CoreDNS-1.2.6 Release Notes."
+tags = ["Release", "1.2.6", "Notes"]
+release = "1.2.6"
+date = "2018-11-05T20:40:29+01:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.2.6) of
+CoreDNS-1.2.6!
+
+## Core
+
+Ignore the error when setting SO_REUSEPORT on a socket fails; this makes CoreDNS work on older
+kernels.
+
+## Plugins
+
+*  [*etcd*](/plugins/etcd) has seen minor bugfixes.
+
+*  [*loop*](/plugins/loop) fixes a bug when dealing with a failing upstream.
+
+*  [*log*](/plugins/log) unifies all logging (done by this plugin and normal logs) and always use
+   RFC3339 timestamps (with millisecond accuracy). The `{when}` verb has been made a noop, it will
+   be removed in the next release.
+
+*  [*cache*](/plugins/cache) got some minor optimizations.
+
+*  [*errors*](/plugins/errors) (and *log*) gotten a new option (`consolidate`) to suppress loging.
+
+*  [*hosts*](/plugins/hosts) will now read the `hosts` file without holding a write lock.
+
+*  [*route53*](/plugins/route53) makes the upstream optional.
+
+## Brought to You By
+
+Carl-Magnus Björkell,
+Chris O'Haver,
+Dzmitry Razhanski,
+Francois Tur,
+Jiacheng Xu,
+Matthias Lechner,
+Miek Gieben,
+Ruslan Drozhdzh,
+Stuart Nelson.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.3.0.md
+++ b/notes/coredns-1.3.0.md
@@ -1,0 +1,51 @@
++++
+title = "CoreDNS-1.3.0 Release"
+description = "CoreDNS-1.3.0 Release Notes."
+tags = ["Release", "1.3.0", "Notes"]
+release = "1.3.0"
+date = "2018-12-15T16:14:29+00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.3.0) of
+CoreDNS-1.3.0!
+
+## Core
+
+In this release we do the EDNS0 handling in the server and make it compliant with
+[https://dnsflagday.net/](https://dnsflagday.net/). This fits a theme where we move more and more
+protocol details into the server to make life easier for plugin authors.
+
+# Plugins
+
+*  [*k8s_external*](/plugins/k8s_external) a new plugin that allows external zones to point to
+   Kubernetes in-cluster services.
+
+*  [*rewrite*](/plugins/rewrite) fixes a bug where a rule would eat the first character of a name
+
+*  [*log*](/plugins/log) now supported the [*metadata*](/plugins/metadata) labels. It also fixes a
+   bug in the formatting of a plugin logging a info/failure/warning
+
+*  [*forward*](/plugins/forward) removes the dynamic read timeout and uses a fixed value now.
+
+*  [*kubernetes*](/plugins/kubernetes) now checks if a zone transfer is allowed. Also allow a TTL of
+   0 to avoid caching in the cache plugin.
+
+## Brought to You By
+
+Chris O'Haver,
+Cricket Liu,
+Daniel Garcia,
+DavadDi,
+Francois Tur,
+Jiacheng Xu,
+John Belamaric,
+Miek Gieben,
+moredhel,
+Sandeep Rajan,
+StormXX,
+stuart nelson,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.3.1.md
+++ b/notes/coredns-1.3.1.md
@@ -1,0 +1,45 @@
++++
+title = "CoreDNS-1.3.1 Release"
+description = "CoreDNS-1.3.1 Release Notes."
+tags = ["Release", "1.3.1", "Notes"]
+release = "1.3.1"
+date = "2019-01-13T15:00:29+00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.3.1)
+of CoreDNS-1.3.1! This is a fairly small release that allows us to announce some backwards
+incompatible changes in the *next* (1.4.0) release:
+
+ *  The `upstream` directive used in various plugin will start to *default* to the coredns process
+    itself. This allow those resolutions to take advantage of other plugins (i.e. caching). The
+    *etcd*'s plugin StubDomain subsystem relied heavily on this functionality and as such will be
+    removed from that plugin.
+
+ *  Multiple endpoints in kubernetes will not be supported going forward.
+
+
+# Plugins
+
+Mostly documentation updates in various plugins. Plus a small fix where we stop setting the RA
+(recursion available) flag on responses in plugins that don't provide recursion.
+
+ *  [*log*](/plugins/log) now allows multiple names to be specified.
+
+ *  [*import*](/plugins/import) was added to give it a README.md to make it's documentation more
+    discoverable.
+
+ *  [*kubernetes*](/plugins/kubernetes) `TTL` is also applied to negative responses (NXDOMAIN, etc).
+
+## Brought to You By
+
+Chris O'Haver,
+ckcd,
+Isolus,
+jmpcyc,
+Miek Gieben,
+Taras Tsugrii,
+Yong Tang.
+
+For documentation see our (in progress!) [manual](/manual). For help and other resources, see our
+[community page](https://coredns.io/community/).

--- a/notes/coredns-1.4.0.md
+++ b/notes/coredns-1.4.0.md
@@ -1,0 +1,89 @@
++++
+title = "CoreDNS-1.4.0 Release"
+description = "CoreDNS-1.4.0 Release Notes."
+tags = ["Release", "1.4.0", "Notes"]
+release = "1.4.0"
+date = "2019-03-03T09:04:07+00:00"
+author = "coredns"
++++
+
+We are pleased to announce the [release](https://github.com/coredns/coredns/releases/tag/v1.4.0)
+of CoreDNS-1.4.0! Our first release after we became a graduated project in
+[CNCF](https://www.cncf.io/).
+
+Deprecation notice for the *next* release:
+
+ *  [*auto*](/plugins/auto) will deprecate **TIMEOUT** and `no_reload` and defaults the use of
+    `reload`. This makes [*file*](/plugins/file) and [*auto*](/plugins/auto) to use the same syntax
+    for reload intervals.
+ *  [*health*](/plugins/health) will revert back to report process level health without plugin
+    status. A new *ready* plugin will make sure plugins have at least completed their startup
+    sequence.
+ *  The [*proxy*](/plugins/proxy) will be moved to an external repository and as such be deprecated
+    from the default set of plugin; use the [*forward*](/plugins/forward) as a replacement.
+
+The [previous](/019/01/13/coredns-1.3.1-release/) announced deprecations have been enacted.
+
+The (unused) gRPC watch functionally was removed from the server.
+
+Note we're actively working on two (probably related) bugs
+([2593](https://github.com/coredns/coredns/issues/2593),
+[2624](https://github.com/coredns/coredns/issues/2624)) which should hopefully result in a fix and
+a new release fairly quickly.
+
+# Plugins
+
+Random updates in documentation and fixes in tests and various plugins.
+
+ *  [*kubernetes*](/plugins/kubernetes) fixes the logging now that kubernetes' client lib switched
+    to klog from glog.
+
+ *  [*hosts*](/plugins/hosts) fixes IPv4 addresses in IPV6 syntax.
+
+ *  [*etcd*](/plugins/etcd) adds credential support and a fix for the reply when the `host` field is
+    empty.
+
+ *  [*log*](/plugins/log) has been made more efficient.
+
+ *  [*forward*](/plugins/forward) drops out of order messages, this is solve occasionally FORMERRs
+    people saw.
+
+## Brought to You By
+
+Think we never had so many contributors for a single release. This is really nice to see. Thank you
+all:
+
+AdamDang,
+Anders Ingemann,
+Andrey Meshkov,
+Brian Bao,
+Carl-Magnus Björkell,
+Chris Aniszczyk,
+Chris O'Haver,
+Christophe de Carvalho,
+ckcd,
+Dan Kohn,
+Darshan Chaudhary,
+DO ANH TUAN,
+Guillaume Gelin,
+Guy Templeton,
+JoeWrightss,
+Kenjiro Nakayama,
+LongKB,
+Miek Gieben,
+mrasu,
+Nguyen Hai Truong,
+Nguyen Phuong An,
+Nguyen Quang Huy,
+Nguyen Van Duc,
+Nguyen Van Trung,
+Rob Maas,
+Ruslan Drozhdzh,
+Sandeep Rajan,
+Thomas Mangin,
+tuanvcw,
+Uladzimir Trehubenka,
+Xiao An,
+Xuanwo,
+Ye Ben,
+Yong Tang.

--- a/notes/coredns-1.4.0.md
+++ b/notes/coredns-1.4.0.md
@@ -13,9 +13,8 @@ of CoreDNS-1.4.0! Our first release after we became a graduated project in
 
 Deprecation notice for the *next* release:
 
- *  [*auto*](/plugins/auto) will deprecate **TIMEOUT** and `no_reload` and defaults the use of
-    `reload`. This makes [*file*](/plugins/file) and [*auto*](/plugins/auto) to use the same syntax
-    for reload intervals.
+ *  [*auto*](/plugins/auto) will deprecate **TIMEOUT** and recommends the use of RELOAD ([2516](https://github.com/coredns/coredns/issues/2516).
+ *  [*auto*](/plugins/file) and [*file*](/plugins/auto) will deprecate NO_RELOAD and recommends the use of RELOAD set to 0 ([2536](https://github.com/coredns/coredns/issues/2536).
  *  [*health*](/plugins/health) will revert back to report process level health without plugin
     status. A new *ready* plugin will make sure plugins have at least completed their startup
     sequence.


### PR DESCRIPTION
Verbatim copy of the current set of notes on coredns.io. Copy them here to
make them authoritative.

'make sync' on the coredns.io site copies them back in. They need to be 
formatted in Hugo style.

Fixes #2355