### PR TITLE
kubernetes: brush up README, rename metric

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -61,7 +61,7 @@ Since shards don't fill up perfectly evenly, evictions will occur before the ent
 Each shard capacity is equal to the total cache size / number of shards (256). Eviction is random, not TTL based.
 Entries with 0 TTL will remain in the cache until randomly evicted when the shard reaches capacity.
 
-## Metrics
+# Metrics
 
 If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -46,7 +46,6 @@ kubernetes [ZONES...] {
 }
 ```
 
-
 * `endpoint` specifies the **URL** for a remote k8s API endpoint.
    If omitted, it will connect to k8s in-cluster using the cluster service account.
 * `tls` **CERT** **KEY** **CACERT** are the TLS cert, key and the CA cert file names for remote k8s connection.
@@ -210,15 +209,15 @@ or the word "any"), then that label will match all values.  The labels that acce
  * multiple wildcards are allowed in a single query, e.g., `A` Request `*.*.svc.zone.` or `SRV` request `*.*.*.*.svc.zone.`
 
  For example, wildcards can be used to resolve all Endpoints for a Service as `A` records. e.g.: `*.service.ns.svc.myzone.local` will return the Endpoint IPs in the Service `service` in namespace `default`:
- ```
+
+```
 *.service.default.svc.cluster.local. 5	IN A	192.168.10.10
 *.service.default.svc.cluster.local. 5	IN A	192.168.25.15
 ```
- This response can be randomized using the `loadbalance` plugin
 
 ## Metadata
 
-The kubernetes plugin will publish the following metadata, if the _metadata_
+The kubernetes plugin will publish the following metadata, if the *metadata*
 plugin is also enabled:
 
  * kubernetes/endpoint: the endpoint name in the query
@@ -232,9 +231,10 @@ plugin is also enabled:
 
 ## Metrics
 
-The *kubernetes* plugin exports the following *Prometheus* metrics.
-* `coredns_kubernetes_dns_programming_latency_seconds{service_kind}` - exports the
-[DNS programming latency SLI](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/dns_programming_latency.md).
+If monitoring is enabled (via the *prometheus* directive) then the following metrics are exported:
+
+* `coredns_kubernetes_dns_programming_duration_seconds{service_kind}` - Exports the
+  [DNS programming latency SLI](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/dns_programming_latency.md).
   The metrics has the `service_kind` label that identifies the kind of the
   [kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service).
   It may take one of the three values:
@@ -244,4 +244,4 @@ The *kubernetes* plugin exports the following *Prometheus* metrics.
 
 ## Bugs
 
- * add support for other service types; only "headless_with_selector" is supported now
+The duration metric only supports the "headless_with_selector" service currently.

--- a/plugin/kubernetes/metrics.go
+++ b/plugin/kubernetes/metrics.go
@@ -28,7 +28,7 @@ var (
 	DnsProgrammingLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: subsystem,
-		Name:      "dns_programming_latency_seconds",
+		Name:      "dns_programming_duration_seconds",
 		// From 1 millisecond to ~17 minutes.
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),
 		Help:    "Histogram of the time (in seconds) it took to program a dns instance.",
@@ -72,5 +72,4 @@ func recordDNSProgrammingLatency(svcs []*object.Service, endpoints *api.Endpoint
 	// "headless service with selector".
 	DnsProgrammingLatency.WithLabelValues("headless_with_selector").
 		Observe(durationSinceFunc(lastChangeTriggerTime).Seconds())
-
 }

--- a/plugin/kubernetes/metrics_test.go
+++ b/plugin/kubernetes/metrics_test.go
@@ -58,31 +58,31 @@ func TestDnsProgrammingLatency(t *testing.T) {
 
 	controller.Stop()
 	expected := `
-        # HELP coredns_kubernetes_dns_programming_latency_seconds Histogram of the time (in seconds) it took to program a dns instance.
-        # TYPE coredns_kubernetes_dns_programming_latency_seconds histogram
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.001"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.002"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.004"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.008"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.016"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.032"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.064"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.128"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.256"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="0.512"} 0
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="1.024"} 1
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="2.048"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="4.096"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="8.192"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="16.384"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="32.768"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="65.536"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="131.072"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="262.144"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="524.288"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_bucket{service_kind="headless_with_selector",le="+Inf"} 2
-        coredns_kubernetes_dns_programming_latency_seconds_sum{service_kind="headless_with_selector"} 3
-        coredns_kubernetes_dns_programming_latency_seconds_count{service_kind="headless_with_selector"} 2
+        # HELP coredns_kubernetes_dns_programming_duration_seconds Histogram of the time (in seconds) it took to program a dns instance.
+        # TYPE coredns_kubernetes_dns_programming_duration_seconds histogram
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.001"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.002"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.004"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.008"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.016"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.032"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.064"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.128"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.256"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="0.512"} 0
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="1.024"} 1
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="2.048"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="4.096"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="8.192"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="16.384"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="32.768"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="65.536"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="131.072"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="262.144"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="524.288"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_bucket{service_kind="headless_with_selector",le="+Inf"} 2
+        coredns_kubernetes_dns_programming_duration_seconds_sum{service_kind="headless_with_selector"} 3
+        coredns_kubernetes_dns_programming_duration_seconds_count{service_kind="headless_with_selector"} 2
 	`
 	if err := testutil.CollectAndCompare(DnsProgrammingLatency, strings.NewReader(expected)); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Other latency metrics have `_duration` in the name change this metric
to be in sync with the other ones.