### PR TITLE
Update README.md to use go 1.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ a Go environment, you could build CoreDNS easily:
 
 ```
 $ docker run --rm -i -t -v $PWD:/go/src/github.com/coredns/coredns \
-      -w /go/src/github.com/coredns/coredns golang:1.11 make
+      -w /go/src/github.com/coredns/coredns golang:1.12 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
Update README.md to use go 1.12, also check to see if #2503 works as expected with new PRs.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>