### PR TITLE
Fix log plugin benchmark and slightly improve performance

### DIFF
--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -26,21 +26,24 @@ type Logger struct {
 // ServeDNS implements the plugin.Handler interface.
 func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
+	name := state.Name()
 	for _, rule := range l.Rules {
-		if !plugin.Name(rule.NameScope).Matches(state.Name()) {
+		if !plugin.Name(rule.NameScope).Matches(name) {
 			continue
 		}
 
 		rrw := dnstest.NewRecorder(w)
 		rc, err := plugin.NextOrFailure(l.Name(), l.Next, ctx, rrw, r)
 
-		tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
-		class := response.Classify(tpe)
 		// If we don't set up a class in config, the default "all" will be added
 		// and we shouldn't have an empty rule.Class.
 		_, ok := rule.Class[response.All]
-		_, ok1 := rule.Class[class]
-		if ok || ok1 {
+		if !ok {
+			tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
+			class := response.Classify(tpe)
+			_, ok = rule.Class[class]
+		}
+		if ok {
 			logstr := l.repl.Replace(ctx, state, rrw, rule.Format)
 			clog.Infof(logstr)
 		}

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -37,13 +37,14 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 		// If we don't set up a class in config, the default "all" will be added
 		// and we shouldn't have an empty rule.Class.
-		_, shouldLog := rule.Class[response.All]
-		if !shouldLog {
+		_, ok := rule.Class[response.All]
+		var ok1 bool
+		if !ok {
 			tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
 			class := response.Classify(tpe)
-			_, shouldLog = rule.Class[class]
+			_, ok1 = rule.Class[class]
 		}
-		if shouldLog {
+		if ok || ok1 {
 			logstr := l.repl.Replace(ctx, state, rrw, rule.Format)
 			clog.Infof(logstr)
 		}

--- a/plugin/log/log.go
+++ b/plugin/log/log.go
@@ -37,13 +37,13 @@ func (l Logger) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 		// If we don't set up a class in config, the default "all" will be added
 		// and we shouldn't have an empty rule.Class.
-		_, ok := rule.Class[response.All]
-		if !ok {
+		_, shouldLog := rule.Class[response.All]
+		if !shouldLog {
 			tpe, _ := response.Typify(rrw.Msg, time.Now().UTC())
 			class := response.Classify(tpe)
-			_, ok = rule.Class[class]
+			_, shouldLog = rule.Class[class]
 		}
-		if ok {
+		if shouldLog {
 			logstr := l.repl.Replace(ctx, state, rrw, rule.Format)
 			clog.Infof(logstr)
 		}

--- a/plugin/log/log_test.go
+++ b/plugin/log/log_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
 	"log"
 	"strings"
 	"testing"
@@ -239,8 +240,7 @@ func TestLogged(t *testing.T) {
 }
 
 func BenchmarkLogged(b *testing.B) {
-	var f bytes.Buffer
-	log.SetOutput(&f)
+	log.SetOutput(ioutil.Discard)
 
 	rule := Rule{
 		NameScope: ".",


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

It fixes memory/alloc reporting for `BenchmarkLogged` and provides a small improvement to the logging logic.

Benchmark results:
```
benchmark              old ns/op     new ns/op     delta
BenchmarkLogged-12     5742          5573          -2.94%

benchmark              old allocs     new allocs     delta
BenchmarkLogged-12     60             60             +0.00%

benchmark              old bytes     new bytes     delta
BenchmarkLogged-12     4536          4145          -8.62%
```

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?


N/A