### PR TITLE
plugin/route53: remove amazon intialization from init

### DIFF
--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -24,20 +24,14 @@ import (
 
 var log = clog.NewWithPlugin("route53")
 
-func init() {
-	plugin.Register("route53",
-		func(c *caddy.Controller) error {
-			f := func(credential *credentials.Credentials) route53iface.Route53API {
-				return route53.New(session.Must(session.NewSession(&aws.Config{
-					Credentials: credential,
-				})))
-			}
-			return setup(c, f)
-		},
-	)
+func init() { plugin.Register("route53", setup) }
+
+// exposed for testing
+var f = func(credential *credentials.Credentials) route53iface.Route53API {
+	return route53.New(session.Must(session.NewSession(&aws.Config{Credentials: credential})))
 }
 
-func setup(c *caddy.Controller, f func(*credentials.Credentials) route53iface.Route53API) error {
+func setup(c *caddy.Controller) error {
 	for c.Next() {
 		keyPairs := map[string]struct{}{}
 		keys := map[string][]string{}

--- a/plugin/route53/setup_test.go
+++ b/plugin/route53/setup_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSetupRoute53(t *testing.T) {
-	f := func(credential *credentials.Credentials) route53iface.Route53API {
+	f = func(credential *credentials.Credentials) route53iface.Route53API {
 		return fakeRoute53{}
 	}
 
@@ -73,7 +73,7 @@ func TestSetupRoute53(t *testing.T) {
 
 	for _, test := range tests {
 		c := caddy.NewTestController("dns", test.body)
-		if err := setup(c, f); (err == nil) == test.expectedError {
+		if err := setup(c); (err == nil) == test.expectedError {
 			t.Errorf("Unexpected errors: %v", err)
 		}
 	}


### PR DESCRIPTION
Don't perform this code in the init, this allocated 1 megabyte of memory
even if you don't use the plugin. Looks to be only there for testing,
adding a comment to reflect that.

Fixes #3342