### PR TITLE
plugin/kubernetes: Disable resync by default

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -48,7 +48,8 @@ kubernetes [ZONES...] {
 }
 ```
 
-* `resyncperiod` specifies the Kubernetes data API **DURATION** period.
+* `resyncperiod` specifies the Kubernetes data API **DURATION** period. By
+  default resync is disabled (DURATION is zero).
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -321,4 +321,4 @@ func searchFromResolvConf() []string {
 	return rc.Search
 }
 
-const defaultResyncPeriod = 5 * time.Hour
+const defaultResyncPeriod = 0


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Disables the client-go resync by default.

### 2. Which issues (if any) are related?
Maybe #2660 

### 3. Which documentation changes (if any) need to be made?
README (done)

### 4. Does this introduce a backward incompatible change or deprecation?
No
