### PR TITLE
Making dnssec's README consistent with other plugins' READMEs

### DIFF
--- a/plugin/dnssec/README.md
+++ b/plugin/dnssec/README.md
@@ -2,11 +2,11 @@
 
 ## Name
 
-*dnssec* - enable on-the-fly DNSSEC signing of served data.
+*dnssec* - enables on-the-fly DNSSEC signing of served data.
 
 ## Description
 
-With *dnssec* any reply that doesn't (or can't) do DNSSEC will get signed on the fly. Authenticated
+With *dnssec*, any reply that doesn't (or can't) do DNSSEC will get signed on the fly. Authenticated
 denial of existence is implemented with NSEC black lies. Using ECDSA as an algorithm is preferred as
 this leads to smaller signatures (compared to RSA). NSEC3 is *not* supported.
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
