### PR TITLE
plugin/file: unify a serial logging

### DIFF
--- a/plugin/file/file.go
+++ b/plugin/file/file.go
@@ -58,7 +58,7 @@ func (f File) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 			if ok {
 				z.TransferIn()
 			} else {
-				log.Infof("Notify from %s for %s: no serial increase seen", state.IP(), zone)
+				log.Infof("Notify from %s for %s: no SOA serial increase seen", state.IP(), zone)
 			}
 			if err != nil {
 				log.Warningf("Notify from %s for %s: failed primary check: %s", state.IP(), zone, err)
@@ -115,7 +115,7 @@ type serialErr struct {
 }
 
 func (s *serialErr) Error() string {
-	return fmt.Sprintf("%s for origin %s in file %s, with serial %d", s.err, s.origin, s.zone, s.serial)
+	return fmt.Sprintf("%s for origin %s in file %s, with %d SOA serial", s.err, s.origin, s.zone, s.serial)
 }
 
 // Parse parses the zone in filename and returns a new Zone or an error.

--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -38,7 +38,7 @@ func (z *Zone) Reload() error {
 				z.Tree = zone.Tree
 				z.Unlock()
 
-				log.Infof("Successfully reloaded zone %q in %q with serial %d", z.origin, zFile, z.Apex.SOA.Serial)
+				log.Infof("Successfully reloaded zone %q in %q with %d SOA serial", z.origin, zFile, z.Apex.SOA.Serial)
 				z.Notify()
 
 			case <-z.reloadShutdown:


### PR DESCRIPTION
Use %d SOA serial when logging about the SOA serial.