### PR TITLE
[test/responsewriter] provide mechanism to specify custom Remote IP a…

### DIFF
--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"net"
+	"sync/atomic"
 
 	"github.com/miekg/dns"
 )
@@ -42,7 +43,10 @@ func (t *ResponseWriter) RemoteAddr() net.Addr {
 }
 
 // WriteMsg implement dns.ResponseWriter interface.
-func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { t.writeMsgCallCount++; return nil }
+func (t *ResponseWriter) WriteMsg(m *dns.Msg) error {
+	atomic.AddUint64(&t.writeMsgCallCount, 1)
+	return nil
+}
 
 // Write implement dns.ResponseWriter interface.
 func (t *ResponseWriter) Write(buf []byte) (int, error) { return len(buf), nil }
@@ -60,10 +64,10 @@ func (t *ResponseWriter) TsigTimersOnly(bool) { return }
 func (t *ResponseWriter) Hijack() { return }
 
 // GetWriteMsgCallCount returns the number of WriteMsg calls that were made.
-func (t *ResponseWriter) GetWriteMsgCallCount() uint64 { return t.writeMsgCallCount }
+func (t *ResponseWriter) GetWriteMsgCallCount() uint64 { return atomic.LoadUint64(&t.writeMsgCallCount) }
 
 // ResetWriteMsgCallCount returns the number of WriteMsg calls that were made.
