### PR TITLE
plugin/grpc: Allow DNS Name in config

### DIFF
--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -76,7 +76,7 @@ func parseGRPCStanza(c *caddyfile.Dispenser) (*GRPC, error) {
 		return g, c.ArgErr()
 	}
 
-	toHosts, err := parse.HostPortOrFile(to...)
+	toHosts, err := parse.HostPortOrFileOrDNSName(to...)
 	if err != nil {
 		return g, err
 	}

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -85,3 +85,62 @@ func TestParseHostPort(t *testing.T) {
 		}
 	}
 }
+
+func TestHostPortOrFileOrDNSName(t *testing.T) {
+	tests := []struct {
+		in        string
+		expected  string
+		shouldErr bool
+	}{
+		{
+			"8.8.8.8",
+			"8.8.8.8:53",
+			false,
+		},
+		{
+			"8.8.8.8:153",
+			"8.8.8.8:153",
+			false,
+		},
+		{
+			"/etc/resolv.conf:53",
+			"",
+			true,
+		},
+		{
+			"resolv.conf",
+			"127.0.0.1:53",
+			false,
+		},
+		{
+			"localhost",
+			"localhost:53",
+			false,
+		},
+		{
+			"localhost:8080",
+			"localhost:8080",
+			false,
+		},
+	}
+
+	err := ioutil.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)
+	if err != nil {
+		t.Fatalf("Failed to write test resolv.conf")
+	}
+	defer os.Remove("resolv.conf")
+
+	for i, tc := range tests {
+		got, err := HostPortOrFileOrDNSName(tc.in)
+		if err == nil && tc.shouldErr {
+			t.Errorf("Test %d, expected error, got nil", i)
+			continue
+		}
+		if err != nil && tc.shouldErr {
+			continue
+		}
+		if got[0] != tc.expected {
+			t.Errorf("Test %d, expected %q, got %q", i, tc.expected, got[0])
+		}
+	}
+}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Possibility to configure DNS upstreams via DNS names. In a container platform for example, using fixed IP might be really tricky and using DNS names would help a lot.
### 2. Which issues (if any) are related?
#2440 and #1592 
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
No