### PR TITLE
plugin/kubernetes: remove some of the klog setup

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
@@ -36,15 +35,7 @@ import (
 var log = clog.NewWithPlugin("kubernetes")
 
 func init() {
-	// Kubernetes plugin uses the kubernetes library, which now uses klog, we must set and parse this flag
-	// so we don't log to the filesystem, which can fill up and crash CoreDNS indirectly by calling os.Exit().
-	// We also set: os.Stderr = os.Stdout in the setup function below so we output to standard out; as we do for
-	// all CoreDNS logging. We can't do *that* in the init function, because we, when starting, also barf some
-	// things to stderr.
-	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
-	klog.InitFlags(klogFlags)
-	logtostderr := klogFlags.Lookup("logtostderr")
-	logtostderr.Value.Set("true")
+	klog.SetOutput(os.Stdout)
 
 	caddy.RegisterPlugin("kubernetes", caddy.Plugin{
 		ServerType: "dns",
@@ -53,9 +44,6 @@ func init() {
 }
 
 func setup(c *caddy.Controller) error {
-	// See comment in the init function.
-	os.Stderr = os.Stdout
-
 	k, err := kubernetesParse(c)
 	if err != nil {
 		return plugin.Error("kubernetes", err)


### PR DESCRIPTION
I don't believe this is actually needed (anymore). The:

os.Stderr = os.Stdout

is a crazy hack that def. needs to go.