### PR TITLE
plugins: remove `upstream [ADDRESS]` from docs

### DIFF
--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -32,7 +32,7 @@ etcd [ZONES...] {
     path PATH
     endpoint ENDPOINT...
     credentials USERNAME PASSWORD
-    upstream [ADDRESS...]
+    upstream
     tls CERT KEY CACERT
 }
 ~~~
@@ -46,9 +46,7 @@ etcd [ZONES...] {
 * `credentials` is used to set the **USERNAME** and **PASSWORD** for accessing the etcd cluster.
 * `upstream` upstream resolvers to be used resolve external names found in etcd (think CNAMEs)
   pointing to external names. If you want CoreDNS to act as a proxy for clients, you'll need to add
-  the *forward* plugin. If no **ADDRESS** is given, CoreDNS will resolve CNAMEs against itself.
-  **ADDRESS** can be an IP address, and IP:port or a string pointing to a file that is structured
-  as /etc/resolv.conf.
+  the *forward* plugin.
 * `tls` followed by:
 
     * no arguments, if the server certificate is signed by a system-installed CA and no client cert is needed

--- a/plugin/federation/README.md
+++ b/plugin/federation/README.md
@@ -23,8 +23,9 @@ federation [ZONES...] {
 
 * Each **NAME** and **DOMAIN** defines federation membership. One entry for each. A duplicate
   **NAME** will silently overwrite any previous value.
-* `upstream` [**ADDRESS**...] resolve the `CNAME` target produced by this plugin.  CoreDNS
-  will resolve External Services against itself.
+* `upstream` resolve the `CNAME` target produced by this plugin.  CoreDNS
+  will resolve External Services against itself and needs the *forward* plugin to be active to do
+  so.
 
 ## Examples
 
@@ -38,18 +39,6 @@ Here we handle all service requests in the `prod` and `stage` federations.
         staging staging.feddomain.com
         upstream
     }
-}
-~~~
-
-Or slightly shorter:
-
-~~~
-cluster.local {
-    kubernetes
-    federation {
-        prod prod.feddomain.com
-        staging staging.feddomain.com
-        upstream
-    }
+    forward . 192.168.1.12
 }
 ~~~

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -39,7 +39,7 @@ kubernetes [ZONES...] {
     labels EXPRESSION
     pods POD-MODE
     endpoint_pod_names
-    upstream [ADDRESS...]
+    upstream
     ttl TTL
     noendpoints
     transfer to ADDRESS...
@@ -60,7 +60,7 @@ kubernetes [ZONES...] {
 * `namespace_labels` **EXPRESSION** only expose the records for Kubernetes namespaces that match this label selector.
    The label selector syntax is described in the
    [Kubernetes User Guide - Labels](http://kubernetes.io/docs/user-guide/labels/). An example that
-   only exposes namespaces labeled as "istio-injection=enabled", would use: 
+   only exposes namespaces labeled as "istio-injection=enabled", would use:
    `labels istio-injection=enabled`.
 * `labels` **EXPRESSION** only exposes the records for Kubernetes objects that match this label selector.
    The label selector syntax is described in the
@@ -90,10 +90,9 @@ kubernetes [ZONES...] {
    follows: Use the hostname of the endpoint, or if hostname is not set, use the
    pod name of the pod targeted by the endpoint. If there is no pod targeted by
    the endpoint, use the dashed IP address form.
-* `upstream` [**ADDRESS**...] defines the upstream resolvers used for resolving services
-  that point to external hosts (aka External Services, aka CNAMEs).  If no **ADDRESS** is given, CoreDNS
-  will resolve External Services against itself. **ADDRESS** can be an IP, an IP:port, or a path
-  to a file structured like resolv.conf.
+* `upstream` defines the upstream resolvers used for resolving services
+  that point to external hosts (aka External Services, aka CNAMEs).  CoreDNS
+  will resolve External Services against itself.
 * `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -58,8 +58,9 @@ Enable route53 with implicit AWS credentials and an upstream:
 ~~~ txt
 . {
 	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
-	  upstream 10.0.0.1
+	  upstream
 	}
+    forward . 10.0.0.1
 }
 ~~~
 


### PR DESCRIPTION
Various plugins still had this documented, the setup functions still
allow it (which is fine), but update the docs that this arguments isn't
there any more.