### PR TITLE
pkg/log: add Clear to stop debug logging

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -64,6 +64,10 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		if site.Debug {
 			s.debug = true
 			log.D.Set()
+		} else {
+			// When reloading we need to explicitly disable debug logging if it is now disabled.
+			s.debug = false
+			log.D.Clear()
 		}
 		// set the config per zone
 		s.zones[site.Zone] = site

--- a/plugin/pkg/log/log.go
+++ b/plugin/pkg/log/log.go
@@ -1,7 +1,7 @@
-// Package log implements a small wrapper around the std lib log package.
-// It implements log levels by prefixing the logs with the current time
-// with in RFC3339Milli and [INFO], [DEBUG], [WARNING] or [ERROR].
-// Debug logging is available and enabled if the *debug* plugin is used.
+// Package log implements a small wrapper around the std lib log package. It
+// implements log levels by prefixing the logs with [INFO], [DEBUG], [WARNING]
+// or [ERROR]. Debug logging is available and enabled if the *debug* plugin is
+// used.
 //
 // log.Info("this is some logging"), will log on the Info level.
 //
@@ -25,14 +25,21 @@ type d struct {
 	sync.RWMutex
 }
 
-// Set sets d to true.
+// Set enables debug logging.
 func (d *d) Set() {
 	d.Lock()
 	d.on = true
 	d.Unlock()
 }
 
-// Value return the boolean value of d.
+// Clear disables debug logging.
+func (d *d) Clear() {
+	d.Lock()
+	d.on = false
+	d.Unlock()
+}
+
+// Value returns if debug logging is enabled.
 func (d *d) Value() bool {
 	d.RLock()
 	b := d.on

--- a/plugin/pkg/log/log_test.go
+++ b/plugin/pkg/log/log_test.go
@@ -23,6 +23,13 @@ func TestDebug(t *testing.T) {
 	if x := f.String(); !strings.Contains(x, debug+"debug") {
 		t.Errorf("Expected debug log to be %s, got %s", debug+"debug", x)
 	}
+	f.Reset()
+
+	D.Clear()
+	Debug("debug")
+	if x := f.String(); x != "" {
+		t.Errorf("Expected no debug logs, got %s", x)
+	}
 }
 
 func TestDebugx(t *testing.T) {


### PR DESCRIPTION
When reloading we need to disable debug output when the debug plugin is
removed from the config file. Add a `Clear` function to pkg/log and use
it in the server server.

Add test case in pkg/log, for actuall check I manually checked the
output by sprinkling some debug statements in the startup and checking
with sending SIGUSR1.

Also clear up the comments in pkg/log to remove the text about time
stamping.

Fixes: #3035