### PR TITLE
Fix response_rcode_count_total metric

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -98,7 +98,7 @@ If monitoring is enabled (via the *prometheus* directive) then the following met
 
 * `coredns_forward_request_duration_seconds{to}` - duration per upstream interaction.
 * `coredns_forward_request_count_total{to}` - query count per upstream.
-* `coredns_forward_response_rcode_total{to, rcode}` - count of RCODEs per upstream.
+* `coredns_forward_response_rcode_count_total{to, rcode}` - count of RCODEs per upstream.
 * `coredns_forward_healthcheck_failure_count_total{to}` - number of failed health checks per upstream.
 * `coredns_forward_healthcheck_broken_count_total{}` - counter of when all upstreams are unhealthy,
   and we are randomly (this always uses the `random` policy) spraying to an upstream.

--- a/plugin/grpc/README.md
+++ b/plugin/grpc/README.md
@@ -64,7 +64,7 @@ If monitoring is enabled (via the *prometheus* directive) then the following met
 
 * `coredns_grpc_request_duration_seconds{to}` - duration per upstream interaction.
 * `coredns_grpc_request_count_total{to}` - query count per upstream.
-* `coredns_grpc_response_rcode_total{to, rcode}` - count of RCODEs per upstream.
+* `coredns_grpc_response_rcode_count_total{to, rcode}` - count of RCODEs per upstream.
   and we are randomly (this always uses the `random` policy) spraying to an upstream.
 
 ## Examples


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Metric name in forward and grpc READMEs is wrong.

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

I saw that man pages also have this wrong but not sure how they are built.

### 4. Does this introduce a backward incompatible change or deprecation?

No.