### PR TITLE
request: use an optional bool type instead of a *bool pointer

### DIFF
--- a/request/bool.go
+++ b/request/bool.go
@@ -1,0 +1,22 @@
+package request
+
+// An optionalBool is a bool value that may not be set and is a replacement for
+// using a *bool pointer.
+type optionalBool int
+
+const (
+	boolUnset optionalBool = iota
+	boolFalse
+	boolTrue
+)
+
+func (o *optionalBool) Set(b bool) {
+	if b {
+		*o = boolTrue
+	} else {
+		*o = boolFalse
+	}
+}
+
+func (o optionalBool) IsSet() bool { return o != boolUnset }
+func (o optionalBool) Value() bool { return o == boolTrue }

--- a/request/request.go
+++ b/request/request.go
@@ -20,7 +20,7 @@ type Request struct {
 
 	// Cache size after first call to Size or Do.
 	size int
-	do   *bool // nil: nothing, otherwise *do value
+	do   optionalBool // nil: nothing, otherwise *do value
 
 	// Caches
 	name      string // lowercase qname.
@@ -149,18 +149,16 @@ func (r *Request) Family() int {
 
 // Do returns if the request has the DO (DNSSEC OK) bit set.
 func (r *Request) Do() bool {
-	if r.do != nil {
-		return *r.do
+	if r.do.IsSet() {
+		return r.do.Value()
 	}
-
-	r.do = new(bool)
 
 	if o := r.Req.IsEdns0(); o != nil {
-		*r.do = o.Do()
-		return *r.do
+		r.do.Set(o.Do())
+	} else {
+		r.do.Set(false)
 	}
-	*r.do = false
-	return false
+	return r.do.Value()
 }
 
 // Len returns the length in bytes in the request.
@@ -175,10 +173,7 @@ func (r *Request) Size() int {
 
 	size := 0
 	if o := r.Req.IsEdns0(); o != nil {
-		if r.do == nil {
-			r.do = new(bool)
-		}
-		*r.do = o.Do()
+		r.do.Set(o.Do())
 		size = int(o.UDPSize())
 	}
 

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -13,7 +13,7 @@ func TestRequestDo(t *testing.T) {
 	st := testRequest()
 
 	st.Do()
-	if st.do == nil {
+	if !st.do.IsSet() {
 		t.Errorf("Expected st.do to be set")
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This saves us from having to allocate a `*bool` pointer when setting the Request.do field by replacing the `*bool` with an optional bool type.
### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A
