### PR TITLE
plugin/metrics: Add a metric to monitor which plugin(s) is(are) enabled

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -19,7 +19,7 @@ The following metrics are exported:
 * `coredns_dns_request_type_count_total{server, zone, type}` - counter of queries per zone and type.
 * `coredns_dns_response_size_bytes{server, zone, proto}` - response size in bytes.
 * `coredns_dns_response_rcode_count_total{server, zone, rcode}` - response per zone and rcode.
-* `coredns_plugin_enabled{server, zone, name}` - enabled pulgin(s) per server and zone.
+* `coredns_plugin_enabled{server, zone, name}` - indicates whether a plugin is enabled on per server and zone basis.
 
 Each counter has a label `zone` which is the zonename used for the request/response.
 

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -76,3 +76,4 @@ When reloading, the Prometheus handler is stopped before the new server instance
 If that new server fails to start, then the initial server instance is still available and DNS queries still served,
 but Prometheus handler stays down.
 Prometheus will not reply HTTP request until a successful reload or a complete restart of CoreDNS.
+Only the plugins that register as Handler are visible in `coredns_plugin_enabled{server, zone, name}`. As of today the plugins reload and bind will not be reported.

--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -19,6 +19,7 @@ The following metrics are exported:
 * `coredns_dns_request_type_count_total{server, zone, type}` - counter of queries per zone and type.
 * `coredns_dns_response_size_bytes{server, zone, proto}` - response size in bytes.
 * `coredns_dns_response_rcode_count_total{server, zone, rcode}` - response per zone and rcode.
+* `coredns_plugin_enabled{server, zone, name}` - enabled pulgin(s) per server and zone.
 
 Each counter has a label `zone` which is the zonename used for the request/response.
 

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -51,6 +51,7 @@ func New(addr string) *Metrics {
 	met.MustRegister(vars.RequestType)
 	met.MustRegister(vars.ResponseSize)
 	met.MustRegister(vars.ResponseRcode)
+	met.MustRegister(vars.PluginEnabled)
 
 	return met
 }

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -50,6 +50,12 @@ func setup(c *caddy.Controller) error {
 		})
 		return nil
 	})
+
+	c.OnRestart(func() error {
+		vars.PluginEnabled.Reset()
+		return nil
+	})
+
 	c.OnStartup(func() error {
 		conf := dnsserver.GetConfig(c)
 		plugins := conf.Handlers()

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -1,12 +1,14 @@
 package metrics
 
 import (
+	"fmt"
 	"net"
 	"runtime"
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/coremain"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics/vars"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/uniq"
 
@@ -49,7 +51,15 @@ func setup(c *caddy.Controller) error {
 		})
 		return nil
 	})
+	c.OnStartup(func() error {
+		plugins := dnsserver.GetConfig(c).Handlers()
+		for _, p := range plugins {
+			vars.PluginEnabled.WithLabelValues(p.Name()).Set(1)
+			fmt.Println(p.Name())
+		}
+		return nil
 
+	})
 	c.OnRestart(m.OnRestart)
 	c.OnFinalShutdown(m.OnFinalShutdown)
 

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -60,11 +60,7 @@ func setup(c *caddy.Controller) error {
 		conf := dnsserver.GetConfig(c)
 		plugins := conf.Handlers()
 		for _, h := range conf.ListenHosts {
-			addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(h, conf.Port))
-			if err != nil {
-				return err
-			}
-			addrstr := conf.Transport + "://" + addr.String()
+			addrstr := conf.Transport + "://" + net.JoinHostPort(h, conf.Port)
 			for _, p := range plugins {
 				vars.PluginEnabled.WithLabelValues(addrstr, conf.Zone, p.Name()).Set(1)
 			}

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -68,7 +68,6 @@ var (
 
 	PluginEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
 		Name:      "plugin_enabled",
 		Help:      "A metric that monitors which plugin(s) is(are) enabled.",
 	}, []string{"server", "zone", "name"})

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -65,6 +65,13 @@ var (
 		Name:      "panic_count_total",
 		Help:      "A metrics that counts the number of panics.",
 	})
+
+	PluginEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: subsystem,
+		Name:      "plugin_enabled",
+		Help:      "A metric that monitors which plugin(s) is(are) enabled.",
+	}, []string{"name"})
 )
 
 const (

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -71,7 +71,7 @@ var (
 		Subsystem: subsystem,
 		Name:      "plugin_enabled",
 		Help:      "A metric that monitors which plugin(s) is(are) enabled.",
-	}, []string{"name"})
+	}, []string{"server", "zone", "name"})
 )
 
 const (

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -69,7 +69,7 @@ var (
 	PluginEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
 		Name:      "plugin_enabled",
-		Help:      "A metric that monitors which plugin(s) is(are) enabled.",
+		Help:      "A metric that indicates whether a plugin is enabled on per server and zone basis.",
 	}, []string{"server", "zone", "name"})
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix #2273 
### 2. Which issues (if any) are related?
#2273 
### 3. Which documentation changes (if any) need to be made?
README.md in the metrics plugin folder.
### 4. Does this introduce a backward incompatible change or deprecation?
No.