### PR TITLE
Remove context.Context from request.Request

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -41,7 +41,7 @@ type (
 
 // ServeDNS implements the plugin.Handler interface.
 func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	state := request.Request{W: w, Req: r, Context: ctx}
+	state := request.Request{W: w, Req: r}
 	qname := state.Name()
 
 	// Precheck with the origins, i.e. are we allowed to look here?
@@ -66,7 +66,7 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return xfr.ServeDNS(ctx, w, r)
 	}
 
-	answer, ns, extra, result := z.Lookup(state, qname)
+	answer, ns, extra, result := z.Lookup(ctx, state, qname)
 
 	m := new(dns.Msg)
 	m.SetReply(r)

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -13,18 +13,18 @@ import (
 type ServiceBackend interface {
 	// Services communicates with the backend to retrieve the service definitions. Exact indicates
 	// on exact match should be returned.
-	Services(state request.Request, exact bool, opt Options) ([]msg.Service, error)
+	Services(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error)
 
 	// Reverse communicates with the backend to retrieve service definition based on a IP address
 	// instead of a name. I.e. a reverse DNS lookup.
-	Reverse(state request.Request, exact bool, opt Options) ([]msg.Service, error)
+	Reverse(ctx context.Context, state request.Request, exact bool, opt Options) ([]msg.Service, error)
 
 	// Lookup is used to find records else where.
-	Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error)
+	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
 
 	// Returns _all_ services that matches a certain name.
 	// Note: it does not implement a specific service.
-	Records(state request.Request, exact bool) ([]msg.Service, error)
+	Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error)
 
 	// IsNameError return true if err indicated a record not found condition
 	IsNameError(err error) bool

--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net"
@@ -13,8 +14,8 @@ import (
 )
 
 // A returns A records from Backend or an error.
