### PR TITLE
New option in forward plugin to retry requests

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     tls_servername NAME
     policy random|round_robin|sequential
     health_check DURATION
+    retry_on RESPONCES...
 }
 ~~~
 
@@ -83,6 +84,8 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
+*  `retry_on` define proxy responses that require retry with next server. This makes sense with `sequential` policy.
+E.g. `retry_on NXDOMAIN`
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyfile"
+	"github.com/miekg/dns"
 )
 
 func init() {
@@ -220,7 +221,26 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}
-
+	case "retry_on":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		for {
+			code := -1
+			for k, v := range dns.RcodeToString {
+				if v == c.Val() {
+					code = k
+					break
+				}
+			}
+			if code == -1 {
+				return c.ArgErr()
+			}
+			f.retryOn = append(f.retryOn, code)
+			if !c.NextArg() {
+				break
+			}
+		}
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}


### PR DESCRIPTION
Added new option to forward plugin to retry request to next server in case of given responses. It makes sense with `sequential` policy. For example, if zone have public and private DNS servers and they resolve same fqdn to different addressees (external and internal) and public server gives NXDOMAIN on internal resources that can be resolved by internal server. It possible to define `retry_on NXDOMAIN` and have prioritized public addresses and internal if only internal available.

### 1. Why is this pull request needed and what does it do?
See above.
### 2. Which issues (if any) are related?
None, it's a FR.
### 3. Which documentation changes (if any) need to be made?
Already updated README.md
### 4. Does this introduce a backward incompatible change or deprecation?
No.
