### PR TITLE
Reload started twice can generate panic

### DIFF
--- a/coremain/run.go
+++ b/coremain/run.go
@@ -95,9 +95,6 @@ func Run() {
 		showVersion()
 	}
 
-	// Execute instantiation events
-	caddy.EmitEvent(caddy.InstanceStartupEvent, instance)
-
 	// Twiddle your thumbs
 	instance.Wait()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fix problem of reload kicked-off twice.
Since last release of Caddy, the event `InstanceStartupEvent` is triggered directly by Caddy when starting the Instance. CoreDNS MUST not trigger that event again.

### 2. Which issues (if any) are related?

#2654

### 3. Which documentation changes (if any) need to be made?

None. It is fixing an bug.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