-func (t *ResponseWriter) ResetWriteMsgCallCount() { t.writeMsgCallCount = 0 }
+func (t *ResponseWriter) ResetWriteMsgCallCount() { atomic.StoreUint64(&t.writeMsgCallCount, 0) }
 
 // ResponseWriter6 returns fixed client and remote address in IPv6.  The remote
 // address is always fe80::42:ff:feca:4c65 and port 40212. The local address is always ::1 and port 53.

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -10,7 +10,9 @@ import (
 // remote will always be 10.240.0.1 and port 40212. The local address is always 127.0.0.1 and
 // port 53.
 type ResponseWriter struct {
-	TCP bool // if TCP is true we return an TCP connection instead of an UDP one.
+	TCP               bool // if TCP is true we return an TCP connection instead of an UDP one.
+	RemoteIP          net.IP
+	writeMsgCallCount uint64
 }
 
 // LocalAddr returns the local address, 127.0.0.1:53 (UDP, TCP if t.TCP is true).
@@ -25,7 +27,13 @@ func (t *ResponseWriter) LocalAddr() net.Addr {
 
 // RemoteAddr returns the remote address, always 10.240.0.1:40212 (UDP, TCP is t.TCP is true).
 func (t *ResponseWriter) RemoteAddr() net.Addr {
-	ip := net.ParseIP("10.240.0.1")
+	var ip net.IP
+	if t.RemoteIP != nil {
+		ip = t.RemoteIP
+	} else {
+		ip = net.ParseIP("10.240.0.1")
+	}
+
 	port := 40212
 	if t.TCP {
 		return &net.TCPAddr{IP: ip, Port: port, Zone: ""}
@@ -34,7 +42,7 @@ func (t *ResponseWriter) RemoteAddr() net.Addr {
 }
 
 // WriteMsg implement dns.ResponseWriter interface.
-func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { return nil }
+func (t *ResponseWriter) WriteMsg(m *dns.Msg) error { t.writeMsgCallCount++; return nil }
 
 // Write implement dns.ResponseWriter interface.
 func (t *ResponseWriter) Write(buf []byte) (int, error) { return len(buf), nil }
@@ -50,6 +58,12 @@ func (t *ResponseWriter) TsigTimersOnly(bool) { return }
 
 // Hijack implement dns.ResponseWriter interface.
 func (t *ResponseWriter) Hijack() { return }
+
+// GetWriteMsgCallCount returns the number of WriteMsg calls that were made.
+func (t *ResponseWriter) GetWriteMsgCallCount() uint64 { return t.writeMsgCallCount }
+
+// ResetWriteMsgCallCount returns the number of WriteMsg calls that were made.
+func (t *ResponseWriter) ResetWriteMsgCallCount() { t.writeMsgCallCount = 0 }
 
 // ResponseWriter6 returns fixed client and remote address in IPv6.  The remote
 // address is always fe80::42:ff:feca:4c65 and port 40212. The local address is always ::1 and port 53.
@@ -67,8 +81,14 @@ func (t *ResponseWriter6) LocalAddr() net.Addr {
 
 // RemoteAddr returns the remote address, always fe80::42:ff:feca:4c65 port 40212 (UDP, TCP is t.TCP is true).
 func (t *ResponseWriter6) RemoteAddr() net.Addr {
-	if t.TCP {
-		return &net.TCPAddr{IP: net.ParseIP("fe80::42:ff:feca:4c65"), Port: 40212, Zone: ""}
+	var ip net.IP
+	if t.RemoteIP != nil {
+		ip = t.RemoteIP
+	} else {
+		ip = net.ParseIP("fe80::42:ff:feca:4c65")
 	}
-	return &net.UDPAddr{IP: net.ParseIP("fe80::42:ff:feca:4c65"), Port: 40212, Zone: ""}
+	if t.TCP {
+		return &net.TCPAddr{IP: ip, Port: 40212, Zone: ""}
+	}
+	return &net.UDPAddr{IP: ip, Port: 40212, Zone: ""}
 }

--- a/plugin/whoami/whoami_test.go
+++ b/plugin/whoami/whoami_test.go
@@ -42,8 +42,9 @@ func TestWhoami(t *testing.T) {
 	for i, tc := range tests {
 		req := new(dns.Msg)
 		req.SetQuestion(dns.Fqdn(tc.qname), tc.qtype)
+		rw := &test.ResponseWriter{}
 
-		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		rec := dnstest.NewRecorder(rw)
 		code, err := wh.ServeDNS(ctx, rec, req)
 
 		if err != tc.expectedErr {
@@ -58,6 +59,11 @@ func TestWhoami(t *testing.T) {
 				if actual != expected {
 					t.Errorf("Test %d: Expected answer %s, but got %s", i, expected, actual)
 				}
+			}
+		}
+		if tc.expectedCode == dns.RcodeSuccess {
+			if rw.GetWriteMsgCallCount() != 1 {
+				t.Errorf("Test %d: Expected DNS message to be written on wire, but got %d", i, rw.GetWriteMsgCallCount())
 			}
 		}
 	}

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/test"
@@ -21,6 +22,22 @@ func TestRequestDo(t *testing.T) {
 func TestRequestRemote(t *testing.T) {
 	st := testRequest()
 	if st.IP() != "10.240.0.1" {
+		t.Errorf("Wrong IP from request")
+	}
+	p := st.Port()
+	if p == "" {
+		t.Errorf("Failed to get Port from request")
+	}
+	if p != "40212" {
+		t.Errorf("Wrong port from request")
+	}
+}
+
+func TestRequestRemoteCustomIP(t *testing.T) {
+	ip := "192.0.2.1"
+
+	st := testRequestFromIP(net.ParseIP(ip))
+	if st.IP() != ip {
 		t.Errorf("Wrong IP from request")
 	}
 	p := st.Port()
@@ -261,6 +278,15 @@ func testRequest() Request {
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(4096, true)
 	return Request{W: &test.ResponseWriter{}, Req: m}
+}
+
+func testRequestFromIP(ip net.IP) Request {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetEdns0(4096, true)
+	rw := &test.ResponseWriter{}
+	rw.RemoteIP = ip
+	return Request{W: rw, Req: m}
 }
 
 func TestRequestClear(t *testing.T) {


### PR DESCRIPTION
…ddress and number of message written

This is useful to build test when the behaviour may be expected based on client IP (Geo IP and the likes)

GetWriteMsgCallCount() make it easier to validate if WriteMsg was called or not.

request/request_test.go contains a test validating the custom IP.
plugin/whoami/whoami_test.go test was modified to validate the
GetWriteMsgCallCount() function.


### 1. Why is this pull request needed and what does it do?

This PR allow customizing the source IP of a test.ResponseWriter

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None that I know.

### 4. Does this introduce a backward incompatible change or deprecation?

No