### PR TITLE
Fix cache corruption edge case

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -171,6 +171,11 @@ func TestCache(t *testing.T) {
 
 		if valid {
 			crr.set(m, k, mt, c.pttl)
+			// cache must not care what plugins above it are doing, including
+			// modifying the returned message after an initial cache miss
+			if len(m.Answer) > 0 {
+				m.Answer[0] = test.A("shouldnotseeme.bad. 0 IN A 127.0.0.53")
+			}
 		}
 
 		i, _ := c.get(time.Now().UTC(), state, "dns://:53")

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -33,7 +33,6 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i.Ns = make([]dns.RR, len(m.Ns))
 	copy(i.Ns, m.Ns)
 	i.Extra = make([]dns.RR, len(m.Extra))
-
 	// Don't copy OPT records as these are hop-by-hop.
 	j := 0
 	for _, e := range m.Extra {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -28,9 +28,16 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i.Authoritative = m.Authoritative
 	i.AuthenticatedData = m.AuthenticatedData
 	i.RecursionAvailable = m.RecursionAvailable
-	i.Answer = append([]dns.RR{}, m.Answer...)
-	i.Ns = m.Ns
+	i.Answer = make([]dns.RR, len(m.Answer))
+	i.Ns = make([]dns.RR, len(m.Ns))
 	i.Extra = make([]dns.RR, len(m.Extra))
+
+	for j, r := range m.Answer {
+		i.Answer[j] = dns.Copy(r)
+	}
+	for j, r := range m.Ns {
+		i.Ns[j] = dns.Copy(r)
+	}
 	// Don't copy OPT records as these are hop-by-hop.
 	j := 0
 	for _, e := range m.Extra {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -29,15 +29,11 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i.AuthenticatedData = m.AuthenticatedData
 	i.RecursionAvailable = m.RecursionAvailable
 	i.Answer = make([]dns.RR, len(m.Answer))
+	copy(i.Answer, m.Answer)
 	i.Ns = make([]dns.RR, len(m.Ns))
+	copy(i.Ns, m.Ns)
 	i.Extra = make([]dns.RR, len(m.Extra))
 
-	for j, r := range m.Answer {
-		i.Answer[j] = dns.Copy(r)
-	}
-	for j, r := range m.Ns {
-		i.Ns[j] = dns.Copy(r)
-	}
 	// Don't copy OPT records as these are hop-by-hop.
 	j := 0
 	for _, e := range m.Extra {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -28,7 +28,7 @@ func newItem(m *dns.Msg, now time.Time, d time.Duration) *item {
 	i.Authoritative = m.Authoritative
 	i.AuthenticatedData = m.AuthenticatedData
 	i.RecursionAvailable = m.RecursionAvailable
-	i.Answer = m.Answer
+	i.Answer = append([]dns.RR{}, m.Answer...)
 	i.Ns = m.Ns
 	i.Extra = make([]dns.RR, len(m.Extra))
 	// Don't copy OPT records as these are hop-by-hop.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Fixes an edge case where cache corruption can occur. This situation can happen when initially populating a new cache item with an answer array, and returning a slice to the same underlying answer array to the caller (upstream plugin). This behaviour is dangerous because it leaks the internal cache state to other plugins which can then inadvertently corrupt the cache by modifying the response message.

### 2. Which issues (if any) are related?
None that I could find.

### 3. Which documentation changes (if any) need to be made?
None required

### 4. Does this introduce a backward incompatible change or deprecation?
No

### Background

I am running a special build of CoreDNS where the cache plugin order is _after_ the autopath plugin.
 
(The reasons for this setup are irrelevant to this PR, but are related to minimizing upstream queries in an environment where I do not control the clients' search domains and the upstream DNS server returns non-cacheable non-authoritative NXDOMAIN responses for some of the search zones.)

In `plugins.cfg` it says:

> [plugins] must not care what plugin above them are doing.

This bug violates the invariant above.

The bug manifested as glibc stub resolver returning non-existent domains when querying CoreDNS after the initial cache miss + population for a domain with several CNAME entries. After the initial miss all subsequent responses from the cache contained the CNAME injected by autopath, but not the A record returned by the upstream DNS server.

The cache plugin protects itself from corruption by returning a [copy of the cached answer array in toMsg](https://github.com/coredns/coredns/blob/dae506b5638c7309399cb273d7f76bc20ee518dd/plugin/cache/item.go#L64). However, it does **not** protect itself on the initial query where it [returns](https://github.com/coredns/coredns/blob/master/plugin/cache/cache.go#L198) the same struct that it [caches](https://github.com/coredns/coredns/blob/master/plugin/cache/cache.go#L172).

The cnamer [modifies this struct in-place](https://github.com/coredns/coredns/blob/master/plugin/autopath/cname.go#L17), consequently polluting the cache if autopath plugin is included *above* the cache plugin.

_Note_: The cache will only be polluted when `append(m.Answer, nil)` does *not* create a new array. I've only seen this behaviour on a domain that has multiple CNAME + 1 A entries, where the initial array allocated has sufficient capacity to store the new `nil` entry. The autopath'd CNAME is then inserted at the front, and the rest of the data shifted right - which is reflected in future cache responses since the same underlying array is store in the cache.

I also considered fixing this issue in the `cnamer()` function, but it leaves the `cache` plugin vulnerable to other similar situations from any upstream plugin that modifies the response.

In any case, the performance penalty should be small as it only involves the extra array copy when populating a cache entry (not on every retrieval).

### Reproducing

1.  Build CoreDNS with `cache` **after** `autopath`.
2.  Use the following Corefile and resolv.conf:

Corefile
```
.:9999 {
        errors
        autopath resolv.conf
        cache .
        forward . 8.8.8.8
    }
```

resolv.conf
```
search foo bar
```

3. Query target domain with `dig -p 9999 @127.0.0.1 A coredns-example.budeanu.com.foo`

(The domain above is real, I set it up to demonstrate this bug mirroring the example I found in a production environment.)

Observe on first lookup:

```
;; ANSWER SECTION:
coredns-example.budeanu.com.foo. 119 IN	CNAME	coredns-example.budeanu.com.
coredns-example.budeanu.com. 119 IN	CNAME	coredns-example-coredns.budeanu.com.
coredns-example-coredns.budeanu.com. 119 IN CNAME super-long-final-cname-example-for-bug-at-coredns.budeanu.com.
super-long-final-cname-example-for-bug-at-coredns.budeanu.com. 119 IN A	127.0.0.1
```

On second lookup we get a corrupted entry (extra CNAME, no A record):

```
;; ANSWER SECTION:
coredns-example.budeanu.com.foo. 119 IN	CNAME	coredns-example.budeanu.com.
coredns-example.budeanu.com.foo. 119 IN	CNAME	coredns-example.budeanu.com.
coredns-example.budeanu.com. 119 IN	CNAME	coredns-example-coredns.budeanu.com.
coredns-example-coredns.budeanu.com. 119 IN CNAME super-long-final-cname-example-for-bug-at-coredns.budeanu.com.
```

cc: @mkobetic
