### PR TITLE
plugin/loadbalance Support shuffling of NS answers

### DIFF
--- a/plugin/loadbalance/loadbalance.go
+++ b/plugin/loadbalance/loadbalance.go
@@ -29,6 +29,7 @@ func roundRobin(in []dns.RR) []dns.RR {
 	cname := []dns.RR{}
 	address := []dns.RR{}
 	mx := []dns.RR{}
+	ns := []dns.RR{}
 	rest := []dns.RR{}
 	for _, r := range in {
 		switch r.Header().Rrtype {
@@ -38,6 +39,8 @@ func roundRobin(in []dns.RR) []dns.RR {
 			address = append(address, r)
 		case dns.TypeMX:
 			mx = append(mx, r)
+		case dns.TypeNS:
+			ns = append(ns, r)
 		default:
 			rest = append(rest, r)
 		}
@@ -45,10 +48,12 @@ func roundRobin(in []dns.RR) []dns.RR {
 
 	roundRobinShuffle(address)
 	roundRobinShuffle(mx)
+	roundRobinShuffle(ns)
 
 	out := append(cname, rest...)
 	out = append(out, address...)
 	out = append(out, mx...)
+	out = append(out, ns...)
 	return out
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

As support for randomizing of NS type answers in the loadbalance plugin.
This is to randomize answers to NS queries

```
dig NS example.com
```

### 2. Which issues (if any) are related?

This addresses issue #2797 

### 3. Which documentation changes (if any) need to be made?

No documentation changes should be required

### 4. Does this introduce a backward incompatible change or deprecation?

No
