### PR TITLE
plugin/file: fix panic in miekg/dns.CompareDomainName()

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -372,7 +372,7 @@ func (z *Zone) additionalProcessing(answer []dns.RR, do bool) (extra []dns.RR) {
 		case *dns.MX:
 			name = x.Mx
 		}
-		if !dns.IsSubDomain(z.origin, name) {
+		if len(name) == 0 || !dns.IsSubDomain(z.origin, name) {
 			continue
 		}
 


### PR DESCRIPTION
Observed with CoreDNS v1.6.4 and miekg/dns v1.1.19
```
panic: runtime error: index out of range [-1]
goroutine 57 [running]:
    /vendor/github.com/miekg/dns.CompareDomainName(0xc000127600, 0x1e, 0x0, 0x0, 0x20)
    /vendor/github.com/miekg/dns/labels.go:62 +0x224
    /vendor/github.com/miekg/dns.IsSubDomain(0xc000127600, 0x1e, 0x0, 0x0, 0x0)
    /vendor/github.com/miekg/dns/defaults.go:253 +0x49
    /vendor/github.com/coredns/coredns/plugin/file.(*Zone).additionalProcessing(0xc0001e4200, 0xc000120480, 0x1, 0x1, 0xc000155c00, 0x1e, 0x1, 0x0)
    /vendor/github.com/coredns/coredns/plugin/file/lookup.go:375 +0x113
    /vendor/github.com/coredns/coredns/plugin/file.(*Zone).Lookup(0xc0001e4200, 0xe88820, 0xc0002c0180, 0xc00019ab40, 0xe8f980, 0xc000141420, 0x0, 0x0, 0x0, 0xc000158db8, ...)
    /vendor/github.com/coredns/coredns/plugin/file/lookup.go:174 +0x2ae9
    /vendor/github.com/coredns/coredns/plugin/file.File.ServeDNS(0xe7dd20, 0xc0002309c0, 0xc000230810, 0xc000120490, 0x1, 0x1, 0xe88820, 0xc0002c0180, 0xe8f980, 0xc000141420, ...)
    /vendor/github.com/coredns/coredns/plugin/file/file.go:85 +0x2d1
```
Root of the issue: there are no check in CompareDomainName(s1, s2 string) (n int) that s1 or s2 is empty (see https://github.com/miekg/dns/blob/master/labels.go#L51).
On CoreDNS file plugin we could have empty string (see https://github.com/coredns/coredns/blob/master/plugin/file/lookup.go#L366).

cc: @miekg
