### PR TITLE
plugin/host: don't append the names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
+	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
 	google.golang.org/genproto v0.0.0-20190701230453-710ae3a149df // indirect
 	google.golang.org/grpc v1.22.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190624190245-7f2218787638/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -11,14 +11,16 @@ file that exists on disk. It checks the file for changes and updates the zones a
 plugin only supports A, AAAA, and PTR records. The hosts plugin can be used with readily
 available hosts files that block access to advertising servers.
 
-The plugin reloads the content of the hosts file every 5 seconds. Upon reload, CoreDNS will use the new definitions.
-Should the file be deleted, any inlined content will continue to be served. When the file is restored, it will then again be used.
+The plugin reloads the content of the hosts file every 5 seconds. Upon reload, CoreDNS will use the
+new definitions. Should the file be deleted, any inlined content will continue to be served. When
+the file is restored, it will then again be used.
 
 This plugin can only be used once per Server Block.
 
 ## The hosts file
 
-Commonly the entries are of the form `IP_address canonical_hostname [aliases...]` as explained by the hosts(5) man page.
+Commonly the entries are of the form `IP_address canonical_hostname [aliases...]` as explained by
+the hosts(5) man page.
 
 Examples:
 
@@ -34,7 +36,8 @@ fdfc:a744:27b5:3b0e::1  example.com example
 
 ### PTR records
 
-PTR records for reverse lookups are generated automatically by CoreDNS (based on the hosts file entries) and cannot be created manually.
+PTR records for reverse lookups are generated automatically by CoreDNS (based on the hosts file
+entries) and cannot be created manually.
 
 ## Syntax
 

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -31,7 +31,7 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	if zone == "" {
 		// PTR zones don't need to be specified in Origins
 		if state.Type() != "PTR" {
-			// If this doesn't match we need to fall through regardless of h.Fallthrough
+			// if this doesn't match we need to fall through regardless of h.Fallthrough
 			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 		}
 	}
@@ -89,7 +89,6 @@ func (h Hosts) otherRecordsExist(qtype uint16, qname string) bool {
 		}
 	}
 	return false
-
 }
 
 // Name implements the plugin.Handle interface.
