### PR TITLE
fuzz: fix rewrite crash by fixing fuzz/do.go

### DIFF
--- a/plugin/pkg/fuzz/do.go
+++ b/plugin/pkg/fuzz/do.go
@@ -13,15 +13,19 @@ import (
 // Do will fuzz p - used by gofuzz. See Makefile.fuzz for comments and context.
 func Do(p plugin.Handler, data []byte) int {
 	ctx := context.TODO()
-	ret := 1
 	r := new(dns.Msg)
 	if err := r.Unpack(data); err != nil {
-		ret = 0
+		return 0 // plugin will never be called when this happens.
+	}
+	// If the data unpack into a dns msg, but does not have a proper question section discard it.
+	// The server parts make sure this is true before calling the plugins; mimic this behavior.
+	if len(r.Question) != 1 {
+		return 0
 	}
 
 	if _, err := p.ServeDNS(ctx, &test.ResponseWriter{}, r); err != nil {
-		ret = 1
+		return 1
 	}
 
-	return ret
+	return 0
 }

--- a/plugin/pkg/fuzz/do.go
+++ b/plugin/pkg/fuzz/do.go
@@ -19,7 +19,7 @@ func Do(p plugin.Handler, data []byte) int {
 	}
 	// If the data unpack into a dns msg, but does not have a proper question section discard it.
 	// The server parts make sure this is true before calling the plugins; mimic this behavior.
-	if len(r.Question) != 1 {
+	if len(r.Question) == 0 {
 		return 0
 	}
 


### PR DESCRIPTION
DNS packets that don't have a valid question section where fuzzed into
plugins. This can't happen in the server because they are handled before
the server calls the plugins. Amend do.go to do the same thing and
actually fuzz things.