### PR TITLE
contrib: add words on adding new plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ faster.
 
 A new plugin is (usually) about 1000 lines of Go. This includes tests and some plugin boiler
 plate. This is a considerable amount of code and will take time review. To prevent too much back and
-forth it is advisable to start with the plugin's `README.md`; its main documentation. This will help
+forth it is advisable to start with the plugin's `README.md`; This will be it's main documentation and will help
 nail down the correct name of the plugin and its various config options.
 
 From there it can work its way through the reset (`setup.go`, the `ServeDNS` hanlder function,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ faster.
 
 ## New Plugins
 
-A new plugin is (usually) about a 1000 lines of Go. This includes tests and some plugin boiler
+A new plugin is (usually) about 1000 lines of Go. This includes tests and some plugin boiler
 plate. This is a considerable amount of code and will take time review. To prevent too much back and
 forth it is advisable to start with the plugin's `README.md`; its main documentation. This will help
 nail down the correct name of the plugin and its various config options.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ plate. This is a considerable amount of code and will take time review. To preve
 forth it is advisable to start with the plugin's `README.md`; This will be it's main documentation and will help
 nail down the correct name of the plugin and its various config options.
 
-From there it can work its way through the reset (`setup.go`, the `ServeDNS` hanlder function,
+From there it can work its way through the reset (`setup.go`, the `ServeDNS` handler function,
 etc.). Doing this will help the reviewers, as each chunk of code is relatively small.
 
 ## Updating Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ plate. This is a considerable amount of code and will take time review. To preve
 forth it is advisable to start with the plugin's `README.md`; This will be it's main documentation and will help
 nail down the correct name of the plugin and its various config options.
 
-From there it can work its way through the reset (`setup.go`, the `ServeDNS` handler function,
+From there it can work its way through the rest (`setup.go`, the `ServeDNS` handler function,
 etc.). Doing this will help the reviewers, as each chunk of code is relatively small.
 
 ## Updating Dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ faster.
 ## New Plugins
 
 A new plugin is (usually) about 1000 lines of Go. This includes tests and some plugin boiler
-plate. This is a considerable amount of code and will take time review. To prevent too much back and
+plate. This is a considerable amount of code and will take time to review. To prevent too much back and
 forth it is advisable to start with the plugin's `README.md`; This will be it's main documentation and will help
 nail down the correct name of the plugin and its various config options.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,16 @@ If possible make a pull request as small as possible, or submit multiple pull re
 feature. Smaller means: easier to understand and review. This in turn means things can be merged
 faster.
 
+## New Plugins
+
+A new plugin is (usually) about a 1000 lines of Go. This includes tests and some plugin boiler
+plate. This is a considerable amount of code and will take time review. To prevent too much back and
+forth it is advisable to start with the plugin's `README.md`; its main documentation. This will help
+nail down the correct name of the plugin and its various config options.
+
+From there it can work its way through the reset (`setup.go`, the `ServeDNS` hanlder function,
+etc.). Doing this will help the reviewers, as each chunk of code is relatively small.
+
 ## Updating Dependencies
 
 We use [Go Modules](https://github.com/golang/go/wiki/Modules) as the tool to manage vendor dependencies.


### PR DESCRIPTION
New plugins are usually dropped in one giant ball of code, add some
words on how this can be approached and made to work faster.

(will at least give us something to point at)