### PR TITLE
Custom tag support in trace plugin

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -30,6 +30,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
 	every AMOUNT
 	service NAME
 	client_server
+	tag key value
 }
 ~~~
 
@@ -38,6 +39,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
 * `service` **NAME** allows you to specify the service name reported to the tracing server.
   Default is `coredns`.
 * `client_server` will enable the `ClientServerSameSpan` OpenTracing feature.
+* `tag` is used to emit custom tags with each trace, it can be included multiple times
 
 ## Zipkin
 You can run Zipkin on a Docker host like this:

--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -40,7 +40,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
   Default is `coredns`.
 * `client_server` will enable the `ClientServerSameSpan` OpenTracing feature.
 * `tag` is used to emit custom tags with each trace, it can be included multiple times
-  If the `metadata` plugin used the value can be dynamic, use the format `{prefix/name}`
+  If the `metadata` plugin is used the value can be dynamic, use the format `{plugin/value}`
 
 ## Zipkin
 You can run Zipkin on a Docker host like this:

--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -40,6 +40,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
   Default is `coredns`.
 * `client_server` will enable the `ClientServerSameSpan` OpenTracing feature.
 * `tag` is used to emit custom tags with each trace, it can be included multiple times
+  If the `metadata` plugin used the value can be dynamic, use the format `{prefix/name}`
 
 ## Zipkin
 You can run Zipkin on a Docker host like this:

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -89,6 +89,15 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 				if err != nil {
 					return nil, err
 				}
+			case "tag":
+				args := c.RemainingArgs()
+				if len(args) != 2 {
+					return nil, c.ArgErr()
+				}
+				if tr.tags == nil {
+					tr.tags = map[string]string{}
+				}
+				tr.tags[args[0]] = args[1]
 			}
 		}
 	}

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -26,7 +26,7 @@ func TestTraceParse(t *testing.T) {
 		{"trace {\n every 100\n service foobar\nclient_server\n}", false, "http://localhost:9411/api/v1/spans", 100, `foobar`, true},
 		{"trace {\n every 2\n client_server true\n}", false, "http://localhost:9411/api/v1/spans", 2, `coredns`, true},
 		{"trace {\n client_server false\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
-		{"trace {\n tag foo bar\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
+		{"trace {\n tag key value\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
 		// fails
 		{`trace footype localhost:4321`, true, "", 1, "", false},
 		{"trace {\n every 2\n client_server junk\n}", true, "", 1, "", false},

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -26,6 +26,7 @@ func TestTraceParse(t *testing.T) {
 		{"trace {\n every 100\n service foobar\nclient_server\n}", false, "http://localhost:9411/api/v1/spans", 100, `foobar`, true},
 		{"trace {\n every 2\n client_server true\n}", false, "http://localhost:9411/api/v1/spans", 2, `coredns`, true},
 		{"trace {\n client_server false\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
+		{"trace {\n tag foo bar\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
 		// fails
 		{`trace footype localhost:4321`, true, "", 1, "", false},
 		{"trace {\n every 2\n client_server junk\n}", true, "", 1, "", false},

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -35,6 +35,7 @@ type trace struct {
 	tracer          ot.Tracer
 	serviceEndpoint string
 	serviceName     string
+	tags            map[string]string
 	clientServer    bool
 	every           uint64
 	count           uint64
@@ -119,6 +120,10 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 	span.SetTag(tagName, req.Name())
 	span.SetTag(tagType, req.Type())
 	span.SetTag(tagRcode, rcode.ToString(rw.Rcode))
+
+	for key, value := range t.tags {
+		span.SetTag(key, value)
+	}
 
 	return status, err
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR adds optional custom tag support to the `trace` plugin. Zero or more tags are supported, and they are added to the emitted spans.

I am managing a large deployment of CoreDNS instances with multiple configurations and exporting sampled traces to Stackdriver and Lightstep. Without custom tags it's hard to tell which instances the traces correspond to.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
`trace` README should explain the use of the `tag` block, this PR includes the necessary changes. 

### 4. Does this introduce a backward incompatible change or deprecation?
No