### PR TITLE
add mips to released ARCH

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -47,7 +47,7 @@ NAME:=coredns
 VERSION:=$(shell grep 'CoreVersion' coremain/version.go | awk '{ print $$3 }' | tr -d '"')
 GITHUB:=coredns
 DOCKER_IMAGE_NAME:=$(DOCKER)/$(NAME)
-LINUX_ARCH:=amd64 arm arm64 ppc64le s390x
+LINUX_ARCH:=amd64 arm arm64 ppc64le s390x mips
 PLATFORMS:=$(subst $(SPACE),$(COMMA),$(foreach arch,$(LINUX_ARCH),linux/$(arch)))
 
 ifeq ($(DOCKER),)


### PR DESCRIPTION

>### 1. Why is this pull request needed and what does it do?
This PR adds build for architecture MIPS to releases. It seems to be working fine. Using it on my router for couple days with etcd backend and forward plugin.

> ### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2745


> ### 3. Which documentation changes (if any) need to be made?
Not sure

> ### 4. Does this introduce a backward incompatible change or deprecation?

No