### PR TITLE
be sure to close connection after completion of xfr out

### DIFF
--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -33,7 +33,10 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	ch := make(chan *dns.Envelope)
 	defer close(ch)
 	tr := new(dns.Transfer)
-	go tr.Out(w, r, ch)
+	go func() {
+		tr.Out(w, r, ch)
+		w.Close()
+	}()
 
 	j, l := 0, 0
 	records = append(records, records[0]) // add closing SOA to the end
@@ -51,7 +54,6 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	}
 
 	w.Hijack()
-	// w.Close() // Client closes connection
 	return dns.RcodeSuccess, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

It makes sure that the 'file' plugin closes the TCP connection when it responds to a zone transfer request.  Otherwise the connection and associated socket will stay in the CLOSE_WAIT state unless/until golang runtime performs GC (which is not documented, but it closes the socket when a TCP connection object is garbage collected).  This is the case even if the client closes the connection (as the original code comment suggests).  Maybe the original code assumed it's enough to let the GC do the job, but I think it's better to close it explicitly since sockets and file descriptors are a different kind of system resource than memory, and can sometimes be more scarce.

### 2. Which issues (if any) are related?

I've not filed a corresponding github issue.  It's easy to reproduce by running coredns with the file plugin and having it respond to an xfr request, and then checking the connection state using tools like netstat or lsof.

### 3. Which documentation changes (if any) need to be made?

I don't think this requires a documentation change, as the effect is mostly invisible to users. (but if the proposed change and its rationale make sense, you may want to update the usage example for miekg/dns.Transfer.Out()).

### 4. Does this introduce a backward incompatible change or deprecation?

I believe the new behavior backward compatible.  I realize that the connection can't accept any subsequent requests if we close it after xfr, but the original implementation can't either anyway, since it "hijacks" the writer.
