### PR TITLE
Make request.Request smaller

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -191,7 +191,7 @@ func TestCache(t *testing.T) {
 		m := tc.in.Msg()
 		m = cacheMsg(m, tc)
 
-		state := request.Request{W: nil, Req: m}
+		state := request.Request{W: &test.ResponseWriter{}, Req: m}
 
 		mt, _ := response.Typify(m, utc)
 		valid, k := key(state.Name(), m, mt, state.Do())

--- a/plugin/pkg/edns/edns.go
+++ b/plugin/pkg/edns/edns.go
@@ -63,7 +63,7 @@ func Version(req *dns.Msg) (*dns.Msg, error) {
 }
 
 // Size returns a normalized size based on proto.
-func Size(proto string, size int) int {
+func Size(proto string, size uint16) uint16 {
 	if proto == "tcp" {
 		return dns.MaxMsgSize
 	}

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -13,7 +13,7 @@ func TestRequestDo(t *testing.T) {
 	st := testRequest()
 
 	st.Do()
-	if st.do == nil {
+	if !st.do {
 		t.Errorf("Expected st.do to be set")
 	}
 }


### PR DESCRIPTION
This makes the request struct smaller and removes the pointer to the do
boolean (tri-bool) as size == 0 will indicate if we have cached it.

Family can be a int8 because it only carries 3 values, Size itself is
just a uint16 under the covers.

This is a more comprehensive fix than #3292

Closes #3292