### PR TITLE
Add a parse friendly Normalize

### DIFF
--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -61,13 +61,26 @@ type (
 
 // Normalize will return the host portion of host, stripping
 // of any port or transport. The host will also be fully qualified and lowercased.
+// An empty string is returned on failure
 func (h Host) Normalize() string {
+	// The error can be ignored here, because this function should only be called after the corefile has already been vetted.
+	host, _ := h.MustNormalize()
+	return host
+}
+
+// MustNormalize will return the host portion of host, stripping
+// of any port or transport. The host will also be fully qualified and lowercased.
+// An error is returned on error
+func (h Host) MustNormalize() (string, error) {
 	s := string(h)
 	_, s = parse.Transport(s)
 
 	// The error can be ignored here, because this function is called after the corefile has already been vetted.
-	host, _, _, _ := SplitHostPort(s)
-	return Name(host).Normalize()
+	host, _, _, err := SplitHostPort(s)
+	if err != nil {
+		return "", err
+	}
+	return Name(host).Normalize(), nil
 }
 
 // SplitHostPort splits s up in a host and port portion, taking reverse address notation into account.

--- a/plugin/normalize_test.go
+++ b/plugin/normalize_test.go
@@ -83,6 +83,17 @@ func TestHostNormalize(t *testing.T) {
 	}
 }
 
+func TestHostMustNormalizeFail(t *testing.T) {
+	hosts := []string{"..:53", "::", ""}
+	for i := 0; i < len(hosts); i++ {
+		ts := hosts[i]
+		h, err := Host(ts).MustNormalize()
+		if err == nil {
+			t.Errorf("Expected error, got %v", h)
+		}
+	}
+}
+
 func TestSplitHostPortReverse(t *testing.T) {
 	tests := map[string]int{
 		"example.org.": 0,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds `MustNormalize()`, which is the same as `Normalize()` but does not ignore parse errors.
Going forward plugins should prefer `MustNormalize()` instead of `Normalize()` when reading parsing the Corefile.

### 2. Which issues (if any) are related?
 #2898

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no