### PR TITLE
Use strings.ToLower instead of manual implementation

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -231,11 +232,10 @@ func (s *Server) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		l := len(q[off:])
 		for i := 0; i < l; i++ {
 			b[i] = q[off+i]
-			// normalize the name for the lookup
-			if b[i] >= 'A' && b[i] <= 'Z' {
-				b[i] |= ('a' - 'A')
-			}
 		}
+
+		// normalize the name for the lookup
+		b = []byte(strings.ToLower(string(b)))
 
 		if h, ok := s.zones[string(b[:l])]; ok {
 			if r.Question[0].Qtype != dns.TypeDS {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Use strings.ToLower instead of manual implementation cause it's faster and has fewer lines of code.

### 2. Which issues (if any) are related?
fixes #3291 

### 3. Which documentation changes (if any) need to be made?
Nothing

### 4. Does this introduce a backward incompatible change or deprecation?
No