### PR TITLE
[plugin/cache] cache failures

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -163,6 +163,9 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	var duration time.Duration
 	if mt == response.NameError || mt == response.NoData {
 		duration = computeTTL(msgTTL, w.minnttl, w.nttl)
+	} else if mt == response.ServerFailureError || mt == response.NotImplementedError {
+		// use default ttl which is 5s
+		duration = minTTL
 	} else {
 		duration = computeTTL(msgTTL, w.minpttl, w.pttl)
 	}
@@ -206,7 +209,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 		i := newItem(m, w.now(), duration)
 		w.pcache.Add(key, i)
 
-	case response.NameError, response.NoData:
+	case response.NameError, response.NoData, response.ServerFailureError, response.NotImplementedError:
 		i := newItem(m, w.now(), duration)
 		w.ncache.Add(key, i)
 

--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -163,7 +163,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	var duration time.Duration
 	if mt == response.NameError || mt == response.NoData {
 		duration = computeTTL(msgTTL, w.minnttl, w.nttl)
-	} else if mt == response.ServerFailureError || mt == response.NotImplementedError {
+	} else if mt == response.ServerError {
 		// use default ttl which is 5s
 		duration = minTTL
 	} else {
@@ -209,7 +209,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 		i := newItem(m, w.now(), duration)
 		w.pcache.Add(key, i)
 
-	case response.NameError, response.NoData, response.ServerFailureError, response.NotImplementedError:
+	case response.NameError, response.NoData, response.ServerError:
 		i := newItem(m, w.now(), duration)
 		w.ncache.Add(key, i)
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -88,6 +88,34 @@ var cacheTestCases = []cacheTestCase{
 		shouldCache: true,
 	},
 	{
+		RecursionAvailable: true, Authoritative: false,
+		Case: test.Case{
+			Rcode: dns.RcodeServerFailure,
+			Qname: "example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{},
+		},
+		in: test.Case{
+			Rcode: dns.RcodeServerFailure,
+			Qname: "example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{},
+		},
+		shouldCache: true,
+	},
+	{
+		RecursionAvailable: true, Authoritative: false,
+		Case: test.Case{
+			Rcode: dns.RcodeNotImplemented,
+			Qname: "example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{},
+		},
+		in: test.Case{
+			Rcode: dns.RcodeNotImplemented,
+			Qname: "example.org.", Qtype: dns.TypeA,
+			Ns: []dns.RR{},
+		},
+		shouldCache: true,
+	},
+	{
 		RecursionAvailable: true, Authoritative: true,
 		Case: test.Case{
 			Qname: "miek.nl.", Qtype: dns.TypeMX,

--- a/plugin/pkg/response/typify.go
+++ b/plugin/pkg/response/typify.go
@@ -15,6 +15,10 @@ const (
 	NoError Type = iota
 	// NameError is a NXDOMAIN in header, SOA in auth.
 	NameError
+	// ServerFailureError is a SERVFAIL in header.
+	ServerFailureError
+	// NotImplementedError means that server does not support the specified Operation code.
+	NotImplementedError
 	// NoData indicates name found, but not the type: NOERROR in header, SOA in auth.
 	NoData
 	// Delegation is a msg with a pointer to another nameserver: NOERROR in header, NS in auth, optionally fluff in additional (not checked).
@@ -28,13 +32,15 @@ const (
 )
 
 var toString = map[Type]string{
-	NoError:    "NOERROR",
-	NameError:  "NXDOMAIN",
-	NoData:     "NODATA",
-	Delegation: "DELEGATION",
-	Meta:       "META",
-	Update:     "UPDATE",
-	OtherError: "OTHERERROR",
+	NoError:             "NOERROR",
+	NameError:           "NXDOMAIN",
+	ServerFailureError:  "SERVFAIL",
+	NotImplementedError: "NOTIMP",
+	NoData:              "NODATA",
+	Delegation:          "DELEGATION",
+	Meta:                "META",
+	Update:              "UPDATE",
+	OtherError:          "OTHERERROR",
 }
 
 func (t Type) String() string { return toString[t] }
@@ -104,6 +110,13 @@ func Typify(m *dns.Msg, t time.Time) (Type, *dns.OPT) {
 	}
 	if soa && m.Rcode == dns.RcodeNameError {
 		return NameError, opt
+	}
+
+	if m.Rcode == dns.RcodeServerFailure {
+		return ServerFailureError, opt
+	}
+	if m.Rcode == dns.RcodeNotImplemented {
+		return NotImplementedError, opt
 	}
 
 	if ns > 0 && m.Rcode == dns.RcodeSuccess {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
cache upstream failures which includes `SERVFAIL` and `NOTIMPL`. for now the `TTL` is 5s.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2574

### 3. Which documentation changes (if any) need to be made?
No

### 4. Does this introduce a backward incompatible change or deprecation?
No
