### PR TITLE
Revert "Validate zone during normalization (#3165)"

### DIFF
--- a/core/dnsserver/address.go
+++ b/core/dnsserver/address.go
@@ -3,7 +3,6 @@ package dnsserver
 import (
 	"fmt"
 	"net"
-	"net/url"
 	"strings"
 
 	"github.com/coredns/coredns/plugin"
@@ -53,13 +52,7 @@ func normalizeZone(str string) (zoneAddr, error) {
 		}
 	}
 
-	z := zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}
-	_, err = url.ParseRequestURI(z.String())
-	if err != nil {
-		return zoneAddr{}, err
-	}
-
-	return z, nil
+	return zoneAddr{Zone: dns.Fqdn(host), Port: port, Transport: trans, IPNet: ipnet}, nil
 }
 
 // SplitProtocolHostPort splits a full formed address like "dns://[::1]:53" into parts.

--- a/core/dnsserver/address_test.go
+++ b/core/dnsserver/address_test.go
@@ -28,7 +28,6 @@ func TestNormalizeZone(t *testing.T) {
 		{"https://.:8443", "https://.:8443", false},
 		{"https://..", "://:", true},
 		{"https://.:", "://:", true},
-		{"dns://.:1053{.:53", "://:", true},
 	} {
 		addr, err := normalizeZone(test.input)
 		actual := addr.String()


### PR DESCRIPTION
This reverts commit f888c5f7f62e8f789fe4939faaa9e3b3a3f7c554.

See additional discussion in https://github.com/coredns/coredns/pull/3165#issuecomment-523476006

