### PR TITLE
plugins: set upstream unconditionally

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -18,7 +18,6 @@ auto [ZONES...] {
     directory DIR [REGEXP ORIGIN_TEMPLATE]
     transfer to ADDRESS...
     reload DURATION
-    upstream
 }
 ~~~
 
@@ -37,8 +36,6 @@ are used.
 * `reload` interval to perform reloads of zones if SOA version changes and zonefiles. It specifies how often CoreDNS should scan the directory to watch for file removal and addition. Default is one minute.
   Value of `0` means to not scan for changes and reload. eg. `30s` checks zonefile every 30 seconds
   and reloads zone when serial changes.
-* `upstream` defines upstream resolvers to be used resolve external names found (think CNAMEs)
-  pointing to external names. CoreDNS will resolve CNAMEs against itself.
 
 All directives from the *file* plugin are supported. Note that *auto* will load all zones found,
 even though the directive might only receive queries for a specific zone. I.e:

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -100,6 +100,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 		for i := range a.Zones.origins {
 			a.Zones.origins[i] = plugin.Host(a.Zones.origins[i]).Normalize()
 		}
+		a.loader.upstream = upstream.New()
 
 		for c.NextBlock() {
 			switch c.Val() {
@@ -148,8 +149,8 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 				a.loader.ReloadInterval = d
 
 			case "upstream":
+				// remove soon
 				c.RemainingArgs() // eat remaining args
-				a.loader.upstream = upstream.New()
 
 			case "transfer":
 				t, _, e := parse.Transfer(c, false)

--- a/plugin/auto/setup_test.go
+++ b/plugin/auto/setup_test.go
@@ -55,7 +55,6 @@ func TestAutoParse(t *testing.T) {
 				directory /tmp (.*) bliep
 				transfer to 127.0.0.1
 				transfer to 127.0.0.2
-				upstream 8.8.8.8
 			}`,
 			false, "/tmp", "bliep", `(.*)`, 60 * time.Second, []string{"127.0.0.1:53", "127.0.0.2:53"},
 		},

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -32,7 +32,6 @@ etcd [ZONES...] {
     path PATH
     endpoint ENDPOINT...
     credentials USERNAME PASSWORD
-    upstream
     tls CERT KEY CACERT
 }
 ~~~
@@ -44,9 +43,6 @@ etcd [ZONES...] {
 * **PATH** the path inside etcd. Defaults to "/skydns".
 * **ENDPOINT** the etcd endpoints. Defaults to "http://localhost:2379".
 * `credentials` is used to set the **USERNAME** and **PASSWORD** for accessing the etcd cluster.
-* `upstream` upstream resolvers to be used resolve external names found in etcd (think CNAMEs)
-  pointing to external names. If you want CoreDNS to act as a proxy for clients, you'll need to add
-  the *forward* plugin.
 * `tls` followed by:
 
     * no arguments, if the server certificate is signed by a system-installed CA and no client cert is needed
@@ -78,7 +74,6 @@ This is the default SkyDNS setup, with everything specified in full:
     etcd skydns.local {
         path /skydns
         endpoint http://localhost:2379
-        upstream
     }
     prometheus
     cache 160 skydns.local
@@ -94,7 +89,6 @@ when resolving external pointing CNAMEs.
 . {
     etcd skydns.local {
         path /skydns
-        upstream
     }
     cache 160 skydns.local
     forward . /etc/resolv.conf

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -45,6 +45,9 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 		username  string
 		password  string
 	)
+
+	etc.Upstream = upstream.New()
+
 	for c.Next() {
 		etc.Zones = c.RemainingArgs()
 		if len(etc.Zones) == 0 {
@@ -75,9 +78,8 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 				}
 				endpoints = args
 			case "upstream":
-				// check args != 0 and error in the future
-				c.RemainingArgs() // clear buffer
-				etc.Upstream = upstream.New()
+				// remove soon
+				c.RemainingArgs()
 			case "tls": // cert key cacertfile
 				args := c.RemainingArgs()
 				tlsConfig, err = mwtls.NewTLSConfigFromArgs(args...)

--- a/plugin/etcd/setup_test.go
+++ b/plugin/etcd/setup_test.go
@@ -35,20 +35,6 @@ func TestSetupEtcd(t *testing.T) {
 }
 `, false, "skydns", []string{"localhost:300"}, "", "", "",
 		},
-		//test for upstream
-		{
-			`etcd {
-	endpoint localhost:300
-	upstream 8.8.8.8:53 8.8.4.4:53
-}`, false, "skydns", []string{"localhost:300"}, "", "", "",
-		},
-		//test for optional upstream address
-		{
-			`etcd {
-	endpoint localhost:300
-	upstream
-}`, false, "skydns", []string{"localhost:300"}, "", "", "",
-		},
 		// negative
 		{
 			`etcd {

--- a/plugin/federation/README.md
+++ b/plugin/federation/README.md
@@ -17,15 +17,11 @@ Enabling *federation* without also having *kubernetes* is a noop.
 ~~~
 federation [ZONES...] {
     NAME DOMAIN
-    upstream
 }
 ~~~
 
 * Each **NAME** and **DOMAIN** defines federation membership. One entry for each. A duplicate
   **NAME** will silently overwrite any previous value.
-* `upstream` resolve the `CNAME` target produced by this plugin.  CoreDNS
-  will resolve External Services against itself and needs the *forward* plugin to be active to do
-  so.
 
 ## Examples
 
@@ -37,7 +33,6 @@ Here we handle all service requests in the `prod` and `stage` federations.
     federation cluster.local {
         prod prod.feddomain.com
         staging staging.feddomain.com
-        upstream
     }
     forward . 192.168.1.12
 }

--- a/plugin/federation/setup.go
+++ b/plugin/federation/setup.go
@@ -47,6 +47,7 @@ func setup(c *caddy.Controller) error {
 
 func federationParse(c *caddy.Controller) (*Federation, error) {
 	fed := New()
+	fed.Upstream = upstream.New()
 
 	for c.Next() {
 		// federation [zones..]
@@ -64,8 +65,8 @@ func federationParse(c *caddy.Controller) (*Federation, error) {
 			x := c.Val()
 			switch x {
 			case "upstream":
+				// remove soon
 				c.RemainingArgs()
-				fed.Upstream = upstream.New()
 			default:
 				args := c.RemainingArgs()
 				if x := len(args); x != 1 {

--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -28,7 +28,6 @@ If you want to round-robin A and AAAA responses look at the *loadbalance* plugin
 file DBFILE [ZONES... ] {
     transfer to ADDRESS...
     reload DURATION
-    upstream
 }
 ~~~
 
@@ -39,9 +38,6 @@ file DBFILE [ZONES... ] {
 * `reload` interval to perform a reload of the zone if the SOA version changes. Default is one minute.
   Value of `0` means to not scan for changes and reload. For example, `30s` checks the zonefile every 30 seconds
   and reloads the zone when serial changes.
-* `upstream` resolve external names found (think CNAMEs) pointing to external names. This is only
-  really useful when CoreDNS is configured as a proxy; for normal authoritative serving you don't
-  need *or* want to use this. CoreDNS will resolve CNAMEs against itself.
 
 ## Examples
 

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -113,8 +113,8 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				reload = d
 
 			case "upstream":
-				// ignore args, will be error later.
-				c.RemainingArgs() // clear buffer
+				// remove soon
+				c.RemainingArgs()
 
 			default:
 				return Zones{}, c.Errf("unknown property '%s'", c.Val())

--- a/plugin/file/setup_test.go
+++ b/plugin/file/setup_test.go
@@ -41,13 +41,6 @@ func TestFileParse(t *testing.T) {
 			false,
 			Zones{Names: []string{"10.in-addr.arpa."}},
 		},
-		{
-			`file ` + zoneFileName1 + ` example.net. {
-				upstream a
-			}`,
-			false, // OK for now as we disregard any options for the `upstream`.
-			Zones{Names: []string{"example.net."}},
-		},
 		// errors.
 		{
 			`file ` + zoneFileName1 + ` miek.nl {

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -14,7 +14,7 @@ cluster.  See the [deployment](https://github.com/coredns/deployment) repository
 to deploy CoreDNS in Kubernetes](https://github.com/coredns/deployment/tree/master/kubernetes).
 
 [stubDomains and upstreamNameservers](https://kubernetes.io/blog/2017/04/configuring-private-dns-zones-upstream-nameservers-kubernetes/)
-are implemented via the *forward* plugin and kubernetes *upstream*. See the examples below.
+are implemented via the *forward* plugin. See the examples below.
 
 This plugin can only be used once per Server Block.
 
@@ -39,7 +39,6 @@ kubernetes [ZONES...] {
     labels EXPRESSION
     pods POD-MODE
     endpoint_pod_names
-    upstream
     ttl TTL
     noendpoints
     transfer to ADDRESS...
@@ -90,9 +89,6 @@ kubernetes [ZONES...] {
    follows: Use the hostname of the endpoint, or if hostname is not set, use the
    pod name of the pod targeted by the endpoint. If there is no pod targeted by
    the endpoint, use the dashed IP address form.
-* `upstream` defines the upstream resolvers used for resolving services
-  that point to external hosts (aka External Services, aka CNAMEs).  CoreDNS
-  will resolve External Services against itself.
 * `ttl` allows you to set a custom TTL for responses. The default is 5 seconds.  The minimum TTL allowed is
   0 seconds, and the maximum is capped at 3600 seconds. Setting TTL to 0 will prevent records from being cached.
 * `noendpoints` will turn off the serving of endpoint records by disabling the watch on endpoints.
@@ -121,13 +117,12 @@ Kubernetes API.
 
 Handle all queries in the `cluster.local` zone. Connect to Kubernetes in-cluster. Also handle all
 `in-addr.arpa` `PTR` requests for `10.0.0.0/17` . Verify the existence of pods when answering pod
-requests. Resolve upstream records against `10.102.3.10`. Note we show the entire server block here:
+requests.
 
 ~~~ txt
 10.0.0.0/17 cluster.local {
     kubernetes {
         pods verified
-        upstream 10.102.3.10:53
     }
 }
 ~~~
@@ -152,15 +147,12 @@ kubernetes cluster.local {
 ## stubDomains and upstreamNameservers
 
 Here we use the *forward* plugin to implement a stubDomain that forwards `example.local` to the nameserver `10.100.0.10:53`.
-The *upstream* option in the *kubernetes* plugin means that ExternalName services (CNAMEs) will be resolved using the respective proxy.
 Also configured is an upstreamNameserver `8.8.8.8:53` that will be used for resolving names that do not fall in `cluster.local`
 or `example.local`.
 
 ~~~ txt
 cluster.local:53 {
-    kubernetes cluster.local {
-        upstream
-    }
+    kubernetes cluster.local
 }
 example.local {
     forward . 10.100.0.10:53

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -162,6 +162,8 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 		return nil, errors.New("non-reverse zone name must be used")
 	}
 
+	k8s.Upstream = upstream.New()
+
 	for c.NextBlock() {
 		switch c.Val() {
 		case "endpoint_pod_names":
@@ -249,8 +251,8 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 		case "fallthrough":
 			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
 		case "upstream":
+			// remove soon
 			c.RemainingArgs() // eat remaining args
-			k8s.Upstream = upstream.New()
 		case "ttl":
 			args := c.RemainingArgs()
 			if len(args) == 0 {

--- a/plugin/kubernetes/setup_test.go
+++ b/plugin/kubernetes/setup_test.go
@@ -381,21 +381,6 @@ func TestKubernetesParse(t *testing.T) {
 			podModeDisabled,
 			fall.F{Zones: []string{"ip6.arpa.", "inaddr.arpa.", "foo.com."}},
 		},
-		// Valid upstream
-		{
-			`kubernetes coredns.local {
-	upstream
-}`,
-			false,
-			"",
-			1,
-			0,
-			defaultResyncPeriod,
-			"",
-			"",
-			podModeDisabled,
-			fall.Zero,
-		},
 		// More than one Kubernetes not allowed
 		{
 			`kubernetes coredns.local

--- a/plugin/loop/README.md
+++ b/plugin/loop/README.md
@@ -87,5 +87,5 @@ There are many ways to work around this issue, some are listed here:
 although this can be different depending on your distribution.
 * Disable the local DNS cache on host nodes, and restore `/etc/resolv.conf` to the original.
 * A quick and dirty fix is to edit your Corefile, replacing `forward . /etc/resolv.conf` with
-the ip address of your upstream DNS, for example `forward . 8.8.8.8`.  But this only fixes the issue for CoreDNS,
+the IP address of your upstream DNS, for example `forward . 8.8.8.8`.  But this only fixes the issue for CoreDNS,
 kubelet will continue to forward the invalid `resolv.conf` to all `default` dnsPolicy Pods, leaving them unable to resolve DNS.

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -16,7 +16,6 @@ The route53 plugin can be used when coredns is deployed on AWS or elsewhere.
 ~~~ txt
 route53 [ZONE:HOSTED_ZONE_ID...] {
     [aws_access_key AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
-    upstream
     credentials PROFILE [FILENAME]
     fallthrough [ZONES...]
 }
@@ -34,9 +33,6 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
     AWS credentials the same way as AWS CLI, e.g., environmental variables, AWS credentials file,
     instance profile credentials, etc.
 
-*   `upstream`is used for resolving services that point to external hosts (eg. used to resolve
-    CNAMEs). CoreDNS will resolve against itself.
-
 *   `credentials` is used for reading the credential file and setting the profile name for a given
     zone.
 
@@ -53,13 +49,11 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 
 ## Examples
 
-Enable route53 with implicit AWS credentials and an upstream:
+Enable route53 with implicit AWS credentials and and resolve CNAMEs via 10.0.0.1:
 
 ~~~ txt
 . {
-	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
-	  upstream
-	}
+	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
     forward . 10.0.0.1
 }
 ~~~

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -23,19 +23,13 @@ func TestSetupRoute53(t *testing.T) {
 		{`route53 example.org:12345678 {
     aws_access_key
 }`, true},
-		{`route53 example.org:12345678 {
-    upstream 10.0.0.1
-}`, false},
+		{`route53 example.org:12345678 { }`, false},
 
-		{`route53 example.org:12345678 {
-    upstream
-}`, false},
-		{`route53 example.org:12345678 {
-    wat
+		{`route53 example.org:12345678 { }`, false},
+		{`route53 example.org:12345678 { wat
 }`, true},
 		{`route53 example.org:12345678 {
     aws_access_key ACCESS_KEY_ID SEKRIT_ACCESS_KEY
-    upstream 1.2.3.4
 }`, false},
 
 		{`route53 example.org:12345678 {
@@ -43,27 +37,21 @@ func TestSetupRoute53(t *testing.T) {
 }`, false},
 		{`route53 example.org:12345678 {
 		credentials
- 		upstream 1.2.3.4
 	}`, true},
 
 		{`route53 example.org:12345678 {
 		credentials default
- 		upstream 1.2.3.4
 	}`, false},
 		{`route53 example.org:12345678 {
 		credentials default credentials
- 		upstream 1.2.3.4
 	}`, false},
 		{`route53 example.org:12345678 {
 		credentials default credentials extra-arg
- 		upstream 1.2.3.4
 	}`, true},
 		{`route53 example.org:12345678 example.org:12345678 {
- 		upstream 1.2.3.4
 	}`, true},
 
 		{`route53 example.org {
- 		upstream 1.2.3.4
 	}`, true},
 	}
 

--- a/plugin/secondary/README.md
+++ b/plugin/secondary/README.md
@@ -23,16 +23,12 @@ A working syntax would be:
 secondary [zones...] {
     transfer from ADDRESS
     transfer to ADDRESS
-    upstream
 }
 ~~~
 
 * `transfer from` specifies from which address to fetch the zone. It can be specified multiple times;
     if one does not work, another will be tried.
 * `transfer to` can be enabled to allow this secondary zone to be transferred again.
-* `upstream` resolve external names found (think CNAMEs) pointing to external names. This is only
-  really useful when CoreDNS is configured as a proxy; for normal authoritative serving you don't
-  need *or* want to use this. CoreDNS will resolve CNAMEs against itself.
 
 When a zone is due to be refreshed (Refresh timer fires) a random jitter of 5 seconds is
 applied, before fetching. In the case of retry this will be 2 seconds. If there are any errors

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -78,7 +78,8 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 						return file.Zones{}, e
 					}
 				case "upstream":
-					c.RemainingArgs() // eat args
+					// remove soon
+					c.RemainingArgs()
 				default:
 					return file.Zones{}, c.Errf("unknown property '%s'", c.Val())
 				}

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -17,7 +17,6 @@ template CLASS TYPE [ZONE...] {
     additional RR
     authority RR
     rcode CODE
-    upstream
     fallthrough [ZONE...]
 }
 ~~~
@@ -29,7 +28,6 @@ template CLASS TYPE [ZONE...] {
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
-* `upstream` defines the upstream resolvers used for resolving CNAMEs. CoreDNS will resolve CNAMEs against itself.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
   If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for
   those zones will be subject to fallthrough.

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -74,6 +74,7 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 		templatePrefix := ""
 
 		t.answer = make([]*gotmpl.Template, 0)
+		t.upstream = upstream.New()
 
 		for c.NextBlock() {
 			switch c.Val() {
@@ -144,8 +145,8 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 				t.fall.SetZonesFromArgs(c.RemainingArgs())
 
 			case "upstream":
-				c.RemainingArgs() // eat remaining args
-				t.upstream = upstream.New()
+				// remove soon
+				c.RemainingArgs()
 			default:
 				return handler, c.ArgErr()
 			}

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -141,13 +141,6 @@ func TestSetupParse(t *testing.T) {
 				}`,
 			false,
 		},
-		{
-			`template ANY ANY up.stream.local {
-					answer "up.stream.local 5 IN CNAME up.river.local"
-					upstream
-				}`,
-			false,
-		},
 	}
 	for i, test := range tests {
 		c := caddy.NewTestController("dns", test.inputFileRules)


### PR DESCRIPTION
`upstream` is not needed as a setting; just set if unconditionally and
remove all documentation and tests for it.

At some point we want remove the hanlding for `upstream` as well and
error out on seeing it.


### 2. Which issues (if any) are related?

Fixes #2954

### 3. Which documentation changes (if any) need to be made?

Remove 'upstream' from all docs and tests.

### 4. Does this introduce a backward incompatible change or deprecation?

No, not yet; this has been promised since 1.3.1