### PR TITLE
plugin/throttle - limit impact burst of queries

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -10,6 +10,7 @@ package dnsserver
 // (after) them during a request, but they must not
 // care what plugin above them are doing.
 var Directives = []string{
+	"throttle",
 	"metadata",
 	"tls",
 	"reload",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/coredns/coredns/plugin/route53"
 	_ "github.com/coredns/coredns/plugin/secondary"
 	_ "github.com/coredns/coredns/plugin/template"
+	_ "github.com/coredns/coredns/plugin/throttle"
 	_ "github.com/coredns/coredns/plugin/tls"
 	_ "github.com/coredns/coredns/plugin/trace"
 	_ "github.com/coredns/coredns/plugin/whoami"

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -19,6 +19,7 @@
 # Local plugin example:
 # log:log
 
+throttle:throttle
 metadata:metadata
 tls:tls
 reload:reload

--- a/plugin/throttle/OWNERS
+++ b/plugin/throttle/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - fturib
+approvers:
+  - fturib

--- a/plugin/throttle/README.md
+++ b/plugin/throttle/README.md
@@ -2,7 +2,7 @@
 
 ## Name
 
-*throttle* - limits the number of inflight queries.
+*throttle* - limits the maximum number of inflight queries.
 
 ## Description
 

--- a/plugin/throttle/README.md
+++ b/plugin/throttle/README.md
@@ -1,0 +1,57 @@
+# throttle
+
+## Name
+
+*throttle* - limits the number of inflight queries.
+
+## Description
+
+This plugin limit the max inflight simultaneous queries.
+While the limit is reached, any new queries received are dropped.
+
+
+The _throttle_ plugin prevents CoreDNS from consuming an unbound amount of memory
+when it receives a burst of incoming queries.
+
+One will need to tune the **MAX-INFLIGHT** with the memory allowed for this pod or process
+
+NOTE: `throttle` acts only on the server block is which it is defined.
+To be most effective, it should be enabled on all DNS server blocks.
+
+## Syntax
+
+~~~ txt
+throttle [MAX-INFLIGHT]
+~~~
+
+* The plugin check the number of in-process queries for each new incoming query.
+it it that number is > **MAX-INFLIGHT** then the query is immediatly dropped.
+* When **TIMEOUT** is defined (and non nul) this plugin verify i
+
+## Examples
+
+Check with the default intervals:
+
+~~~ corefile
+. {
+    throttle 1000
+}
+~~~
+
+Check that no more than 1000 queries are served in same time
+
+
+## Metrics
+
+If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
+
+* `coredns_throttle_seen_queries{server, kind}` - Total queries seen by the throttle, per `server`.
+
+   Query `kind` can be either:
+   - `incoming` : total queries getting into this plugin chain
+   - `dropped`: total queries dropped because hit the limit **MAX-INFLIGHT**
+   - `served`: total queries served by throttle
+
+
+* `coredns_throttle_flight_queries{server}` - Total simultaneous queries currently processed by the throttle, per `server`.
+

--- a/plugin/throttle/setup.go
+++ b/plugin/throttle/setup.go
@@ -1,0 +1,61 @@
+package throttle
+
+import (
+	"strconv"
+
+	"github.com/coredns/coredns/core/dnsserver"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+
+	"github.com/mholt/caddy"
+)
+
+var log = clog.NewWithPlugin(throttle)
+
+func init() {
+	caddy.RegisterPlugin(throttle, caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+const throttle = "throttle"
+
+func setup(c *caddy.Controller) error {
+	ql, err := parse(c)
+	if err != nil {
+		return err
+	}
+
+	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
+		ql.Next = next
+		return ql
+	})
+
+	c.OnStartup(func() error {
+		metrics.MustRegister(c, throttleCount, flightCount)
+		return nil
+	})
+
+	return nil
+}
+
+func parse(c *caddy.Controller) (*Throttle, error) {
+	for c.Next() {
+		args := c.RemainingArgs()
+		if len(args) != 1 {
+			return nil, plugin.Error(throttle, c.ArgErr())
+		}
+
+		l, err := strconv.ParseInt(args[0], 10, 32)
+		if err != nil {
+			return nil, plugin.Error(throttle, err)
+		}
+
+		return &Throttle{workerLimit: l}, nil
+
+	}
+	return nil, c.ArgErr()
+}

--- a/plugin/throttle/setup_test.go
+++ b/plugin/throttle/setup_test.go
@@ -1,0 +1,30 @@
+package throttle
+
+import (
+	"testing"
+
+	"github.com/mholt/caddy"
+)
+
+func TestSetupThrottle(t *testing.T) {
+	c := caddy.NewTestController("dns", `throttle`)
+	if err := setup(c); err == nil {
+		t.Fatal("Expected errors, but got none")
+	}
+
+	c = caddy.NewTestController("dns", `throttle 10`)
+	if err := setup(c); err != nil {
+		t.Fatalf("Expected no errors, but got: %v", err)
+	}
+
+	c = caddy.NewTestController("dns", `throttle 10 whatever`)
+	if err := setup(c); err == nil {
+		t.Fatal("Expected errors, but got none")
+	}
+
+	c = caddy.NewTestController("dns", `throttle whatever`)
+	if err := setup(c); err == nil {
+		t.Fatal("Expected errors, but got none")
+	}
+
+}

--- a/plugin/throttle/throttle.go
+++ b/plugin/throttle/throttle.go
@@ -1,0 +1,68 @@
+package throttle
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/coredns/coredns/plugin/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
+)
+
+// Throttle holds the count of queries currently in process and the upper limit expected
+type Throttle struct {
+	workerCount int64
+	workerLimit int64
+	Next        plugin.Handler
+}
+
+// ServeDNS implements the plugin.Handler interface.
+func (t *Throttle) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+
+	count := atomic.AddInt64(&t.workerCount, 1)
+	defer atomic.AddInt64(&t.workerCount, -1)
+
+	server := metrics.WithServer(ctx)
+	throttleCount.WithLabelValues(server, incoming).Inc()
+	flightCount.WithLabelValues(server).Set(float64(count))
+
+	// just drop the queries when current inflight bucket is full
+	if count > t.workerLimit {
+		w.Close()
+		// just return success w/o writing in the writer -> it is a drop
+		// it is in purpose to not return a response as it would keep the goroutine alive the time of writing
+		throttleCount.WithLabelValues(server, dropped).Inc()
+		return dns.RcodeSuccess, nil
+	}
+
+	code, err := plugin.NextOrFailure(t.Name(), t.Next, ctx, w, r)
+	throttleCount.WithLabelValues(server, served).Inc()
+	return code, err
+}
+
+// Name implements the Handler interface.
+func (t Throttle) Name() string { return throttle }
+
+var (
+	throttleCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "throttle",
+		Name:      "seen_queries",
+		Help:      "Total queries seen by throttle mechanism.",
+	}, []string{"server", "type"})
+	flightCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "throttle",
+		Name:      "inflight_queries",
+		Help:      "The number of simultaneous queries inside throttle mechanism.",
+	}, []string{"server"})
+)
+
+const (
+	incoming = "incoming"
+	served   = "served"
+	dropped  = "dropped"
+)

