### PR TITLE
plugin/rewrite: fix EDNS rewrite

### DIFF
--- a/plugin/rewrite/edns0_test.go
+++ b/plugin/rewrite/edns0_test.go
@@ -1,0 +1,259 @@
+package rewrite
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/test"
+
+	"github.com/miekg/dns"
+)
+
+func TestEdns0Rewrite(t *testing.T) {
+	tests := []struct {
+		ruleArgs []string
+		reqOPT   *dns.OPT
+		expOPT   *dns.OPT
+	}{
+		//NSID tests
+		{
+			[]string{"nsid", "set"}, nil, nil,
+		},
+		{
+			[]string{"nsid", "set"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""}}),
+		},
+		{
+			[]string{"nsid", "append"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""}}),
+		},
+		{
+			[]string{"nsid", "replace"},
+			newOpt(nil),
+			newOpt(nil),
+		},
+		{
+			[]string{"nsid", "set"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: "??"}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""}}),
+		},
+		{
+			[]string{"nsid", "append"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: "??"}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: "??"}}),
+		},
+		{
+			[]string{"nsid", "replace"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: "??"}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""}}),
+		},
+
+		//Subnet tests
+		{
+			[]string{"subnet", "set", "24", "56"}, nil, nil,
+		},
+		{
+			[]string{"subnet", "set", "24", "56"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 24, SourceScope: 0,
+				Address: net.ParseIP("10.240.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "append", "24", "56"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 24, SourceScope: 0,
+				Address: net.ParseIP("10.240.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "replace", "24", "56"},
+			newOpt(nil),
+			newOpt(nil),
+		},
+		{
+			[]string{"subnet", "set", "24", "56"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 28, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 24, SourceScope: 0,
+				Address: net.ParseIP("10.240.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "set", "24", "56"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("10.0.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "append", "24", "56"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "replace", "24", "56"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 28, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 24, SourceScope: 0,
+				Address: net.ParseIP("10.240.0.0").To4(),
+			}}),
+		},
+		{
+			[]string{"subnet", "replace", "24", "56"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("192.0.0.0").To4(),
+			}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_SUBNET{
+				Code: dns.EDNS0SUBNET, Family: 1, SourceNetmask: 8, SourceScope: 0,
+				Address: net.ParseIP("10.0.0.0").To4(),
+			}}),
+		},
+
+		//Local (predefined) tests
+		{
+			[]string{"local", "set", "0xfff1", "1234"}, nil, nil,
+		},
+		{
+			[]string{"local", "set", "0xfff1", "1234"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("1234")}}),
+		},
+		{
+			[]string{"local", "append", "0xfff1", "1234"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("1234")}}),
+		},
+		{
+			[]string{"local", "replace", "0xfff1", "1234"},
+			newOpt(nil),
+			newOpt(nil),
+		},
+		{
+			[]string{"local", "set", "0xfff1", "1234"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("1234")}}),
+		},
+		{
+			[]string{"local", "append", "0xfff1", "1234"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+		},
+		{
+			[]string{"local", "replace", "0xfff1", "1234"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("1234")}}),
+		},
+
+		//Local (variable) tests
+		{
+			[]string{"local", "set", "0xfff1", "{qname}"}, nil, nil,
+		},
+		{
+			[]string{"local", "set", "0xfff1", "{qname}"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("example.com")}}),
+		},
+		{
+			[]string{"local", "append", "0xfff1", "{qname}"},
+			newOpt(nil),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("example.com")}}),
+		},
+		{
+			[]string{"local", "replace", "0xfff1", "{qname}"},
+			newOpt(nil),
+			newOpt(nil),
+		},
+		{
+			[]string{"local", "set", "0xfff1", "{qname}"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("example.com")}}),
+		},
+		{
+			[]string{"local", "append", "0xfff1", "{qname}"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+		},
+		{
+			[]string{"local", "replace", "0xfff1", "{qname}"},
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("ABCD")}}),
+			newOpt([]dns.EDNS0{&dns.EDNS0_LOCAL{Code: 0xfff1, Data: []byte("example.com")}}),
+		},
+	}
+
+	rw := Rewrite{Next: plugin.HandlerFunc(msgPrinter)}
+
+	ctx := context.TODO()
+	for i, tc := range tests {
+		r, e := newEdns0Rule("stop", tc.ruleArgs...)
+		if e != nil {
+			t.Errorf("Test %d: failed to create rule: %s", i, e)
+			continue
+		}
+		rw.Rules = []Rule{r}
+
+		m := new(dns.Msg)
+		m.SetQuestion("example.com", dns.TypeA)
+		if tc.reqOPT != nil {
+			m.Extra = []dns.RR{tc.reqOPT}
+		}
+
+		rec := dnstest.NewRecorder(&test.ResponseWriter{})
+		rw.ServeDNS(ctx, rec, m)
+		resp := rec.Msg
+		respOpt := resp.IsEdns0()
+
+		if tc.expOPT == nil {
+			if respOpt != nil {
+				t.Errorf("Test %d: unexpected OPT record in response %v", i, respOpt)
+			}
+			continue
+		}
+		if respOpt == nil {
+			t.Errorf("Test %d: not found OPT record in response", i)
+			continue
+		}
+		if !reflect.DeepEqual(tc.expOPT.Option, respOpt.Option) {
+			t.Errorf("Test %d: unexpected options, expected %v, got %v", i, tc.expOPT.Option, respOpt.Option)
+			for i, a := range respOpt.Option {
+				if s, ok := a.(*dns.EDNS0_SUBNET); ok {
+					t.Logf("Exp option %d = %#v", i, *s)
+					e := tc.expOPT.Option[i].(*dns.EDNS0_SUBNET)
+					t.Logf("Act option %d = %#v", i, *e)
+				}
+			}
+		}
+	}
+}
+
+func newOpt(opt []dns.EDNS0) *dns.OPT {
+	e := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+	e.SetUDPSize(4096)
+	e.Option = opt
+	return e
+}

--- a/plugin/rewrite/reverter.go
+++ b/plugin/rewrite/reverter.go
@@ -24,6 +24,7 @@ type ResponseReverter struct {
 	dns.ResponseWriter
 	originalQuestion dns.Question
 	ResponseRewrite  bool
+	RemoveOPT        bool
 	ResponseRules    []ResponseRule
 }
 
@@ -38,6 +39,9 @@ func NewResponseReverter(w dns.ResponseWriter, r *dns.Msg) *ResponseReverter {
 // WriteMsg records the status code and calls the underlying ResponseWriter's WriteMsg method.
 func (r *ResponseReverter) WriteMsg(res *dns.Msg) error {
 	res.Question[0] = r.originalQuestion
+	if r.RemoveOPT {
+		removeEdns0Opt(res)
+	}
 	if r.ResponseRewrite {
 		for _, rr := range res.Answer {
 			var (


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
- if rewrite plugin inserts OPT record into user query it must remove OPT from response, see #2484 and https://tools.ietf.org/html/rfc6891#section-7
- if rewrite plugin modifies existing ECS option it must not send bigger part of client address than specified in original ECS option, see https://tools.ietf.org/html/rfc7871#section-7.1.2
- added unit tests for EDNS rules
- fixed 'append' operation for `edns0NsidRule` and `edns0LocalRule`
### 2. Which issues (if any) are related?
#2484
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
no