@@ -97,39 +96,36 @@ func (h Hosts) Name() string { return "hosts" }
 
 // a takes a slice of net.IPs and returns a slice of A RRs.
 func a(zone string, ttl uint32, ips []net.IP) []dns.RR {
-	answers := []dns.RR{}
-	for _, ip := range ips {
+	answers := make([]dns.RR, len(ips))
+	for i, ip := range ips {
 		r := new(dns.A)
-		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeA,
-			Class: dns.ClassINET, Ttl: ttl}
+		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl}
 		r.A = ip
-		answers = append(answers, r)
+		answers[i] = r
 	}
 	return answers
 }
 
 // aaaa takes a slice of net.IPs and returns a slice of AAAA RRs.
 func aaaa(zone string, ttl uint32, ips []net.IP) []dns.RR {
-	answers := []dns.RR{}
-	for _, ip := range ips {
+	answers := make([]dns.RR, len(ips))
+	for i, ip := range ips {
 		r := new(dns.AAAA)
-		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeAAAA,
-			Class: dns.ClassINET, Ttl: ttl}
+		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: ttl}
 		r.AAAA = ip
-		answers = append(answers, r)
+		answers[i] = r
 	}
 	return answers
 }
 
 // ptr takes a slice of host names and filters out the ones that aren't in Origins, if specified, and returns a slice of PTR RRs.
 func (h *Hosts) ptr(zone string, ttl uint32, names []string) []dns.RR {
-	answers := []dns.RR{}
-	for _, n := range names {
+	answers := make([]dns.RR, len(names))
+	for i, n := range names {
 		r := new(dns.PTR)
-		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypePTR,
-			Class: dns.ClassINET, Ttl: ttl}
+		r.Hdr = dns.RR_Header{Name: zone, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: ttl}
 		r.Ptr = dns.Fqdn(n)
-		answers = append(answers, r)
+		answers[i] = r
 	}
 	return answers
 }

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -2,7 +2,6 @@ package hosts
 
 import (
 	"context"
-	"io"
 	"strings"
 	"testing"
 
@@ -12,20 +11,17 @@ import (
 	"github.com/miekg/dns"
 )
 
-func (h *Hostsfile) parseReader(r io.Reader) {
-	h.hmap = h.parse(r)
-}
-
 func TestLookupA(t *testing.T) {
 	h := Hosts{
 		Next: test.ErrorHandler(),
 		Hostsfile: &Hostsfile{
 			Origins: []string{"."},
-			hmap:    newHostsMap(),
+			hmap:    newMap(),
+			inline:  newMap(),
 			options: newOptions(),
 		},
 	}
-	h.parseReader(strings.NewReader(hostsExample))
+	h.hmap = h.parse(strings.NewReader(hostsExample))
 
 	ctx := context.TODO()
 

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -26,7 +26,7 @@ func init() {
 func periodicHostsUpdate(h *Hosts) chan bool {
 	parseChan := make(chan bool)
 
-	if h.options.reload == durationOf0s {
+	if h.options.reload == 0 {
 		return parseChan
 	}
 
@@ -78,7 +78,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 	h := Hosts{
 		Hostsfile: &Hostsfile{
 			path:    "/etc/hosts",
-			hmap:    newHostsMap(),
+			hmap:    newMap(),
 			options: options,
 		},
 	}
@@ -152,7 +152,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 				if err != nil {
 					return h, c.Errf("invalid duration for reload '%s'", remaining[0])
 				}
-				if reload < durationOf0s {
+				if reload < 0 {
 					return h, c.Errf("invalid negative duration for reload '%s'", remaining[0])
 				}
 				options.reload = reload

--- a/plugin/hosts/setup_test.go
+++ b/plugin/hosts/setup_test.go
@@ -100,7 +100,7 @@ func TestHostsInlineParse(t *testing.T) {
 	tests := []struct {
 		inputFileRules      string
 		shouldErr           bool
-		expectedbyAddr      map[string][]string
+		expectedaddr        map[string][]string
 		expectedFallthrough fall.F
 	}{
 		{
@@ -148,19 +148,20 @@ func TestHostsInlineParse(t *testing.T) {
 			t.Fatalf("Test %d expected no errors, but got '%v'", i, err)
 		} else if !test.shouldErr {
 			if !h.Fall.Equal(test.expectedFallthrough) {
-				t.Fatalf("Test %d expected fallthrough of %v, got %v", i, test.expectedFallthrough, h.Fall)
+				t.Errorf("Test %d expected fallthrough of %v, got %v", i, test.expectedFallthrough, h.Fall)
 			}
-			for k, expectedVal := range test.expectedbyAddr {
-				if val, ok := h.hmap.byAddr[k]; !ok {
-					t.Fatalf("Test %d expected %v, got no entry", i, k)
-				} else {
-					if len(expectedVal) != len(val) {
-						t.Fatalf("Test %d expected %v records for %v, got %v", i, len(expectedVal), k, len(val))
-					}
-					for j := range expectedVal {
-						if expectedVal[j] != val[j] {
-							t.Fatalf("Test %d expected %v for %v, got %v", i, expectedVal[j], j, val[j])
-						}
+			for k, expectedVal := range test.expectedaddr {
+				val, ok := h.inline.addr[k]
+				if !ok {
+					t.Errorf("Test %d expected %v, got no entry", i, k)
+					continue
+				}
+				if len(expectedVal) != len(val) {
+					t.Errorf("Test %d expected %v records for %v, got %v", i, len(expectedVal), k, len(val))
+				}
+				for j := range expectedVal {
+					if expectedVal[j] != val[j] {
+						t.Errorf("Test %d expected %v for %v, got %v", i, expectedVal[j], j, val[j])
 					}
 				}
 			}


### PR DESCRIPTION
The host plugin kept on adding entries instead of overwriting.

A bunch of other cleanup as well. Use functions defined in the plugin
package, don't re-parse strings if you don't have to and use To4() to
check the family for IP addresses.

Fixes: #3014