### PR TITLE
release: add 1.5.0 release notes

### DIFF
--- a/notes/coredns-1.5.0.md
+++ b/notes/coredns-1.5.0.md
@@ -1,0 +1,41 @@
++++
+title = "CoreDNS-1.5.0 Release"
+description = "CoreDNS-1.5.0 Release Notes."
+tags = ["Release", "1.5.0", "Notes"]
+release = "1.5.0"
+date = "2019-03-31T09:39:07+00:00"
+author = "coredns"
++++
+
+A new [release](https://github.com/coredns/coredns/releases/tag/v1.4.0): CoreDNS-1.5.0.
+
+**Two** new plugins in this releasse: [*grpc*](/plugins/grpc), and [*ready*](/plugins/ready). And
+some polish and simplications in the core server code.
+
+# Plugins
+
+* a new [*ready*](/plugins/ready) was added that signals a plugin is ready to receive queries. First user is the *kubernetes* plugin.
+* a new [*grpc*](/plugins/grpc) was added to implements forwarding gRPC. If you were relying on this in the [*proxy*](/explugins/proxy) plugin you can now use this one.
+* the [*cancel*](/plugins/cancel) was added that adds a context.WithTimeout to each context.
+* the [*forward*](/plugins/forward) adds dnstap support.
+* the [*route53*](/plugins/route53) now supports wildcards.
+* the [*pprof*](/plugins/pprof) adds a `block` option that enables the block profiling.
+
+## Brought to You By
+
+Aleks,
+Chris O'Haver,
+David,
+dilyevsky,
+Francois Tur,
+Iñigo,
+Jiacheng Xu,
+Matt Greenfield,
+MengZeLee,
+Miek Gieben,
+peiranliushop,
+Rajveer Malviya,
+Ruslan Drozhdzh,
+Stefan Budeanu,
+Xiao An,
+Yong Tang.

--- a/notes/coredns-1.5.0.md
+++ b/notes/coredns-1.5.0.md
@@ -9,7 +9,7 @@ author = "coredns"
 
 A new [release](https://github.com/coredns/coredns/releases/tag/v1.5.0): CoreDNS-1.5.0.
 
-**Two** new plugins in this releasse: [*grpc*](/plugins/grpc), and [*ready*](/plugins/ready). And
+**Two** new plugins in this release: [*grpc*](/plugins/grpc), and [*ready*](/plugins/ready). And
 some polish and simplications in the core server code.
 
 The use of **TIMEOUT** and **no_reload** in [*file*](/plugins/file) and [*auto*](/plugins/auto) have

--- a/notes/coredns-1.5.0.md
+++ b/notes/coredns-1.5.0.md
@@ -15,7 +15,7 @@ some polish and simplications in the core server code.
 # Plugins
 
 * a new [*ready*](/plugins/ready) was added that signals a plugin is ready to receive queries. First user is the *kubernetes* plugin.
-* a new [*grpc*](/plugins/grpc) was added to implements forwarding gRPC. If you were relying on this in the [*proxy*](/explugins/proxy) plugin you can now use this one.
+* a new [*grpc*](/plugins/grpc) was added to implement forwarding gRPC. If you were relying on this in the [*proxy*](/explugins/proxy) you can migrate to this one.
 * the [*cancel*](/plugins/cancel) was added that adds a context.WithTimeout to each context.
 * the [*forward*](/plugins/forward) adds dnstap support.
 * the [*route53*](/plugins/route53) now supports wildcards.

--- a/notes/coredns-1.5.0.md
+++ b/notes/coredns-1.5.0.md
@@ -7,10 +7,13 @@ date = "2019-03-31T09:39:07+00:00"
 author = "coredns"
 +++
 
-A new [release](https://github.com/coredns/coredns/releases/tag/v1.4.0): CoreDNS-1.5.0.
+A new [release](https://github.com/coredns/coredns/releases/tag/v1.5.0): CoreDNS-1.5.0.
 
 **Two** new plugins in this releasse: [*grpc*](/plugins/grpc), and [*ready*](/plugins/ready). And
 some polish and simplications in the core server code.
+
+The use of **TIMEOUT** and **no_reload** in [*file*](/plugins/file) and [*auto*](/plugins/auto) have
+been fully deprecated.
 
 # Plugins
 


### PR DESCRIPTION
Add the release notes to the notes/ directory to prepare for a release.

This is copied from the Wiki