### PR TITLE
plugin/file: z.Expired needs be read under a rlock

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -69,7 +69,10 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		return dns.RcodeSuccess, nil
 	}
 
-	if z.Expired != nil && *z.Expired {
+	z.RLock()
+	exp := z.Expired
+	z.RUnlock()
+	if exp != nil && *exp {
 		log.Errorf("Zone %s is expired", zone)
 		return dns.RcodeServerFailure, nil
 	}

--- a/plugin/file/zone.go
+++ b/plugin/file/zone.go
@@ -22,13 +22,13 @@ type Zone struct {
 	file    string
 	*tree.Tree
 	Apex
+	Expired *bool
 
 	sync.RWMutex
 
 	TransferTo   []string
 	StartupOnce  sync.Once
 	TransferFrom []string
-	Expired      *bool
 
 	ReloadInterval time.Duration
 	reloadShutdown chan bool


### PR DESCRIPTION
Read lock before reading the Expired field of a zone.

Fixes: #3053