### PR TITLE
snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,54 @@
+name: coredns
+summary: DNS server.
+description: CoreDNS is a DNS server that chains plugins .
+  
+confinement: devmode
+base: core18
+
+architectures:
+  - build-on: i386
+  - build-on: amd64
+  - build-on: armhf
+  - build-on: arm64
+
+apps:
+    coredns:
+    command: bin/coredns
+    plugs:
+      - home
+      - network
+      - removable-media
+      - docker
+      
+
+parts:
+  coredns:
+    plugin: go
+    source: https://github.com/coredns/coredns.git
+    source-type: git
+    override-pull: |
+      git clone https://github.com/coredns/coredns.git src/github.com/coredns/coredns
+      cd src/github.com/coredns/coredns
+      last_committed_tag="$(git describe --tags --abbrev=0)"
+      last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "beta:" { print $2 }')"
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag_ver}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "${last_committed_tag}"
+      fi
+      snapcraftctl set-version "$(git describe --tags | sed 's/v//')"
+    override-build: |
+      export GOPATH=$PWD
+      cd src/github.com/coredns/coredns
+      env CGO_ENABLED=0 GOOS=linux \
+      go build --ldflags "-s -w \
+        -X 'github.com/coredns/coredns/version.GitCommit=$(git rev-list -1 HEAD)' \
+        -X 'github.com/coredns/coredns/version.Version=$(git describe --tags --abbrev=0)'" \
+        -a -installsuffix cgo -o $SNAPCRAFT_PART_INSTALL/bin/coredns
+    build-snaps:
+      - go
+    build-packages:
+      - git
+      - sed


### PR DESCRIPTION
Includes a snapcraft.yaml to build [snap](https://snapcraft.io/).
# Prep
sudo snap install snapcraft --classic
sudo snap install multipass --beta --classic

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Linux package format supported by 41 Linux distros.
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
Not much I added a few changes above under Prep.
### 4. Does this introduce a backward incompatible change or deprecation?
