### PR TITLE
Fix for 3235. Adds go.sum and go.mod to .dockerignore to avoid permis…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ test/*
 vendor/*
 build/*
 release/*
+go.sum
+go.mod


### PR DESCRIPTION
…sion issues during docker build process.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Adds two files to .dockerignore that may be owned by root if the coredns binary was built in a golang docker container with root permissions and the docker container based on that build is built from a non-root context. See #3235 for details.

### 2. Which issues (if any) are related?
#3235 

### 3. Which documentation changes (if any) need to be made?
None. Perhaps for clarity, if similar issues occur in the future, reference this issue in the documentation on docker build process.

### 4. Does this introduce a backward incompatible change or deprecation?
No
