### PR TITLE
Fix lowercase presummit

### DIFF
--- a/plugin/kubernetes/metadata_test.go
+++ b/plugin/kubernetes/metadata_test.go
@@ -120,7 +120,7 @@ func TestMetadata(t *testing.T) {
 			md[l] = metadata.ValueFunc(ctx, l)()
 		}
 		if mapsDiffer(tc.Md, md) {
-			t.Errorf("case %d expected metadata %v and got %v", i, tc.Md, md)
+			t.Errorf("Case %d expected metadata %v and got %v", i, tc.Md, md)
 		}
 	}
 }


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

While running make encountered the following error:
```
$ docker run -i -t --rm -v $PWD:/v --net=host -w /v golang:1.12 make
...
...
** presubmit/test-lowercase
plugin/kubernetes/metadata_test.go:			t.Errorf("case %d expected metadata %v and got %v", i, tc.Md, md)
** presubmit/test-lowercase: please start with an upper case letter when using t.Error*()
Makefile:62: recipe for target 'presubmit' failed
make: *** [presubmit] Error 1
```


### 2. Which issues (if any) are related?
n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?
n/a
Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
