### PR TITLE
Provide example to utilize k8s_external plugin

### DIFF
--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -83,7 +83,6 @@ spec:
  type: ClusterIP
 ~~~
 
-This will create a resource record for `test.default.example.org`.
 
 # Also See
 

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -68,7 +68,7 @@ Enable names under `example.org` to be resolved to in cluster DNS addresses.
 }
 ~~~
 
-Create a service in Kubernetes.
+With the Corefile above, the following Service will get an `A` record for `test.default.example.org` with IP address `192.168.200.123`.
 
 ~~~
 apiVersion: v1

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -68,6 +68,23 @@ Enable names under `example.org` to be resolved to in cluster DNS addresses.
 }
 ~~~
 
+Create a service in Kubernetes.
+
+~~~
+apiVersion: v1
+kind: Service
+metadata:
+ name: test
+ namespace: default
+spec:
+ clusterIP: None
+ externalIPs:
+ - 192.168.200.123
+ type: ClusterIP
+~~~
+
+This will create a resource record for `test.default.example.org`.
+
 # Also See
 
 For some background see [resolve external IP address](https://github.com/kubernetes/dns/issues/242).


### PR DESCRIPTION
The example provides a specific use case of k8s_external and may help others to grasp `k8s_external`'s capabilities.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
For me as a DNS newbie it is quite challenging to read the description of the plugin. I was unsure what it actually provided.

### 2. Which issues (if any) are related?
n/a

### 3. Which documentation changes (if any) need to be made?
n/a

### 4. Does this introduce a backward incompatible change or deprecation?
No