### PR TITLE
plugin/kubernetes: Use target namespaces in endpoint fqdns

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -292,7 +292,7 @@ func endpointFQDN(ep *object.Endpoints, zone string, endpointNameMode bool) []st
 	var names []string
 	for _, ss := range ep.Subsets {
 		for _, addr := range ss.Addresses {
-			names = append(names, dnsutil.Join(endpointHostname(addr, endpointNameMode), serviceFQDN(ep, zone)))
+			names = append(names, dnsutil.Join(endpointHostname(addr, endpointNameMode), ep.GetName(), addr.TargetRefNamespace, Svc, zone))
 		}
 	}
 	return names

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -292,7 +292,13 @@ func endpointFQDN(ep *object.Endpoints, zone string, endpointNameMode bool) []st
 	var names []string
 	for _, ss := range ep.Subsets {
 		for _, addr := range ss.Addresses {
-			names = append(names, dnsutil.Join(endpointHostname(addr, endpointNameMode), ep.GetName(), addr.TargetRefNamespace, Svc, zone))
+			var namespace string
+			if addr.TargetRefNamespace != "" {
+				namespace = addr.TargetRefNamespace
+			} else {
+				namespace = ep.Namespace
+			}
+			names = append(names, dnsutil.Join(endpointHostname(addr, endpointNameMode), ep.GetName(), namespace, Svc, zone))
 		}
 	}
 	return names

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -130,7 +130,7 @@ func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
 			Subsets: []object.EndpointSubset{
 				{
 					Addresses: []object.EndpointAddress{
-						{IP: "172.0.0.1", Hostname: "ep1a"},
+						{IP: "172.0.0.1", Hostname: "ep1a", TargetRefNamespace: "testns"},
 					},
 					Ports: []object.EndpointPort{
 						{Port: 80, Protocol: "tcp", Name: "http"},
@@ -144,7 +144,7 @@ func (APIConnServiceTest) EpIndex(string) []*object.Endpoints {
 			Subsets: []object.EndpointSubset{
 				{
 					Addresses: []object.EndpointAddress{
-						{IP: "172.0.0.2"},
+						{IP: "172.0.0.2", TargetRefNamespace: "testns2"},
 					},
 					Ports: []object.EndpointPort{
 						{Port: 80, Protocol: "tcp", Name: "http"},
@@ -187,7 +187,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 			Subsets: []object.EndpointSubset{
 				{
 					Addresses: []object.EndpointAddress{
-						{IP: "172.0.0.1", Hostname: "ep1a"},
+						{IP: "172.0.0.1", Hostname: "ep1a", TargetRefNamespace: "testns"},
 					},
 					Ports: []object.EndpointPort{
 						{Port: 80, Protocol: "tcp", Name: "http"},
@@ -201,7 +201,7 @@ func (APIConnServiceTest) EndpointsList() []*object.Endpoints {
 			Subsets: []object.EndpointSubset{
 				{
 					Addresses: []object.EndpointAddress{
-						{IP: "172.0.0.2"},
+						{IP: "172.0.0.2", TargetRefNamespace: "testns2"},
 					},
 					Ports: []object.EndpointPort{
 						{Port: 80, Protocol: "tcp", Name: "http"},
@@ -401,11 +401,13 @@ func TestEndpointFQDN(t *testing.T) {
 				{
 					Addresses: []object.EndpointAddress{
 						{
-							IP:       "172.0.0.1",
-							Hostname: "ep1a",
+							IP:                 "172.0.0.1",
+							Hostname:           "ep1a",
+							TargetRefNamespace: "testns",
 						},
 						{
-							IP: "172.0.0.2",
+							IP:                 "172.0.0.2",
+							TargetRefNamespace: "testns2",
 						},
 					},
 				},
@@ -416,7 +418,7 @@ func TestEndpointFQDN(t *testing.T) {
 
 	expected := []string{
 		"ep1a.svc1.testns.svc.cluster.local.",
-		"172-0-0-2.svc1.testns.svc.cluster.local.",
+		"172-0-0-2.svc1.testns2.svc.cluster.local.",
 	}
 
 	for i := range fqdns {

--- a/plugin/kubernetes/object/endpoint.go
+++ b/plugin/kubernetes/object/endpoint.go
@@ -27,10 +27,11 @@ type EndpointSubset struct {
 
 // EndpointAddress is a tuple that describes single IP address.
 type EndpointAddress struct {
-	IP            string
-	Hostname      string
-	NodeName      string
-	TargetRefName string
+	IP                 string
+	Hostname           string
+	NodeName           string
+	TargetRefName      string
+	TargetRefNamespace string
 }
 
 // EndpointPort is a tuple that describes a single port.
@@ -75,6 +76,7 @@ func ToEndpoints(obj interface{}) interface{} {
 			}
 			if a.TargetRef != nil {
 				ea.TargetRefName = a.TargetRef.Name
+				ea.TargetRefNamespace = a.TargetRef.Namespace
 			}
 			sub.Addresses[j] = ea
 		}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Endpoints can target Pods in other namespaces.  Although this doesn't happen normally when endpoints are automatically created based on Service selectors, it can occur when an endpoint is manually created.  

Since each target of an endpoint can be in a different namespace, this means we have to store the target's namespace in addition to the name in our custom object.  This increases memory footprint of the endpoint cache.

If the added memory is a concern, one strategy we could use to reduce memory in the k8s object cache could be to maintain a list of enumerated namespaces, which would allow us to replace all namespace strings in our custom objects with integers.

### 2. Which issues (if any) are related?

@johnbelamaric discovered this issue when looking into https://github.com/kubernetes/kubernetes/issues/47992

### 3. Which documentation changes (if any) need to be made?

none?  Probably too esoteric to come up in the readme.

### 4. Does this introduce a backward incompatible change or deprecation?

no