### PR TITLE
fallthrough support for forward plugin

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     tls_servername NAME
     policy random|round_robin|sequential
     health_check DURATION
+    fallthrough [ZONES...]
 }
 ~~~
 
@@ -83,6 +84,10 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
+* `fallthrough` If zone matches and no record can be generated, pass request to the next plugin.
+  If **[ZONES...]** is omitted, then fallthrough happens for all zones for which the plugin
+  is authoritative. If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only
+  queries for those zones will be subject to fallthrough.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.
@@ -142,6 +147,17 @@ Proxy everything except `example.org` using the host's `resolv.conf`'s nameserve
 . {
     forward . /etc/resolv.conf {
         except example.org
+    }
+}
+~~~
+
+Load example.hosts file and only serve example.org and example.net from it and fall through to the
+next plugin if query doesn't match.
+
+~~~
+. {
+    hosts example.hosts example.org example.net {
+        fallthrough
     }
 }
 ~~~

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -65,7 +65,7 @@ func (f *Forward) Name() string { return "forward" }
 func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 
 	state := request.Request{W: w, Req: r}
-	qname := state.Name()
+	queryName := state.Name()
 	if !f.match(state) {
 		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
 	}
@@ -153,10 +153,6 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 			formerr.SetRcode(state.Req, dns.RcodeFormatError)
 			w.WriteMsg(formerr)
 
-			if f.fall.Through(qname) {
-				return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
-			}
-
 			return 0, taperr
 		}
 
@@ -164,11 +160,11 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		return 0, taperr
 	}
 
-	if !f.fall.Through(qname) && upstreamErr != nil {
+	if !f.fall.Through(queryName) && upstreamErr != nil {
 		return dns.RcodeServerFailure, upstreamErr
 	}
 
-	if f.fall.Through(qname) {
+	if f.fall.Through(queryName) {
 		return plugin.NextOrFailure(f.Name(), f.Next, ctx, w, r)
 	}
 

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -206,6 +206,8 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 			return fmt.Errorf("expire can't be negative: %s", dur)
 		}
 		f.expire = dur
+	case "fallthrough":
+		f.fall.SetZonesFromArgs(c.RemainingArgs())
 	case "policy":
 		if !c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -27,6 +27,8 @@ func TestSetup(t *testing.T) {
 		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true}, ""},
 		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true}, ""},
 		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, forceTCP: true}, ""},
+		{"forward . 127.0.0.1 {\nfallthrough\n}\n", false, ".", nil, 2, options{}, ""},
+		{"forward . 127.0.0.1 {\nfallthrough hello.com\n}\n", false, ".", nil, 2, options{}, ""},
 		{"forward . 127.0.0.1:53", false, ".", nil, 2, options{}, ""},
 		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{}, ""},
 		{"forward . [::1]:53", false, ".", nil, 2, options{}, ""},


### PR DESCRIPTION
fallthrough support for forward plugin

### 1. Why is this pull request needed and what does it do?

```
test {
    forward . 127.0.0.1:8600 {
        force_tcp
    }
    cache 300
}
```

In this situation, a plugin handles the query, but the reply it got from its backend (i.e. maybe it got NXDOMAIN) is such that it wants other plugins in the chain to take a look as well. If fallthrough is provided (and enabled!), the next plugin is called. A plugin that works like this is the hosts plugin. First, a lookup in the host table (/etc/hosts) is attempted, if it finds an answer, it returns that. If not, it will fallthrough to the next one in the hope that other plugins may return something to the client.

However looking at `forward` plugin, it doesn't seem to have support for `fallthrough` - https://coredns.io/plugins/forward/

This PR adds `fallthrough` support to `forward` plugin.

### 2. Which issues (if any) are related?

Not an issue. New feature

### 3. Which documentation changes (if any) need to be made?

`forward` plugin documentation

### 4. Does this introduce a backward incompatible change or deprecation?

Yes
