### PR TITLE
plugin/template: allow an empty response

### DIFF
--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -155,10 +155,6 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 			t.regex = append(t.regex, regexp.MustCompile(".*"))
 		}
 
-		if len(t.answer) == 0 && len(t.authority) == 0 && t.rcode == dns.RcodeSuccess {
-			return handler, c.Errf("no answer section for template found: %v", handler)
-		}
-
 		handler.Templates = append(handler.Templates, t)
 	}
 

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -36,13 +36,6 @@ func TestSetupParse(t *testing.T) {
 		{`template X`, true},
 		{`template ANY`, true},
 		{`template ANY X`, true},
-		{`template ANY ANY (?P<x>`, true},
-		{
-			`template ANY ANY {
-
-			}`,
-			true,
-		},
 		{
 			`template ANY ANY .* {
 				notavailable
@@ -92,6 +85,13 @@ func TestSetupParse(t *testing.T) {
 			true,
 		},
 		// examples
+		{`template ANY ANY (?P<x>`, false},
+		{
+			`template ANY ANY {
+
+			}`,
+			false,
+		},
 		{
 			`template ANY A example.com {
 				match ip-(?P<a>[0-9]*)-(?P<b>[0-9]*)-(?P<c>[0-9]*)-(?P<d>[0-9]*)[.]example[.]com


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Allows _template_ to produce a NODATA response.
Desire to do this has come up several times in the past, specifically to create a black hole for AAAA requests.  This would allow users to do that with ...

```
   template IN AAAA .
``` 

But in general, I see _template_ as a flexible hacking/debugging tool, and I think allowing a NODATA response makes it a bit more flexible.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?