### PR TITLE
Makefiles: remove GO111MODULE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ check: presubmit core/plugin/zplugin.go core/dnsserver/zdirectives.go
 .PHONY: travis
 travis:
 ifeq ($(TEST_TYPE),core)
-	( cd request ;go test -v -race ./... )
-	( cd core ;go test -v -race  ./... )
-	( cd coremain ;go test -v -race ./... )
+	( cd request; go test -race ./... )
+	( cd core; go test -race  ./... )
+	( cd coremain; go test -race ./... )
 endif
 ifeq ($(TEST_TYPE),integration)
-	( cd test ;go test -v -race ./... )
+	( cd test; go test -race ./... )
 endif
 ifeq ($(TEST_TYPE),plugin)
-	( cd plugin ;go test -v -race ./... )
+	( cd plugin; go test -race ./... )
 endif
 ifeq ($(TEST_TYPE),coverage)
 	for d in `go list ./... | grep -v vendor`; do \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: coredns
 
 .PHONY: coredns
 coredns: $(CHECKS)
-	GO111MODULE=on CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
+	CGO_ENABLED=$(CGO_ENABLED) $(SYSTEM) go build $(BUILDOPTS) -ldflags="-s -w -X github.com/coredns/coredns/coremain.GitCommit=$(GITCOMMIT)" -o $(BINARY)
 
 .PHONY: check
 check: presubmit core/plugin/zplugin.go core/dnsserver/zdirectives.go
@@ -22,25 +22,23 @@ check: presubmit core/plugin/zplugin.go core/dnsserver/zdirectives.go
 .PHONY: travis
 travis:
 ifeq ($(TEST_TYPE),core)
-	( cd request ; GO111MODULE=on go test -v -race ./... )
-	( cd core ; GO111MODULE=on go test -v -race  ./... )
-	( cd coremain ; GO111MODULE=on go test -v -race ./... )
+	( cd request ;go test -v -race ./... )
+	( cd core ;go test -v -race  ./... )
+	( cd coremain ;go test -v -race ./... )
 endif
 ifeq ($(TEST_TYPE),integration)
-	( cd test ; GO111MODULE=on go test -v -race ./... )
+	( cd test ;go test -v -race ./... )
 endif
 ifeq ($(TEST_TYPE),plugin)
-	( cd plugin ; GO111MODULE=on go test -v -race ./... )
+	( cd plugin ;go test -v -race ./... )
 endif
 ifeq ($(TEST_TYPE),coverage)
 	for d in `go list ./... | grep -v vendor`; do \
 		t=$$(date +%s); \
-		GO111MODULE=on go test -i -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
-		GO111MODULE=on go test -v -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
-		echo "Coverage test $$d took $$(($$(date +%s)-t)) seconds"; \
+		go test -i -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
+		go test -coverprofile=cover.out -covermode=atomic $$d || exit 1; \
 		if [ -f cover.out ]; then \
-			cat cover.out >> coverage.txt; \
-			rm cover.out; \
+			cat cover.out >> coverage.txt && rm cover.out; \
 		fi; \
 	done
 endif
@@ -61,11 +59,11 @@ ifeq ($(TEST_TYPE),fuzzit)
 endif
 
 core/plugin/zplugin.go core/dnsserver/zdirectives.go: plugin.cfg
-	GO111MODULE=on go generate coredns.go
+	go generate coredns.go
 
 .PHONY: gen
 gen:
-	GO111MODULE=on go generate coredns.go
+	go generate coredns.go
 
 .PHONY: pb
 pb:
@@ -78,5 +76,5 @@ presubmit:
 
 .PHONY: clean
 clean:
-	GO111MODULE=on go clean
+	go clean
 	rm -f coredns


### PR DESCRIPTION
This is the default in 1.13 it can be removed; also make the test output
log less, so failure are more pronounced in the travis output, hide
coverage stats for instance.