### PR TITLE
Bump Travis CI to use golang 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - "1.12.x"
+  - "1.13.x"
 
 cache:
   directories:


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Bump Travis CI to use golang 1.13.x

### 2. Which issues (if any) are related?

n/a
### 3. Which documentation changes (if any) need to be made?
n/a
### 4. Does this introduce a backward incompatible change or deprecation?

n/a

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
