### PR TITLE
plugin/k8s_external: Correct test case and code

### DIFF
--- a/plugin/k8s_external/apex.go
+++ b/plugin/k8s_external/apex.go
@@ -20,7 +20,7 @@ func (e *External) serveApex(state request.Request) (int, error) {
 		addr := e.externalAddrFunc(state)
 		for _, rr := range addr {
 			rr.Header().Ttl = e.ttl
-			rr.Header().Name = state.QName()
+			rr.Header().Name = dnsutil.Join("ns1", e.apex, state.QName())
 			m.Extra = append(m.Extra, rr)
 		}
 	default:

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -59,7 +59,7 @@ var testsApex = []test.Case{
 			test.NS("example.com.	5	IN	NS	ns1.dns.example.com."),
 		},
 		Extra: []dns.RR{
-			test.A("example.com.	5	IN	A	127.0.0.1"),
+			test.A("ns1.dns.example.com.	5	IN	A	127.0.0.1"),
 		},
 	},
 	{


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

The NS test case was expecting the wrong A record name (expecting `example.com` instead of `ns1.dns.example.com`). This fixes the test case, and the code that was passing the bad test case.

### 2. Which issues (if any) are related?
Further fixes #3064

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no
