### PR TITLE
plugins: skip initializing if the origins don't match

### DIFF
--- a/plugin.md
+++ b/plugin.md
@@ -12,7 +12,7 @@ The main method that gets called is `ServeDNS`. It has three parameters:
 will return a SERVFAIL to the client. The response code tells CoreDNS if a *reply has been
 written by the plugin chain or not*. In the latter case CoreDNS will take care of that.
 
-CoreDNS treats:
+CoreDNS treats (see plugin.ClientWrite):
 
 * SERVFAIL (dns.RcodeServerFailure)
 * REFUSED (dns.RcodeRefused)

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -23,6 +23,9 @@ func init() {
 func setup(c *caddy.Controller) error {
 	zones, err := fileParse(c)
 	if err != nil {
+		if err == plugin.ErrOrigin {
+			return nil
+		}
 		return plugin.Error("file", err)
 	}
 
@@ -71,6 +74,9 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 		copy(origins, c.ServerBlockKeys)
 		args := c.RemainingArgs()
 		if len(args) > 0 {
+			if err := plugin.Origins(c, args); err != nil {
+				return Zones{}, err
+			}
 			origins = args
 		}
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,25 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/caddyserver/caddy"
+)
+
+func TestOrigins(t *testing.T) {
+	c := caddy.NewTestController("dns", "")
+	c.ServerBlockKeys = []string{"example.net", "example.org"}
+
+	c.ServerBlockKeyIndex = 0
+	if err := Origins(c, []string{"example.net"}); err != nil {
+		t.Errorf("Expected nil error, got %s", err)
+	}
+	c.ServerBlockKeyIndex = 0
+	if err := Origins(c, []string{"sub.example.net"}); err != nil {
+		t.Errorf("Expected nil error, got %s", err)
+	}
+	c.ServerBlockKeyIndex = 1
+	if err := Origins(c, []string{"example.net"}); err == nil {
+		t.Errorf("Expected ErrOrigin, got nil")
+	}
+}


### PR DESCRIPTION
ServerBlocks are parsed for each name in the serverblock keys, this may
lead to block being setup multiple times while the intent was probably
to do things once:

~~~
miek.nl miek.org {
    file plugin/sign/testdata/db.miek.nl.signed miek.nl {
        reload 5s
    }
    file plugin/sign/testdata/db.miek.org.signed miek.org {
        reload 5s
    }
}
~~~

Each file plugin should do a thing for the origin specified after it,
but this the first one is done for miek.nl and miek.org and the second
one too; so 4 in total. I don't believe this is the intent.

This add Origins function that checks for this. This returns an
ErrOrigin for which the plugin needs to check.

This PR makes *all* tests fail because a caddy.NewTestController doesn't
set up the full environment that Origins expects. Not sure how to handle
this case.

Fixes: #3026

Note all plugins that do this need this fix.