### PR TITLE
Add external mdns plugin

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -39,6 +39,7 @@ any:any
 chaos:chaos
 loadbalance:loadbalance
 cache:cache
+mdns:github.com/openshift-metal3/coredns-mdns
 rewrite:rewrite
 dnssec:dnssec
 autopath:autopath


### PR DESCRIPTION
This adds a plugin that reads mDNS records from the local network
and responds to queries based on those records. It is useful for
providing mDNS records to non-mDNS-aware applications by making
them accessible through a standard DNS server.