### PR TITLE
Fix incompatibility between dnstap and trace plugins

### DIFF
--- a/plugin/dnstap/context_test.go
+++ b/plugin/dnstap/context_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestDnstapContext(t *testing.T) {
-	ctx := tapContext{context.TODO(), Dnstap{}}
+	ctx := ContextWithTapper(context.TODO(), Dnstap{})
 	tapper := TapperFromContext(ctx)
 
 	if tapper == nil {

--- a/plugin/dnstap/gocontext.go
+++ b/plugin/dnstap/gocontext.go
@@ -1,0 +1,23 @@
+package dnstap
+
+import "context"
+
+type contextKey struct{}
+
+var dnstapKey = contextKey{}
+
+// ContextWithTapper returns a new `context.Context` that holds a reference to
+// `t`'s Tapper.
+func ContextWithTapper(ctx context.Context, t Tapper) context.Context {
+	return context.WithValue(ctx, dnstapKey, t)
+}
+
+// TapperFromContext returns the `Tapper` previously associated with `ctx`, or
+// `nil` if no such `Tapper` could be found.
+func TapperFromContext(ctx context.Context) Tapper {
+	val := ctx.Value(dnstapKey)
+	if sp, ok := val.(Tapper); ok {
+		return sp
+	}
+	return nil
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Enabling the trace plugin partially disables the dnstap plugin. This PR fixes the incompatibility.

Currently the `dnstap` plugin provides a `TapperFromContext` function that uses a type assertion to get the Tapper from the go Context. This approach is incompatible with the `trace` plugin, which requires replacing the context passed to each subsequent plugin with the result of `ContextWithSpan`. The latter can never pass a type assertion for Tapper, and thus `TapperFromContext` always returns nil in subsequent plugins (e.g. proxy).

### 2. Which issues (if any) are related?
None directly, but https://github.com/coredns/coredns/issues/1448 will be affected once it's implemented.

### 3. Which documentation changes (if any) need to be made?
None, public API is maintained as-is.

### 4. Does this introduce a backward incompatible change or deprecation?
No

### Details
When `trace` functionality is actually built into the plugin framework directly in [NextOrFailure](https://github.com/coredns/coredns/blob/master/plugin/plugin.go#L77). When trace is enabled each subsequent plugin is called with the result of `ContextWithSpan`.

The dnstap [documentation](https://github.com/coredns/coredns/blob/master/plugin/dnstap/README.md#using-dnstap-in-your-plugin) recommends using it from other plugins with:

>     if t := dnstap.TapperFromContext(ctx); t != nil {

The current implementation expects `t, _ = ctx.(Tapper)` to pass, but it cannot because the Tapper has been wrapped in a context with span.

Presumably this approach was taken for performance reasons, but it is incompatible with plugins that also alter the context (like trace). The fix is to set/get the tapper with `context.WithValue`.

Note that the only plugin currently using dnstap is the deprecated proxy, but forward is slated to get support and will also be affected: https://github.com/coredns/coredns/issues/1448 

### Reproducing

1. Build coredns with the `proxy` plugin
1. Enable dnstap, send requests through and notice the `FORWARED_QUERY` and `FORWARDED_RESPONSE` messages.
1. Enable tracing, notice that the `FORWARDED_QUERY` and `FORWARDED_RESPONSE` messages are missing because `dnstap.TapperFromContext(ctx)` always returns `nil` in the `proxy` plugin.