### PR TITLE
Fix grpc test vet warning

### DIFF
--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -22,7 +22,8 @@ func TestGrpc(t *testing.T) {
 	}
 	defer g.Stop()
 
-	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	conn, err := grpc.DialContext(ctx, tcp, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		t.Fatalf("Expected no error but got: %s", err)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This fixes the vet warning: the cancel function returned by
context.WithTimeout should be called, not discarded, to avoid a context
leak.

### 2. Which issues (if any) are related?
none 

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no