### PR TITLE
plugin/erratic: doc and zone transfer

### DIFF
--- a/plugin/erratic/README.md
+++ b/plugin/erratic/README.md
@@ -6,15 +6,12 @@
 
 ## Description
 
-*erratic* returns a static response to all queries, but the responses can be delayed, dropped or truncated.
-The *erratic* plugin will respond to every A or AAAA query. For any other type it will return
-a SERVFAIL response. The reply for A will return 192.0.2.53 (see [RFC
-5737](https://tools.ietf.org/html/rfc5737),
-for AAAA it returns 2001:DB8::53 (see [RFC 3849](https://tools.ietf.org/html/rfc3849)) and for an
-AXFR request it will respond with a small zone transfer.
-
-*erratic* can also be used in conjunction with the *autopath* plugin. This is mostly to aid in
-testing.
+*erratic* returns a static response to all queries, but the responses can be delayed,
+dropped or truncated. The *erratic* plugin will respond to every A or AAAA query. For
+any other type it will return a SERVFAIL response (except AXFR). The reply for A will return
+192.0.2.53 ([RFC 5737](https://tools.ietf.org/html/rfc5737)), for AAAA it returns 2001:DB8::53 ([RFC
+3849](https://tools.ietf.org/html/rfc3849)). For an AXFR request it will respond with a small
+zone transfer.
 
 ## Syntax
 
@@ -47,7 +44,7 @@ example.org {
 }
 ~~~
 
-Or even shorter if the defaults suits you. Note this only drops queries, it does not delay them.
+Or even shorter if the defaults suit you. Note this only drops queries, it does not delay them.
 
 ~~~ corefile
 example.org {

--- a/plugin/erratic/xfr.go
+++ b/plugin/erratic/xfr.go
@@ -2,6 +2,7 @@ package erratic
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/coredns/coredns/plugin/test"
 	"github.com/coredns/coredns/request"
@@ -46,6 +47,11 @@ func xfr(state request.Request, truncate bool) {
 		close(ch)
 	}()
 
-	tr.Out(state.W, state.Req, ch)
-	state.W.Hijack()
+	wg := new(sync.WaitGroup)
+	wg.Add(1)
+	go func() {
+		tr.Out(state.W, state.Req, ch)
+		wg.Done()
+	}()
+	wg.Wait()
 }


### PR DESCRIPTION
Fix the documentation, remove autopath entry and fix the transfer by
copying some bits from the file plugin.