### PR TITLE
fuzz: use gofuzz build tag instead of fuzz

### DIFF
--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -24,13 +24,8 @@ FUZZ:=$(dir $(wildcard plugin/*/fuzz.go)) # plugin/cache/
 PLUGINS:=$(foreach f,$(FUZZ),$(subst plugin, ,$(f:/=))) # > /cache
 PLUGINS:=$(foreach f,$(PLUGINS),$(subst /, ,$(f))) # > cache
 
-.PHONY: vendor
-vendor:
-	@echo "Vendoring code till go-fuzz supports Go modules!"
-	@go mod vendor
-
 .PHONY: echo
-echo: vendor
+echo:
 	@echo $(PLUGINS) corefile
 
 all: $(PLUGINS) corefile

--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -24,8 +24,13 @@ FUZZ:=$(dir $(wildcard plugin/*/fuzz.go)) # plugin/cache/
 PLUGINS:=$(foreach f,$(FUZZ),$(subst plugin, ,$(f:/=))) # > /cache
 PLUGINS:=$(foreach f,$(PLUGINS),$(subst /, ,$(f))) # > cache
 
+.PHONY: vendor
+vendor:
+	@echo "Vendoring code till go-fuzz supports Go modules!"
+	@go mod vendor
+
 .PHONY: echo
-echo:
+echo: vendor
 	@echo $(PLUGINS) corefile
 
 all: $(PLUGINS) corefile
@@ -33,20 +38,20 @@ all: $(PLUGINS) corefile
 .PHONY: $(PLUGINS)
 $(PLUGINS): echo
 ifeq ($(LIBFUZZER), YES)
-	go-fuzz-build -tags fuzz -libfuzzer -o $(@).a ./plugin/$(@)
+	go-fuzz-build -libfuzzer -o $(@).a ./plugin/$(@)
 	clang -fsanitize=fuzzer $(@).a -o $(@)
 else
-	go-fuzz-build -tags fuzz $(REPO)/plugin/$(@)
+	go-fuzz-build $(REPO)/plugin/$(@)
 	go-fuzz -bin=./$(@)-fuzz.zip -workdir=fuzz/$(@)
 endif
 
 .PHONY: corefile
 corefile:
 ifeq ($(LIBFUZZER), YES)
-	go-fuzz-build -tags fuzz -libfuzzer -o $(@).a ./test
+	go-fuzz-build -libfuzzer -o $(@).a ./test
 	clang -fsanitize=fuzzer $(@).a -o $(@)
 else
-	go-fuzz-build -tags fuzz $(REPO)/test
+	go-fuzz-build $(REPO)/test
 	go-fuzz -bin=./test-fuzz.zip -workdir=fuzz/$(@)
 endif
 

--- a/plugin/cache/fuzz.go
+++ b/plugin/cache/fuzz.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package cache
 

--- a/plugin/chaos/fuzz.go
+++ b/plugin/chaos/fuzz.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package chaos
 

--- a/plugin/file/fuzz.go
+++ b/plugin/file/fuzz.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package file
 

--- a/plugin/rewrite/fuzz.go
+++ b/plugin/rewrite/fuzz.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package rewrite
 

--- a/plugin/whoami/fuzz.go
+++ b/plugin/whoami/fuzz.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package whoami
 

--- a/test/fuzz_corefile.go
+++ b/test/fuzz_corefile.go
@@ -1,4 +1,4 @@
-// +build fuzz
+// +build gofuzz
 
 package test
 


### PR DESCRIPTION
Since go-fuzz does not support Go modules yet, vendor dependencies.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Use build tag `gofuzz` instead of `fuzz` for fuzzing.

### 2. Which issues (if any) are related?
fixes #3174  