### PR TITLE
plugin/pprof - add option to enable block profiling

### DIFF
--- a/plugin/pprof/README.md
+++ b/plugin/pprof/README.md
@@ -17,10 +17,14 @@ This plugin can only be used once per Server Block.
 ## Syntax
 
 ~~~
-pprof [ADDRESS]
+pprof [ADDRESS] [BLOCKRATE]
 ~~~
 
-If not specified, ADDRESS defaults to localhost:6053.
+- If not specified, **ADDRESS** defaults to localhost:6053.
+
+- **BLOCKRATE** allow to enable `block` profiling. see [Diagnostics, chapter profiling](https://golang.org/doc/diagnostics.html).
+if you need to use `block` profile, set a positive value to **BLOCKRATE**. See [runtime.SetBlockProfileRate](https://golang.org/pkg/runtime/#SetBlockProfileRate).
+ if not specified, **BLOCKRATE** default's to 0, which means block profiling disabled.
 
 ## Examples
 
@@ -42,11 +46,11 @@ Listen on an alternate address:
 }
 ~~~
 
-Listen on an all addresses on port 6060:
+Listen on an all addresses on port 6060: and enable block profiling
 
 ~~~ txt
 . {
-    pprof :6060
+    pprof :6060 1
 }
 ~~~
 

--- a/plugin/pprof/README.md
+++ b/plugin/pprof/README.md
@@ -17,14 +17,16 @@ This plugin can only be used once per Server Block.
 ## Syntax
 
 ~~~
-pprof [ADDRESS] [BLOCKRATE]
+pprof [ADDRESS] {
+   block [RATE]
+}
 ~~~
 
 - If not specified, **ADDRESS** defaults to localhost:6053.
 
-- **BLOCKRATE** allow to enable `block` profiling. see [Diagnostics, chapter profiling](https://golang.org/doc/diagnostics.html).
-if you need to use `block` profile, set a positive value to **BLOCKRATE**. See [runtime.SetBlockProfileRate](https://golang.org/pkg/runtime/#SetBlockProfileRate).
- if not specified, **BLOCKRATE** default's to 0, which means block profiling disabled.
+- `block` option allow to enable the `block` profiling. see [Diagnostics, chapter profiling](https://golang.org/doc/diagnostics.html).
+if you need to use `block` profile, set a positive value to **RATE**. See [runtime.SetBlockProfileRate](https://golang.org/pkg/runtime/#SetBlockProfileRate).
+ if not specified, **RATE** default's to 1. if `block` option is not specified the `block` profiling is disabled.
 
 ## Examples
 
@@ -50,7 +52,9 @@ Listen on an all addresses on port 6060: and enable block profiling
 
 ~~~ txt
 . {
-    pprof :6060 1
+    pprof :6060 {
+       block
+    }
 }
 ~~~
 

--- a/plugin/pprof/pprof.go
+++ b/plugin/pprof/pprof.go
@@ -6,12 +6,14 @@ import (
 	"net"
 	"net/http"
 	pp "net/http/pprof"
+	"runtime"
 )
 
 type handler struct {
-	addr string
-	ln   net.Listener
-	mux  *http.ServeMux
+	addr     string
+	rateBloc int
+	ln       net.Listener
+	mux      *http.ServeMux
 }
 
 func (h *handler) Startup() error {
@@ -29,6 +31,8 @@ func (h *handler) Startup() error {
 	h.mux.HandleFunc(path+"/profile", pp.Profile)
 	h.mux.HandleFunc(path+"/symbol", pp.Symbol)
 	h.mux.HandleFunc(path+"/trace", pp.Trace)
+
+	runtime.SetBlockProfileRate(h.rateBloc)
 
 	go func() {
 		http.Serve(h.ln, h.mux)

--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -33,26 +33,38 @@ func setup(c *caddy.Controller) error {
 		i++
 
 		args := c.RemainingArgs()
-		if len(args) >= 1 {
+		if len(args) == 1 {
 			h.addr = args[0]
 			_, _, e := net.SplitHostPort(h.addr)
 			if e != nil {
-				return e
+				return plugin.Error("pprof", c.Errf("%v", e))
 			}
 		}
-		if len(args) >= 2 {
-			l, err := strconv.ParseInt(args[1], 10, 32)
-			if err != nil {
-				return plugin.Error("pprof", err)
+
+		if len(args) > 1 {
+			return plugin.Error("pprof", c.ArgErr())
+		}
+
+		for c.NextBlock() {
+			switch c.Val() {
+			case "block":
+				args := c.RemainingArgs()
+				if len(args) > 1 {
+					return plugin.Error("pprof", c.ArgErr())
+				}
+				h.rateBloc = 1
+				if len(args) > 0 {
+					t, err := strconv.Atoi(args[0])
+					if err != nil {
+						return plugin.Error("pprof", c.Errf("property '%s' invalid integer value '%v'", "block", args[0]))
+					}
+					h.rateBloc = t
+				}
+			default:
+				return plugin.Error("pprof", c.Errf("unknown property '%s'", c.Val()))
 			}
-			h.rateBloc = int(l)
 		}
-		if len(args) > 2 {
-			return plugin.Error("pprof", c.ArgErr())
-		}
-		if c.NextBlock() {
-			return plugin.Error("pprof", c.ArgErr())
-		}
+
 	}
 
 	pprofOnce.Do(func() {

--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -2,6 +2,7 @@ package pprof
 
 import (
 	"net"
+	"strconv"
 	"sync"
 
 	"github.com/coredns/coredns/plugin"
@@ -32,14 +33,21 @@ func setup(c *caddy.Controller) error {
 		i++
 
 		args := c.RemainingArgs()
-		if len(args) == 1 {
+		if len(args) >= 1 {
 			h.addr = args[0]
 			_, _, e := net.SplitHostPort(h.addr)
 			if e != nil {
 				return e
 			}
 		}
-		if len(args) > 1 {
+		if len(args) >= 2 {
+			l, err := strconv.ParseInt(args[1], 10, 32)
+			if err != nil {
+				return plugin.Error("pprof", err)
+			}
+			h.rateBloc = int(l)
+		}
+		if len(args) > 2 {
 			return plugin.Error("pprof", c.ArgErr())
 		}
 		if c.NextBlock() {

--- a/plugin/pprof/setup_test.go
+++ b/plugin/pprof/setup_test.go
@@ -14,14 +14,21 @@ func TestPProf(t *testing.T) {
 		{`pprof`, false},
 		{`pprof 1.2.3.4:1234`, false},
 		{`pprof :1234`, false},
-		{`pprof :1234 -1`, false},
-		{`pprof :1234 0`, false},
-		{`pprof :1234 20`, false},
-		{`pprof {}`, true},
+		{`pprof :1234 -1`, true},
+		{`pprof {
+                }`, false},
 		{`pprof /foo`, true},
 		{`pprof {
             a b
         }`, true},
+		{`pprof { block
+                }`, false},
+		{`pprof :1234 { 
+                   block 20
+                }`, false},
+		{`pprof { 
+                   block 20 30
+                }`, true},
 		{`pprof
           pprof`, true},
 	}

--- a/plugin/pprof/setup_test.go
+++ b/plugin/pprof/setup_test.go
@@ -14,6 +14,9 @@ func TestPProf(t *testing.T) {
 		{`pprof`, false},
 		{`pprof 1.2.3.4:1234`, false},
 		{`pprof :1234`, false},
+		{`pprof :1234 -1`, false},
+		{`pprof :1234 0`, false},
+		{`pprof :1234 20`, false},
 		{`pprof {}`, true},
 		{`pprof /foo`, true},
 		{`pprof {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

In order to collect profiling information for blocked routines, we need to set a specific function of runtime.

see changes in the README.

### 2. Which issues (if any) are related?

This pprof option is useful to investigate the reason of high number of goroutines and associated memory or CPU.

This profiling mode was needed to investigate: #2593
Will allow to investigate the Mem+CPU spike here : #2624

### 3. Which documentation changes (if any) need to be made?

README is updated

### 4. Does this introduce a backward incompatible change or deprecation?

no.