### PR TITLE
WIP: Add Continuous Fuzzing Integration to Fuzzit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
-
+services:
+  - docker
 language: go
 go:
   - "1.12.x"
@@ -18,10 +19,16 @@ branches:
   - master
 
 env:
-  - TEST_TYPE=coverage
-  - TEST_TYPE=integration
-  - TEST_TYPE=core
-  - TEST_TYPE=plugin
+  global:
+    # This is FUZZIT_API_KEY
+    - secure: "IGpZAyt1e5BZ1C4LeJG+GrgFZzaBQkJ3BX/+MwWN85aJSDk5gwThS53OCr/7RFgBKBgP9xBv9i9hAv0PxVaRE0ETIzjc0rQzceJIWiYKfFYQyscFahKfSiGsWP32rMlU3K67tA7yITS+Z8mMyVH9Ndr1Fg9AmLL+WfATdrd6dP8hzsUpaghKlnJee9TycrfamDpISzecdOY9xzxcwRyphZxuCc/n236Nt7f7Ccz0zx/Qa5igX6mjKZpUyBpS2u02GmNJTfc3W5SbTRP5bSJ+ozSkZZyG3tTpYmeN87AQJ/oG7rUEzqGLt78i7jSYAXghJZT06H/fHFsOKssCj1m0hYiarnGoGzXScLDqp2fpkyzilsUT+W0VgXTy2Nq+88Sideiy6UwDwpqHr5ktyoYFeSVB/aCTJl5oxDxBqs9dfeJSEAy7/AYy8kJoIE/yPYsBnGw10CAED4Rf5mfDgstkZRBdAO0xLBihkPsgza2975DVf27YSjJZ4eKrnR+G/aNCKycLQvWD/5c2bcLCJqyz0uMLQC/4LspS9b5bAKurzqFRdrD5q78NDcbodHelc7zBlFrRwGFCUjXTbQoU6r+1FA8y2Z+n1bd7mIF1JBVHurYAygyYXOcry870hyucGojonvdgBvHp6txeYyPU14VvTNwkF2mddpBCvoSTSPZ5X64="
+  matrix:
+    - TEST_TYPE=coverage
+    - TEST_TYPE=integration
+    - TEST_TYPE=core
+    - TEST_TYPE=plugin
+    - TEST_TYPE=fuzzit-regression
+    - TEST_TYPE=fuzzit
 
 # In the Travis VM-based build environment, IPv6 networking is not
 # enabled by default. The sysctl operations below enable IPv6.
@@ -35,7 +42,10 @@ before_install:
   - env
 
 script:
-  - make TEST_TYPE=$TEST_TYPE travis
+  # we always run fuzzit regressions
+  - 'if [ "$TEST_TYPE" != "fuzzit" ]; then make TEST_TYPE=$TEST_TYPE travis; fi'
+  # we run fuzzit (fuzzing) only for pushes to master
+  - 'if [ "$TEST_TYPE" = "fuzzit" ] && [ $TRAVIS_PULL_REQUEST = "false" ] ; then make TEST_TYPE=$TEST_TYPE travis; fi'
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -14,6 +14,7 @@
 #$ go get github.com/dvyukov/go-fuzz/go-fuzz-build
 
 REPO:="github.com/coredns/coredns"
+# set LIBFUZZER=YES to build libfuzzer compatible targets
 
 FUZZ:=$(dir $(wildcard plugin/*/fuzz.go)) # plugin/cache/
 PLUGINS:=$(foreach f,$(FUZZ),$(subst plugin, ,$(f:/=))) # > /cache
@@ -25,8 +26,14 @@ echo:
 
 .PHONY: $(PLUGINS)
 $(PLUGINS): echo
+ifeq ($(LIBFUZZER), YES)
+	go-fuzz-build -tags fuzz -libfuzzer -o $(@).a ./plugin/$(@)
+	clang -fsanitize=fuzzer $(@).a -o $(@)
+else
 	go-fuzz-build -tags fuzz $(REPO)/plugin/$(@)
 	go-fuzz -bin=./$(@)-fuzz.zip -workdir=fuzz/$(@)
+endif
+
 
 .PHONY: corefile
 corefile:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Documentation](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/coredns/coredns)
 [![Build Status](https://img.shields.io/travis/coredns/coredns/master.svg?label=build)](https://travis-ci.org/coredns/coredns)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=coredns&branch=master)](https://fuzzit.dev)
 [![Code Coverage](https://img.shields.io/codecov/c/github/coredns/coredns/master.svg)](https://codecov.io/github/coredns/coredns?branch=master)
 [![Docker Pulls](https://img.shields.io/docker/pulls/coredns/coredns.svg)](https://hub.docker.com/r/coredns/coredns)
 [![Go Report Card](https://goreportcard.com/badge/github.com/coredns/coredns)](https://goreportcard.com/report/coredns/coredns)


### PR DESCRIPTION
This feature introduce continuous fuzzing with the following
features:

* Ruzzing: fuzz-targets are run continuously on master
( the fuzzers are updated every time new code is pushed to master)
* Regresion: In addition to unit-tests travis runs all fuzz
targets through the generated corpus to catch bugs early  on
in the CI process before merge.

### 1. Why is this pull request needed and what does it do?

Fuzzing should be run continuously.

We saw that you did a good job writing good fuzz targets and decided to contribute free compute resources for this project.

You can sign-up [here](https://app.fuzzit.dev/orgs/coredns/dashboard) and I'll add you to the core-dns team.

There is a crash already probably was introduced because regression wasn't run on one of the PRs.

Please review.

Cheers,
Yevgeny & the Fuzzit Team:)
