### PR TITLE
Rebase coredns to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,4 @@
-FROM debian:stable-slim
-
-RUN apt-get update && apt-get -uy upgrade
-RUN apt-get -y install ca-certificates && update-ca-certificates
-
-FROM scratch
-
-COPY --from=0 /etc/ssl/certs /etc/ssl/certs
+FROM gcr.io/distroless/static:latest
 ADD coredns /coredns
 
 EXPOSE 53 53/udp


### PR DESCRIPTION
Advantage of using Distroless comparing to empty baseimage.
* Avoid the caveats when running go static binaries due to some missing non-binary dependencies.
* Distroless has ca-certifiactes preinstalled.
* A nit Dockerfile.

See detailed comparisons in https://github.com/kubernetes/enhancements/blob/master/keps/sig-release/20190316-rebase-images-to-distroless.md#type-1-from-scratch

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
