### PR TITLE
plugin/kubernetes: add ready function

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -107,6 +107,11 @@ kubernetes [ZONES...] {
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
 
+## Ready
+
+This plugin reports readiness to the ready plugin. This will happen after it has synced to the
+Kubernetes API.
+
 ## Examples
 
 Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Also handle all

--- a/plugin/kubernetes/ready.go
+++ b/plugin/kubernetes/ready.go
@@ -1,0 +1,4 @@
+package kubernetes
+
+// Ready implements the ready.Readiness interface.
+func (k *Kubernetes) Ready() bool { return k.APIConn.HasSynced() }


### PR DESCRIPTION
Add ready function as the health function is now gone.

Signed-off-by: Miek Gieben <miek@miek.nl>