### PR TITLE
plugin/metrics: fix failed reload

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -137,9 +137,7 @@ func (m *Metrics) stopServer() error {
 }
 
 // OnFinalShutdown tears down the metrics listener on shutdown and restart.
-func (m *Metrics) OnFinalShutdown() error {
-	return m.stopServer()
-}
+func (m *Metrics) OnFinalShutdown() error { return m.stopServer() }
 
 func keys(m map[string]struct{}) []string {
 	sx := []string{}

--- a/plugin/metrics/register.go
+++ b/plugin/metrics/register.go
@@ -7,7 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// MustRegister registers the prometheus Collectors when the metrics middleware is used.
+// MustRegister registers the prometheus Collectors when the metrics plugin is used.
 func MustRegister(c *caddy.Controller, cs ...prometheus.Collector) {
 	m := dnsserver.GetConfig(c).Handler("prometheus")
 	if m == nil {

--- a/plugin/metrics/setup_test.go
+++ b/plugin/metrics/setup_test.go
@@ -22,7 +22,7 @@ func TestPrometheusParse(t *testing.T) {
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.input)
-		m, err := prometheusParse(c)
+		m, err := parse(c)
 		if test.shouldErr && err == nil {
 			t.Errorf("Test %v: Expected error but found nil", i)
 			continue


### PR DESCRIPTION
Fix metrics endpoint on a failed reload, follows the same lines as the
previous PRs, see for e.g. 076b8d4f. Test with a Corefile with 2 server
blocks and metrics enabled and then introducing a syntax error:

~~~
[ERROR] Restart failed: Corefile:5 - Error during parsing: Unknown directive 'jfkdjk'
[ERROR] SIGUSR1: starting with listener file descriptors: Corefile:5 - Error during parsing: Unknown directive 'jfkdjk'
~~~

And then curl-ing the metrics endpoint.

See #2659 and as this is the last one.

Fixes: #2659

Getting this all right turns out to be tricky, also it's not easy
testable which is something I should fix.