### PR TITLE
Add `namespace_labels` configuration for kubernetes plugin

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -56,6 +56,11 @@ kubernetes [ZONES...] {
 * `kubeconfig` **KUBECONFIG** **CONTEXT** authenticates the connection to a remote k8s cluster using a kubeconfig file. It supports TLS, username and password, or token-based authentication. This option is ignored if connecting in-cluster (i.e., the endpoint is not specified).
 * `namespaces` **NAMESPACE [NAMESPACE...]** only exposes the k8s namespaces listed.
    If this option is omitted all namespaces are exposed
+* `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
+   The label selector syntax is described in the
+   [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that
+   only exposes namespaces labeled as "istio-injection=enabled", would use: 
+   `labels istio-injection=enabled`.
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
    [Kubernetes User Guide - Labels](https://kubernetes.io/docs/user-guide/labels/). An example that

--- a/plugin/kubernetes/external.go
+++ b/plugin/kubernetes/external.go
@@ -30,7 +30,7 @@ func (k *Kubernetes) External(state request.Request) ([]msg.Service, int) {
 	port := "*"
 	protocol := "*"
 	namespace := segs[last]
-	if !k.namespaceExposed(namespace) || !k.namespace(namespace) {
+	if !k.namespaceExposed(namespace) {
 		return nil, dns.RcodeNameError
 	}
 

--- a/plugin/kubernetes/namespace.go
+++ b/plugin/kubernetes/namespace.go
@@ -1,20 +1,27 @@
 package kubernetes
 
-// namespace checks if namespace n exists in this cluster. This returns true
-// even for non exposed namespaces, see namespaceExposed.
-func (k *Kubernetes) namespace(n string) bool {
-	ns, err := k.APIConn.GetNamespaceByName(n)
+// filteredNamespaceExists checks if namespace exists in this cluster
+// according to any `namespace_labels` plugin configuration specified.
+// Returns true even for namespaces not exposed by plugin configuration,
+// see namespaceExposed.
+func (k *Kubernetes) filteredNamespaceExists(namespace string) bool {
+	ns, err := k.APIConn.GetNamespaceByName(namespace)
 	if err != nil {
 		return false
 	}
-	return ns.ObjectMeta.Name == n
+	return ns.ObjectMeta.Name == namespace
 }
 
-// namespaceExposed returns true when the namespace is exposed.
-func (k *Kubernetes) namespaceExposed(namespace string) bool {
+// configuredNamespace returns true when the namespace is exposed through the plugin
+// `namespaces` configuration.
+func (k *Kubernetes) configuredNamespace(namespace string) bool {
 	_, ok := k.Namespaces[namespace]
 	if len(k.Namespaces) > 0 && !ok {
 		return false
 	}
 	return true
+}
+
+func (k *Kubernetes) namespaceExposed(namespace string) bool {
+	return k.configuredNamespace(namespace) && k.filteredNamespaceExists(namespace)
 }

--- a/plugin/kubernetes/namespace_test.go
+++ b/plugin/kubernetes/namespace_test.go
@@ -1,0 +1,72 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestFilteredNamespaceExists(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{}, "foobar" },
+		{false, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.filteredNamespaceExists(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Filtered namespace %s was expected to exist", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceExposed(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{ "foobar": {} }, "foobar" },
+		{false, map[string]struct{}{ "foobar": {} }, "nsnoexist" },
+		{true, map[string]struct{}{}, "foobar" },
+		{true, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.configuredNamespace(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be exposed", i, test.testNamespace)
+		}
+	}
+}
+
+func TestNamespaceValid(t *testing.T) {
+	tests := []struct{
+		expected             bool
+		kubernetesNamespaces map[string]struct{}
+		testNamespace        string
+	}{
+		{true, map[string]struct{}{ "foobar": {} }, "foobar" },
+		{false, map[string]struct{}{ "foobar": {} }, "nsnoexist" },
+		{true, map[string]struct{}{}, "foobar" },
+		{false, map[string]struct{}{}, "nsnoexist" },
+	}
+
+	k := Kubernetes{}
+	k.APIConn = &APIConnServeTest{}
+	for i, test := range tests {
+		k.Namespaces = test.kubernetesNamespaces
+		actual := k.namespaceExposed(test.testNamespace)
+		if actual != test.expected {
+			t.Errorf("Test %d failed. Namespace %s was expected to be valid", i, test.testNamespace)
+		}
+	}
+}

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -13,15 +13,16 @@ import (
 
 func TestKubernetesParse(t *testing.T) {
 	tests := []struct {
-		input                 string        // Corefile data as string
-		shouldErr             bool          // true if test case is expected to produce an error.
-		expectedErrContent    string        // substring from the expected error. Empty for positive cases.
-		expectedZoneCount     int           // expected count of defined zones.
-		expectedNSCount       int           // expected count of namespaces.
-		expectedResyncPeriod  time.Duration // expected resync period value
-		expectedLabelSelector string        // expected label selector value
-		expectedPodMode       string
-		expectedFallthrough   fall.F
+		input                          string        // Corefile data as string
+		shouldErr                      bool          // true if test case is expected to produce an error.
+		expectedErrContent             string        // substring from the expected error. Empty for positive cases.
+		expectedZoneCount              int           // expected count of defined zones.
+		expectedNSCount                int           // expected count of namespaces.
+		expectedResyncPeriod           time.Duration // expected resync period value
+		expectedLabelSelector          string        // expected label selector value
+		expectedNamespaceLabelSelector string        // expected namespace label selector value
+		expectedPodMode                string
+		expectedFallthrough            fall.F
 	}{
 		// positive
 		{
@@ -31,6 +32,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -43,6 +45,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -54,6 +57,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -68,6 +72,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -80,6 +85,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -94,6 +100,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -106,6 +113,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			30 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -120,6 +128,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			15 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -133,6 +142,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"environment=prod",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -146,6 +156,36 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespace_labels istio-injection=enabled
+}`,
+			false,
+			"",
+			1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
+			podModeDisabled,
+			fall.Zero,
+		},
+		{
+			`kubernetes coredns.local {
+    namespaces foo bar
+    namespace_labels istio-injection=enabled
+}`,
+			true,
+			"Error during parsing: namespaces and namespace_labels cannot both be set",
+			-1,
+			0,
+			defaultResyncPeriod,
+			"",
+			"istio-injection=enabled",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -163,6 +203,7 @@ func TestKubernetesParse(t *testing.T) {
 			2,
 			15 * time.Minute,
 			"application=nginx,environment in (production,qa,staging)",
+			"",
 			podModeDisabled,
 			fall.Root,
 		},
@@ -177,6 +218,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -189,6 +231,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			-1,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -203,6 +246,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Minute,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -215,6 +259,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -229,6 +274,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -242,6 +288,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			0 * time.Second,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -254,6 +301,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			0 * time.Second,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -269,6 +317,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -282,6 +331,7 @@ func TestKubernetesParse(t *testing.T) {
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeInsecure,
 			fall.Zero,
@@ -297,6 +347,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeVerified,
 			fall.Zero,
 		},
@@ -310,6 +361,7 @@ func TestKubernetesParse(t *testing.T) {
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeVerified,
 			fall.Zero,
@@ -325,6 +377,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.F{Zones: []string{"ip6.arpa.", "inaddr.arpa.", "foo.com."}},
 		},
@@ -339,6 +392,7 @@ func TestKubernetesParse(t *testing.T) {
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -351,6 +405,7 @@ kubernetes cluster.local`,
 			-1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,
@@ -365,6 +420,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -378,6 +434,7 @@ kubernetes cluster.local`,
 			0,
 			defaultResyncPeriod,
 			"",
+			"",
 			podModeDisabled,
 			fall.Zero,
 		},
@@ -390,6 +447,7 @@ kubernetes cluster.local`,
 			1,
 			0,
 			defaultResyncPeriod,
+			"",
 			"",
 			podModeDisabled,
 			fall.Zero,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The current `kubernetes` plugin does not correctly support a `labels` configuration for namespaces. 

This is due the way the API watches are created for a namespace and pods/services/endpoints. A namespace specific label would not be configured on pods/services/endpoints and as a result, trying to specify a label on a namespace restricts watches on pods/services/endpoints that CoreDNS is aware about.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2653

### 3. Which documentation changes (if any) need to be made?

The `kubernetes` plugin `README.md` documentation has been updated.