### PR TITLE
Use whitelist in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,2 @@
-.git/*
-core/*
-coremain/*
-hooks/*
-man/*
-pb/*
-plugin/*
-request/*
-test/*
-vendor/*
-build/*
-release/*
-go.sum
-go.mod
+*
+!coredns


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Simplify the .dockerignore by using a white list instead of trying to blacklist everything else.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No.
