### PR TITLE
run gofmt -w -s **/*.go

### DIFF
--- a/owners_generate.go
+++ b/owners_generate.go
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	
+
 	// sort it and format it
 	list := []string{}
 	for k := range o {

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -79,7 +79,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 func TestRoute53(t *testing.T) {
 	ctx := context.Background()
 
-	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Duration(1)*time.Minute)
+	r, err := New(ctx, fakeRoute53{}, map[string][]string{"bad.": {"0987654321"}}, time.Minute)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestRoute53(t *testing.T) {
 		t.Fatalf("Expected errors for zone bad.")
 	}
 
-	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, time.Duration(90)*time.Second)
+	r, err = New(ctx, fakeRoute53{}, map[string][]string{"org.": {"1357986420", "1234567890"}, "gov.": {"Z098765432", "1234567890"}}, 90*time.Second)
 	if err != nil {
 		t.Fatalf("Failed to create Route53: %v", err)
 	}


### PR DESCRIPTION
format and simplify; highlighted some stuff in route53_test.go that
could be further simplified.