### PR TITLE
Add server instance to the context in ServerTLS and ServerHTTPS

### DIFF
--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -129,7 +129,8 @@ func (s *ServergRPC) Query(ctx context.Context, in *pb.DnsPacket) (*pb.DnsPacket
 
 	w := &gRPCresponse{localAddr: s.listenAddr, remoteAddr: a, Msg: msg}
 
-	s.ServeDNS(ctx, w, msg)
+	dnsCtx := context.WithValue(ctx, Key{}, s.Server)
+	s.ServeDNS(dnsCtx, w, msg)
 
 	packed, err := w.Msg.Pack()
 	if err != nil {

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -117,7 +117,7 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// We just call the normal chain handler - all error handling is done there.
 	// We should expect a packet to be returned that we can send to the client.
-	ctx := context.WithValue(context.Background(), Key{}, s)
+	ctx := context.WithValue(context.Background(), Key{}, s.Server)
 	s.ServeDNS(ctx, dw, msg)
 
 	// See section 4.2.1 of RFC 8484.

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -117,7 +117,8 @@ func (s *ServerHTTPS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// We just call the normal chain handler - all error handling is done there.
 	// We should expect a packet to be returned that we can send to the client.
-	s.ServeDNS(context.Background(), dw, msg)
+	ctx := context.WithValue(context.Background(), Key{}, s)
+	s.ServeDNS(ctx, dw, msg)
 
 	// See section 4.2.1 of RFC 8484.
 	// We are using code 500 to indicate an unexpected situation when the chain

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -44,7 +44,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 
 	// Only fill out the TCP server for this one.
 	s.server[tcp] = &dns.Server{Listener: l, Net: "tcp-tls", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.WithValue(context.Background(), Key{}, s)
+		ctx := context.WithValue(context.Background(), Key{}, s.Server)
 		s.ServeDNS(ctx, w, r)
 	})}
 	s.m.Unlock()

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -44,7 +44,7 @@ func (s *ServerTLS) Serve(l net.Listener) error {
 
 	// Only fill out the TCP server for this one.
 	s.server[tcp] = &dns.Server{Listener: l, Net: "tcp-tls", Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
-		ctx := context.Background()
+		ctx := context.WithValue(context.Background(), Key{}, s)
 		s.ServeDNS(ctx, w, r)
 	})}
 	s.m.Unlock()


### PR DESCRIPTION
The problem with the current code is that there's no way to get the server instance inside a plugin.
Because of that "metrics" plugin sets empty "server" label for requests served over TLS or HTTPS.
