### PR TITLE
Raise error if regexp and template are not specified together

### DIFF
--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -120,7 +120,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 					}
 				}
 
-				// regexp
+				// regexp template
 				if c.NextArg() {
 					a.loader.re, err = regexp.Compile(c.Val())
 					if err != nil {
@@ -129,10 +129,10 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 					if a.loader.re.NumSubexp() == 0 {
 						return a, c.Errf("Need at least one sub expression")
 					}
-				}
 
-				// template
-				if c.NextArg() {
+					if !c.NextArg() {
+						return a, c.ArgErr()
+					}
 					a.loader.template = rewriteToExpand(c.Val())
 				}
 

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -75,6 +75,13 @@ func TestAutoParse(t *testing.T) {
 			}`,
 			true, "/tmp", "bliep", `(.*)`, 10 * time.Second, nil,
 		},
+		// no template specified.
+		{
+			`auto {
+				directory /tmp (.*)
+			}`,
+			true, "/tmp", "", `(.*)`, 60 * time.Second, nil,
+		},
 		// no directory specified.
 		{
 			`auto example.org {


### PR DESCRIPTION
Signed-off-by: Xiao An <hac@zju.edu.cn>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Bond `regexp` and `template` together for the directive `directory`, so that users have to specify either both or none of them, as described in the README. 

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
No.