### PR TITLE
default config: add log

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -28,7 +28,7 @@ func init() {
 		DefaultInput: func() caddy.Input {
 			return caddy.CaddyfileInput{
 				Filepath:       "Corefile",
-				Contents:       []byte(".:" + Port + " {\nwhoami\n}\n"),
+				Contents:       []byte(".:" + Port + " {\nwhoami\nlog\n}\n"),
 				ServerTypeName: serverType,
 			}
 		},


### PR DESCRIPTION
When there is no Corefile found we load the default. Add the log plugin
to it, so you can see queries actually landing in CoreDNS.