### PR TITLE
Support logging to dnstap in forward plugin

### DIFF
--- a/plugin/dnstap/test/helpers.go
+++ b/plugin/dnstap/test/helpers.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"context"
 	"net"
 	"reflect"
 
@@ -9,12 +8,6 @@ import (
 
 	tap "github.com/dnstap/golang-dnstap"
 )
-
-// Context is a message trap.
-type Context struct {
-	context.Context
-	TrapTapper
-}
 
 // TestingData returns the Data matching coredns/test.ResponseWriter.
 func TestingData() (d *msg.Builder) {

--- a/plugin/forward/dnstap.go
+++ b/plugin/forward/dnstap.go
@@ -1,0 +1,61 @@
+package forward
+
+import (
+	"context"
+	"time"
+
+	"github.com/coredns/coredns/plugin/dnstap"
+	"github.com/coredns/coredns/plugin/dnstap/msg"
+	"github.com/coredns/coredns/request"
+
+	tap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+func toDnstap(ctx context.Context, host string, f *Forward, state request.Request, reply *dns.Msg, start time.Time) error {
+	tapper := dnstap.TapperFromContext(ctx)
+	if tapper == nil {
+		return nil
+	}
+	// Query
+	b := msg.New().Time(start).HostPort(host)
+	opts := f.opts
+	t := ""
+	switch {
+	case opts.forceTCP: // TCP flag has precedence over UDP flag
+		t = "tcp"
+	case opts.preferUDP:
+		t = "udp"
+	default:
+		t = state.Proto()
+	}
+
+	if t == "tcp" {
+		b.SocketProto = tap.SocketProtocol_TCP
+	} else {
+		b.SocketProto = tap.SocketProtocol_UDP
+	}
+
+	if tapper.Pack() {
+		b.Msg(state.Req)
+	}
+	m, err := b.ToOutsideQuery(tap.Message_FORWARDER_QUERY)
+	if err != nil {
+		return err
+	}
+	tapper.TapMessage(m)
+
+	// Response
+	if reply != nil {
+		if tapper.Pack() {
+			b.Msg(reply)
+		}
+		m, err := b.Time(time.Now()).ToOutsideResponse(tap.Message_FORWARDER_RESPONSE)
+		if err != nil {
+			return err
+		}
+		tapper.TapMessage(m)
+	}
+
+	return nil
+}

--- a/plugin/forward/dnstap_test.go
+++ b/plugin/forward/dnstap_test.go
@@ -1,0 +1,63 @@
+package forward
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/dnstap"
+	"github.com/coredns/coredns/plugin/dnstap/msg"
+	"github.com/coredns/coredns/plugin/dnstap/test"
+	mwtest "github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/request"
+
+	tap "github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+func testCase(t *testing.T, f *Forward, q, r *dns.Msg, datq, datr *msg.Builder) {
+	tapq, _ := datq.ToOutsideQuery(tap.Message_FORWARDER_QUERY)
+	tapr, _ := datr.ToOutsideResponse(tap.Message_FORWARDER_RESPONSE)
+	tapper := test.TrapTapper{}
+	ctx := dnstap.ContextWithTapper(context.TODO(), &tapper)
+	err := toDnstap(ctx, "10.240.0.1:40212", f,
+		request.Request{W: &mwtest.ResponseWriter{}, Req: q}, r, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tapper.Trap) != 2 {
+		t.Fatalf("Messages: %d", len(tapper.Trap))
+	}
+	if !test.MsgEqual(tapper.Trap[0], tapq) {
+		t.Errorf("Want: %v\nhave: %v", tapq, tapper.Trap[0])
+	}
+	if !test.MsgEqual(tapper.Trap[1], tapr) {
+		t.Errorf("Want: %v\nhave: %v", tapr, tapper.Trap[1])
+	}
+}
+
+func TestDnstap(t *testing.T) {
+	q := mwtest.Case{Qname: "example.org", Qtype: dns.TypeA}.Msg()
+	r := mwtest.Case{
+		Qname: "example.org.", Qtype: dns.TypeA,
+		Answer: []dns.RR{
+			mwtest.A("example.org. 3600	IN	A 10.0.0.1"),
+		},
+	}.Msg()
+	tapq, tapr := test.TestingData(), test.TestingData()
+	fu := New()
+	fu.opts.preferUDP = true
+	testCase(t, fu, q, r, tapq, tapr)
+	tapq.SocketProto = tap.SocketProtocol_TCP
+	tapr.SocketProto = tap.SocketProtocol_TCP
+	ft := New()
+	ft.opts.forceTCP = true
+	testCase(t, ft, q, r, tapq, tapr)
+}
+
+func TestNoDnstap(t *testing.T) {
+	err := toDnstap(context.TODO(), "", nil, request.Request{}, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
`proxy` plugin, which supported logging to dnstap, has been deprecated. We are using `forward` plugin as a replacement. Logging to dnstap is not yet supported in `forward` plugin.
dnstap messages are required in our logging system, thus we need to add the support for dnstap logging in `forward`

The implementation references the code in `proxy` plugin [here](https://github.com/coredns/coredns/blob/v1.3.1/plugin/proxy/dnstap.go) and [here](https://github.com/coredns/coredns/blob/v1.3.1/plugin/proxy/dnstap_test.go) with minor changes.

### 2. Which issues (if any) are related?
[plugin/forward: add dnstap support](https://github.com/coredns/coredns/issues/1448)

### 3. Which documentation changes (if any) need to be made?
`dnstap` should be supported by default in `forward` in the same way as `proxy`, thus no documentation changes is required.

### 4. Does this introduce a backward incompatible change or deprecation?
Not backward incompatible. 
We are adding a feature to forward, not removing anything.
