### PR TITLE
plugin/cancel: enable by default

### DIFF
--- a/core/dnsserver/cancel_test.go
+++ b/core/dnsserver/cancel_test.go
@@ -1,0 +1,41 @@
+package dnsserver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// We can't include the actual cancel plugin here, because that create a cyclic dependency. Just make
+// a plugin with the same name because that's what triggers the check.
+type cancel struct{}
+
+func (c cancel) Name() string { return "cancel" }
+func (c cancel) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return 0, nil
+}
+
+func TestCancelEnabled(t *testing.T) {
+	c := testConfig("dns", cancel{})
+	s, err := NewServer("127.0.0.1:53", []*Config{c})
+
+	if err != nil {
+		t.Fatalf("Expected no error for NewServer, got %s", err)
+	}
+	if !s.cancel {
+		t.Errorf("Expected cancel to be true, got false")
+	}
+}
+
+func TestCancelDisabled(t *testing.T) {
+	c := testConfig("dns", testPlugin{})
+	s, err := NewServer("127.0.0.1:53", []*Config{c})
+
+	if err != nil {
+		t.Fatalf("Expected no error for NewServer, got %s", err)
+	}
+	if s.cancel {
+		t.Errorf("Expected cancel to be false, got true")
+	}
+}

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -125,7 +125,6 @@ func (s *Server) Serve(l net.Listener) error {
 			s.ServeDNS(ctx, w, r)
 		})}
 	} else {
-		println("enabling canceling, becuase not loaded")
 		s.server[tcp] = &dns.Server{Listener: l, Net: "tcp", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
 			ctx := context.WithValue(context.Background(), Key{}, s)
 			ctx, cancel := context.WithTimeout(ctx, 5001*time.Millisecond)

--- a/plugin/cancel/README.md
+++ b/plugin/cancel/README.md
@@ -7,7 +7,7 @@
 ## Description
 
 The *cancel* plugin creates a canceling context for each request. It adds a timeout that gets
-triggered after 5001 milliseconds.
+triggered after 5001 milliseconds. This plugin is loaded by *default*.
 
 The 5001 number is chosen because the default timeout for DNS clients is 5 seconds, after that they
 give up.

--- a/plugin/done.go
+++ b/plugin/done.go
@@ -3,6 +3,16 @@ package plugin
 import "context"
 
 // Done is a non-blocking function that returns true if the context has been canceled.
+// If a context is canceled it is highly likely the client that sent us this request has
+// stopped caring. This means no reply whould be sent back.
+//
+// Typical use case for returning from a plugin when the context has been canceled:
+// (p is a plugin.Handler)
+//
+// if plugin.Done(ctx) {
+// 	return dns.RcodeSuccess, plugin.Error(p.Name(), ctx.Err())
+// }
+//
 func Done(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -82,6 +82,10 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			fails = 0
 		}
 
+		if plugin.Done(ctx) {
+			return dns.RcodeSuccess, plugin.Error(f.Name(), ctx.Err())
+		}
+
 		proxy := list[i]
 		i++
 		if proxy.Down(f.maxfails) {


### PR DESCRIPTION
Enable the cancel plugin (with some hackery to prevent cyclic imports)
to be active in every server. If the plugin *is* loaded that takes
precedence, allowing folks to set different timeouts than the default of
5001 ms.

Add several tests and document how to plugin.Done(ctx) in code.
Implement it in *forward* to actually make that return early if we're
only executing that plugin late in the process.