### PR TITLE
cleanup: remove redundant return statement

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -302,7 +302,6 @@ func (s *Server) OnStartupComplete() {
 	if out != "" {
 		fmt.Print(out)
 	}
-	return
 }
 
 // Tracer returns the tracer in the server if defined.

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -93,7 +93,6 @@ func (s *ServergRPC) OnStartupComplete() {
 	if out != "" {
 		fmt.Print(out)
 	}
-	return
 }
 
 // Stop stops the server. It blocks until the server is
@@ -165,8 +164,8 @@ func (r *gRPCresponse) Write(b []byte) (int, error) {
 // These methods implement the dns.ResponseWriter interface from Go DNS.
 func (r *gRPCresponse) Close() error              { return nil }
 func (r *gRPCresponse) TsigStatus() error         { return nil }
-func (r *gRPCresponse) TsigTimersOnly(b bool)     { return }
-func (r *gRPCresponse) Hijack()                   { return }
+func (r *gRPCresponse) TsigTimersOnly(b bool)     {}
+func (r *gRPCresponse) Hijack()                   {}
 func (r *gRPCresponse) LocalAddr() net.Addr       { return r.localAddr }
 func (r *gRPCresponse) RemoteAddr() net.Addr      { return r.remoteAddr }
 func (r *gRPCresponse) WriteMsg(m *dns.Msg) error { r.Msg = m; return nil }

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -82,7 +82,6 @@ func (s *ServerHTTPS) OnStartupComplete() {
 	if out != "" {
 		fmt.Print(out)
 	}
-	return
 }
 
 // Stop stops the server. It blocks until the server is totally stopped.

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -78,5 +78,4 @@ func (s *ServerTLS) OnStartupComplete() {
 	if out != "" {
 		fmt.Print(out)
 	}
-	return
 }

--- a/plugin/erratic/xfr.go
+++ b/plugin/erratic/xfr.go
@@ -48,5 +48,4 @@ func xfr(state request.Request, truncate bool) {
 
 	tr.Out(state.W, state.Req, ch)
 	state.W.Hijack()
-	return
 }

--- a/plugin/file/tree/tree.go
+++ b/plugin/file/tree/tree.go
@@ -290,7 +290,6 @@ func (t *Tree) Delete(rr dns.RR) {
 	if el.Empty() {
 		t.deleteNode(rr)
 	}
-	return
 }
 
 // DeleteNode deletes the node that matches rr according to Less().

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -43,7 +43,6 @@ func (h *health) OnStartup() error {
 		// We're always healthy.
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, http.StatusText(http.StatusOK))
-		return
 	})
 
 	go func() { http.Serve(h.ln, h.mux) }()

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -152,7 +152,7 @@ var tests = []test.Case{
 type external struct{}
 
 func (external) HasSynced() bool                              { return true }
-func (external) Run()                                         { return }
+func (external) Run()                                         {}
 func (external) Stop() error                                  { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints    { return nil }
 func (external) SvcIndexReverse(string) []*object.Service     { return nil }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -79,7 +79,7 @@ func TestExternal(t *testing.T) {
 type external struct{}
 
 func (external) HasSynced() bool                              { return true }
-func (external) Run()                                         { return }
+func (external) Run()                                         {}
 func (external) Stop() error                                  { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints    { return nil }
 func (external) SvcIndexReverse(string) []*object.Service     { return nil }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -521,7 +521,7 @@ type APIConnServeTest struct {
 }
 
 func (a APIConnServeTest) HasSynced() bool                         { return !a.notSynced }
-func (APIConnServeTest) Run()                                      { return }
+func (APIConnServeTest) Run()                                      {}
 func (APIConnServeTest) Stop() error                               { return nil }
 func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -61,7 +61,7 @@ func TestEndpointHostname(t *testing.T) {
 type APIConnServiceTest struct{}
 
 func (APIConnServiceTest) HasSynced() bool                           { return true }
-func (APIConnServiceTest) Run()                                      { return }
+func (APIConnServiceTest) Run()                                      {}
 func (APIConnServiceTest) Stop() error                               { return nil }
 func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return nil }
 func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -13,7 +13,7 @@ import (
 type APIConnTest struct{}
 
 func (APIConnTest) HasSynced() bool                          { return true }
-func (APIConnTest) Run()                                     { return }
+func (APIConnTest) Run()                                     {}
 func (APIConnTest) Stop() error                              { return nil }
 func (APIConnTest) PodIndex(string) []*object.Pod            { return nil }
 func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -16,7 +16,7 @@ import (
 type APIConnReverseTest struct{}
 
 func (APIConnReverseTest) HasSynced() bool                    { return true }
-func (APIConnReverseTest) Run()                               { return }
+func (APIConnReverseTest) Run()                               {}
 func (APIConnReverseTest) Stop() error                        { return nil }
 func (APIConnReverseTest) PodIndex(string) []*object.Pod      { return nil }
 func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -184,7 +184,6 @@ func (k *Kubernetes) transfer(c chan dns.RR, zone string) {
 			}
 		}
 	}
-	return
 }
 
 // emitAddressRecord generates a new A or AAAA record based on the msg.Service and writes it to

--- a/plugin/test/responsewriter.go
+++ b/plugin/test/responsewriter.go
@@ -51,10 +51,10 @@ func (t *ResponseWriter) Close() error { return nil }
 func (t *ResponseWriter) TsigStatus() error { return nil }
 
 // TsigTimersOnly implement dns.ResponseWriter interface.
-func (t *ResponseWriter) TsigTimersOnly(bool) { return }
+func (t *ResponseWriter) TsigTimersOnly(bool) {}
 
 // Hijack implement dns.ResponseWriter interface.
-func (t *ResponseWriter) Hijack() { return }
+func (t *ResponseWriter) Hijack() {}
 
 // ResponseWriter6 returns fixed client and remote address in IPv6.  The remote
 // address is always fe80::42:ff:feca:4c65 and port 40212. The local address is always ::1 and port 53.


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
remove `redundant return statement` warnings reported by staticcheck
