### PR TITLE
plugin/hosts: send nxdomain response

### DIFF
--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -92,6 +92,11 @@ var hostsTestCases = []test.Case{
 		Qname: "example.org.", Qtype: dns.TypeMX,
 		Answer: []dns.RR{},
 	},
+	{
+		Qname: "unknown.example.org", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Answer: []dns.RR{},
+	},
 }
 
 const hostsExample = `


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

[As specified in the plugin documentation](https://github.com/coredns/coredns/blob/master/plugin.md#writing-plugins), CoreDNS assumes a plugin has sent a response in all cases except SERVFAIL, REFUSED, FORMERR, and NOTIMP. The hosts plugin was returning NXDOMAIN but sending no response in the case where it didn't have any records for the qname, and fallthrough was not available. __This resulted in no response being sent to the client.__

Additionally, when writing a test case, I encountered a segfault in plugin/test SortAndCheck because it dereferences the response without checking for nil (resp is nil when the plugin fails to write one). Perhaps this commit should be a separate PR?

### 2. Which issues (if any) are related?

I didn't find an issue on github.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.
