### PR TITLE
plugin/health: cleanups

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-Enabled process wide health endpoint. When CoreDNS is up and running this returns a 200 OK http
+Enabled process wide health endpoint. When CoreDNS is up and running this returns a 200 OK HTTP
 status code. The health is exported, by default, on port 8080/health .
 
 ## Syntax

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -18,6 +18,7 @@ func (h *health) overloaded() {
 	}
 	url := "http://" + h.Addr
 	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
 
 	for {
 		select {
@@ -32,7 +33,6 @@ func (h *health) overloaded() {
 			HealthDuration.Observe(time.Since(start).Seconds())
 
 		case <-h.stop:
-			tick.Stop()
 			return
 		}
 	}

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -19,13 +19,12 @@ func init() {
 }
 
 func setup(c *caddy.Controller) error {
-	addr, lame, err := healthParse(c)
+	addr, lame, err := parse(c)
 	if err != nil {
 		return plugin.Error("health", err)
 	}
 
-	h := newHealth(addr)
-	h.lameduck = lame
+	h := &health{Addr: addr, stop: make(chan bool), lameduck: lame}
 
 	c.OnStartup(func() error {
 		metrics.MustRegister(c, HealthDuration)
@@ -40,7 +39,7 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func healthParse(c *caddy.Controller) (string, time.Duration, error) {
+func parse(c *caddy.Controller) (string, time.Duration, error) {
 	addr := ""
 	dur := time.Duration(0)
 	for c.Next() {

--- a/plugin/health/setup_test.go
+++ b/plugin/health/setup_test.go
@@ -30,7 +30,7 @@ func TestSetupHealth(t *testing.T) {
 
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		_, _, err := healthParse(c)
+		_, _, err := parse(c)
 
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %d: Expected error but found none for input %s", i, test.input)


### PR DESCRIPTION
Small, trivial cleanup: got triggered because I saw a comment on how
health plugins polls other plugins which isn't true.

* Remove useless newHealth function
* healthParse -> parse
* Remove useless constants

Net deletion of code.