### PR TITLE
Fix handling truncated responses in forward

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -109,9 +109,6 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		opts := f.opts
 		for {
 			ret, err = proxy.Connect(ctx, state, opts)
-			if err == nil && ret != nil && !ret.Truncated {
-				break
-			}
 			if err == ErrCachedClosed { // Remote side closed conn, can only happen with TCP.
 				continue
 			}

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -109,7 +109,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		opts := f.opts
 		for {
 			ret, err = proxy.Connect(ctx, state, opts)
-			if err == nil {
+			if err == nil && ret != nil && !ret.Truncated {
 				break
 			}
 			if err == ErrCachedClosed { // Remote side closed conn, can only happen with TCP.


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Currently, `forward` plugin does not handle truncated responses as it was supposed to because there's no error returned when a truncated response is received

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
On the contrary