### PR TITLE
server: cancel context after 501 milliseconds

### DIFF
--- a/core/dnsserver/cancel_test.go
+++ b/core/dnsserver/cancel_test.go
@@ -19,13 +19,11 @@ func (s sleepPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	m := new(dns.Msg)
 	m.SetReply(r)
 	for {
-		select {
-		case <-ctx.Done():
-			// use BadTime to return something time related
-			m.Rcode = dns.RcodeBadTime
+		if plugin.Done(ctx) {
+			m.Rcode = dns.RcodeBadTime // use BadTime to return something time related
 			w.WriteMsg(m)
 			return 0, nil
-		default:
+		} else {
 			time.Sleep(20 * time.Millisecond)
 			i++
 			if i > 2 {

--- a/core/dnsserver/cancel_test.go
+++ b/core/dnsserver/cancel_test.go
@@ -23,14 +23,13 @@ func (s sleepPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 			m.Rcode = dns.RcodeBadTime // use BadTime to return something time related
 			w.WriteMsg(m)
 			return 0, nil
-		} else {
-			time.Sleep(20 * time.Millisecond)
-			i++
-			if i > 2 {
-				m.Rcode = dns.RcodeServerFailure
-				w.WriteMsg(m)
-				return 0, nil
-			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		i++
+		if i > 2 {
+			m.Rcode = dns.RcodeServerFailure
+			w.WriteMsg(m)
+			return 0, nil
 		}
 	}
 	return 0, nil

--- a/core/dnsserver/cancel_test.go
+++ b/core/dnsserver/cancel_test.go
@@ -1,0 +1,68 @@
+package dnsserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+type sleepPlugin struct{}
+
+func (s sleepPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	i := 0
+	m := new(dns.Msg)
+	m.SetReply(r)
+	for {
+		select {
+		case <-ctx.Done():
+			// use BadTime to return something time related
+			m.Rcode = dns.RcodeBadTime
+			w.WriteMsg(m)
+			return 0, nil
+		default:
+			time.Sleep(20 * time.Millisecond)
+			i++
+			if i > 2 {
+				m.Rcode = dns.RcodeServerFailure
+				w.WriteMsg(m)
+				return 0, nil
+			}
+		}
+	}
+	return 0, nil
+}
+
+func (s sleepPlugin) Name() string { return "sleepplugin" }
+
+func sleepConfig(p plugin.Handler) *Config {
+	c := &Config{Zone: "example.com.", Transport: "dns", ListenHosts: []string{"127.0.0.1"}, Port: "53"}
+	c.AddPlugin(func(next plugin.Handler) plugin.Handler { return p })
+	return c
+}
+
+func TestContextCancel(t *testing.T) {
+	s, err := NewServer("127.0.0.1:53", []*Config{sleepConfig(sleepPlugin{})})
+	if err != nil {
+		t.Fatalf("Expected no error for NewServer, got %s", err)
+	}
+
+	// have to make the context here, which is a bit unfortunate because it copies some code from server.go
+	ctx := context.WithValue(context.TODO(), Key{}, s)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	m := new(dns.Msg)
+	m.SetQuestion("aaa.example.com.", dns.TypeTXT)
+
+	s.ServeDNS(ctx, w, m)
+	if w.Rcode != dns.RcodeBadTime {
+		t.Error("Expected ServeDNS to be canceled by context")
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.28.0 h1:KZ/88LWSw8NxMkjdQyX7LQSGR9PkHr4PaVuNm8zgFq0=
 cloud.google.com/go v0.28.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataDog/zstd v1.3.5 h1:DtpNbljikUepEPD16hD4LvIcmhnhdLTiW/5pHgbmp14=
 github.com/DataDog/zstd v1.3.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Shopify/sarama v1.21.0 h1:0GKs+e8mn1RRUzfg9oUXv3v7ZieQLmOZF/bfnmmGhM8=
 github.com/Shopify/sarama v1.21.0/go.mod h1:yuqtN/pe8cXRWG5zPaO7hCfNJp5MwmkoJEoLjkm5tCQ=

--- a/plugin.md
+++ b/plugin.md
@@ -4,7 +4,7 @@
 
 The main method that gets called is `ServeDNS`. It has three parameters:
 
-* a `context.Context`;
+* a `context.Context`. The context is canceled after 501 Milliseconds.
 * `dns.ResponseWriter` that is, basically, the client's connection;
 * `*dns.Msg` the request from the client.
 

--- a/plugin/cancel.go
+++ b/plugin/cancel.go
@@ -1,0 +1,16 @@
+package plugin
+
+import "context"
+
+// Done returns true if the context has been canceled, usually because the timeout has expired.
+func Done(ctx context.Context) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The context in each request is canceled after 501 ms. Plugins that check
ctx.Done() can abort (return) from whatever they are executing because
the waiting client will never see the reply.

The irony of this approach is that the cancelation is done by starting
another go-routine. It would be cooler if we would only start that
routine after x seconds, but doing that requires a go routine.

I don't believe Go provides out-of-the-box feature to look at the
packet's timestamp. Even if it did it requires each plugin to look at
it, the context.WithTimeout is somewhat cleaner.