### PR TITLE
TLS hardening

### DIFF
--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -27,7 +27,6 @@ func setup(c *caddy.Controller) error {
 }
 
 func setTLSDefaults(tls *ctls.Config) {
-	os.Setenv("GODEBUG", "tls13=1")
 	tls.MinVersion = ctls.VersionTLS12
 	tls.MaxVersion = ctls.VersionTLS13
 	tls.CipherSuites = []uint16{

--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -26,7 +26,7 @@ func setup(c *caddy.Controller) error {
 	return nil
 }
 
-func hardenTLS(tls *ctls.Config) {
+func setTLSDefaults(tls *ctls.Config) {
 	os.Setenv("GODEBUG", "tls13=1")
 	tls.MinVersion = ctls.VersionTLS12
 	tls.MaxVersion = ctls.VersionTLS13
@@ -90,7 +90,7 @@ func parseTLS(c *caddy.Controller) error {
 		// NewTLSConfigFromArgs only sets RootCAs, so we need to let ClientCAs refer to it.
 		tls.ClientCAs = tls.RootCAs
 
-		hardenTLS(tls)
+		setTLSDefaults(tls)
 
 		config.TLSConfig = tls
 	}

--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -2,7 +2,6 @@ package tls
 
 import (
 	ctls "crypto/tls"
-	"os"
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The TLS plugin overwrites the tls.Config from Caddy, and zeroes the minimum version, maximum version and default ciphersuites.

This results in some issues when using CoreDNS with TLS support:

SSLv3, TLSv1.0 and TLSv1.1 are accepted.
The are some weak ciphersuites accepted.
No server preferred ciphersuite order is provided.
No TLS 1.3 support

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2935

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
Drops support for SSLv3, TLS v1.0 and TLS v1.1