### PR TITLE
plugin/debug: add printing memory stats

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.28.0 h1:KZ/88LWSw8NxMkjdQyX7LQSGR9PkHr4PaVuNm8zgFq0=
 cloud.google.com/go v0.28.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/zstd v1.3.5 h1:DtpNbljikUepEPD16hD4LvIcmhnhdLTiW/5pHgbmp14=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Shopify/sarama v1.21.0 h1:0GKs+e8mn1RRUzfg9oUXv3v7ZieQLmOZF/bfnmmGhM8=
 github.com/Shopify/sarama v1.21.0/go.mod h1:yuqtN/pe8cXRWG5zPaO7hCfNJp5MwmkoJEoLjkm5tCQ=

--- a/plugin/debug/README.md
+++ b/plugin/debug/README.md
@@ -18,6 +18,21 @@ Note that the *errors* plugin (if loaded) will also set a `recover` negating thi
 debug
 ~~~
 
+Memory reporting is also supported with this expanded syntax:
+
+~~~ txt
+debug {
+    memory
+}
+~~~
+
+Using the `memory` directive will make CoreDNS print out the memory usage of the process every
+second:
+
+~~~
+2019-03-14T07:03:15.065Z [DEBUG] alloc:     2.2199 MiB, total alloc:     2.2199 MiB, system:    68.5627 MiB
+~~~
+
 Some plugin will debug log DNS messages. This is done in the following format:
 
 ~~~
@@ -45,4 +60,5 @@ Disable the ability to recover from crashes and show debug logging:
 
 ## Also See
 
-https://www.wireshark.org/docs/man-pages/text2pcap.html.
+<https://www.wireshark.org/docs/man-pages/text2pcap.html> and
+<https://golang.org/pkg/runtime/#MemStats>.

--- a/plugin/debug/debug.go
+++ b/plugin/debug/debug.go
@@ -16,12 +16,32 @@ func init() {
 
 func setup(c *caddy.Controller) error {
 	config := dnsserver.GetConfig(c)
+	mem := true
 
 	for c.Next() {
-		if c.NextArg() {
+		args := c.RemainingArgs()
+		if len(args) != 0 {
 			return plugin.Error("debug", c.ArgErr())
 		}
+
 		config.Debug = true
+		for c.NextBlock() {
+			switch c.Val() {
+			case "memory":
+				if len(c.RemainingArgs()) != 0 {
+					return plugin.Error("debug", c.ArgErr())
+				}
+				mem = true
+			default:
+				return plugin.Error("debug", c.ArgErr())
+			}
+		}
+	}
+	if mem {
+		stop := make(chan struct{})
+		c.OnStartup(func() error { reportMemory(stop); return nil })
+		c.OnRestart(func() error { stop <- struct{}{}; return nil })
+		c.OnFinalShutdown(func() error { stop <- struct{}{}; return nil })
 	}
 
 	return nil

--- a/plugin/debug/debug_test.go
+++ b/plugin/debug/debug_test.go
@@ -15,13 +15,15 @@ func TestDebug(t *testing.T) {
 		expectedDebug bool
 	}{
 		// positive
-		{
-			`debug`, false, true,
-		},
+		{`debug`, false, true},
+		{`debug {
+			memory
+		}`, false, true},
 		// negative
-		{
-			`debug off`, true, false,
-		},
+		{`debug off`, true, false},
+		{`debug {
+			memori
+		}`, true, true},
 	}
 
 	for i, test := range tests {
@@ -30,7 +32,7 @@ func TestDebug(t *testing.T) {
 		cfg := dnsserver.GetConfig(c)
 
 		if test.shouldErr && err == nil {
-			t.Fatalf("Test %d: Expected error but found %s for input %s", i, err, test.input)
+			t.Fatalf("Test %d: Expected error but found none for input %s", i, test.input)
 		}
 
 		if err != nil {

--- a/plugin/debug/memory.go
+++ b/plugin/debug/memory.go
@@ -1,0 +1,28 @@
+package debug
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/log"
+)
+
+// reportMemory reports the memory used by the current process by logging to standard error every second.
+func reportMemory(stop chan struct{}) error {
+	go func() {
+		tick := time.NewTicker(1 * time.Second)
+		var m runtime.MemStats
+		for {
+			select {
+			case <-tick.C:
+				runtime.ReadMemStats(&m)
+				log.Debugf("alloc: %10.4f MiB, total alloc: %10.4f MiB, system: %10.4f MiB",
+					float32(m.Alloc)/1024/1024, float32(m.TotalAlloc)/1024/1024, float32(m.Sys)/1024/1024)
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	return nil
+}


### PR DESCRIPTION
This eases looking at memory stats and doesn't require the use of
prometheus to extract it from the process.