### PR TITLE
plugin/cache: allow disabling of positive/negative cache

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -53,8 +53,12 @@ cache [TTL] [ZONES...] {
 
 ## Capacity and Eviction
 
-If **CAPACITY** _is not_ specified, the default cache size is 9984 per cache. The minimum allowed cache size is 1024.
-If **CAPACITY** _is_ specified, the actual cache size used will be rounded down to the nearest number divisible by 256 (so all shards are equal in size).
+If **CAPACITY** is zero, the corresponding cache will be disabled.
+
+If **CAPACITY** _is not_ specified, the default cache size is 9984 per cache.
+
+If **CAPACITY** _is_ specified, the actual cache size used will be rounded down to the nearest 
+number divisible by 256 (so all shards are equal in size). The minimum allowed cache size is 1024.
 
 Eviction is done per shard. In effect, when a shard reaches capacity, items are evicted from that shard.
 Since shards don't fill up perfectly evenly, evictions will occur before the entire cache reaches full capacity.
@@ -100,6 +104,16 @@ Enable caching for all zones, keep a positive cache size of 5000 and a negative 
      cache {
          success 5000
          denial 2500
+    }
+ }
+ ~~~
+
+Enable caching for all zones but disable negative caching:
+
+~~~ corefile
+ . {
+     cache {
+         denial 0
     }
  }
  ~~~

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -345,9 +345,8 @@ func zeroLengthCacheBackend(pos bool) plugin.Handler {
 		w.WriteMsg(m)
 		if pos {
 			return dns.RcodeSuccess, nil
-		} else {
-			return dns.RcodeNameError, nil
 		}
+		return dns.RcodeNameError, nil
 	})
 }
 

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -191,8 +191,12 @@ func cacheParse(c *caddy.Controller) (*Cache, error) {
 		}
 		ca.Zones = origins
 
-		ca.pcache = cache.New(ca.pcap)
-		ca.ncache = cache.New(ca.ncap)
+		if ca.pcap > 0 {
+			ca.pcache = cache.New(ca.pcap)
+		}
+		if ca.ncap > 0 {
+			ca.ncache = cache.New(ca.ncap)
+		}
 	}
 
 	return ca, nil


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Allows users to specify zero for positive or negative cache to disable the corresponding cache.

This expands on #2588, ...
* skips initialization of a cache if disabled (zero length)
* adds unit test
* updates README

### 2. Which issues (if any) are related?

#2588 (stalled)

### 3. Which documentation changes (if any) need to be made?

included

### 4. Does this introduce a backward incompatible change or deprecation?

not realistically