### PR TITLE
plugin/file: close reader for reload

### DIFF
--- a/plugin/file/reload.go
+++ b/plugin/file/reload.go
@@ -25,6 +25,7 @@ func (z *Zone) Reload() error {
 
 				serial := z.SOASerialIfDefined()
 				zone, err := Parse(reader, z.origin, zFile, serial)
+				reader.Close()
 				if err != nil {
 					if _, ok := err.(*serialErr); !ok {
 						log.Errorf("Parsing zone %q: %v", z.origin, err)


### PR DESCRIPTION
This reloader didn't close the openened file handle. Add a close. Can't
use `defer` because this is in a endless loop.

<strike>Fixes: #3191</strike>