### PR TITLE
[plugin/route53]: Increase ListResourceRecordSets paging size.

### DIFF
--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -248,6 +248,7 @@ func (h *Route53) updateZones(ctx context.Context) error {
 				newZ.Upstream = h.upstream
 				in := &route53.ListResourceRecordSetsInput{
 					HostedZoneId: aws.String(hostedZone.id),
+					MaxItems: aws.String("1000"),
 				}
 				err = h.client.ListResourceRecordSetsPagesWithContext(ctx, in,
 					func(out *route53.ListResourceRecordSetsOutput, last bool) bool {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

without the paging parameter set, it will default to 100 records per request. with large enough zones and potentially multiple coredns daemons configured to pull from route 53, this can quickly add up and reach aws global api rate limits (5/sec per root account). increasing paging to max can help reduce the number of requests needed to pull records for a zone without no down side that i am aware of.

### 2. Which issues (if any) are related?

this helps issue #2353, but probably is not a complete fix.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.