### PR TITLE
core: Close (TCP) connections

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -188,6 +188,8 @@ func (s *Server) Address() string { return s.Addr }
 // defined in the request so that the correct zone
 // (configuration and plugin stack) will handle the request.
 func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) {
+	defer w.Close()
+
 	// The default dns.Mux checks the question section size, but we have our
 	// own mux here. Check if we have a question section. If not drop them here.
 	if r == nil || len(r.Question) == 0 {

--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -50,8 +50,6 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 		ch <- &dns.Envelope{RR: records[j:]}
 	}
 
-	w.Hijack()
-	// w.Close() // Client closes connection
 	return dns.RcodeSuccess, nil
 }
 


### PR DESCRIPTION
This was triggered by #2866 and #2872, but it triggers a race. It seems
simpler to just close this in the main server so none of the plugins
need to worry about it.

Unrelated: it may be worth checking/finding out how useful Hijack
actually is in miekg/dns

/cc @jinmeiib