### PR TITLE
Update build command inside docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ CoreDNS requires Go to compile. However, if you already have docker installed an
 setup a Go environment, you could build CoreDNS easily:
 
 ```
-$ docker run --rm -i -t -v $PWD:/go/src/github.com/coredns/coredns \
-      -w /go/src/github.com/coredns/coredns golang:1.12 make
+$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.12 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
Since we use golang 1.12 and gomod, it is not necessary to match the impor path to `/go/src/github.com/coredns/coredns` in order to build coredns. 

For that reason the build command inside docker could be simplified with:
```
$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.12 make
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>