### PR TITLE
Update to 1.12.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 language: go
 go:
-  - "1.11.x"
+  - "1.12.x"
 
 go_import_path: github.com/coredns/coredns
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Golang 1.12.0 has been released. Tested locally that 1.12.0 works with CoreDNS. This PR will bring Travis CI to 1.12.0 (assume Travis CI support 1.12.0).

### 2. Which issues (if any) are related?

(This PR may potentially help `gomod` effort in #2503, as 1.12.0 consists of changes that improves `gomod`)

### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>