### PR TITLE
Remove trailing whitespaces

### DIFF
--- a/plugin/grpc/README.md
+++ b/plugin/grpc/README.md
@@ -22,7 +22,7 @@ grpc FROM TO...
 * **TO...** are the destination endpoints to proxy to. The number of upstreams is
   limited to 15.
 
-Multiple upstreams are randomized (see `policy`) on first use. When a proxy returns an error 
+Multiple upstreams are randomized (see `policy`) on first use. When a proxy returns an error
 the next upstream in the list is tried.
 
 Extra knobs are available with an expanded syntax:

--- a/plugin/pprof/setup_test.go
+++ b/plugin/pprof/setup_test.go
@@ -23,10 +23,10 @@ func TestPProf(t *testing.T) {
         }`, true},
 		{`pprof { block
                 }`, false},
-		{`pprof :1234 { 
+		{`pprof :1234 {
                    block 20
                 }`, false},
-		{`pprof { 
+		{`pprof {
                    block 20 30
                 }`, true},
 		{`pprof


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

While running make notices the following:
```
** presubmit/trailing-whitespace
plugin/grpc/README.md:Multiple upstreams are randomized (see `policy`) on first use. When a proxy returns an error
plugin/pprof/setup_test.go:		{`pprof :1234 {
plugin/pprof/setup_test.go:		{`pprof {
** presubmit/trailing-whitespace: please remove any trailing white space
```

This fix removes the whitespaces


### 2. Which issues (if any) are related?

n/a

### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>