### PR TITLE
plugin/autopath docs: remove last use of middleware

### DIFF
--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -20,7 +20,7 @@ through the search path.
 
 It is assume the search path ordering is identical between server and client.
 
-Middleware implementing autopath, must have a function called `AutoPath` of type
+Plugins implementing autopath, must have a function called `AutoPath` of type
 autopath.Func. Note the searchpath must be ending with the empty string.
 
 I.e:


### PR DESCRIPTION
This has somehow survived; the docs still used Middleware instead of
Plugins.