### PR TITLE
plugin/kubernetes: skip deleting pods

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -372,11 +372,6 @@ func (k *Kubernetes) findPods(r recordRequest, zone string) (pods []msg.Service,
 			continue
 		}
 
-		// exclude pods in the process of termination
-		if p.Deleting {
-			continue
-		}
-
 		// check for matching ip and namespace
 		if ip == p.PodIP && match(namespace, p.Namespace) {
 			s := msg.Service{Key: strings.Join([]string{zonePath, Pod, namespace, podname}, "/"), Host: ip, TTL: k.ttl}

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -7,6 +7,7 @@ import (
 
 // Endpoints is a stripped down api.Endpoints with only the items we need for CoreDNS.
 type Endpoints struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
 	Version   string
 	Name      string
 	Namespace string

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -7,11 +7,11 @@ import (
 
 // Pod is a stripped down api.Pod with only the items we need for CoreDNS.
 type Pod struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
 	Version   string
 	PodIP     string
 	Name      string
 	Namespace string
-	Deleting  bool
 
 	*Empty
 }
@@ -29,9 +29,10 @@ func ToPod(obj interface{}) interface{} {
 		Namespace: pod.GetNamespace(),
 		Name:      pod.GetName(),
 	}
+	// don't add pods that are being deleted.
 	t := pod.ObjectMeta.DeletionTimestamp
-	if t != nil {
-		p.Deleting = !(*t).Time.IsZero()
+	if t != nil && !(*t).Time.IsZero() {
+		return nil
 	}
 
 	*pod = api.Pod{}
@@ -48,7 +49,6 @@ func (p *Pod) DeepCopyObject() runtime.Object {
 		PodIP:     p.PodIP,
 		Namespace: p.Namespace,
 		Name:      p.Name,
-		Deleting:  p.Deleting,
 	}
 	return p1
 }

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -7,6 +7,7 @@ import (
 
 // Service is a stripped down api.Service with only the items we need for CoreDNS.
 type Service struct {
+	// Don't add new fields to this struct without talking to the CoreDNS maintainers.
 	Version      string
 	Name         string
 	Namespace    string


### PR DESCRIPTION
Don't add pods to our internal cache that are being deleted. This saves
a field in the struct as well.

Add (extra) comments about adding fields to the
object/{Pod,Service,Endpoint} structs.

See #2846 for a discussion. No documentation changes are needed and this
should be backwards compatible.