### PR TITLE
file: close correctlty after AXFR

### DIFF
--- a/test/file_xfr_test.go
+++ b/test/file_xfr_test.go
@@ -80,7 +80,7 @@ func TestLargeAXFR(t *testing.T) {
 		t.Fatalf("Got an unexpected number of RRs: %d", nrr)
 	}
 
-	// Once xfr is completed the server should close the connection, so a further read should result in an error.
+	// Once xfr is completed the server closes the connection, so a further read should result in an error.
 	co.SetReadDeadline(time.Now().Add(time.Second))
 	_, err = co.ReadMsg()
 	if err == nil {


### PR DESCRIPTION
Don't hijack, but wait for the writes to be done and then safely close
the connection.

Fixes: #2929

Signed-off-by: Miek Gieben <miek@miek.nl>