### PR TITLE
Add render.com to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -27,3 +27,4 @@
 * [Zinza Technology](https://zinza.com.vn) uses CoreDNS within Kubernetes in production, with standard configuration.
 * [Hualala](https://www.hualala.com/home)  uses CoreDNS in Kubernetes using default configuration, in its Lab. Expected to be in production soon.
 * [Hellofresh](https://www.hellofresh.com/) uses CoreDNS in multiple Kubernetes clusters, with Forward plugin.
+* [Render](https://render.com) uses CoreDNS in production across all its Kubernetes clusters.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
It adds [Render](https://render.com) (a modern cloud provider) to the list of CoreDNS adopters.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
No.