### PR TITLE
replacer: evaluate format once and improve perf by ~3x

### DIFF
--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -211,10 +211,7 @@ func parseFormat(s string) replacer {
 		}
 		i := strings.LastIndexByte(s[:j], '{')
 		if i < 0 {
-			// Handle: "A } {foo}"
-			//            ^j
-			//
-			// By treating "A }" as a literal
+			// Handle: "A } {foo}" by treating "A }" as a literal
 			rep = append(rep, node{
 				value: s[:j+1],
 				typ:   typeLiteral,
@@ -270,7 +267,10 @@ func loadFormat(s string) replacer {
 	return v.(replacer)
 }
 
-// bufPool stores pointers to scratch buffers
+// bufPool stores pointers to scratch buffers.  We store a pointer to the slice
+// as it saves an allocation during the slice => interface{} conversion.  If we
+// were to store the slice value a pointer to it would have to be created on
+// each Put().
 var bufPool = sync.Pool{
 	New: func() interface{} {
 		b := make([]byte, 0, 256)

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -129,7 +129,6 @@ func appendValue(b []byte, state request.Request, rr *dnstest.Recorder, label st
 		}
 		return append(b, EmptyValue...)
 	default:
-		// TODO (CEV): consider panicking since this should be impossible
 		return append(b, EmptyValue...)
 	}
 }

--- a/plugin/pkg/replacer/replacer.go
+++ b/plugin/pkg/replacer/replacer.go
@@ -35,44 +35,25 @@ const (
 )
 
 // labels are all supported labels that can be used in the default Replacer.
-var labels = [...]string{
-	"{type}",
-	"{name}",
-	"{class}",
-	"{proto}",
-	"{size}",
-	"{remote}",
-	"{port}",
-	"{local}",
+var labels = map[string]struct{}{
+	"{type}":   {},
+	"{name}":   {},
+	"{class}":  {},
+	"{proto}":  {},
+	"{size}":   {},
+	"{remote}": {},
+	"{port}":   {},
+	"{local}":  {},
 	// Header values.
-	headerReplacer + "id}",
-	headerReplacer + "opcode}",
-	headerReplacer + "do}",
-	headerReplacer + "bufsize}",
-	// Recorded replacements.
-	"{rcode}",
-	"{rsize}",
-	"{duration}",
-	headerReplacer + "rflags}",
-}
-
-var knownLabels = map[string]struct{}{
-	"{type}":                    {},
-	"{name}":                    {},
-	"{class}":                   {},
-	"{proto}":                   {},
-	"{size}":                    {},
-	"{remote}":                  {},
-	"{port}":                    {},
-	"{local}":                   {},
 	headerReplacer + "id}":      {},
 	headerReplacer + "opcode}":  {},
 	headerReplacer + "do}":      {},
 	headerReplacer + "bufsize}": {},
-	"{rcode}":                   {},
-	"{rsize}":                   {},
-	"{duration}":                {},
-	headerReplacer + "rflags}":  {},
+	// Recorded replacements.
+	"{rcode}":                  {},
+	"{rsize}":                  {},
+	"{duration}":               {},
+	headerReplacer + "rflags}": {},
 }
 
 // appendValue appends the current value of label.
@@ -221,7 +202,7 @@ func parseFormat(s string) replacer {
 
 		val := s[i : j+1]
 		var typ nodeType
-		switch _, ok := knownLabels[val]; {
+		switch _, ok := labels[val]; {
 		case ok:
 			typ = typeLabel
 		case strings.HasPrefix(val, "{/"):

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -173,7 +173,7 @@ func TestParseFormat(t *testing.T) {
 	}
 }
 
-func TestParseFormat_Nodes(t *testing.T) {
+func TestParseFormatNodes(t *testing.T) {
 	// If we parse the format successfully the result of joining all the
 	// segments should match the original format.
 	formats := []string{

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -245,7 +245,7 @@ func TestLabels(t *testing.T) {
 		t.Fatalf("Expect %d labels, got %d", len(expect), len(labels))
 	}
 
-	for _, lbl := range labels {
+	for lbl := range labels {
 		repl := replacer.Replace(ctx, state, w, lbl)
 		if lbl == "{duration}" {
 			if repl[len(repl)-1] != 's' {
@@ -390,17 +390,6 @@ func TestMetadataMalformed(t *testing.T) {
 		r := repl.Replace(ctx, state, nil, ts.expr)
 		if r != ts.result {
 			t.Errorf("Test %d - expr : %s, expected %q, got %q", i, ts.expr, ts.result, r)
-		}
-	}
-}
-
-func TestKnownLabels(t *testing.T) {
-	if len(knownLabels) != len(labels) {
-		t.Fatalf("Want len: %d got: %d", len(labels), len(knownLabels))
-	}
-	for _, s := range labels {
-		if _, ok := knownLabels[s]; !ok {
-			t.Errorf("Missing label: %q", s)
 		}
 	}
 }

--- a/plugin/pkg/replacer/replacer_test.go
+++ b/plugin/pkg/replacer/replacer_test.go
@@ -2,6 +2,8 @@ package replacer
 
 import (
 	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/metadata"
@@ -11,6 +13,9 @@ import (
 
 	"github.com/miekg/dns"
 )
+
+// This is the default format used by the log package
+const CommonLogFormat = `{remote}:{port} - {>id} "{type} {class} {name} {proto} {size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {duration}`
 
 func TestReplacer(t *testing.T) {
 	w := dnstest.NewRecorder(&test.ResponseWriter{})
@@ -29,6 +34,178 @@ func TestReplacer(t *testing.T) {
 	}
 	if x := replacer.Replace(context.TODO(), state, nil, "{size}"); x != "29" {
 		t.Errorf("Expected size to be 29, got %q", x)
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	type formatTest struct {
+		Format   string
+		Expected replacer
+	}
+	tests := []formatTest{
+		{
+			Format:   "",
+			Expected: replacer{},
+		},
+		{
+			Format: "A",
+			Expected: replacer{
+				{"A", typeLiteral},
+			},
+		},
+		{
+			Format: "A {A}",
+			Expected: replacer{
+				{"A {A}", typeLiteral},
+			},
+		},
+		{
+			Format: "{{remote}}",
+			Expected: replacer{
+				{"{", typeLiteral},
+				{"{remote}", typeLabel},
+				{"}", typeLiteral},
+			},
+		},
+		{
+			Format: "{ A {remote} A }",
+			Expected: replacer{
+				{"{ A ", typeLiteral},
+				{"{remote}", typeLabel},
+				{" A }", typeLiteral},
+			},
+		},
+		{
+			Format: "{remote}}",
+			Expected: replacer{
+				{"{remote}", typeLabel},
+				{"}", typeLiteral},
+			},
+		},
+		{
+			Format: "{{remote}",
+			Expected: replacer{
+				{"{", typeLiteral},
+				{"{remote}", typeLabel},
+			},
+		},
+		{
+			Format: `Foo } {remote}`,
+			Expected: replacer{
+				// we don't do any optimizations to join adjacent literals
+				{"Foo }", typeLiteral},
+				{" ", typeLiteral},
+				{"{remote}", typeLabel},
+			},
+		},
+		{
+			Format: `{ Foo`,
+			Expected: replacer{
+				{"{ Foo", typeLiteral},
+			},
+		},
+		{
+			Format: `} Foo`,
+			Expected: replacer{
+				{"}", typeLiteral},
+				{" Foo", typeLiteral},
+			},
+		},
+		{
+			Format: "A { {remote} {type} {/meta1} } B",
+			Expected: replacer{
+				{"A { ", typeLiteral},
+				{"{remote}", typeLabel},
+				{" ", typeLiteral},
+				{"{type}", typeLabel},
+				{" ", typeLiteral},
+				{"meta1", typeMetadata},
+				{" }", typeLiteral},
+				{" B", typeLiteral},
+			},
+		},
+		{
+			Format: `LOG {remote}:{port} - {>id} "{type} {class} {name} {proto} ` +
+				`{size} {>do} {>bufsize}" {rcode} {>rflags} {rsize} {/meta1}-{/meta2} ` +
+				`{duration} END OF LINE`,
+			Expected: replacer{
+				{"LOG ", typeLiteral},
+				{"{remote}", typeLabel},
+				{":", typeLiteral},
+				{"{port}", typeLabel},
+				{" - ", typeLiteral},
+				{"{>id}", typeLabel},
+				{` "`, typeLiteral},
+				{"{type}", typeLabel},
+				{" ", typeLiteral},
+				{"{class}", typeLabel},
+				{" ", typeLiteral},
+				{"{name}", typeLabel},
+				{" ", typeLiteral},
+				{"{proto}", typeLabel},
+				{" ", typeLiteral},
+				{"{size}", typeLabel},
+				{" ", typeLiteral},
+				{"{>do}", typeLabel},
+				{" ", typeLiteral},
+				{"{>bufsize}", typeLabel},
+				{`" `, typeLiteral},
+				{"{rcode}", typeLabel},
+				{" ", typeLiteral},
+				{"{>rflags}", typeLabel},
+				{" ", typeLiteral},
+				{"{rsize}", typeLabel},
+				{" ", typeLiteral},
+				{"meta1", typeMetadata},
+				{"-", typeLiteral},
+				{"meta2", typeMetadata},
+				{" ", typeLiteral},
+				{"{duration}", typeLabel},
+				{" END OF LINE", typeLiteral},
+			},
+		},
+	}
+	for i, x := range tests {
+		r := parseFormat(x.Format)
+		if !reflect.DeepEqual(r, x.Expected) {
+			t.Errorf("%d: Expected:\n\t%+v\nGot:\n\t%+v", i, x.Expected, r)
+		}
+	}
+}
+
+func TestParseFormat_Nodes(t *testing.T) {
+	// If we parse the format successfully the result of joining all the
+	// segments should match the original format.
+	formats := []string{
+		"",
+		"msg",
+		"{remote}",
+		"{remote}",
+		"{{remote}",
+		"{{remote}}",
+		"{{remote}} A",
+		CommonLogFormat,
+		CommonLogFormat + " FOO} {BAR}",
+		"A " + CommonLogFormat + " FOO} {BAR}",
+		"A " + CommonLogFormat + " {/meta}",
+	}
+	join := func(r replacer) string {
+		a := make([]string, len(r))
+		for i, n := range r {
+			if n.typ == typeMetadata {
+				a[i] = "{/" + n.value + "}"
+			} else {
+				a[i] = n.value
+			}
+		}
+		return strings.Join(a, "")
+	}
+	for _, format := range formats {
+		r := parseFormat(format)
+		s := join(r)
+		if s != format {
+			t.Errorf("Expected format to be: '%s' got: '%s'", format, s)
+		}
 	}
 }
 
@@ -95,6 +272,34 @@ func BenchmarkReplacer(b *testing.B) {
 	replacer := New()
 	for i := 0; i < b.N; i++ {
 		replacer.Replace(context.TODO(), state, nil, "{type} {name} {size}")
+	}
+}
+
+func BenchmarkReplacer_CommonLogFormat(b *testing.B) {
+
+	w := dnstest.NewRecorder(&test.ResponseWriter{})
+	r := new(dns.Msg)
+	r.SetQuestion("example.org.", dns.TypeHINFO)
+	r.Id = 1053
+	r.AuthenticatedData = true
+	r.CheckingDisabled = true
+	r.MsgHdr.AuthenticatedData = true
+	w.WriteMsg(r)
+	state := request.Request{W: w, Req: r}
+
+	replacer := New()
+	ctxt := context.TODO()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		replacer.Replace(ctxt, state, w, CommonLogFormat)
+	}
+}
+
+func BenchmarkParseFormat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		parseFormat(CommonLogFormat)
 	}
 }
 
@@ -185,6 +390,17 @@ func TestMetadataMalformed(t *testing.T) {
 		r := repl.Replace(ctx, state, nil, ts.expr)
 		if r != ts.result {
 			t.Errorf("Test %d - expr : %s, expected %q, got %q", i, ts.expr, ts.result, r)
+		}
+	}
+}
+
+func TestKnownLabels(t *testing.T) {
+	if len(knownLabels) != len(labels) {
+		t.Fatalf("Want len: %d got: %d", len(labels), len(knownLabels))
+	}
+	for _, s := range labels {
+		if _, ok := knownLabels[s]; !ok {
+			t.Errorf("Missing label: %q", s)
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Why: request logging as it currently exists is incredibly slow and wasteful.  This improves the performance of logging by almost 3x and reduces memory usage by ~8x.

Benchmark results:

```
benchmark                                old ns/op     new ns/op     delta
BenchmarkReplacer-12                     644           324           -49.69%
BenchmarkReplacer_CommonLogFormat-12     4228          1471          -65.21%

benchmark                                old allocs     new allocs     delta
BenchmarkReplacer-12                     8              2              -75.00%
BenchmarkReplacer_CommonLogFormat-12     51             17             -66.67%

benchmark                                old bytes     new bytes     delta
BenchmarkReplacer-12                     240           48            -80.00%
BenchmarkReplacer_CommonLogFormat-12     3723          446           -88.02%
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A
