### PR TITLE
WIP: add debian packaging

### DIFF
--- a/coredns.postinst
+++ b/coredns.postinst
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+        if ! getent passwd coredns > /dev/null; then
+            adduser --system --disabled-password --disabled-login --home /var/lib/coredns \
+                    --quiet --force-badname --group coredns
+        fi
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/coredns.service
+++ b/coredns.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=CoreDNS DNS server
+Documentation=https://coredns.io
+After=network.target
+
+[Service]
+PermissionsStartOnly=true
+LimitNOFILE=1048576
+LimitNPROC=512
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
+User=coredns
+WorkingDirectory=~
+ExecStart=/usr/bin/coredns -conf=/etc/coredns/Corefile
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,40 @@
+name: "coredns"
+arch: "amd64"
+platform: "linux"
+version: "v${MY_APP_VERSION}"
+section: "default"
+priority: "extra"
+replaces:
+- foobar
+provides:
+- bar
+depends:
+- ca-certificates
+- adduser
+suggests:
+- dnsutils
+maintainer: "CoreDNS Maintainers <info@coredns.io>"
+description: |
+  DNS server that chains plugins, written in Go.
+vendor: "CoreDNS"
+homepage: "https://coredns.io"
+license: "MIT"
+bindir: "/usr/bin"
+files:
+  ./coredns: "/usr/bin/coredns"
+config_files:
+  "/dev/null": "/etc/coredns/Corefile"
+  "man/*.7": "/usr/share/man/man7/"
+  "man/coredns.1": "/usr/share/man/man1/coredns.1"
+  "man/corefile.5": "/usr/share/man/man5/corefile.5"
+  "coredns.service": "/lib/systemd/system/coredns.service"
+
+overrides:
+  #rpm:
+    #scripts:
+    #  preinstall: ./scripts/preinstall.sh
+    #  postremove: ./scripts/postremove.sh
+  deb:
+    scripts:
+      postinstall: ./coredns.postinst
+      #preremove: ./scripts/preremove.sh


### PR DESCRIPTION
Uses https://github.com/goreleaser/nfpm, nfpm pkg create a debian
foo.deb that can be installed.

nfpm can be used as a lib (and goreleaser uses it). We can do the
minimal thing add a little Go binary to create deb and maybe rpms.

Signed-off-by: Miek Gieben <miek@miek.nl>
