### PR TITLE
pkg/log: remove timestamp

### DIFF
--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -14,7 +14,6 @@ import (
 	golog "log"
 	"os"
 	"sync"
-	"time"
 )
 
 // D controls whether we should output debug logs. If true, we do, once set
@@ -41,17 +40,14 @@ func (d *d) Value() bool {
 	return b
 }
 
-// RFC3339Milli doesn't exist, invent it here.
-func clock() string { return time.Now().Format("2006-01-02T15:04:05.000Z07:00") }
-
 // logf calls log.Printf prefixed with level.
 func logf(level, format string, v ...interface{}) {
-	golog.Print(clock(), level, fmt.Sprintf(format, v...))
+	golog.Print(level, fmt.Sprintf(format, v...))
 }
 
 // log calls log.Print prefixed with level.
 func log(level string, v ...interface{}) {
-	golog.Print(clock(), level, fmt.Sprint(v...))
+	golog.Print(level, fmt.Sprint(v...))
 }
 
 // Debug is equivalent to log.Print(), but prefixed with "[DEBUG] ". It only outputs something
@@ -102,9 +98,9 @@ func Fatalf(format string, v ...interface{}) { logf(fatal, format, v...); os.Exi
 func Discard() { golog.SetOutput(ioutil.Discard) }
 
 const (
-	debug   = " [DEBUG] "
-	err     = " [ERROR] "
-	fatal   = " [FATAL] "
-	info    = " [INFO] "
-	warning = " [WARNING] "
+	debug   = "[DEBUG] "
+	err     = "[ERROR] "
+	fatal   = "[FATAL] "
+	info    = "[INFO] "
+	warning = "[WARNING] "
 )

--- a/plugin/pkg/log/plugin_test.go
+++ b/plugin/pkg/log/plugin_test.go
@@ -19,19 +19,3 @@ func TestPlugins(t *testing.T) {
 		t.Errorf("Expected log to be %s, got %s", info+ts, x)
 	}
 }
-
-func TestPluginsDateTime(t *testing.T) {
-	var f bytes.Buffer
-	const ts = "test"
-	golog.SetFlags(0) // Set to 0 because we're doing our own time, with timezone
-	golog.SetOutput(&f)
-
-	lg := NewWithPlugin("testplugin")
-
-	lg.Info(ts)
-	// rude check if the date/time is there
-	str := f.String()
-	if str[4] != '-' || str[7] != '-' || str[10] != 'T' {
-		t.Errorf("Expected date got %s...", str[:15])
-	}
-}


### PR DESCRIPTION
journald timestamps, kubernetes timestamps, syslog timestamps. It seems
silly to add our own timestamps to the logging output as these external
ones *also* do it. Only when just running coredns this might be weird.

Remove the timestamping from pkg/log.

Remove test that tested for this.

Fixes: #3211