### PR TITLE
plugin/route53: make refresh frequency adjustable

### DIFF
--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -18,6 +18,7 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
     aws_access_key [AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
     credentials PROFILE [FILENAME]
     fallthrough [ZONES...]
+    refresh DURATION
 }
 ~~~
 
@@ -47,6 +48,14 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 
 *   **ZONES** zones it should be authoritative for. If empty, the zones from the configuration
     block.
+
+*   `refresh` can be used to control how long between record retrievals from Route 53. It requires
+    a duration string as a parameter to specify the duration between update cycles. Each update
+    cycle may result in many AWS API calls depending on how many domains use this plugin and how
+    many records are in each. Adjusting the update frequency may help reduce the potential of API
+    rate-limiting imposed by AWS.
+
+*   **DURATION** A duration string. Defaults to `1m`. If units are unspecified, seconds are assumed.
 
 ## Examples
 
@@ -84,5 +93,14 @@ Enable route53 with multiple hosted zones with the same domain:
 ~~~ txt
 . {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 example.org.:Z93A52145678156
+}
+~~~
+
+Enable route53 and refresh records every 3 minutes
+~~~ txt
+. {
+    route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
+      refresh 3m
+    }
 }
 ~~~

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/fall"
@@ -79,7 +80,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, &upstream.Upstream{})
+	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, &upstream.Upstream{}, time.Duration(1) * time.Minute)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, &upstream.Upstream{})
+	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, &upstream.Upstream{}, time.Duration(90) * time.Second)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -51,6 +51,22 @@ func TestSetupRoute53(t *testing.T) {
 		{`route53 example.org:12345678 example.org:12345678 {
 	}`, true},
 
+		{`route53 example.org:12345678 {
+	refresh 90
+}`, false},
+		{`route53 example.org:12345678 {
+	refresh 5m
+}`, false},
+		{`route53 example.org:12345678 {
+	refresh
+}`, true},
+		{`route53 example.org:12345678 {
+	refresh foo
+}`, true},
+		{`route53 example.org:12345678 {
+	refresh -1m
+}`, true},
+
 		{`route53 example.org {
 	}`, true},
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

the current update frequency for the refresh loop in the route 53 plugin is hard-coded
to 1 minute. aws rate-limits the number of api requests so less frequent record refreshes
can help when reaching those limits depending upon your individual scenarios. this pull
adds a configuration option to the route53 plugin to adjust the refresh frequency.

thanks for getting my last pull released so quickly. this is the last local change that
i have been running and would love to get it contributed back to the project.

### 2. Which issues (if any) are related?

Another step to solving #2353 

### 3. Which documentation changes (if any) need to be made?

Included in pull.

### 4. Does this introduce a backward incompatible change or deprecation?

No, maintains current behavior by default.