### PR TITLE
plugin/loop: Update troubleshooting step

### DIFF
--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -80,7 +80,7 @@ requests to itself.
 
 There are many ways to work around this issue, some are listed here:
 
-* Add the following to your `kubelet` config yaml: `ResolverConfig: <path-to-your-real-resolv-conf-file>` (or via command line flag `--resolv-conf` deprecated in 1.10).  Your "real"
+* Add the following to your `kubelet` config yaml: `resolvConf: <path-to-your-real-resolv-conf-file>` (or via command line flag `--resolv-conf` deprecated in 1.10).  Your "real"
   `resolv.conf` is the one that contains the actual IPs of your upstream servers, and no local/loopback address.
   This flag tells `kubelet` to pass an alternate `resolv.conf` to Pods. For systems using `systemd-resolved`,
 `/run/systemd/resolve/resolv.conf` is typically the location of the "real" `resolv.conf`,

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -80,7 +80,7 @@ requests to itself.
 
 There are many ways to work around this issue, some are listed here:
 
-* Add the following to `kubelet`: `--resolv-conf <path-to-your-real-resolv-conf-file>`.  Your "real"
+* Add the following to your `kubelet` config yaml: `ResolverConfig: <path-to-your-real-resolv-conf-file>` (or set it with the deprecated command flag `--resolv-conf`).  Your "real"
   `resolv.conf` is the one that contains the actual IPs of your upstream servers, and no local/loopback address.
   This flag tells `kubelet` to pass an alternate `resolv.conf` to Pods. For systems using `systemd-resolved`,
 `/run/systemd/resolve/resolv.conf` is typically the location of the "real" `resolv.conf`,

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -80,7 +80,7 @@ requests to itself.
 
 There are many ways to work around this issue, some are listed here:
 
-* Add the following to your `kubelet` config yaml: `ResolverConfig: <path-to-your-real-resolv-conf-file>` (or set it with the deprecated command flag `--resolv-conf`).  Your "real"
+* Add the following to your `kubelet` config yaml: `ResolverConfig: <path-to-your-real-resolv-conf-file>` (or via command line flag `--resolv-conf` deprecated in 1.10).  Your "real"
   `resolv.conf` is the one that contains the actual IPs of your upstream servers, and no local/loopback address.
   This flag tells `kubelet` to pass an alternate `resolv.conf` to Pods. For systems using `systemd-resolved`,
 `/run/systemd/resolve/resolv.conf` is typically the location of the "real" `resolv.conf`,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Looks like `kubelet` has deprecated command flags, preferring options be specified in its config yaml file. This updates the corresponding troubleshooting step in *loop*.

### 2. Which issues (if any) are related?
#2790

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?