### PR TITLE
plugin/file: respond correctly to IXFR message

### DIFF
--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -69,6 +69,9 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	return dns.RcodeSuccess, nil
 }
 
+// Name implements the plugin.Handler interface.
+func (x Xfr) Name() string { return "xfr" }
+
 // ServeIxfr checks if we need to serve a simpler IXFR for the incoming message.
 // See RFC 1995 Section 3: "... and the authority section containing the SOA record of client's version of the zone."
 // and Section 2, paragraph 4 where we only need to echo the SOA record back.
@@ -81,7 +84,6 @@ func (x Xfr) ServeIxfr(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	soa, ok := r.Ns[0].(*dns.SOA)
 	if !ok {
 		return dns.RcodeServerFailure, nil
-
 	}
 
 	x.RLock()
@@ -89,7 +91,6 @@ func (x Xfr) ServeIxfr(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 		x.RUnlock()
 		return dns.RcodeServerFailure, nil
 	}
-
 	serial := x.Apex.SOA.Serial
 	x.RUnlock()
 
@@ -102,8 +103,5 @@ func (x Xfr) ServeIxfr(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	}
 	return dns.RcodeServerFailure, nil
 }
-
-// Name implements the plugin.Handler interface.
-func (x Xfr) Name() string { return "xfr" }
 
 const transferLength = 1000 // Start a new envelop after message reaches this size in bytes. Intentionally small to test multi envelope parsing.

--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -31,7 +31,7 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	if state.QType() == dns.TypeIXFR {
 		code, _ := x.ServeIxfr(ctx, w, r)
 		if plugin.ClientWrite(code) {
-			return 0, nil
+			return code, nil
 		}
 	}
 

--- a/plugin/file/xfr.go
+++ b/plugin/file/xfr.go
@@ -26,6 +26,15 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 		return 0, plugin.Error(x.Name(), fmt.Errorf("xfr called with non transfer type: %d", state.QType()))
 	}
 
+	// For IXFR we take the SOA in the IXFR message (if there), compare it what we have and then decide to do an
+	// AXFR or just reply with one SOA message back.
+	if state.QType() == dns.TypeIXFR {
+		code, _ := x.ServeIxfr(ctx, w, r)
+		if plugin.ClientWrite(code) {
+			return 0, nil
+		}
+	}
+
 	records := x.All()
 	if len(records) == 0 {
 		return dns.RcodeServerFailure, nil
@@ -58,6 +67,40 @@ func (x Xfr) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (in
 	wg.Wait() // to wait before we can return and close the connection.
 
 	return dns.RcodeSuccess, nil
+}
+
+// ServeIxfr checks if we need to serve a simpler IXFR for the incoming message.
+// See RFC 1995 Section 3: "... and the authority section containing the SOA record of client's version of the zone."
+// and Section 2, paragraph 4 where we only need to echo the SOA record back.
+// This function must be called when the qtype is IXFR. It returns a plugin.ClientWrite(code) == false, when it didn't
+// write anything and we should perform an AXFR.
+func (x Xfr) ServeIxfr(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	if len(r.Ns) != 1 {
+		return dns.RcodeServerFailure, nil
+	}
+	soa, ok := r.Ns[0].(*dns.SOA)
+	if !ok {
+		return dns.RcodeServerFailure, nil
+
+	}
+
+	x.RLock()
+	if x.Apex.SOA == nil {
+		x.RUnlock()
+		return dns.RcodeServerFailure, nil
+	}
+
+	serial := x.Apex.SOA.Serial
+	x.RUnlock()
+
+	if soa.Serial == serial { // Section 2, para 4; echo SOA back. We have the same zone
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = []dns.RR{soa}
+		w.WriteMsg(m)
+		return 0, nil
+	}
+	return dns.RcodeServerFailure, nil
 }
 
 // Name implements the plugin.Handler interface.

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -83,3 +83,49 @@ func TestSecondaryZoneTransfer(t *testing.T) {
 		t.Fatalf("Expected answer section")
 	}
 }
+
+func TestIxfrResponse(t *testing.T) {
+	// ixfr query with current soa should return single packet with that soa (no transfer needed).
+	name, rm, err := test.TempFile(".", exampleOrg)
+	if err != nil {
+		t.Fatalf("Failed to create zone: %s", err)
+	}
+	defer rm()
+
+	corefile := `example.org:0 {
+       file ` + name + ` {
+	       transfer to *
+       }
+}
+`
+
+	i, udp, _, err := CoreDNSServerAndPorts(corefile)
+	if err != nil {
+		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
+	}
+	defer i.Stop()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeIXFR)
+	m.Ns = []dns.RR{test.SOA("example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600")} // copied from exampleOrg
+
+	var r *dns.Msg
+	// This is now async; we need to wait for it to be transferred.
+	for i := 0; i < 10; i++ {
+		r, _ = dns.Exchange(m, udp)
+		if len(r.Answer) != 0 {
+			break
+		}
+		time.Sleep(100 * time.Microsecond)
+	}
+	if len(r.Answer) != 1 {
+		t.Fatalf("Expected answer section with single RR")
+	}
+	soa, ok := r.Answer[0].(*dns.SOA)
+	if !ok {
+		t.Fatalf("Expected answer section with SOA RR")
+	}
+	if soa.Serial != 2015082541 {
+		t.Fatalf("Serial should be %d, got %d", 2015082541, soa.Serial)
+	}
+}


### PR DESCRIPTION
Respond with a sing SOA record to an IXFR request if the SOA serials
match.

The added test fails on the current code with:

~~~
=== RUN   TestIxfrResponse
--- FAIL: TestIxfrResponse (0.00s)
    secondary_test.go:122: Expected answer section with single RR
FAIL
exit status 1
~~~

And obviously passes with the new code. This should cut down on the
weird number of zone transfers that I was seeing. At some point IXFR
support might be cool.

Fixes: #3176