### PR TITLE
Correct some if/iff mixups

### DIFF
--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -5,7 +5,7 @@ client's search path resolution by performing these lookups on the server...
 The server has a copy (via AutoPathFunc) of the client's search path and on
 receiving a query it first establishes if the suffix matches the FIRST configured
 element. If no match can be found the query will be forwarded up the plugin
-chain without interference (if 'fallthrough' has been set).
+chain without interference (if, and only if, 'fallthrough' has been set).
 
 If the query is deemed to fall in the search path the server will perform the
 queries with each element of the search path appended in sequence until a

--- a/plugin/dnssec/dnskey.go
+++ b/plugin/dnssec/dnskey.go
@@ -83,12 +83,12 @@ func (d Dnssec) getDNSKEY(state request.Request, zone string, do bool, server st
 	return m
 }
 
-// Return true if this is a zone key with the SEP bit unset. This implies a ZSK (rfc4034 2.1.1).
+// Return true if, and only if, this is a zone key with the SEP bit unset. This implies a ZSK (rfc4034 2.1.1).
 func (k DNSKEY) isZSK() bool {
 	return k.K.Flags&(1<<8) == (1<<8) && k.K.Flags&1 == 0
 }
 
-// Return true if this is a zone key with the SEP bit set. This implies a KSK (rfc4034 2.1.1).
+// Return true if, and only if, this is a zone key with the SEP bit set. This implies a KSK (rfc4034 2.1.1).
 func (k DNSKEY) isKSK() bool {
 	return k.K.Flags&(1<<8) == (1<<8) && k.K.Flags&1 == 1
 }


### PR DESCRIPTION
This is a fixup for https://github.com/coredns/coredns/pull/3310 which
replaced some 'iff's with 'if' under the assumption they were typos.

I'm fairly confident they were "If and only if"
(https://en.wikipedia.org/wiki/If_and_only_if), which is commonly
shortened as "iff".

I believe the shortening is common enough while programming that it's
reasonable to keep them as they were rather than expand them to 'if and
only if' to avoid any other confusion, but I could see it either way.