### PR TITLE
plugin/route53: various updates

### DIFF
--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -46,11 +46,11 @@ type zone struct {
 type zones map[string][]*zone
 
 // New reads from the keys map which uses domain names as its key and hosted
-// zone id lists as its values, validates that each domain name/zone id pair does
-// exist, and returns a new *Route53. In addition to this, upstream is passed
-// for doing recursive queries against CNAMEs.
-// Returns error if it cannot verify any given domain name/zone id pair.
-func New(ctx context.Context, c route53iface.Route53API, keys map[string][]string, up *upstream.Upstream, refresh time.Duration) (*Route53, error) {
+// zone id lists as its values, validates that each domain name/zone id pair
+// does exist, and returns a new *Route53. In addition to this, upstream is use
+// for doing recursive queries against CNAMEs. Returns error if it cannot
+// verify any given domain name/zone id pair.
+func New(ctx context.Context, c route53iface.Route53API, keys map[string][]string, refresh time.Duration) (*Route53, error) {
 	zones := make(map[string][]*zone, len(keys))
 	zoneNames := make([]string, 0, len(keys))
 	for dns, hostedZoneIDs := range keys {
@@ -72,7 +72,7 @@ func New(ctx context.Context, c route53iface.Route53API, keys map[string][]strin
 		client:    c,
 		zoneNames: zoneNames,
 		zones:     zones,
-		upstream:  up,
+		upstream:  upstream.New(),
 		refresh:   refresh,
 	}, nil
 }

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
 	"github.com/coredns/coredns/plugin/pkg/fall"
-	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/plugin/test"
 	crequest "github.com/coredns/coredns/request"
 
@@ -80,7 +79,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, &upstream.Upstream{}, time.Duration(1) * time.Minute)
+	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Duration(1)*time.Minute)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -88,7 +87,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, &upstream.Upstream{}, time.Duration(90) * time.Second)
+	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, time.Duration(90)*time.Second)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}


### PR DESCRIPTION
In the setup function use plugin.Error() to wrap the errors with the
plugin name. Because there isn't a separate setup() function this is
done for all returned errors.

Remove *upstream.Upstream from the New parameters as this is always set
and adjust the tests to account for this.