### PR TITLE
Revert "be sure to close connection after completion of xfr out. (#2866)"

### DIFF
--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -33,10 +33,7 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	ch := make(chan *dns.Envelope)
 	defer close(ch)
 	tr := new(dns.Transfer)
-	go func() {
-		tr.Out(w, r, ch)
-		w.Close()
-	}()
+	go tr.Out(w, r, ch)
 
 	j, l := 0, 0
 	records = append(records, records[0]) // add closing SOA to the end
@@ -54,6 +51,7 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	}
 
 	w.Hijack()
+	// w.Close() // Client closes connection
 	return dns.RcodeSuccess, nil
 }
 


### PR DESCRIPTION
This reverts commit a657e1f6618ee94c46fa9374dd29c21345710d38.

See https://github.com/coredns/coredns/pull/2866

This might still be needed, but it kills our CI, revert for now and then
figure out what's needed here.