### PR TITLE
plugin/log: remove ErrorFunc

### DIFF
--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -41,8 +41,8 @@ func TestLoggedStatus(t *testing.T) {
 	rec := dnstest.NewRecorder(&test.ResponseWriter{})
 
 	rcode, _ := logger.ServeDNS(ctx, rec, r)
-	if rcode != 0 {
-		t.Errorf("Expected rcode to be 0 - was: %d", rcode)
+	if rcode != 2 {
+		t.Errorf("Expected rcode to be 2 - was: %d", rcode)
 	}
 
 	logged := f.String()

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
-		return Logger{Next: next, Rules: rules, ErrorFunc: dnsserver.DefaultErrorFunc, repl: replacer.New()}
+		return Logger{Next: next, Rules: rules, repl: replacer.New()}
 	})
 
 	return nil


### PR DESCRIPTION
The server handles this case no need to also do it in the log plugin.

Means DefaultErrorFunc can be private to the dnsserver and is now
renamed to just errorFunc

Fixes: #2715