### PR TITLE
plugin/file: fix setting ReloadInterval

### DIFF
--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -97,7 +97,6 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 			names = append(names, origins[i])
 		}
 
-		upstr := upstream.New()
 		t := []string{}
 		var e error
 
@@ -128,11 +127,15 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				if t != nil {
 					z[origin].TransferTo = append(z[origin].TransferTo, t...)
 				}
-				z[origin].ReloadInterval = reload
-				z[origin].Upstream = upstr
 			}
 		}
 	}
+
+	for origin := range z {
+		z[origin].ReloadInterval = reload
+		z[origin].Upstream = upstream.New()
+	}
+
 	if openErr != nil {
 		if reload == 0 {
 			// reload hasn't been set make this a fatal error

--- a/plugin/file/setup_test.go
+++ b/plugin/file/setup_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/test"
 
@@ -87,6 +88,38 @@ func TestFileParse(t *testing.T) {
 					t.Fatalf("Test %d expected %v for %d th zone, got %v", i, name, j, actualZones.Names[j])
 				}
 			}
+		}
+	}
+}
+
+func TestParseReload(t *testing.T) {
+	name, rm, err := test.TempFile(".", dbMiekNL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rm()
+
+	tests := []struct {
+		input  string
+		reload time.Duration
+	}{
+		{
+			`file ` + name + ` example.org.`,
+			1 * time.Minute,
+		},
+		{
+			`file ` + name + ` example.org. {
+				reload 5s
+			}`,
+			5 * time.Second,
+		},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		z, _ := fileParse(c)
+		if x := z.Z["example.org."].ReloadInterval; x != test.reload {
+			t.Fatalf("Test %d expected reload to be %s, but got %s", i, test.reload, x)
 		}
 	}
 }

--- a/plugin/file/setup_test.go
+++ b/plugin/file/setup_test.go
@@ -109,7 +109,7 @@ func TestParseReload(t *testing.T) {
 		},
 		{
 			`file ` + name + ` example.org. {
-				reload 5s
+			reload 5s
 			}`,
 			5 * time.Second,
 		},
@@ -119,7 +119,7 @@ func TestParseReload(t *testing.T) {
 		c := caddy.NewTestController("dns", test.input)
 		z, _ := fileParse(c)
 		if x := z.Z["example.org."].ReloadInterval; x != test.reload {
-			t.Fatalf("Test %d expected reload to be %s, but got %s", i, test.reload, x)
+			t.Errorf("Test %d expected reload to be %s, but got %s", i, test.reload, x)
 		}
 	}
 }


### PR DESCRIPTION
The reload interval was only correctly set if there was an extra
block for the file. Move this down to set up.

Add test case that fails before, but now works.