### PR TITLE
pkg/log: fix data race on d

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -62,7 +62,7 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 	for _, site := range group {
 		if site.Debug {
 			s.debug = true
-			log.D = true
+			log.D.Set()
 		}
 		// set the config per zone
 		s.zones[site.Zone] = site

--- a/plugin/debug/pcap.go
+++ b/plugin/debug/pcap.go
@@ -23,7 +23,7 @@ import (
 //
 // msg will prefix the pcap dump.
 func Hexdump(m *dns.Msg, v ...interface{}) {
-	if !log.D {
+	if !log.D.Value() {
 		return
 	}
 
@@ -39,7 +39,7 @@ func Hexdump(m *dns.Msg, v ...interface{}) {
 
 // Hexdumpf dumps a DNS message as Hexdump, but allows a format string.
 func Hexdumpf(m *dns.Msg, format string, v ...interface{}) {
-	if !log.D {
+	if !log.D.Value() {
 		return
 	}
 

--- a/plugin/debug/pcap_test.go
+++ b/plugin/debug/pcap_test.go
@@ -17,8 +17,19 @@ func msg() *dns.Msg {
 	m.SetQuestion("example.local.", dns.TypeA)
 	m.SetEdns0(4096, true)
 	m.Id = 10
-
 	return m
+}
+
+func TestNoDebug(t *testing.T) {
+	// Must come first, because set log.D.Set() which is impossible to undo.
+	var f bytes.Buffer
+	golog.SetOutput(&f)
+
+	str := "Hi There!"
+	Hexdumpf(msg(), "%s %d", str, 10)
+	if len(f.Bytes()) != 0 {
+		t.Errorf("Expected no output, got %d bytes", len(f.Bytes()))
+	}
 }
 
 func ExampleLogHexdump() {
@@ -36,7 +47,7 @@ func ExampleLogHexdump() {
 func TestHexdump(t *testing.T) {
 	var f bytes.Buffer
 	golog.SetOutput(&f)
-	log.D = true
+	log.D.Set()
 
 	str := "Hi There!"
 	Hexdump(msg(), str)
@@ -50,7 +61,7 @@ func TestHexdump(t *testing.T) {
 func TestHexdumpf(t *testing.T) {
 	var f bytes.Buffer
 	golog.SetOutput(&f)
-	log.D = true
+	log.D.Set()
 
 	str := "Hi There!"
 	Hexdumpf(msg(), "%s %d", str, 10)
@@ -58,17 +69,5 @@ func TestHexdumpf(t *testing.T) {
 
 	if !strings.Contains(logged, "[DEBUG] "+fmt.Sprintf("%s %d", str, 10)) {
 		t.Errorf("The string %s %d, is not contained in the logged output: %s", str, 10, logged)
-	}
-}
-
-func TestNoDebug(t *testing.T) {
-	var f bytes.Buffer
-	golog.SetOutput(&f)
-	log.D = false
-
-	str := "Hi There!"
-	Hexdumpf(msg(), "%s %d", str, 10)
-	if len(f.Bytes()) != 0 {
-		t.Errorf("Expected no output, got %d bytes", len(f.Bytes()))
 	}
 }

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -17,7 +17,7 @@ func TestDebug(t *testing.T) {
 		t.Errorf("Expected no debug logs, got %s", x)
 	}
 
-	D = true
+	D.Set()
 	Debug("debug")
 	if x := f.String(); !strings.Contains(x, debug+"debug") {
 		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
@@ -28,7 +28,7 @@ func TestDebugx(t *testing.T) {
 	var f bytes.Buffer
 	golog.SetOutput(&f)
 
-	D = true
+	D.Set()
 
 	Debugf("%s", "debug")
 	if x := f.String(); !strings.Contains(x, debug+"debug") {

--- a/plugin/pkg/log/plugin.go
+++ b/plugin/pkg/log/plugin.go
@@ -24,7 +24,7 @@ func (p P) log(level string, v ...interface{}) {
 
 // Debug logs as log.Debug.
 func (p P) Debug(v ...interface{}) {
-	if !D {
+	if !D.Value() {
 		return
 	}
 	p.log(debug, v...)
@@ -32,7 +32,7 @@ func (p P) Debug(v ...interface{}) {
 
 // Debugf logs as log.Debugf.
 func (p P) Debugf(format string, v ...interface{}) {
-	if !D {
+	if !D.Value() {
 		return
 	}
 	p.logf(debug, format, v...)


### PR DESCRIPTION
Wrap d in a mutex to prevent data race. This makes is slower, but this
is a debugging aid anyway. It's not used normally.