### PR TITLE
plugin kubernetes: Fix NXDOMAIN/NODATA default case

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -54,7 +54,9 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		fallthrough
 	default:
 		// Do a fake A lookup, so we can distinguish between NODATA and NXDOMAIN
-		_, err = plugin.A(ctx, &k, zone, state, nil, plugin.Options{})
+		fake := state.NewWithQuestion(state.QName(), dns.TypeA)
+		fake.Zone = state.Zone
+		_, err = plugin.A(ctx, &k, zone, fake, nil, plugin.Options{})
 	}
 
 	if k.IsNameError(err) {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -349,6 +349,30 @@ var dnsTestCases = []test.Case{
 			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	// NS query for qname != zone (existing domain)
+	{
+		Qname: "testns.svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeSuccess,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (non existing domain)
+	{
+		Qname: "foo.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
+	// NS query for qname != zone (non existing domain)
+	{
+		Qname: "foo.svc.cluster.local.", Qtype: dns.TypeNS,
+		Rcode: dns.RcodeNameError,
+		Ns: []dns.RR{
+			test.SOA("cluster.local.	5	IN	SOA	ns.dns.cluster.local. hostmaster.cluster.local. 1499347823 7200 1800 86400 5"),
+		},
+	},
 }
 
 func TestServeDNS(t *testing.T) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR fixes the NXDOMAIN/NODATA default case in ServeDNS.  The default case intends to determine if NXDOMAIN or NODATA should be returned to a client for other unhandled query types and non-apex NS queries.

For example:
`foo.cluster.local.  HINFO` -> was `NODATA`, should be `NXDOMAIN`
`foo.cluster.local.  NS` -> was `NODATA`, should be `NXDOMAIN`

This PR replaces #3105 (which only addressed the NS case)

### 2. Which issues (if any) are related?
#3098 #3105 

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No