### PR TITLE
plugin/kubernetes: Handle multiple local IPs and bind

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -381,14 +381,13 @@ func NS(ctx context.Context, b ServiceBackend, zone string, state request.Reques
 			return nil, nil, fmt.Errorf("NS record must be an IP address: %s", serv.Host)
 
 		case dns.TypeA, dns.TypeAAAA:
+			serv.Host = msg.Domain(serv.Key)
 			extra = append(extra, newAddress(serv, serv.Host, ip, what))
-
 			ns := serv.NewNS(state.QName())
-			if _, ok := seen[ns.Header().Name]; ok {
+			if _, ok := seen[ns.Ns]; ok {
 				continue
 			}
-			serv.Host = msg.Domain(serv.Key)
-			seen[ns.Header().Name] = true
+			seen[ns.Ns] = true
 			records = append(records, ns)
 		}
 	}

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -43,10 +43,10 @@ type Kubernetes struct {
 	Fall             fall.F
 	ttl              uint32
 	opts             dnsControlOpts
-	primaryZoneIndex   int
-	localIPs           []net.IP
-	autoPathSearch     []string // Local search path from /etc/resolv.conf. Needed for autopath.
-	TransferTo         []string
+	primaryZoneIndex int
+	localIPs         []net.IP
+	autoPathSearch   []string // Local search path from /etc/resolv.conf. Needed for autopath.
+	TransferTo       []string
 }
 
 // New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -43,9 +43,8 @@ type Kubernetes struct {
 	Fall             fall.F
 	ttl              uint32
 	opts             dnsControlOpts
-
 	primaryZoneIndex   int
-	interfaceAddrsFunc func() []net.IP
+	localIPs           []net.IP
 	autoPathSearch     []string // Local search path from /etc/resolv.conf. Needed for autopath.
 	TransferTo         []string
 }
