### PR TITLE
Add whitelist option to forward plugin

### DIFF
--- a/man/coredns-forward.7
+++ b/man/coredns-forward.7
@@ -59,6 +59,7 @@ Extra knobs are available with an expanded syntax:
 .nf
 forward FROM TO... {
     except IGNORED\_NAMES...
+    whitelist ALLOWED_NAMES...
     force\_tcp
     prefer\_udp
     expire DURATION
@@ -77,6 +78,8 @@ forward FROM TO... {
 .IP \(bu 4
 \fBIGNORED_NAMES\fP in \fB\fCexcept\fR is a space-separated list of domains to exclude from forwarding.
 Requests that match none of these names will be passed through.
+.IP \(bu 4
+\fBALLOWED_NAMES\fP in \fB\fCewhitelist\fR is a space-separated list of domains to allow to be forwarded. If whitelist is set all domains not in the list will not be forwarded.
 .IP \(bu 4
 \fB\fCforce_tcp\fR, use TCP even when the request comes in over UDP.
 .IP \(bu 4

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -42,6 +42,7 @@ Extra knobs are available with an expanded syntax:
 ~~~
 forward FROM TO... {
     except IGNORED_NAMES...
+    whitelist ALLOWED_NAMES...
     force_tcp
     prefer_udp
     expire DURATION
@@ -56,6 +57,7 @@ forward FROM TO... {
 * **FROM** and **TO...** as above.
 * **IGNORED_NAMES** in `except` is a space-separated list of domains to exclude from forwarding.
   Requests that match none of these names will be passed through.
+* **ALLOWED_NAMES** in `whitelist` is a space-separated list of domains to allowto be forwarded. If whitelist is set all domains not in the list will not be forwarded.
 * `force_tcp`, use TCP even when the request comes in over UDP.
 * `prefer_udp`, try first using UDP even when the request comes in over TCP. If response is truncated
   (TC flag set in response) then do another attempt over TCP. In case if both `force_tcp` and

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -28,8 +28,9 @@ type Forward struct {
 	p          Policy
 	hcInterval time.Duration
 
-	from    string
-	ignored []string
+	from      string
+	ignored   []string
+        whitelist []string
 
 	tlsConfig     *tls.Config
 	tlsServerName string
@@ -175,7 +176,13 @@ func (f *Forward) isAllowedDomain(name string) bool {
 	if dns.Name(name) == dns.Name(f.from) {
 		return true
 	}
-
+        if len(f.whitelist) > 0 {
+		for _, allowed := range f.whitelist {
+			if plugin.Name(allowed).Matches(name) {
+				return true
+			}
+		}
+                return false
 	for _, ignore := range f.ignored {
 		if plugin.Name(ignore).Matches(name) {
 			return false

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -144,6 +144,15 @@ func parseBlock(c *caddyfile.Dispenser, f *Forward) error {
 			ignore[i] = plugin.Host(ignore[i]).Normalize()
 		}
 		f.ignored = ignore
+	case "whitelist":
+		whitelist := c.RemainingArgs()
+		if len(whitelist) == 0 {
+			return c.ArgErr()
+		}
+		for i := 0; i < len(whitelist); i++ {
+			whitelist[i] = plugin.Host(whitelist[i]).Normalize()
+		}
+		f.whitelist = whitelist
 	case "max_fails":
 		if !c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -23,6 +23,7 @@ func TestSetup(t *testing.T) {
 		// positive
 		{"forward . 127.0.0.1", false, ".", nil, 2, options{}, ""},
 		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, options{}, ""},
+		{"forward . 127.0.0.1 {\nwhitelist github.com\n}\n", false, ".", nil, 2, options{}, ""},
 		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, options{}, ""},
 		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true}, ""},
 		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true}, ""},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I was thinking about ways of preventing DNS exfiltration.

Currently at $WORK we already whitelist the servers we talk to
Why not also allow a whitelist of dns names that you can request?

So I sat down to see how hard it would be and here is the first attempt.

I plan to write some more tests, but I thought I would find out if this is the right place in the plugins before committing more effort. 

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

I've made changes to the README in the plugin and the associated man page to document the new option.

### 4. Does this introduce a backward incompatible change or deprecation?

Nope, it is adding a new option to a plugin.