### PR TITLE
all: simplify registering plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,18 +32,15 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
 	github.com/philhofer/fwd v1.0.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/prometheus/common v0.7.0
-	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/tinylib/msgp v1.1.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	go.etcd.io/etcd v0.0.0-20190823073701-67d0c21bb04c
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
+	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
+	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
 	google.golang.org/api v0.10.0
 	google.golang.org/genproto v0.0.0-20190701230453-710ae3a149df // indirect
 	google.golang.org/grpc v1.23.0

--- a/plugin/acl/setup.go
+++ b/plugin/acl/setup.go
@@ -13,12 +13,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() {
-	caddy.RegisterPlugin("acl", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("acl", setup) }
 
 func newDefaultFilter() *iptree.Tree {
 	defaultFilter := iptree.NewTree()

--- a/plugin/any/setup.go
+++ b/plugin/any/setup.go
@@ -7,12 +7,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("any", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("any", setup) }
 
 func setup(c *caddy.Controller) error {
 	a := Any{}

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -18,12 +18,7 @@ import (
 
 var log = clog.NewWithPlugin("auto")
 
-func init() {
-	caddy.RegisterPlugin("auto", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("auto", setup) }
 
 func setup(c *caddy.Controller) error {
 	a, err := autoParse(c)

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -11,13 +11,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() {
-	caddy.RegisterPlugin("autopath", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-
-}
+func init() { plugin.Register("autopath", setup) }
 
 func setup(c *caddy.Controller) error {
 	ap, mw, err := autoPathParse(c)

--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -17,12 +17,7 @@ import (
 
 var log = clog.NewWithPlugin("azure")
 
-func init() {
-	caddy.RegisterPlugin("azure", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("azure", setup) }
 
 func setup(c *caddy.Controller) error {
 	env, keys, fall, err := parse(c)

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -16,12 +16,7 @@ import (
 
 var log = clog.NewWithPlugin("cache")
 
-func init() {
-	caddy.RegisterPlugin("cache", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("cache", setup) }
 
 func setup(c *caddy.Controller) error {
 	ca, err := cacheParse(c)

--- a/plugin/chaos/setup.go
+++ b/plugin/chaos/setup.go
@@ -11,13 +11,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("chaos", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-
-}
+func init() { plugin.Register("chaos", setup) }
 
 func setup(c *caddy.Controller) error {
 	version, authors, err := parse(c)

--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -18,9 +18,8 @@ import (
 var log = clog.NewWithPlugin("clouddns")
 
 func init() {
-	caddy.RegisterPlugin("clouddns", caddy.Plugin{
-		ServerType: "dns",
-		Action: func(c *caddy.Controller) error {
+	plugin.Register("clouddns",
+		func(c *caddy.Controller) error {
 			f := func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
 				var err error
 				var client *gcp.Service
@@ -35,7 +34,7 @@ func init() {
 			}
 			return setup(c, f)
 		},
-	})
+	)
 }
 
 func setup(c *caddy.Controller, f func(ctx context.Context, opt option.ClientOption) (gcpDNS, error)) error {

--- a/plugin/deprecated/setup.go
+++ b/plugin/deprecated/setup.go
@@ -20,7 +20,7 @@ import (
 )
 
 // removed has the names of the plugins that need to error on startup.
-var removed = []string{"reverse"}
+var removed = []string{""}
 
 func setup(c *caddy.Controller) error {
 	c.Next()
@@ -29,10 +29,7 @@ func setup(c *caddy.Controller) error {
 }
 
 func init() {
-	for _, plugin := range removed {
-		caddy.RegisterPlugin(plugin, caddy.Plugin{
-			ServerType: "dns",
-			Action:     setup,
-		})
+	for _, plug := range removed {
+		plugin.Register(plug, setup)
 	}
 }

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -17,12 +17,7 @@ import (
 
 var log = clog.NewWithPlugin("dnssec")
 
-func init() {
-	caddy.RegisterPlugin("dnssec", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("dnssec", setup) }
 
 func setup(c *caddy.Controller) error {
 	zones, keys, capacity, splitkeys, err := dnssecParse(c)

--- a/plugin/dnstap/setup.go
+++ b/plugin/dnstap/setup.go
@@ -15,12 +15,7 @@ import (
 
 var log = clog.NewWithPlugin("dnstap")
 
-func init() {
-	caddy.RegisterPlugin("dnstap", caddy.Plugin{
-		ServerType: "dns",
-		Action:     wrapSetup,
-	})
-}
+func init() { plugin.Register("dnstap", wrapSetup) }
 
 func wrapSetup(c *caddy.Controller) error {
 	if err := setup(c); err != nil {

--- a/plugin/erratic/setup.go
+++ b/plugin/erratic/setup.go
@@ -11,12 +11,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("erratic", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("erratic", setup) }
 
 func setup(c *caddy.Controller) error {
 	e, err := parseErratic(c)

--- a/plugin/errors/setup.go
+++ b/plugin/errors/setup.go
@@ -10,12 +10,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("errors", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("errors", setup) }
 
 func setup(c *caddy.Controller) error {
 	handler, err := errorsParse(c)

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -15,12 +15,7 @@ import (
 
 var log = clog.NewWithPlugin("etcd")
 
-func init() {
-	caddy.RegisterPlugin("etcd", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("etcd", setup) }
 
 func setup(c *caddy.Controller) error {
 	e, err := etcdParse(c)

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -13,12 +13,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("file", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("file", setup) }
 
 func setup(c *caddy.Controller) error {
 	zones, err := fileParse(c)

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -16,12 +16,7 @@ import (
 	"github.com/caddyserver/caddy/caddyfile"
 )
 
-func init() {
-	caddy.RegisterPlugin("forward", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("forward", setup) }
 
 func setup(c *caddy.Controller) error {
 	f, err := parseForward(c)

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -14,12 +14,7 @@ import (
 	"github.com/caddyserver/caddy/caddyfile"
 )
 
-func init() {
-	caddy.RegisterPlugin("grpc", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("grpc", setup) }
 
 func setup(c *caddy.Controller) error {
 	g, err := parseGRPC(c)

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -11,12 +11,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("health", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("health", setup) }
 
 func setup(c *caddy.Controller) error {
 	addr, lame, err := parse(c)

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -16,12 +16,7 @@ import (
 
 var log = clog.NewWithPlugin("hosts")
 
-func init() {
-	caddy.RegisterPlugin("hosts", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("hosts", setup) }
 
 func periodicHostsUpdate(h *Hosts) chan bool {
 	parseChan := make(chan bool)

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -9,12 +9,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("k8s_external", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("k8s_external", setup) }
 
 func setup(c *caddy.Controller) error {
 	e, err := parse(c)

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -34,12 +34,7 @@ import (
 
 var log = clog.NewWithPlugin("kubernetes")
 
-func init() {
-	caddy.RegisterPlugin("kubernetes", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("kubernetes", setup) }
 
 func setup(c *caddy.Controller) error {
 	klog.SetOutput(os.Stdout)

--- a/plugin/loadbalance/setup.go
+++ b/plugin/loadbalance/setup.go
@@ -12,12 +12,7 @@ import (
 
 var log = clog.NewWithPlugin("loadbalance")
 
-func init() {
-	caddy.RegisterPlugin("loadbalance", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("loadbalance", setup) }
 
 func setup(c *caddy.Controller) error {
 	err := parse(c)

--- a/plugin/log/setup.go
+++ b/plugin/log/setup.go
@@ -12,12 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() {
-	caddy.RegisterPlugin("log", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("log", setup) }
 
 func setup(c *caddy.Controller) error {
 	rules, err := logParse(c)

--- a/plugin/loop/setup.go
+++ b/plugin/loop/setup.go
@@ -13,12 +13,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("loop", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("loop", setup) }
 
 func setup(c *caddy.Controller) error {
 	l, err := parse(c)

--- a/plugin/metadata/setup.go
+++ b/plugin/metadata/setup.go
@@ -7,12 +7,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("metadata", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("metadata", setup) }
 
 func setup(c *caddy.Controller) error {
 	m, err := metadataParse(c)

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -20,12 +20,7 @@ var (
 	registry = newReg()
 )
 
-func init() {
-	caddy.RegisterPlugin("prometheus", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("prometheus", setup) }
 
 func setup(c *caddy.Controller) error {
 	m, err := parse(c)

--- a/plugin/nsid/setup.go
+++ b/plugin/nsid/setup.go
@@ -10,12 +10,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("nsid", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("nsid", setup) }
 
 func setup(c *caddy.Controller) error {
 	nsid, err := nsidParse(c)

--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -15,12 +15,7 @@ var log = clog.NewWithPlugin("pprof")
 
 const defaultAddr = "localhost:6053"
 
-func init() {
-	caddy.RegisterPlugin("pprof", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("pprof", setup) }
 
 func setup(c *caddy.Controller) error {
 	h := &handler{addr: defaultAddr}

--- a/plugin/ready/setup.go
+++ b/plugin/ready/setup.go
@@ -9,12 +9,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("ready", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("ready", setup) }
 
 func setup(c *caddy.Controller) error {
 	addr, err := parse(c)

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -1,0 +1,11 @@
+package plugin
+
+import "github.com/caddyserver/caddy"
+
+// Register registers your plugin with CoreDNS and allows it to be called when the server is running.
+func Register(name string, action caddy.SetupFunc) {
+	caddy.RegisterPlugin(name, caddy.Plugin{
+		ServerType: "dns",
+		Action:     action,
+	})
+}

--- a/plugin/reload/setup.go
+++ b/plugin/reload/setup.go
@@ -14,12 +14,7 @@ import (
 
 var log = clog.NewWithPlugin("reload")
 
-func init() {
-	caddy.RegisterPlugin("reload", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("reload", setup) }
 
 // the info reload is global to all application, whatever number of reloads.
 // it is used to transmit data between Setup and start of the hook called 'onInstanceStartup'

--- a/plugin/rewrite/setup.go
+++ b/plugin/rewrite/setup.go
@@ -10,12 +10,7 @@ import (
 
 var log = clog.NewWithPlugin("rewrite")
 
-func init() {
-	caddy.RegisterPlugin("rewrite", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("rewrite", setup) }
 
 func setup(c *caddy.Controller) error {
 	rewrites, err := rewriteParse(c)

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -25,9 +25,8 @@ import (
 var log = clog.NewWithPlugin("route53")
 
 func init() {
-	caddy.RegisterPlugin("route53", caddy.Plugin{
-		ServerType: "dns",
-		Action: func(c *caddy.Controller) error {
+	plugin.Register("route53",
+		func(c *caddy.Controller) error {
 			f := func(credential *credentials.Credentials) route53iface.Route53API {
 				return route53.New(session.Must(session.NewSession(&aws.Config{
 					Credentials: credential,
@@ -35,7 +34,7 @@ func init() {
 			}
 			return setup(c, f)
 		},
-	})
+	)
 }
 
 func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Route53API) error {

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -10,12 +10,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("secondary", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("secondary", setup) }
 
 func setup(c *caddy.Controller) error {
 	zones, err := secondaryParse(c)

--- a/plugin/sign/setup.go
+++ b/plugin/sign/setup.go
@@ -12,12 +12,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("sign", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("sign", setup) }
 
 func setup(c *caddy.Controller) error {
 	sign, err := parse(c)

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -12,12 +12,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() {
-	caddy.RegisterPlugin("template", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setupTemplate,
-	})
-}
+func init() { plugin.Register("template", setupTemplate) }
 
 func setupTemplate(c *caddy.Controller) error {
 	handler, err := templateParse(c)

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -11,12 +11,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("trace", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("trace", setup) }
 
 func setup(c *caddy.Controller) error {
 	t, err := traceParse(c)

--- a/plugin/whoami/setup.go
+++ b/plugin/whoami/setup.go
@@ -7,12 +7,7 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() {
-	caddy.RegisterPlugin("whoami", caddy.Plugin{
-		ServerType: "dns",
-		Action:     setup,
-	})
-}
+func init() { plugin.Register("whoami", setup) }
 
 func setup(c *caddy.Controller) error {
 	c.Next() // 'whoami'


### PR DESCRIPTION
Abstract the caddy call and make it simpler.

See #3261 for some part of the discussion.

Go from:

~~~ go
func init() {
       caddy.RegisterPlugin("any", caddy.Plugin{
               ServerType: "dns",
               Action:     setup,
       })
}
~~~

To:

~~~ go
func init() { plugin.Register("any", setup) }
~~~

This requires some external documents in coredns.io to be updated as
well; the old way still works, so it's backwards compatible.