@@ -56,7 +55,6 @@ func New(zones []string) *Kubernetes {
 	k := new(Kubernetes)
 	k.Zones = zones
 	k.Namespaces = make(map[string]struct{})
-	k.interfaceAddrsFunc = func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1")} }
 	k.podMode = podModeDisabled
 	k.ttl = defaultTTL
 

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -45,7 +45,7 @@ type Kubernetes struct {
 	opts             dnsControlOpts
 
 	primaryZoneIndex   int
-	interfaceAddrsFunc func() net.IP
+	interfaceAddrsFunc func() []net.IP
 	autoPathSearch     []string // Local search path from /etc/resolv.conf. Needed for autopath.
 	TransferTo         []string
 }
@@ -56,7 +56,7 @@ func New(zones []string) *Kubernetes {
 	k := new(Kubernetes)
 	k.Zones = zones
 	k.Namespaces = make(map[string]struct{})
-	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("127.0.0.1") }
+	k.interfaceAddrsFunc = func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1")} }
 	k.podMode = podModeDisabled
 	k.ttl = defaultTTL
 

--- a/plugin/kubernetes/kubernetes_apex_test.go
+++ b/plugin/kubernetes/kubernetes_apex_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -63,6 +64,7 @@ func TestServeDNSApex(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
 	k.Next = test.NextHandler(dns.RcodeSuccess, nil)
+	k.localIPs = []net.IP{net.ParseIP("127.0.0.1")}
 	ctx := context.TODO()
 
 	for i, tc := range kubeApexCases {
@@ -85,7 +87,7 @@ func TestServeDNSApex(t *testing.T) {
 		}
 
 		if err := test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
+			t.Errorf("Test %d: %v", i, err)
 		}
 	}
 }

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -310,16 +310,16 @@ func TestServicesAuthority(t *testing.T) {
 		key  string
 	}
 	type svcTest struct {
-		interfaceAddrs func() net.IP
+		interfaceAddrs func() []net.IP
 		qname          string
 		qtype          uint16
 		answer         *svcAns
 	}
 	tests := []svcTest{
-		{interfaceAddrs: func() net.IP { return net.ParseIP("127.0.0.1") }, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: &svcAns{host: "127.0.0.1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
-		{interfaceAddrs: func() net.IP { return net.ParseIP("127.0.0.1") }, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
-		{interfaceAddrs: func() net.IP { return net.ParseIP("::1") }, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
-		{interfaceAddrs: func() net.IP { return net.ParseIP("::1") }, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: &svcAns{host: "::1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
+		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: &svcAns{host: "127.0.0.1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
+		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
+		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("::1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
+		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("::1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: &svcAns{host: "::1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
 	}
 
 	for i, test := range tests {

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -313,13 +313,21 @@ func TestServicesAuthority(t *testing.T) {
 		localIPs []net.IP
 		qname    string
 		qtype    uint16
-		answer   *svcAns
+		answer   []svcAns
 	}
 	tests := []svcTest{
-		{localIPs: []net.IP{net.ParseIP("127.0.0.1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: &svcAns{host: "127.0.0.1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
-		{localIPs: []net.IP{net.ParseIP("127.0.0.1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
-		{localIPs: []net.IP{net.ParseIP("::1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
-		{localIPs: []net.IP{net.ParseIP("::1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: &svcAns{host: "::1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
+		{localIPs: []net.IP{net.ParseIP("1.2.3.4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: []svcAns{{host: "1.2.3.4", key: "/" + coredns + "/test/interwebs/dns/ns"}}},
+		{localIPs: []net.IP{net.ParseIP("1.2.3.4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
+		{localIPs: []net.IP{net.ParseIP("1:2::3:4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
+		{localIPs: []net.IP{net.ParseIP("1:2::3:4")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: []svcAns{{host: "1:2::3:4", key: "/" + coredns + "/test/interwebs/dns/ns"}}},
+		{
+			localIPs: []net.IP{net.ParseIP("1.2.3.4"), net.ParseIP("1:2::3:4")},
+			qname:    "ns.dns.interwebs.test.",
+			qtype:    dns.TypeNS, answer: []svcAns{
+				{host: "1.2.3.4", key: "/" + coredns + "/test/interwebs/dns/ns"},
+				{host: "1:2::3:4", key: "/" + coredns + "/test/interwebs/dns/ns"},
+			},
+		},
 	}
 
 	for i, test := range tests {
@@ -334,7 +342,7 @@ func TestServicesAuthority(t *testing.T) {
 			t.Errorf("Test %d: got error '%v'", i, e)
 			continue
 		}
-		if test.answer != nil && len(svcs) != 1 {
+		if test.answer != nil && len(svcs) != len(test.answer) {
 			t.Errorf("Test %d, expected 1 answer, got %v", i, len(svcs))
 			continue
 		}
@@ -347,11 +355,13 @@ func TestServicesAuthority(t *testing.T) {
 			continue
 		}
 
-		if test.answer.host != svcs[0].Host {
-			t.Errorf("Test %d, expected host '%v', got '%v'", i, test.answer.host, svcs[0].Host)
-		}
-		if test.answer.key != svcs[0].Key {
-			t.Errorf("Test %d, expected key '%v', got '%v'", i, test.answer.key, svcs[0].Key)
+		for i, answer := range test.answer {
+			if answer.host != svcs[i].Host {
+				t.Errorf("Test %d, expected host '%v', got '%v'", i, answer.host, svcs[i].Host)
+			}
+			if answer.key != svcs[i].Key {
+				t.Errorf("Test %d, expected key '%v', got '%v'", i, answer.key, svcs[i].Key)
+			}
 		}
 	}
 }

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -310,20 +310,20 @@ func TestServicesAuthority(t *testing.T) {
 		key  string
 	}
 	type svcTest struct {
-		interfaceAddrs func() []net.IP
-		qname          string
-		qtype          uint16
-		answer         *svcAns
+		localIPs []net.IP
+		qname    string
+		qtype    uint16
+		answer   *svcAns
 	}
 	tests := []svcTest{
-		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: &svcAns{host: "127.0.0.1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
-		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("127.0.0.1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
-		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("::1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
-		{interfaceAddrs: func() []net.IP { return []net.IP{net.ParseIP("::1") }}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: &svcAns{host: "::1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
+		{localIPs: []net.IP{net.ParseIP("127.0.0.1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA, answer: &svcAns{host: "127.0.0.1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
+		{localIPs: []net.IP{net.ParseIP("127.0.0.1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA},
+		{localIPs: []net.IP{net.ParseIP("::1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeA},
+		{localIPs: []net.IP{net.ParseIP("::1")}, qname: "ns.dns.interwebs.test.", qtype: dns.TypeAAAA, answer: &svcAns{host: "::1", key: "/" + coredns + "/test/interwebs/dns/ns"}},
 	}
 
 	for i, test := range tests {
-		k.interfaceAddrsFunc = test.interfaceAddrs
+		k.localIPs = test.localIPs
 
 		state := request.Request{
 			Req:  &dns.Msg{Question: []dns.Question{{Name: test.qname, Qtype: test.qtype}}},

--- a/plugin/kubernetes/local.go
+++ b/plugin/kubernetes/local.go
@@ -11,13 +11,13 @@ import (
 func boundIPs(c *caddy.Controller) (ips []net.IP) {
 	conf := dnsserver.GetConfig(c)
 	hosts := conf.ListenHosts
-	if  hosts == nil || hosts[0] == "" {
+	if hosts == nil || hosts[0] == "" {
 		hosts = nil
 		addrs, err := net.InterfaceAddrs()
 		if err != nil {
 			return nil
 		}
-		for _, addr := range addrs{
+		for _, addr := range addrs {
 			hosts = append(hosts, addr.String())
 		}
 	}
@@ -26,6 +26,7 @@ func boundIPs(c *caddy.Controller) (ips []net.IP) {
 		ip4 := ip.To4()
 		if ip4 != nil && !ip4.IsLoopback() {
 			ips = append(ips, ip4)
+			continue
 		}
 		ip6 := ip.To16()
 		if ip6 != nil && !ip6.IsLoopback() {

--- a/plugin/kubernetes/local.go
+++ b/plugin/kubernetes/local.go
@@ -4,7 +4,7 @@ import (
 	"net"
 )
 
-func localPodIP() net.IP {
+func localPodIP() (ips []net.IP) {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
 		return nil
@@ -14,29 +14,31 @@ func localPodIP() net.IP {
 		ip, _, _ := net.ParseCIDR(addr.String())
 		ip4 := ip.To4()
 		if ip4 != nil && !ip4.IsLoopback() {
-			return ip4
+			ips = append(ips, ip4)
 		}
 		ip6 := ip.To16()
 		if ip6 != nil && !ip6.IsLoopback() {
-			return ip6
+			ips = append(ips, ip6)
 		}
 	}
-	return nil
+	return ips
 }
 
 // LocalNodeName is exclusively used in federation plugin, will be deprecated later.
 func (k *Kubernetes) LocalNodeName() string {
-	localIP := k.interfaceAddrsFunc()
-	if localIP == nil {
+	localIPs := k.interfaceAddrsFunc()
+	if len(localIPs) == 0 {
 		return ""
 	}
 
-	// Find endpoint matching localIP
-	for _, ep := range k.APIConn.EpIndexReverse(localIP.String()) {
-		for _, eps := range ep.Subsets {
-			for _, addr := range eps.Addresses {
-				if localIP.Equal(net.ParseIP(addr.IP)) {
-					return addr.NodeName
+	// Find fist endpoint matching any localIP
+	for _, localIP := range localIPs {
+		for _, ep := range k.APIConn.EpIndexReverse(localIP.String()) {
+			for _, eps := range ep.Subsets {
+				for _, addr := range eps.Addresses {
+					if localIP.Equal(net.ParseIP(addr.IP)) {
+						return addr.NodeName
+					}
 				}
 			}
 		}

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -21,7 +21,7 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 		svcIPs   []net.IP
 	)
 
-	// Find the CoreDNS Endpoint
+	// Find the CoreDNS Endpoints
 	for _, localIP := range k.localIPs {
 		endpoints := k.APIConn.EpIndexReverse(localIP.String())
 

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -22,8 +22,7 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 	)
 
 	// Find the CoreDNS Endpoint
-	localIPs := k.interfaceAddrsFunc()
-	for _, localIP := range localIPs {
+	for _, localIP := range k.localIPs {
 		endpoints := k.APIConn.EpIndexReverse(localIP.String())
 
 		// Collect IPs for all Services of the Endpoints
@@ -58,7 +57,7 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 	// If no local IPs matched any endpoints, use the localIPs directly
 	if len(svcIPs) == 0 {
 		svcNames = []string{defaultNSName + zone}
-		svcIPs = localIPs
+		svcIPs = k.localIPs
 	}
 
 	// Create an RR slice of collected IPs

--- a/plugin/kubernetes/ns.go
+++ b/plugin/kubernetes/ns.go
@@ -56,8 +56,12 @@ func (k *Kubernetes) nsAddrs(external bool, zone string) []dns.RR {
 
 	// If no local IPs matched any endpoints, use the localIPs directly
 	if len(svcIPs) == 0 {
-		svcNames = []string{defaultNSName + zone}
-		svcIPs = k.localIPs
+		svcIPs = make([]net.IP, len(k.localIPs))
+		svcNames = make([]string, len(k.localIPs))
+		for i, localIP := range k.localIPs {
+			svcNames[i] = defaultNSName + zone
+			svcIPs[i] = localIP
+		}
 	}
 
 	// Create an RR slice of collected IPs

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -111,7 +111,7 @@ func TestNsAddrs(t *testing.T) {
 
 	k := New([]string{"inter.webs.test."})
 	k.APIConn = &APIConnTest{}
-	k.interfaceAddrsFunc = func() net.IP { return net.ParseIP("10.244.0.20") }
+	k.interfaceAddrsFunc = func() []net.IP { return []net.IP{net.ParseIP("10.244.0.20")} }
 
 	cdrs := k.nsAddrs(false, k.Zones[0])
 

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -111,7 +111,7 @@ func TestNsAddrs(t *testing.T) {
 
 	k := New([]string{"inter.webs.test."})
 	k.APIConn = &APIConnTest{}
-	k.interfaceAddrsFunc = func() []net.IP { return []net.IP{net.ParseIP("10.244.0.20")} }
+	k.localIPs = []net.IP{net.ParseIP("10.244.0.20")}
 
 	cdrs := k.nsAddrs(false, k.Zones[0])
 

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -61,6 +61,12 @@ func setup(c *caddy.Controller) error {
 		return k
 	})
 
+	// get locally bound addresses
+	c.OnStartup(func() error {
+		k.localIPs = boundIPs(c)
+		return nil
+	})
+
 	return nil
 }
 
@@ -113,7 +119,6 @@ func kubernetesParse(c *caddy.Controller) (*Kubernetes, error) {
 func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 
 	k8s := New([]string{""})
-	k8s.interfaceAddrsFunc = localPodIP
 	k8s.autoPathSearch = searchFromResolvConf()
 
 	opts := dnsControlOpts{


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Handle NS responses for following cases:
* CoreDNS is bound to more than one local address.
* CoreDNS is bound to a specific address/addresses with the bind plugin:  Only use the bound IPs.

example: CoreDNS bound to two IP addresses
```
;; ANSWER SECTION:
cluster.local.		5	IN	NS	ns.dns.cluster.local.

;; ADDITIONAL SECTION:
ns.dns.cluster.local.	5	IN	AAAA	1::2:3:4:5
ns.dns.cluster.local.	5	IN	A	10.84.16.183
```

Previously, we would always only use the _first_ non-loopback address seen on the local system.
This would fail in cases where:
* CoreDNS is using the bind plugin to bind to an IP other than the first non-loopback address. CoreDNS would then answer with an IP that it is not bound to.
* In a Kubernetes cluster, if CoreDNS runs in a dual stack pod, the first IP may not be targeted by a service (or each IP could be targeted by different services), in which case CoreDNS would answer incompletely, or with the Pod IP instead of the Service IP.


### 2. Which issues (if any) are related?
#3160
Also related to dual stack support in k8s.


### 3. Which documentation changes (if any) need to be made?
no

### 4. Does this introduce a backward incompatible change or deprecation?
no