### PR TITLE
plugin/clouddns: remove initialization from init

### DIFF
--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -17,27 +17,23 @@ import (
 
 var log = clog.NewWithPlugin("clouddns")
 
-func init() {
-	plugin.Register("clouddns",
-		func(c *caddy.Controller) error {
-			f := func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
-				var err error
-				var client *gcp.Service
-				if opt != nil {
-					client, err = gcp.NewService(ctx, opt)
-				} else {
-					// if credentials file is not provided in the Corefile
-					// authenticate the client using env variables
-					client, err = gcp.NewService(ctx)
-				}
-				return gcpClient{client}, err
-			}
-			return setup(c, f)
-		},
-	)
+func init() { plugin.Register("clouddns", setup) }
+
+// exposed for testing
+var f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
+	var err error
+	var client *gcp.Service
+	if opt != nil {
+		client, err = gcp.NewService(ctx, opt)
+	} else {
+		// if credentials file is not provided in the Corefile
+		// authenticate the client using env variables
+		client, err = gcp.NewService(ctx)
+	}
+	return gcpClient{client}, err
 }
 
-func setup(c *caddy.Controller, f func(ctx context.Context, opt option.ClientOption) (gcpDNS, error)) error {
+func setup(c *caddy.Controller) error {
 	for c.Next() {
 		keyPairs := map[string]struct{}{}
 		keys := map[string][]string{}

--- a/plugin/clouddns/setup_test.go
+++ b/plugin/clouddns/setup_test.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/api/option"
 )
 
-var f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
-	return fakeGCPClient{}, nil
-}
-
 func TestSetupCloudDNS(t *testing.T) {
+	f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
+		return fakeGCPClient{}, nil
+	}
+
 	tests := []struct {
 		body          string
 		expectedError bool

--- a/plugin/clouddns/setup_test.go
+++ b/plugin/clouddns/setup_test.go
@@ -8,11 +8,11 @@ import (
 	"google.golang.org/api/option"
 )
 
-func TestSetupCloudDNS(t *testing.T) {
-	f := func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
-		return fakeGCPClient{}, nil
-	}
+var f = func(ctx context.Context, opt option.ClientOption) (gcpDNS, error) {
+	return fakeGCPClient{}, nil
+}
 
+func TestSetupCloudDNS(t *testing.T) {
 	tests := []struct {
 		body          string
 		expectedError bool
@@ -41,7 +41,7 @@ func TestSetupCloudDNS(t *testing.T) {
 
 	for _, test := range tests {
 		c := caddy.NewTestController("dns", test.body)
-		if err := setup(c, f); (err == nil) == test.expectedError {
+		if err := setup(c); (err == nil) == test.expectedError {
 			t.Errorf("Unexpected errors: %v", err)
 		}
 	}


### PR DESCRIPTION
Init should just call the plugin.Register with a setup function.

Fixes: #3343