### PR TITLE
Remove server addr from the context

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -251,11 +251,6 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		}
 
 		if h, ok := s.zones[string(b[:l])]; ok {
-
-			// Set server's address in the context so plugins can reference back to this,
-			// This will makes those metrics unique.
-			ctx = context.WithValue(ctx, plugin.ServerCtx{}, s.Addr)
-
 			if r.Question[0].Qtype != dns.TypeDS {
 				if h.FilterFunc == nil {
 					rcode, _ := h.pluginChain.ServeDNS(ctx, w, r)
@@ -298,10 +293,6 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 
 	// Wildcard match, if we have found nothing try the root zone as a last resort.
 	if h, ok := s.zones["."]; ok && h.pluginChain != nil {
-
-		// See comment above.
-		ctx = context.WithValue(ctx, plugin.ServerCtx{}, s.Addr)
-
 		rcode, _ := h.pluginChain.ServeDNS(ctx, w, r)
 		if !plugin.ClientWrite(rcode) {
 			errorFunc(ctx, w, r, rcode)
@@ -356,7 +347,7 @@ const (
 	maxreentries = 10
 )
 
-// Key is the context key for the current server
+// Key is the context key for the current server added to the context.
 type Key struct{}
 
 // EnableChaos is a map with plugin names for which we should open CH class queries as we block these by default.

--- a/plugin/metrics/context.go
+++ b/plugin/metrics/context.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"context"
 
-	"github.com/coredns/coredns/plugin/metrics/vars"
+	"github.com/coredns/coredns/core/dnsserver"
 )
 
 // WithServer returns the current server handling the request. It returns the
@@ -15,4 +15,10 @@ import (
 // Basic usage with a metric:
 //
 // <metric>.WithLabelValues(metrics.WithServer(ctx), labels..).Add(1)
-func WithServer(ctx context.Context) string { return vars.WithServer(ctx) }
+func WithServer(ctx context.Context) string {
+	srv := ctx.Value(dnsserver.Key{})
+	if srv == nil {
+		return ""
+	}
+	return srv.(*dnsserver.Server).Addr
+}

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -26,7 +26,7 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	rw := dnstest.NewRecorder(w)
 	status, err := plugin.NextOrFailure(m.Name(), m.Next, ctx, rw, r)
 
-	vars.Report(ctx, state, zone, rcode.ToString(rw.Rcode), rw.Len, rw.Start)
+	vars.Report(WithServer(ctx), state, zone, rcode.ToString(rw.Rcode), rw.Len, rw.Start)
 
 	return status, err
 }

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -1,25 +1,21 @@
 package vars
 
 import (
-	"context"
 	"time"
 
-	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
 
 // Report reports the metrics data associated with request.
-func Report(ctx context.Context, req request.Request, zone, rcode string, size int, start time.Time) {
+func Report(server string, req request.Request, zone, rcode string, size int, start time.Time) {
 	// Proto and Family.
 	net := req.Proto()
 	fam := "1"
 	if req.Family() == 2 {
 		fam = "2"
 	}
-
-	server := WithServer(ctx)
 
 	typ := req.QType()
 	RequestCount.WithLabelValues(server, zone, net, fam).Inc()
@@ -39,15 +35,6 @@ func Report(ctx context.Context, req request.Request, zone, rcode string, size i
 	RequestSize.WithLabelValues(server, zone, net).Observe(float64(req.Len()))
 
 	ResponseRcode.WithLabelValues(server, zone, rcode).Inc()
-}
-
-// WithServer returns the current server handling the request.
-func WithServer(ctx context.Context) string {
-	srv := ctx.Value(plugin.ServerCtx{})
-	if srv == nil {
-		return ""
-	}
-	return srv.(string)
 }
 
 var monitorType = map[uint16]struct{}{

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -106,6 +106,3 @@ var TimeBuckets = prometheus.ExponentialBuckets(0.00025, 2, 16) // from 0.25ms t
 
 // ErrOnce is returned when a plugin doesn't support multiple setups per server.
 var ErrOnce = errors.New("this plugin can only be used once per Server Block")
-
-// ServerCtx is the context key to pass server address context to the plugins handling the request.
-type ServerCtx struct{}

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 	"github.com/coredns/coredns/plugin/test"
@@ -69,7 +68,7 @@ func TestTrace(t *testing.T) {
 				every:  1,
 				tracer: m,
 			}
-			ctx := context.WithValue(context.TODO(), plugin.ServerCtx{}, server)
+			ctx := context.TODO()
 			if _, err := tr.ServeDNS(ctx, w, tc.question); err != nil {
 				t.Fatalf("Error during tr.ServeDNS(ctx, w, %v): %v", tc.question, err)
 			}


### PR DESCRIPTION
This was added twice, just leave the server which also holds the address.

Conflicts with #2719 but should be easy to fix.

Signed-off-by: Miek Gieben <miek@miek.nl>