### PR TITLE
plugin/kubernetes: Fix non-apex NS queries NXDOMAIN/NODATA responses

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -28,6 +28,8 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	)
 
 	switch state.QType() {
+	case dns.TypeAXFR, dns.TypeIXFR:
+		k.Transfer(ctx, state)
 	case dns.TypeA:
 		records, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
 	case dns.TypeAAAA:
@@ -50,10 +52,9 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 			break
 		}
 		fallthrough
-	case dns.TypeAXFR, dns.TypeIXFR:
-		k.Transfer(ctx, state)
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
+		//fake := state.NewWithQuestion(state.QName(), dns.TypeA)
 		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
 	}
 

--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -54,7 +54,6 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		fallthrough
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
-		//fake := state.NewWithQuestion(state.QName(), dns.TypeA)
 		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
 	}
 

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -341,6 +341,22 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	// NS query for qname != zone (non-existing domain)
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (existing domain)
+	{
+		Qname: "svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
 }
 
 func TestServeDNS(t *testing.T) {

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -107,7 +107,7 @@ func (k *Kubernetes) Services(ctx context.Context, state request.Request, exact 
 
 	case dns.TypeNS:
 		var e error
-		// Expect for the apex zone and special ns.dns subdomain, check to see there
+		// Except for the apex zone and special ns.dns subdomain, check to see if there
 		// exists another record at the same level.  This is to determine if the response
 		// should be a NXDOMAIN or NODATA.
 		if state.QName() != state.Zone && state.QName() != "ns.dns." + state.Zone {

--- a/plugin/kubernetes/kubernetes_apex_test.go
+++ b/plugin/kubernetes/kubernetes_apex_test.go
@@ -85,7 +85,7 @@ func TestServeDNSApex(t *testing.T) {
 		}
 
 		if err := test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
+			t.Fatalf("Test %d, got: %v", i, err)
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Previously non-apex NS queries always return NODATA, even if the subdomain does not actually exist (e.g. `foo.cluster.local`).  This PR checks the service records to determine if there is a record at the same level (NODATA), or if there is not (NXDOMAIN).


**This PR depends on, and includes parts of the fix in #3098.  So, #3098 should merge first, then this PR can be rebased with master, and merged.**

### 2. Which issues (if any) are related?
#3098

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no