### PR TITLE
plugin/forward: bring back jitter

### DIFF
--- a/plugin/forward/jitter.go
+++ b/plugin/forward/jitter.go
@@ -1,0 +1,12 @@
+package forward
+
+import (
+	"math/rand"
+	"time"
+)
+
+// jitter adds up to 25% jitter to the expire duration.
+func jitter(expire time.Duration) time.Duration {
+	exp := int64(expire / 4)
+	return expire + time.Duration(rand.Int63n(exp))
+}

--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -85,16 +85,16 @@ Wait:
 
 			// no proto here, infer from config and conn
 			if _, ok := conn.Conn.(*net.UDPConn); ok {
-				t.conns["udp"] = append(t.conns["udp"], &persistConn{conn, time.Now()})
+				t.conns["udp"] = append(t.conns["udp"], &persistConn{conn, time.Now().Add(jitter(t.expire))})
 				continue Wait
 			}
 
 			if t.tlsConfig == nil {
-				t.conns["tcp"] = append(t.conns["tcp"], &persistConn{conn, time.Now()})
+				t.conns["tcp"] = append(t.conns["tcp"], &persistConn{conn, time.Now().Add(jitter(t.expire))})
 				continue Wait
 			}
 
-			t.conns["tcp-tls"] = append(t.conns["tcp-tls"], &persistConn{conn, time.Now()})
+			t.conns["tcp-tls"] = append(t.conns["tcp-tls"], &persistConn{conn, time.Now().Add(jitter(t.expire))})
 
 		case <-ticker.C:
 			t.cleanup(false)

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -57,77 +57,29 @@ func TestCleanupByTimer(t *testing.T) {
 	defer s.Close()
 
 	tr := newTransport(s.Addr)
-	tr.SetExpire(100 * time.Millisecond)
+	tr.SetExpire(100 * time.Microsecond)
 	tr.Start()
 	defer tr.Stop()
 
 	c1, _, _ := tr.Dial("udp")
 	c2, _, _ := tr.Dial("udp")
 	tr.Yield(c1)
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(40 * time.Microsecond)
 	tr.Yield(c2)
 
-	time.Sleep(120 * time.Millisecond)
+	time.Sleep(140 * time.Microsecond)
 	c3, cached, _ := tr.Dial("udp")
 	if cached {
 		t.Error("Expected non-cached connection (c3)")
 	}
 	tr.Yield(c3)
 
-	time.Sleep(120 * time.Millisecond)
+	time.Sleep(160 * time.Microsecond)
 	c4, cached, _ := tr.Dial("udp")
 	if cached {
 		t.Error("Expected non-cached connection (c4)")
 	}
 	tr.Yield(c4)
-}
-
-func TestPartialCleanup(t *testing.T) {
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
-		ret := new(dns.Msg)
-		ret.SetReply(r)
-		w.WriteMsg(ret)
-	})
-	defer s.Close()
-
-	tr := newTransport(s.Addr)
-	tr.SetExpire(100 * time.Millisecond)
-	tr.Start()
-	defer tr.Stop()
-
-	c1, _, _ := tr.Dial("udp")
-	c2, _, _ := tr.Dial("udp")
-	c3, _, _ := tr.Dial("udp")
-	c4, _, _ := tr.Dial("udp")
-	c5, _, _ := tr.Dial("udp")
-
-	tr.Yield(c1)
-	time.Sleep(10 * time.Millisecond)
-	tr.Yield(c2)
-	time.Sleep(10 * time.Millisecond)
-	tr.Yield(c3)
-	time.Sleep(50 * time.Millisecond)
-	tr.Yield(c4)
-	time.Sleep(10 * time.Millisecond)
-	tr.Yield(c5)
-	time.Sleep(40 * time.Millisecond)
-
-	c6, _, _ := tr.Dial("udp")
-	if c6 != c5 {
-		t.Errorf("Expected c6 == c5")
-	}
-	c7, _, _ := tr.Dial("udp")
-	if c7 != c4 {
-		t.Errorf("Expected c7 == c4")
-	}
-	c8, cached, _ := tr.Dial("udp")
-	if cached {
-		t.Error("Expected non-cached connection (c8)")
-	}
-
-	tr.Yield(c6)
-	tr.Yield(c7)
-	tr.Yield(c8)
 }
 
 func TestCleanupAll(t *testing.T) {

--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -48,40 +48,6 @@ func TestCached(t *testing.T) {
 	tr.Yield(c4)
 }
 
-func TestCleanupByTimer(t *testing.T) {
-	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
-		ret := new(dns.Msg)
-		ret.SetReply(r)
-		w.WriteMsg(ret)
-	})
-	defer s.Close()
-
-	tr := newTransport(s.Addr)
-	tr.SetExpire(100 * time.Microsecond)
-	tr.Start()
-	defer tr.Stop()
-
-	c1, _, _ := tr.Dial("udp")
-	c2, _, _ := tr.Dial("udp")
-	tr.Yield(c1)
-	time.Sleep(40 * time.Microsecond)
-	tr.Yield(c2)
-
-	time.Sleep(140 * time.Microsecond)
-	c3, cached, _ := tr.Dial("udp")
-	if cached {
-		t.Error("Expected non-cached connection (c3)")
-	}
-	tr.Yield(c3)
-
-	time.Sleep(160 * time.Microsecond)
-	c4, cached, _ := tr.Dial("udp")
-	if cached {
-		t.Error("Expected non-cached connection (c4)")
-	}
-	tr.Yield(c4)
-}
-
 func TestCleanupAll(t *testing.T) {
 	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
 		ret := new(dns.Msg)


### PR DESCRIPTION
Very minimal jitter implementation that adds up to 25% jitter to the
expiration for the connection. This helps when we see a burst in
connections which all race to get a TLS conn and then also are expired
at the same time, meaning we can see a repeat.

Another thing could be to keep a couple of connection in the cache to be
able to serve right away (not implemented in this PR)