### PR TITLE
`template` plugin should parse quoted zone scopes correctly

### DIFF
--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -62,7 +62,7 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 		tokenizedZones := c.RemainingArgs()
 		var zones []string
 		for _, z := range tokenizedZones {
-			zones = append(zones, strings.Fields(z)...)
+			zones = append(zones, strings.Fields(strings.Trim(z, `'"`))...)
 		}
 		if len(zones) == 0 {
 			zones = make([]string, len(c.ServerBlockKeys))

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"regexp"
+	"strings"
 	gotmpl "text/template"
 
 	"github.com/coredns/coredns/core/dnsserver"
@@ -58,7 +59,11 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 			return handler, c.Errf("invalid RR class %s", c.Val())
 		}
 
-		zones := c.RemainingArgs()
+		tokenizedZones := c.RemainingArgs()
+		var zones []string
+		for _, z := range tokenizedZones {
+			zones = append(zones, strings.Fields(z)...)
+		}
 		if len(zones) == 0 {
 			zones = make([]string, len(c.ServerBlockKeys))
 			copy(zones, c.ServerBlockKeys)

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -161,3 +161,33 @@ func TestSetupParse(t *testing.T) {
 		}
 	}
 }
+
+func TestSetupParseZones(t *testing.T) {
+	// Verify that template plugin parser should parse double quoted list of zones correctly
+	serverBlockKeys := []string{".:8053"}
+	tests := []struct {
+		inputFileRules string
+		count          int
+	}{
+		{
+			`template ANY ANY a.example.com b.example.com c.example.com {
+				rcode NXDOMAIN
+			}`, 3,
+		},
+		{
+			`template ANY ANY " a.example.com  b.example.com	 c.example.com " {
+				rcode NXDOMAIN
+			}`, 3,
+		},
+	}
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.inputFileRules)
+		c.ServerBlockKeys = serverBlockKeys
+		templates, _ := templateParse(c)
+		zoneCount := len(templates.Templates[0].zones)
+		if zoneCount != test.count {
+			t.Fatalf("Test %d expected %d zones, but got %d \n%v",
+				i, test.count, zoneCount, templates.Templates[0].zones)
+		}
+	}
+}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -163,21 +163,35 @@ func TestSetupParse(t *testing.T) {
 }
 
 func TestSetupParseZones(t *testing.T) {
-	// Verify that template plugin parser should parse double quoted list of zones correctly
+	// Verify that `template` plugin parser should parse double/single quoted list of zones correctly
 	serverBlockKeys := []string{".:8053"}
 	tests := []struct {
 		inputFileRules string
 		count          int
 	}{
+		// zones field is not quoted
 		{
 			`template ANY ANY a.example.com b.example.com c.example.com {
 				rcode NXDOMAIN
 			}`, 3,
 		},
+		// zones field is double quoted
 		{
 			`template ANY ANY " a.example.com  b.example.com	 c.example.com " {
 				rcode NXDOMAIN
 			}`, 3,
+		},
+		// zones field is single quoted
+		{
+			`template ANY ANY ' a.example.com  b.example.com	 c.example.com ' {
+				rcode NXDOMAIN
+			}`, 3,
+		},
+		// zones field is double quoted and the length is more than 255 (max length of DNS full domain name)
+		{
+			`template ANY ANY "com.c.example.internal com.cluster.local com.svc.cluster.local com.google.internal com.default.svc.cluster.local com.example-core.svc.cluster.local net.c.example.internal net.cluster.local net.svc.cluster.local net.google.internal net.default.svc.cluster.local" {
+				rcode NXDOMAIN
+			}`, 11,
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR allows `template` plugin to accept double quoted and single quoted zone scopes.
All these templates below should be valid.
```
template ANY ANY a.com b.com c.com {
}

template ANY ANY " a.com  b.com   c.com " {
}

template ANY ANY ' a.com  b.com   c.com ' {
}
```
### 2. Which issues (if any) are related?
If zone scopes in coredns plugin `template` is a double/single quoted list of zones, the plugin parser does not generated syntax error when coredns config file is loaded/reloaded. Instead, it converts the list into a single zone and add `.` at the end of the zone to make it a fully qualified domain name.

For example, the following template will be parsed into one zone [`a.com b.com c.com.`], instead of 3 zones [`a.com.`, `b.com.`, `c.com.`]
```
template ANY ANY "a.com b.com c.com" {
}
```
As a result, dns query name will not match any of the zone names.
In worse case, when the string of the whole list of quoted zones is longer than 255 chars, the plugin parser will convert the list into a single zone root [`.`], because it exceeds 255, the longest valid full domain name, according to [RFC2181](https://tools.ietf.org/html/rfc2181) and [coredns](https://github.com/coredns/coredns/blob/a6dbc837b3f04d0acda790fbccadf127945c4164/plugin/normalize.go#L94)
When that happens, all dns queries for the server block will fall into the `template`, causing dns server behave wrongly. In fact, this exact use case caused dns server outage in our production env.

### 3. Which documentation changes (if any) need to be made?
Change is not required in my opinion. Current [CoreDns manual](https://coredns.io/plugins/template/) does not explicitly specify that quoted zone scopes is a syntax error. It indicates that quotation marks are allowed.

### 4. Does this introduce a backward incompatible change or deprecation?
No. This change is backward compatible. 
