### PR TITLE
plugin/kubernetes: Don't do a zone transfer for NS requests

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -51,6 +51,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 			records, extra, err = plugin.NS(ctx, &k, zone, state, plugin.Options{})
 			break
 		}
+		_, err = parseRequest(state)
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
 		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -51,7 +51,6 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 			records, extra, err = plugin.NS(ctx, &k, zone, state, plugin.Options{})
 			break
 		}
-		fallthrough
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
 		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -44,14 +44,14 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		records, extra, err = plugin.SRV(ctx, &k, zone, state, plugin.Options{})
 	case dns.TypeSOA:
 		records, err = plugin.SOA(ctx, &k, zone, state, plugin.Options{})
+	case dns.TypeAXFR, dns.TypeIXFR:
+		k.Transfer(ctx, state)
 	case dns.TypeNS:
 		if state.Name() == zone {
 			records, extra, err = plugin.NS(ctx, &k, zone, state, plugin.Options{})
 			break
 		}
 		fallthrough
-	case dns.TypeAXFR, dns.TypeIXFR:
-		k.Transfer(ctx, state)
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
 		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -341,9 +341,17 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// NS query for qname != zone
+	// NS query for qname != zone (non-existing domain)
 	{
 		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (existing domain)
+	{
+		Qname: "svc.cluster.local.", Qtype: dns.TypeNS,
 		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -341,6 +341,14 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	// NS query for qname != zone
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
 }
 
 func TestServeDNS(t *testing.T) {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -341,14 +341,6 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	},
-	// NS query for qname != zone (non-existing domain)
-	{
-		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
-		Rcode: dns.RcodeNameError,
-		Ns: []dns.RR{
-			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
-		},
-	},
 	// NS query for qname != zone (existing domain)
 	{
 		Qname: "svc.cluster.local.", Qtype: dns.TypeNS,

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -343,8 +343,8 @@ var dnsTestCases = []test.Case{
 	},
 	// NS query for qname != zone
 	{
-		Qname: "foo.cluster.local.", Qtype: dns.TypeA,
-		Rcode: dns.RcodeNameError,
+		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

A `NS` request for a non-apex zone (e.g. for `anything.cluster.local.`, when the zone is `cluster.local.`), would trigger a zone transfer to the client.

This was caused by the `AXFR` switch case being inserted between the `NS` case, and default case.  I'm still looking into whether the `NS` case's `fallthrough` is necessary. It looks to be in place to handle returning of NXDOMAIN vs NODATA responses, but does not appear to work.  If it is not necessary, we should remove it.

### 2. Which issues (if any) are related?
I discovered this when looking into kubernetes/kubernetes#81137

### 3. Which documentation changes (if any) need to be made?
none.

### 4. Does this introduce a backward incompatible change or deprecation?
no.