### PR TITLE
Validate zone during normalization

### DIFF
--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -3,6 +3,7 @@ package dnsserver
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
@@ -52,7 +53,13 @@ func normalizeZone(str string) (zoneAddr, error) {
 		}
 	}
 
-	return zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
+	z := zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}
+	_, err = url.ParseRequestURI(z.String())
+	if err != nil {
+		return zoneAddr{}, err
+	}
+
+	return z, nil
 }
 
 // SplitProtocolHostPort splits a full formed address like "dns://[::1]:53" into parts.

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -28,6 +28,7 @@ func TestNormalizeZone(t *testing.T) {
 		{"https://.:8443", "https://.:8443", false},
 		{"https://..", "://:", true},
 		{"https://.:", "://:", true},
+		{"dns://.:1053{.:53", "://:", true},
 	} {
 		addr, err := normalizeZone(test.input)
 		actual := addr.String()


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
There is currently no validation on host zone, which lead to incorrect behavior after parsing zone in the Corefile.
I've added a RequestURL validation after the normalization to verify if the final zone is valid or not.
### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3164
### 3. Which documentation changes (if any) need to be made?
-
### 4. Does this introduce a backward incompatible change or deprecation?
No