--- a/plugin/throttle/throttle.go
+++ b/plugin/throttle/throttle.go
@@ -22,8 +22,8 @@ type Throttle struct {
 // ServeDNS implements the plugin.Handler interface.
 func (t *Throttle) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 
-	count := atomic.AddInt64(&t.workerCount, 1)
-	defer atomic.AddInt64(&t.workerCount, -1)
+	count := atomic.AddInt64(&(t.workerCount), 1)
+	defer atomic.AddInt64(&(t.workerCount), -1)
 
 	server := metrics.WithServer(ctx)
 	throttleCount.WithLabelValues(server, incoming).Inc()
@@ -44,7 +44,7 @@ func (t *Throttle) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 }
 
 // Name implements the Handler interface.
-func (t Throttle) Name() string { return throttle }
+func (t *Throttle) Name() string { return throttle }
 
 var (
 	throttleCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/plugin/throttle/throttle_test.go
+++ b/plugin/throttle/throttle_test.go
@@ -1,0 +1,85 @@
+package throttle
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+type sleepPlugin struct{}
+
+func (s sleepPlugin) Name() string { return "sleep" }
+
+func (s sleepPlugin) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+
+	time.Sleep(10 * time.Millisecond)
+	m.Rcode = dns.RcodeRefused
+	w.WriteMsg(m)
+	return 0, nil
+}
+
+func TestThrottle(t *testing.T) {
+
+	tests := []struct {
+		maxInflight int
+		tries       int
+		dropped     int
+	}{
+		{0, 10, 10},
+		{1, 1, 0},
+		{1, 2, 1},
+		{10, 20, 10},
+		{10, 9, 0},
+	}
+
+	for n, tst := range tests {
+
+		th := Throttle{Next: sleepPlugin{}, workerLimit: int64(tst.maxInflight)}
+		var written int32
+		var dropped int32
+
+		for i := 0; i < tst.tries; i++ {
+			go func() {
+				ctx := context.Background()
+				w := dnstest.NewRecorder(&test.ResponseWriter{})
+				m := new(dns.Msg)
+				m.SetQuestion("aaa.example.com.", dns.TypeTXT)
+				th.ServeDNS(ctx, w, m)
+				if w.Msg == nil {
+					atomic.AddInt32(&dropped, 1)
+					return
+				}
+				atomic.AddInt32(&written, 1)
+			}()
+		}
+
+		i := 0
+		for {
+			if atomic.LoadInt32(&written)+atomic.LoadInt32(&dropped) == int32(tst.tries) {
+				break
+			}
+
+			if i > 5 {
+				t.Fatalf("Test %d - Looped %d times 10ms, expected %d msg to be processed, got %d written and %d dropped", n, i, tst.tries, written, dropped)
+			}
+			// wait it is finished
+			time.Sleep(10 * time.Millisecond)
+			i++
+		}
+
+		if written > int32(th.workerLimit) {
+			t.Errorf("Test %d - expected only %d msg to be written, got %d", n, th.workerLimit, written)
+		}
+		if dropped != int32(tst.dropped) {
+			t.Errorf("Test %d - expected %d msg droppes, got %d", n, tst.dropped, dropped)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This plugin offers:
* a limitation of simultaneous inflight queries (drop any out-of-limit incoming queries)
* metrics for investigation (incoming, in process, dropped, etc ...)

So far, the test shows that the limitation of inflight queries is useful to prevent OOM crash in case of burst. However, that need to provide in Corefile a MAX-INFLIGHT, that is somehow related to the MAX-MEMORY of the deployment.

NOTE: Investigation of initial issue #2593 shows that this plugin is efficient for preventing OOM when incoming queries is getting high.

### 2. Which issues (if any) are related?

[request spike creates memory spike](https://github.com/coredns/coredns/issues/2593)

### 3. Which documentation changes (if any) need to be made?
README included.

### 4. Does this introduce a backward incompatible change or deprecation?
No.

