### PR TITLE
cache: remove prefetch closure

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -15,7 +15,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// Cache is plugin that looks up responses in a cache and caches replies.
+// Cache is a plugin that looks up responses in a cache and caches replies.
 // It has a success and a denial of existence cache.
 type Cache struct {
 	Next  plugin.Handler


### PR DESCRIPTION
    cache: move goroutine closure to separate function to save memory
    
    The goroutine closure was causing objects to be heap allocated.  Moving
    it to a separate function fixes that.
    
    ```benchmark                                old ns/op     new ns/op     delta
    BenchmarkCacheResponse/NoPrefetch-12     773           713           -7.76%
    BenchmarkCacheResponse/Prefetch-12       878           837           -4.67%
    BenchmarkHash-12                         9.17          9.18          +0.11%
    
    benchmark                                old allocs     new allocs     delta
    BenchmarkCacheResponse/NoPrefetch-12     9              8              -11.11%
    BenchmarkCacheResponse/Prefetch-12       9              8              -11.11%
    BenchmarkHash-12                         0              0              +0.00%
    
    benchmark                                old bytes     new bytes     delta
    BenchmarkCacheResponse/NoPrefetch-12     471           327           -30.57%
    BenchmarkCacheResponse/Prefetch-12       471           327           -30.57%
    BenchmarkHash-12                         0             0             +0.00%
    ```
    
    Signed-off-by: Charlie Vieth <charlie.vieth@gmail.com>
    Signed-off-by: Miek Gieben <miek@miek.nl>
