### PR TITLE
plugin/file: New zone should have zero records

### DIFF
--- a/plugin/file/xfr_test.go
+++ b/plugin/file/xfr_test.go
@@ -3,6 +3,7 @@ package file
 import (
 	"fmt"
 	"strings"
+	"testing"
 )
 
 func ExampleZone_All() {
@@ -31,4 +32,12 @@ func ExampleZone_All() {
 	// xfr_test.go:15: archive.miek.nl.	1800	IN	CNAME	a.miek.nl.
 	// xfr_test.go:15: a.miek.nl.	1800	IN	A	139.162.196.78
 	// xfr_test.go:15: a.miek.nl.	1800	IN	AAAA	2a01:7e00::f03c:91ff:fef1:6735
+}
+
+func TestAllNewZone(t *testing.T) {
+	zone := NewZone("example.org.", "stdin")
+	records := zone.All()
+	if len(records) != 0 {
+		t.Errorf("Expected %d records in empty zone, got %d", 0, len(records))
+	}
 }

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -173,15 +173,21 @@ func (z *Zone) All() []dns.RR {
 		records = append(records, a.All()...)
 	}
 
+	// Either the entire Apex is filled or none it, this isn't enforced here though.
 	if len(z.Apex.SIGNS) > 0 {
 		records = append(z.Apex.SIGNS, records...)
 	}
-	records = append(z.Apex.NS, records...)
+	if len(z.Apex.NS) > 0 {
+		records = append(z.Apex.NS, records...)
+	}
 
 	if len(z.Apex.SIGSOA) > 0 {
 		records = append(z.Apex.SIGSOA, records...)
 	}
-	return append([]dns.RR{z.Apex.SOA}, records...)
+	if z.Apex.SOA != nil {
+		return append([]dns.RR{z.Apex.SOA}, records...)
+	}
+	return records
 }
 
 // NameFromRight returns the labels from the right, staring with the


### PR DESCRIPTION
After calling NewZone the number of records should be zero, but due to
how zone.All() was implemented so empty RRs would be added. This then
fails the == 0 check in xfr.go and put nil in the slice, this then
subsequently panics on the Len().

Fix this making All() smarter when adding records. Added little test to
enfore this.