### PR TITLE
plugin/kubernetes: Don't duplicate service records in zone transfer

### DIFF
--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -110,14 +110,15 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 		case api.ServiceTypeClusterIP, api.ServiceTypeNodePort, api.ServiceTypeLoadBalancer:
 			clusterIP := net.ParseIP(svc.ClusterIP)
 			if clusterIP != nil {
+				s := msg.Service{Host: svc.ClusterIP, TTL: k.ttl}
+				s.Key = strings.Join(svcBase, "/")
+
+				// Change host from IP to Name for SRV records
+				host := emitAddressRecord(c, s)
+
 				for _, p := range svc.Ports {
-
-					s := msg.Service{Host: svc.ClusterIP, Port: int(p.Port), TTL: k.ttl}
+					s := msg.Service{Host: host, Port: int(p.Port), TTL: k.ttl}
 					s.Key = strings.Join(svcBase, "/")
-
-					// Change host from IP to Name for SRV records
-					host := emitAddressRecord(c, s)
-					s.Host = host
 
 					// Need to generate this to handle use cases for peer-finder
 					// ref: https://github.com/coredns/coredns/pull/823


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Noticed this while working on the new transfer plugin (#3223).  The existing kubernetes transfer code creates a duplicate service A/AAAA record for every port the service defines.  AFAIK, zone transfer recipients should tolerate duplicate records in a zone transfer, but it does make the transfer larger than it needs to be.

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No