### PR TITLE
update doc to not use the root zone for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ When starting CoreDNS without any configuration, it loads the
 
 ~~~ txt
 .:53
-2016/09/18 09:20:50 [INFO] CoreDNS-001
-CoreDNS-001
+   ______                ____  _   _______
+  / ____/___  ________  / __ \/ | / / ___/	~ CoreDNS-1.6.3
+ / /   / __ \/ ___/ _ \/ / / /  |/ /\__ \ 	~ linux/amd64, go1.13,
+/ /___/ /_/ / /  /  __/ /_/ / /|  /___/ /
+\____/\____/_/   \___/_____/_/ |_//____/
 ~~~
 
 Any query sent to port 53 should return some information; your sending address, port and protocol
@@ -128,14 +131,17 @@ Serve `example.org` on port 1053, but forward everything that does *not* match `
 recursive nameserver *and* rewrite ANY queries to HINFO.
 
 ~~~ txt
-.:1053 {
-    rewrite ANY HINFO
-    forward . 8.8.8.8:53
-
-    file /var/lib/coredns/example.org.signed example.org {
+example.org:1053 {
+    file /var/lib/coredns/example.org.signed {
         transfer to *
         transfer to 2001:500:8f::53
     }
+    errors
+    log
+}
+. {
+    any
+    forward . 8.8.8.8:53
     errors
     log
 }

--- a/go.mod
+++ b/go.mod
@@ -32,18 +32,15 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5
 	github.com/philhofer/fwd v1.0.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/prometheus/common v0.7.0
-	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/tinylib/msgp v1.1.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
 	go.etcd.io/etcd v0.0.0-20190823073701-67d0c21bb04c
-	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-	golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3
-	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 // indirect
+	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
+	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd
 	google.golang.org/api v0.10.0
 	google.golang.org/genproto v0.0.0-20190701230453-710ae3a149df // indirect
 	google.golang.org/grpc v1.23.0

--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -56,8 +56,8 @@ Load `org` domains from `/etc/coredns/zones/org` and allow transfers to the inte
 notifies to 10.240.1.1
 
 ~~~ corefile
-. {
-    auto org {
+org {
+    auto {
         directory /etc/coredns/zones/org
         transfer to *
         transfer to 10.240.1.1

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -93,13 +93,13 @@ Proxy to Google Public DNS and only cache responses for example.org (or below).
 }
 ~~~
 
-Enable caching for all zones, keep a positive cache size of 5000 and a negative cache size of 2500:
+Enable caching for `example.org`, keep a positive cache size of 5000 and a negative cache size of 2500:
 
 ~~~ corefile
- . {
-     cache {
-         success 5000
-         denial 2500
+example.org {
+    cache {
+        success 5000
+        denial 2500
     }
- }
- ~~~
+}
+~~~

--- a/plugin/cancel/README.md
+++ b/plugin/cancel/README.md
@@ -25,7 +25,7 @@ cancel [TIMEOUT]
 ## Examples
 
 ~~~ corefile
-. {
+example.org {
     cancel
     whoami
 }
@@ -34,7 +34,7 @@ cancel [TIMEOUT]
 Or with a custom timeout:
 
 ~~~ corefile
-. {
+example.org {
     cancel 1s
     whoami
 }

--- a/plugin/clouddns/README.md
+++ b/plugin/clouddns/README.md
@@ -49,7 +49,7 @@ clouddns [ZONE:PROJECT_ID:HOSTED_ZONE_NAME...] {
 Enable clouddns with implicit GCP credentials and resolve CNAMEs via 10.0.0.1:
 
 ~~~ txt
-. {
+example.org {
     clouddns example.org.:gcp-example-project:example-zone
     forward . 10.0.0.1
 }
@@ -58,7 +58,7 @@ Enable clouddns with implicit GCP credentials and resolve CNAMEs via 10.0.0.1:
 Enable clouddns with fallthrough:
 
 ~~~ txt
-. {
+example.org {
     clouddns example.org.:gcp-example-project:example-zone clouddns example.com.:gcp-example-project:example-zone-2 {
         fallthrough example.gov.
     }

--- a/plugin/debug/README.md
+++ b/plugin/debug/README.md
@@ -45,4 +45,4 @@ Disable the ability to recover from crashes and show debug logging:
 
 ## Also See
 
-https://www.wireshark.org/docs/man-pages/text2pcap.html.
+<https://www.wireshark.org/docs/man-pages/text2pcap.html>.

--- a/plugin/erratic/README.md
+++ b/plugin/erratic/README.md
@@ -40,7 +40,7 @@ This plugin reports readiness to the ready plugin.
 ## Examples
 
 ~~~ corefile
-. {
+example.org {
     erratic {
         drop 3
     }
@@ -50,7 +50,7 @@ This plugin reports readiness to the ready plugin.
 Or even shorter if the defaults suits you. Note this only drops queries, it does not delay them.
 
 ~~~ corefile
-. {
+example.org {
     erratic
 }
 ~~~
@@ -58,7 +58,7 @@ Or even shorter if the defaults suits you. Note this only drops queries, it does
 Delay 1 in 3 queries for 50ms
 
 ~~~ corefile
-. {
+example.org {
     erratic {
         delay 3 50ms
     }
@@ -68,7 +68,7 @@ Delay 1 in 3 queries for 50ms
 Delay 1 in 3 and truncate 1 in 5.
 
 ~~~ corefile
-. {
+example.org {
     erratic {
         delay 3 5ms
         truncate 5
@@ -79,7 +79,7 @@ Delay 1 in 3 and truncate 1 in 5.
 Drop every second query.
 
 ~~~ corefile
-. {
+example.org {
     erratic {
         drop 2
         truncate 2
@@ -89,5 +89,4 @@ Drop every second query.
 
 ## Also See
 
-[RFC 3849](https://tools.ietf.org/html/rfc3849) and
-[RFC 5737](https://tools.ietf.org/html/rfc5737).
+[RFC 3849](https://tools.ietf.org/html/rfc3849) and [RFC 5737](https://tools.ietf.org/html/rfc5737).

--- a/plugin/errors/README.md
+++ b/plugin/errors/README.md
@@ -38,10 +38,10 @@ For better performance, it's recommended to use the `^` or `$` metacharacters in
 
 ## Examples
 
-Use the *whoami* to respond to queries and Log errors to standard output.
+Use the *whoami* to respond to queries in the example.org domain and Log errors to standard output.
 
 ~~~ corefile
-. {
+example.org {
     whoami
     errors
 }

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -77,15 +77,19 @@ This causes two lookups from CoreDNS to etcdv3 in certain cases.
 This is the default SkyDNS setup, with everything specified in full:
 
 ~~~ corefile
-. {
-    etcd skydns.local {
+skydns.local {
+    etcd {
         path /skydns
         endpoint http://localhost:2379
     }
     prometheus
-    cache 160 skydns.local
+    cache
     loadbalance
+}
+
+. {
     forward . 8.8.8.8:53 8.8.4.4:53
+    cache
 }
 ~~~
 
@@ -93,12 +97,16 @@ Or a setup where we use `/etc/resolv.conf` as the basis for the proxy and the up
 when resolving external pointing CNAMEs.
 
 ~~~ corefile
-. {
-    etcd skydns.local {
+skydns.local {
+    etcd {
         path /skydns
     }
-    cache 160 skydns.local
+    cache
+}
+
+. {
     forward . /etc/resolv.conf
+    cache
 }
 ~~~
 

--- a/plugin/hosts/README.md
+++ b/plugin/hosts/README.md
@@ -104,11 +104,12 @@ next plugin if query doesn't match.
 Load hosts file inlined in Corefile.
 
 ~~~
-. {
-    hosts example.hosts example.org {
+example.hosts example.org {
+    hosts {
         10.0.0.1 example.org
         fallthrough
     }
+    whoami
 }
 ~~~
 

--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -92,7 +92,7 @@ The default Common Log Format is:
 Each of these logs will be outputted with `log.Infof`, so a typical example looks like this:
 
 ~~~ txt
-2018-10-30T19:10:07.547Z [INFO] [::1]:50759 - 29008 "A IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 68 0.037990251s
+[INFO] [::1]:50759 - 29008 "A IN example.org. udp 41 false 4096" NOERROR qr,rd,ra,ad 68 0.037990251s
 ~~~~
 
 ## Examples

--- a/plugin/nsid/README.md
+++ b/plugin/nsid/README.md
@@ -28,7 +28,7 @@ If **DATA** is not given, the host's name is used.
 Enable nsid:
 
 ~~~ corefile
-. {
+example.org {
     whoami
     nsid Use The Force
 }

--- a/plugin/route53/README.md
+++ b/plugin/route53/README.md
@@ -62,8 +62,11 @@ route53 [ZONE:HOSTED_ZONE_ID...] {
 Enable route53 with implicit AWS credentials and resolve CNAMEs via 10.0.0.1:
 
 ~~~ txt
-. {
+example.org {
 	route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7
+}
+
+. {
     forward . 10.0.0.1
 }
 ~~~
@@ -71,7 +74,7 @@ Enable route53 with implicit AWS credentials and resolve CNAMEs via 10.0.0.1:
 Enable route53 with explicit AWS credentials:
 
 ~~~ txt
-. {
+example.org {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
       aws_access_key AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
     }
@@ -91,14 +94,14 @@ Enable route53 with fallthrough:
 Enable route53 with multiple hosted zones with the same domain:
 
 ~~~ txt
-. {
+example.org {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 example.org.:Z93A52145678156
 }
 ~~~
 
 Enable route53 and refresh records every 3 minutes
 ~~~ txt
-. {
+example.org {
     route53 example.org.:Z1Z2Z3Z4DZ5Z6Z7 {
       refresh 3m
     }

--- a/plugin/whoami/README.md
+++ b/plugin/whoami/README.md
@@ -34,7 +34,7 @@ whoami
 Start a server on the default port and load the *whoami* plugin.
 
 ~~~ corefile
-. {
+example.org {
     whoami
 }
 ~~~


### PR DESCRIPTION
Update all documentation in the tree to use example.org as an example
configuration (in so far possible). As to get out of the just use "."
and fallthrough and things would be fine.