### PR TITLE
Add `$GOPATH/pkg/mod` to Travis CI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ language: go
 go:
   - "1.12.x"
 
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+
 go_import_path: github.com/coredns/coredns
 
 git:


### PR DESCRIPTION
in order to speed up the go mod.

This fix is related to #2684.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
