### PR TITLE
Bump the resync period to five hours

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -321,4 +321,4 @@ func searchFromResolvConf() []string {
 	return rc.Search
 }
 
-const defaultResyncPeriod = 5 * time.Minute
+const defaultResyncPeriod = 5 * time.Hour


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Bumps the default client-go resync period to 5 hours from 5 minutes. Resync is no longer recommended to be done frequently, and uses extra CPU unnecessarily. Note that it does NOT refetch data from the API.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None, the default wasn't documented before (maybe it should be though :) )

### 4. Does this introduce a backward incompatible change or deprecation?
No.
