### PR TITLE
Improve the memory usage and performance of the cache plugin

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -326,3 +326,9 @@ func TestComputeTTL(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		hash("example.org", 1024, true)
+	}
+}

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -60,9 +60,14 @@ func (i *item) toMsg(m *dns.Msg, now time.Time) *dns.Msg {
 	m1.RecursionAvailable = i.RecursionAvailable
 	m1.Rcode = i.Rcode
 
-	m1.Answer = make([]dns.RR, len(i.Answer))
-	m1.Ns = make([]dns.RR, len(i.Ns))
-	m1.Extra = make([]dns.RR, len(i.Extra))
+	m1.Answer = i.Answer
+	m1.Ns = i.Ns
+	m1.Extra = i.Extra
+
+	a := make([]dns.RR, len(i.Answer)+len(i.Ns)+len(i.Extra))
+	m1.Answer, a = a[:len(i.Answer)], a[len(i.Answer):]
+	m1.Ns, a = a[:len(i.Ns)], a[len(i.Ns):]
+	m1.Extra = a[:len(i.Extra)]
 
 	ttl := uint32(i.ttl(now))
 	for j, r := range i.Answer {

--- a/plugin/cache/item.go
+++ b/plugin/cache/item.go
@@ -9,15 +9,13 @@ import (
 
 type item struct {
 	Rcode              int
-	AuthenticatedData  bool
-	RecursionAvailable bool
 	Answer             []dns.RR
 	Ns                 []dns.RR
 	Extra              []dns.RR
-
-	origTTL uint32
-	stored  time.Time
-
+	AuthenticatedData  bool
+	RecursionAvailable bool
+	origTTL            uint32
+	stored             time.Time
 	*freq.Freq
 }
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This PR reduces the memory usage of the cache plugin (14 vs 8 allocs and 540 vs 327 B) and improves performance as a side effect.

**PR:**
```
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/cache
BenchmarkCacheResponse/NoPrefetch-12         	 1601374	       732 ns/op	     327 B/op	       8 allocs/op
BenchmarkCacheResponse/Prefetch-12           	 1434120	       830 ns/op	     327 B/op	       8 allocs/op
BenchmarkHash-12                             	130255627	         9.25 ns/op	       0 B/op	       0 allocs/op
PASS
```

master@ 004c5fca9d7dfb8b58d608e4d50833b40953441f
```
goos: darwin
goarch: amd64
pkg: github.com/coredns/coredns/plugin/cache
BenchmarkCacheResponse-12    	 1181955	       971 ns/op	     540 B/op	      14 allocs/op
PASS
```

### 2. Which issues (if any) are related?
N/A
### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A