### PR TITLE
Move to dns.Truncate

### DIFF
--- a/request/writer.go
+++ b/request/writer.go
@@ -15,8 +15,7 @@ func NewScrubWriter(req *dns.Msg, w dns.ResponseWriter) *ScrubWriter { return &S
 // scrub on the message m and will then write it to the client.
 func (s *ScrubWriter) WriteMsg(m *dns.Msg) error {
 	state := Request{Req: s.req, W: s.ResponseWriter}
-
-	n := state.Scrub(m)
-	state.SizeAndDo(n)
-	return s.ResponseWriter.WriteMsg(n)
+	state.SizeAndDo(m)
+	state.Scrub(m)
+	return s.ResponseWriter.WriteMsg(m)
 }


### PR DESCRIPTION
Ditch our truncation code and use the upstream one in miekg/dns.
This saves code on our end, end upstream is also more efficient as every
RR is Len-ed only once. With our bin-search this is not guaranteed.

Fixes #2728