### PR TITLE
Remove internal loop detection

### DIFF
--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -48,21 +48,6 @@ func TestNewServer(t *testing.T) {
 	}
 }
 
-func TestIncrementDepthAndCheck(t *testing.T) {
-	ctx := context.Background()
-	var err error
-	for i := 0; i <= maxreentries; i++ {
-		ctx, err = incrementDepthAndCheck(ctx)
-		if err != nil {
-			t.Errorf("Expected no error for depthCheck (i=%v), got %s", i, err)
-		}
-	}
-	_, err = incrementDepthAndCheck(ctx)
-	if err == nil {
-		t.Errorf("Expected error for depthCheck (i=%v)", maxreentries+1)
-	}
-}
-
 func BenchmarkCoreServeDNS(b *testing.B) {
 	s, err := NewServer("127.0.0.1:53", []*Config{testConfig("dns", testPlugin{})})
 	if err != nil {


### PR DESCRIPTION
I can't actually think of a situation where we can create an internal
loop. Sure externally triggered cycles can happen, but this is where the
*loop* plugin comes in that detects those.

Fixes #2602

Signed-off-by: Miek Gieben <miek@miek.nl>