### PR TITLE
plugin/file: allow README.md testing

### DIFF
--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -44,7 +44,7 @@ file DBFILE [ZONES... ] {
 Load the `example.org` zone from `example.org.signed` and allow transfers to the internet, but send
 notifies to 10.240.1.1
 
-~~~ txt
+~~~ corefile
 example.org {
     file example.org.signed {
         transfer to *
@@ -55,7 +55,7 @@ example.org {
 
 Or use a single zone file for multiple zones:
 
-~~~ txt
+~~~ corefile
 . {
     file example.org.signed example.org example.net {
         transfer to *
@@ -67,7 +67,7 @@ Or use a single zone file for multiple zones:
 Note that if you have a configuration like the following you may run into a problem of the origin
 not being correctly recognized:
 
-~~~ txt
+~~~ corefile
 . {
     file db.example.org
 }
@@ -78,7 +78,7 @@ which, in this case, is the root zone. Any contents of `db.example.org` will the
 origin set; this may or may not do what you want.
 It's better to be explicit here and specify the correct origin. This can be done in two ways:
 
-~~~ txt
+~~~ corefile
 . {
     file db.example.org example.org
 }
@@ -86,7 +86,7 @@ It's better to be explicit here and specify the correct origin. This can be done
 
 Or
 
-~~~ txt
+~~~ corefile
 example.org {
     file db.example.org
 }

--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -145,7 +145,7 @@ func Parse(f io.Reader, origin, fileName string, serial int64) (*Zone, error) {
 		}
 	}
 	if !seenSOA {
-		return nil, fmt.Errorf("file %q has no SOA record", fileName)
+		return nil, fmt.Errorf("file %q has no SOA record for origin %s", fileName, origin)
 	}
 
 	return z, nil

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -87,6 +87,7 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 			origins[i] = plugin.Host(origins[i]).Normalize()
 			z[origins[i]] = NewZone(origins[i], fileName)
 			if openErr == nil {
+				reader.Seek(0, 0)
 				zone, err := Parse(reader, origins[i], fileName, 0)
 				if err == nil {
 					z[origins[i]] = zone

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -11,6 +11,6 @@ short	1	IN	A	127.0.0.3
 
 *.w        3600 IN      TXT     "Wildcard"
 a.b.c.w    IN      TXT     "Not a wildcard"
-cname      IN      CNAME   www
+cname      IN      CNAME   www.example.net.
 service    IN      SRV     8080 10 10 @
 `

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -2,14 +2,15 @@ package test
 
 const exampleOrg = `; example.org test file
 $TTL 3600
-example.org.		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
-example.org.		IN	NS	b.iana-servers.net.
-example.org.		IN	NS	a.iana-servers.net.
-example.org.		IN	A	127.0.0.1
-example.org.		IN	A	127.0.0.2
-short.example.org.	1	IN	A	127.0.0.3
-*.w.example.org.        IN      TXT     "Wildcard"
-a.b.c.w.example.org.    IN      TXT     "Not a wildcard"
-cname.example.org.      IN      CNAME   www.example.net.
-service.example.org.    IN      SRV     8080 10 10 example.org.
+@		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+@		IN	NS	b.iana-servers.net.
+@		IN	NS	a.iana-servers.net.
+@		IN	A	127.0.0.1
+@		IN	A	127.0.0.2
+short	1	IN	A	127.0.0.3
+
+*.w        3600 IN      TXT     "Wildcard"
+a.b.c.w    IN      TXT     "Not a wildcard"
+cname      IN      CNAME   www
+service    IN      SRV     8080 10 10 @
 `


### PR DESCRIPTION
Allow readme testing for the file plugin and fix bugs that where found:

* the reader wasn't reset when re-reading the same io.reader for a
  different origin.

Builds upon #3051