-func A(b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
-	services, err := checkForApex(b, zone, state, opt)
+func A(ctx context.Context, b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
+	services, err := checkForApex(ctx, b, zone, state, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +44,7 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 			if dns.IsSubDomain(zone, dns.Fqdn(serv.Host)) {
 				state1 := state.NewWithQuestion(serv.Host, state.QType())
 				state1.Zone = zone
-				nextRecords, err := A(b, zone, state1, append(previousRecords, newRecord), opt)
+				nextRecords, err := A(ctx, b, zone, state1, append(previousRecords, newRecord), opt)
 
 				if err == nil {
 					// Not only have we found something we should add the CNAME and the IP addresses.
@@ -57,7 +58,7 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 			// This means we can not complete the CNAME, try to look else where.
 			target := newRecord.Target
 			// Lookup
-			m1, e1 := b.Lookup(state, target, state.QType())
+			m1, e1 := b.Lookup(ctx, state, target, state.QType())
 			if e1 != nil {
 				continue
 			}
@@ -80,8 +81,8 @@ func A(b ServiceBackend, zone string, state request.Request, previousRecords []d
 }
 
 // AAAA returns AAAA records from Backend or an error.
-func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
-	services, err := checkForApex(b, zone, state, opt)
+func AAAA(ctx context.Context, b ServiceBackend, zone string, state request.Request, previousRecords []dns.RR, opt Options) (records []dns.RR, err error) {
+	services, err := checkForApex(ctx, b, zone, state, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +112,7 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 			if dns.IsSubDomain(zone, dns.Fqdn(serv.Host)) {
 				state1 := state.NewWithQuestion(serv.Host, state.QType())
 				state1.Zone = zone
-				nextRecords, err := AAAA(b, zone, state1, append(previousRecords, newRecord), opt)
+				nextRecords, err := AAAA(ctx, b, zone, state1, append(previousRecords, newRecord), opt)
 
 				if err == nil {
 					// Not only have we found something we should add the CNAME and the IP addresses.
@@ -124,7 +125,7 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 			}
 			// This means we can not complete the CNAME, try to look else where.
 			target := newRecord.Target
-			m1, e1 := b.Lookup(state, target, state.QType())
+			m1, e1 := b.Lookup(ctx, state, target, state.QType())
 			if e1 != nil {
 				continue
 			}
@@ -149,8 +150,8 @@ func AAAA(b ServiceBackend, zone string, state request.Request, previousRecords 
 
 // SRV returns SRV records from the Backend.
 // If the Target is not a name but an IP address, a name is created on the fly.
-func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
-	services, err := b.Services(state, false, opt)
+func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
+	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -199,12 +200,12 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 			lookup[srv.Target] = struct{}{}
 
 			if !dns.IsSubDomain(zone, srv.Target) {
-				m1, e1 := b.Lookup(state, srv.Target, dns.TypeA)
+				m1, e1 := b.Lookup(ctx, state, srv.Target, dns.TypeA)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, srv.Target, dns.TypeAAAA)
+				m1, e1 = b.Lookup(ctx, state, srv.Target, dns.TypeAAAA)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
@@ -218,7 +219,7 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 			// Internal name, we should have some info on them, either v4 or v6
 			// Clients expect a complete answer, because we are a recursor in their view.
 			state1 := state.NewWithQuestion(srv.Target, dns.TypeA)
-			addr, e1 := A(b, zone, state1, nil, opt)
+			addr, e1 := A(ctx, b, zone, state1, nil, opt)
 			if e1 == nil {
 				extra = append(extra, addr...)
 			}
@@ -242,8 +243,8 @@ func SRV(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 }
 
 // MX returns MX records from the Backend. If the Target is not a name but an IP address, a name is created on the fly.
-func MX(b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
-	services, err := b.Services(state, false, opt)
+func MX(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
+	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,12 +267,12 @@ func MX(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 			lookup[mx.Mx] = struct{}{}
 
 			if !dns.IsSubDomain(zone, mx.Mx) {
-				m1, e1 := b.Lookup(state, mx.Mx, dns.TypeA)
+				m1, e1 := b.Lookup(ctx, state, mx.Mx, dns.TypeA)
 				if e1 == nil {
 					extra = append(extra, m1.Answer...)
 				}
 
-				m1, e1 = b.Lookup(state, mx.Mx, dns.TypeAAAA)
+				m1, e1 = b.Lookup(ctx, state, mx.Mx, dns.TypeAAAA)
 				if e1 == nil {
 					// If we have seen CNAME's we *assume* that they are already added.
 					for _, a := range m1.Answer {
@@ -284,7 +285,7 @@ func MX(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 			}
 			// Internal name
 			state1 := state.NewWithQuestion(mx.Mx, dns.TypeA)
-			addr, e1 := A(b, zone, state1, nil, opt)
+			addr, e1 := A(ctx, b, zone, state1, nil, opt)
 			if e1 == nil {
 				extra = append(extra, addr...)
 			}
@@ -308,8 +309,8 @@ func MX(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 }
 
 // CNAME returns CNAME records from the backend or an error.
-func CNAME(b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
-	services, err := b.Services(state, true, opt)
+func CNAME(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+	services, err := b.Services(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -324,8 +325,8 @@ func CNAME(b ServiceBackend, zone string, state request.Request, opt Options) (r
 }
 
 // TXT returns TXT records from Backend or an error.
-func TXT(b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
-	services, err := b.Services(state, false, opt)
+func TXT(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -337,8 +338,8 @@ func TXT(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 }
 
 // PTR returns the PTR records from the backend, only services that have a domain name as host are included.
-func PTR(b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
-	services, err := b.Reverse(state, true, opt)
+func PTR(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records []dns.RR, err error) {
+	services, err := b.Reverse(ctx, state, true, opt)
 	if err != nil {
 		return nil, err
 	}
@@ -357,14 +358,14 @@ func PTR(b ServiceBackend, zone string, state request.Request, opt Options) (rec
 }
 
 // NS returns NS records from  the backend
-func NS(b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
+func NS(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) (records, extra []dns.RR, err error) {
 	// NS record for this zone live in a special place, ns.dns.<zone>. Fake our lookup.
 	// only a tad bit fishy...
 	old := state.QName()
 
 	state.Clear()
 	state.Req.Question[0].Name = "ns.dns." + zone
-	services, err := b.Services(state, false, opt)
+	services, err := b.Services(ctx, state, false, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -387,7 +388,7 @@ func NS(b ServiceBackend, zone string, state request.Request, opt Options) (reco
 }
 
 // SOA returns a SOA record from the backend.
-func SOA(b ServiceBackend, zone string, state request.Request, opt Options) ([]dns.RR, error) {
+func SOA(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) ([]dns.RR, error) {
 	minTTL := b.MinTTL(state)
 	ttl := uint32(300)
 	if minTTL < ttl {
@@ -416,11 +417,11 @@ func SOA(b ServiceBackend, zone string, state request.Request, opt Options) ([]d
 }
 
 // BackendError writes an error response to the client.
-func BackendError(b ServiceBackend, zone string, rcode int, state request.Request, err error, opt Options) (int, error) {
+func BackendError(ctx context.Context, b ServiceBackend, zone string, rcode int, state request.Request, err error, opt Options) (int, error) {
 	m := new(dns.Msg)
 	m.SetRcode(state.Req, rcode)
 	m.Authoritative = true
-	m.Ns, _ = SOA(b, zone, state, opt)
+	m.Ns, _ = SOA(ctx, b, zone, state, opt)
 
 	state.W.WriteMsg(m)
 	// Return success as the rcode to signal we have written to the client.
@@ -439,9 +440,9 @@ func newAddress(s msg.Service, name string, ip net.IP, what uint16) dns.RR {
 }
 
 // checkForApex checks the special apex.dns directory for records that will be returned as A or AAAA.
-func checkForApex(b ServiceBackend, zone string, state request.Request, opt Options) ([]msg.Service, error) {
+func checkForApex(ctx context.Context, b ServiceBackend, zone string, state request.Request, opt Options) ([]msg.Service, error) {
 	if state.Name() != zone {
-		return b.Services(state, false, opt)
+		return b.Services(ctx, state, false, opt)
 	}
 
 	// If the zone name itself is queried we fake the query to search for a special entry
@@ -450,14 +451,14 @@ func checkForApex(b ServiceBackend, zone string, state request.Request, opt Opti
 	state.Clear()
 	state.Req.Question[0].Name = dnsutil.Join("apex.dns", zone)
 
-	services, err := b.Services(state, false, opt)
+	services, err := b.Services(ctx, state, false, opt)
 	if err == nil {
 		state.Req.Question[0].Name = old
 		return services, err
 	}
 
 	state.Req.Question[0].Name = old
-	return b.Services(state, false, opt)
+	return b.Services(ctx, state, false, opt)
 }
 
 // item holds records.

--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -36,14 +36,13 @@ type Etcd struct {
 	PathPrefix string
 	Upstream   *upstream.Upstream
 	Client     *etcdcv3.Client
-	Ctx        context.Context
 
 	endpoints []string // Stored here as well, to aid in testing.
 }
 
 // Services implements the ServiceBackend interface.
-func (e *Etcd) Services(state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
-	services, err = e.Records(state, exact)
+func (e *Etcd) Services(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
+	services, err = e.Records(ctx, state, exact)
 	if err != nil {
 		return
 	}
@@ -53,13 +52,13 @@ func (e *Etcd) Services(state request.Request, exact bool, opt plugin.Options) (
 }
 
 // Reverse implements the ServiceBackend interface.
-func (e *Etcd) Reverse(state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
-	return e.Services(state, exact, opt)
+func (e *Etcd) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) (services []msg.Service, err error) {
+	return e.Services(ctx, state, exact, opt)
 }
 
 // Lookup implements the ServiceBackend interface.
-func (e *Etcd) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
-	return e.Upstream.Lookup(state, name, typ)
+func (e *Etcd) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	return e.Upstream.Lookup(ctx, state, name, typ)
 }
 
 // IsNameError implements the ServiceBackend interface.
@@ -69,11 +68,11 @@ func (e *Etcd) IsNameError(err error) bool {
 
 // Records looks up records in etcd. If exact is true, it will lookup just this
 // name. This is used when find matches when completing SRV lookups for instance.
-func (e *Etcd) Records(state request.Request, exact bool) ([]msg.Service, error) {
+func (e *Etcd) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
 	name := state.Name()
 
 	path, star := msg.PathWithWildcard(name, e.PathPrefix)
-	r, err := e.get(path, !exact)
+	r, err := e.get(ctx, path, !exact)
 	if err != nil {
 		return nil, err
 	}
@@ -81,8 +80,8 @@ func (e *Etcd) Records(state request.Request, exact bool) ([]msg.Service, error)
 	return e.loopNodes(r.Kvs, segments, star, state.QType())
 }
 
-func (e *Etcd) get(path string, recursive bool) (*etcdcv3.GetResponse, error) {
-	ctx, cancel := context.WithTimeout(e.Ctx, etcdTimeout)
+func (e *Etcd) get(ctx context.Context, path string, recursive bool) (*etcdcv3.GetResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, etcdTimeout)
 	defer cancel()
 	if recursive == true {
 		if !strings.HasSuffix(path, "/") {

--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -294,7 +294,6 @@ func newEtcdPlugin() *Etcd {
 	return &Etcd{
 		Upstream:   upstream.New(),
 		PathPrefix: "skydns",
-		Ctx:        context.Background(),
 		Zones:      []string{"skydns.test.", "skydns_extra.test.", "skydns_zonea.test.", "skydns_zoneb.test.", "skydns_zonec.test.", "skydns_zoned.test.", "in-addr.arpa."},
 		Client:     client,
 	}

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -1,7 +1,6 @@
 package etcd
 
 import (
-	"context"
 	"crypto/tls"
 
 	"github.com/coredns/coredns/core/dnsserver"
@@ -38,10 +37,7 @@ func setup(c *caddy.Controller) error {
 }
 
 func etcdParse(c *caddy.Controller) (*Etcd, error) {
-	etc := Etcd{
-		PathPrefix: "skydns",
-		Ctx:        context.Background(),
-	}
+	etc := Etcd{PathPrefix: "skydns"}
 	var (
 		tlsConfig *tls.Config
 		err       error

--- a/plugin/federation/federation.go
+++ b/plugin/federation/federation.go
@@ -51,7 +51,7 @@ func (f *Federation) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
 	}
 
-	state := request.Request{W: w, Req: r, Context: ctx}
+	state := request.Request{W: w, Req: r}
 
 	zone := plugin.Zones(f.zones).Matches(state.Name())
 	if zone == "" {
@@ -109,7 +109,7 @@ func (f *Federation) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.
 	m.Answer = []dns.RR{service.NewCNAME(state.QName(), service.Host)}
 
 	if f.Upstream != nil {
-		aRecord, err := f.Upstream.Lookup(state, service.Host, state.QType())
+		aRecord, err := f.Upstream.Lookup(ctx, state, service.Host, state.QType())
 		if err == nil && aRecord != nil && len(aRecord.Answer) > 0 {
 			m.Answer = append(m.Answer, aRecord.Answer...)
 		}

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -31,7 +31,7 @@ type (
 
 // ServeDNS implements the plugin.Handle interface.
 func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	state := request.Request{W: w, Req: r, Context: ctx}
+	state := request.Request{W: w, Req: r}
 
 	qname := state.Name()
 	// TODO(miek): match the qname better in the map
@@ -79,7 +79,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return xfr.ServeDNS(ctx, w, r)
 	}
 
-	answer, ns, extra, result := z.Lookup(state, qname)
+	answer, ns, extra, result := z.Lookup(ctx, state, qname)
 
 	m := new(dns.Msg)
 	m.SetReply(r)

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -1,6 +1,8 @@
 package file
 
 import (
+	"context"
+
 	"github.com/coredns/coredns/plugin/file/tree"
 	"github.com/coredns/coredns/request"
 
@@ -25,7 +27,7 @@ const (
 
 // Lookup looks up qname and qtype in the zone. When do is true DNSSEC records are included.
 // Three sets of records are returned, one for the answer, one for authority  and one for the additional section.
-func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, []dns.RR, Result) {
+func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) ([]dns.RR, []dns.RR, []dns.RR, Result) {
 
 	qtype := state.QType()
 	do := state.Do()
@@ -106,7 +108,7 @@ func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, 
 			// Only one DNAME is allowed per name. We just pick the first one to synthesize from.
 			dname := dnamerrs[0]
 			if cname := synthesizeCNAME(state.Name(), dname.(*dns.DNAME)); cname != nil {
-				answer, ns, extra, rcode := z.additionalProcessing(state, elem, []dns.RR{cname})
+				answer, ns, extra, rcode := z.additionalProcessing(ctx, state, elem, []dns.RR{cname})
 
 				if do {
 					sigs := elem.Types(dns.TypeRRSIG)
@@ -157,7 +159,7 @@ func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, 
 	if found && shot {
 
 		if rrs := elem.Types(dns.TypeCNAME); len(rrs) > 0 && qtype != dns.TypeCNAME {
-			return z.additionalProcessing(state, elem, rrs)
+			return z.additionalProcessing(ctx, state, elem, rrs)
 		}
 
 		rrs := elem.Types(qtype, qname)
@@ -193,7 +195,7 @@ func (z *Zone) Lookup(state request.Request, qname string) ([]dns.RR, []dns.RR, 
 		auth := z.ns(do)
 
 		if rrs := wildElem.Types(dns.TypeCNAME, qname); len(rrs) > 0 {
-			return z.additionalProcessing(state, wildElem, rrs)
+			return z.additionalProcessing(ctx, state, wildElem, rrs)
 		}
 
 		rrs := wildElem.Types(qtype, qname)
@@ -296,7 +298,7 @@ func (z *Zone) ns(do bool) []dns.RR {
 }
 
 // aditionalProcessing adds signatures and tries to resolve CNAMEs that point to external names.
-func (z *Zone) additionalProcessing(state request.Request, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
+func (z *Zone) additionalProcessing(ctx context.Context, state request.Request, elem *tree.Elem, rrs []dns.RR) ([]dns.RR, []dns.RR, []dns.RR, Result) {
 
 	qtype := state.QType()
 	do := state.Do()
@@ -312,7 +314,7 @@ func (z *Zone) additionalProcessing(state request.Request, elem *tree.Elem, rrs 
 	targetName := rrs[0].(*dns.CNAME).Target
 	elem, _ = z.Tree.Search(targetName)
 	if elem == nil {
-		rrs = append(rrs, z.externalLookup(state, targetName, qtype)...)
+		rrs = append(rrs, z.externalLookup(ctx, state, targetName, qtype)...)
 		return rrs, z.ns(do), nil, Success
 	}
 
@@ -333,7 +335,7 @@ Redo:
 		targetName := cname[0].(*dns.CNAME).Target
 		elem, _ = z.Tree.Search(targetName)
 		if elem == nil {
-			rrs = append(rrs, z.externalLookup(state, targetName, qtype)...)
+			rrs = append(rrs, z.externalLookup(ctx, state, targetName, qtype)...)
 			return rrs, z.ns(do), nil, Success
 		}
 
@@ -371,8 +373,8 @@ func cnameForType(targets []dns.RR, origQtype uint16) []dns.RR {
 	return ret
 }
 
-func (z *Zone) externalLookup(state request.Request, target string, qtype uint16) []dns.RR {
-	m, e := z.Upstream.Lookup(state, target, qtype)
+func (z *Zone) externalLookup(ctx context.Context, state request.Request, target string, qtype uint16) []dns.RR {
+	m, e := z.Upstream.Lookup(ctx, state, target, qtype)
 	if e != nil {
 		return nil
 	}

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -33,17 +34,18 @@ func TestZoneReload(t *testing.T) {
 	z.Reload()
 	time.Sleep(time.Second)
 
+	ctx := context.TODO()
 	r := new(dns.Msg)
 	r.SetQuestion("miek.nl", dns.TypeSOA)
 	state := request.Request{W: &test.ResponseWriter{}, Req: r}
-	if _, _, _, res := z.Lookup(state, "miek.nl."); res != Success {
+	if _, _, _, res := z.Lookup(ctx, state, "miek.nl."); res != Success {
 		t.Fatalf("Failed to lookup, got %d", res)
 	}
 
 	r = new(dns.Msg)
 	r.SetQuestion("miek.nl", dns.TypeNS)
 	state = request.Request{W: &test.ResponseWriter{}, Req: r}
-	if _, _, _, res := z.Lookup(state, "miek.nl."); res != Success {
+	if _, _, _, res := z.Lookup(ctx, state, "miek.nl."); res != Success {
 		t.Fatalf("Failed to lookup, got %d", res)
 	}
 

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
@@ -281,7 +282,7 @@ func TestServices(t *testing.T) {
 			Req:  &dns.Msg{Question: []dns.Question{{Name: test.qname, Qtype: test.qtype}}},
 			Zone: "interwebs.test.", // must match from k.Zones[0]
 		}
-		svcs, e := k.Services(state, false, plugin.Options{})
+		svcs, e := k.Services(context.TODO(), state, false, plugin.Options{})
 		if e != nil {
 			t.Errorf("Test %d: got error '%v'", i, e)
 			continue

--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"context"
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
@@ -10,11 +11,11 @@ import (
 )
 
 // Reverse implements the ServiceBackend interface.
-func (k *Kubernetes) Reverse(state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
+func (k *Kubernetes) Reverse(ctx context.Context, state request.Request, exact bool, opt plugin.Options) ([]msg.Service, error) {
 
 	ip := dnsutil.ExtractAddressFromReverse(state.Name())
 	if ip == "" {
-		_, e := k.Records(state, exact)
+		_, e := k.Records(ctx, state, exact)
 		return nil, e
 	}
 

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -45,7 +45,7 @@ func (k *Kubernetes) Transfer(ctx context.Context, state request.Request) (int, 
 	ch := make(chan *dns.Envelope)
 	tr := new(dns.Transfer)
 
-	soa, err := plugin.SOA(k, state.Zone, state, plugin.Options{})
+	soa, err := plugin.SOA(ctx, k, state.Zone, state, plugin.Options{})
 	if err != nil {
 		return dns.RcodeServerFailure, nil
 	}

--- a/plugin/pkg/upstream/upstream.go
+++ b/plugin/pkg/upstream/upstream.go
@@ -2,6 +2,7 @@
 package upstream
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/miekg/dns"
@@ -18,8 +19,8 @@ type Upstream struct{}
 func New() *Upstream { return &Upstream{} }
 
 // Lookup routes lookups to our selves or forward to a remote.
-func (u *Upstream) Lookup(state request.Request, name string, typ uint16) (*dns.Msg, error) {
-	server, ok := state.Context.Value(dnsserver.Key{}).(*dnsserver.Server)
+func (u *Upstream) Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error) {
+	server, ok := ctx.Value(dnsserver.Key{}).(*dnsserver.Server)
 	if !ok {
 		return nil, fmt.Errorf("no full server is running")
 	}
@@ -29,7 +30,7 @@ func (u *Upstream) Lookup(state request.Request, name string, typ uint16) (*dns.
 
 	nw := nonwriter.New(state.W)
 
-	server.ServeDNS(state.Context, nw, req)
+	server.ServeDNS(ctx, nw, req)
 
 	return nw.Msg, nil
 }

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -117,7 +117,7 @@ func (h *Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	var result file.Result
 	for _, hostedZone := range z {
 		h.zMu.RLock()
-		m.Answer, m.Ns, m.Extra, result = hostedZone.z.Lookup(state, qname)
+		m.Answer, m.Ns, m.Extra, result = hostedZone.z.Lookup(ctx, state, qname)
 		h.zMu.RUnlock()
 		if len(m.Answer) != 0 {
 			break

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -51,7 +51,7 @@ type templateData struct {
 
 // ServeDNS implements the plugin.Handler interface.
 func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	state := request.Request{W: w, Req: r, Context: ctx}
+	state := request.Request{W: w, Req: r}
 
 	zone := plugin.Zones(h.Zones).Matches(state.Name())
 	if zone == "" {
@@ -85,7 +85,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			}
 			msg.Answer = append(msg.Answer, rr)
 			if template.upstream != nil && (state.QType() == dns.TypeA || state.QType() == dns.TypeAAAA) && rr.Header().Rrtype == dns.TypeCNAME {
-				up, _ := template.upstream.Lookup(state, rr.(*dns.CNAME).Target, state.QType())
+				up, _ := template.upstream.Lookup(ctx, state, rr.(*dns.CNAME).Target, state.QType())
 				msg.Answer = append(msg.Answer, up.Answer...)
 			}
 		}

--- a/request/request.go
+++ b/request/request.go
@@ -2,7 +2,6 @@
 package request
 
 import (
-	"context"
 	"net"
 	"strings"
 
@@ -19,12 +18,9 @@ type Request struct {
 	// Optional lowercased zone of this query.
 	Zone string
 
-	Context context.Context
-
 	// Cache size after first call to Size or Do.
 	size int
 	do   *bool // nil: nothing, otherwise *do value
-	// TODO(miek): opt record itself as well?
 
 	// Caches
 	name      string // lowercase qname.


### PR DESCRIPTION
This removes the context from request.Request and makes all the changes
in the code to make it compile again. It's all mechanical. It did
unearth some weirdness in that the context was kept in handler structs
which may cause havoc with concurrently handling of requests.

Fixes #2721