### PR TITLE
plugin/k8s_external: zone transfers

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -404,7 +404,7 @@ func SOA(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 
 	header := dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Ttl: ttl, Class: dns.ClassINET}
 
-	Mbox := hostmaster + "."
+	Mbox := hostmaster + ".dns"
 	Ns := "ns.dns."
 	if zone[0] != '.' {
 		Mbox += zone

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -83,6 +83,20 @@ spec:
  type: ClusterIP
 ~~~
 
+## Zone Transfers
+
+The *k8s_external* plugin can be used in conjunction with the *transfer* plugin to enable
+zone transfers.
+
+~~~
+    . {
+        transfer example.org {
+            to *
+        }
+        kubernetes cluster.local
+        k8s_external example.org
+    }
+~~~
 
 # Also See
 

--- a/plugin/k8s_external/apex.go
+++ b/plugin/k8s_external/apex.go
@@ -93,7 +93,7 @@ func (e *External) soa(state request.Request) *dns.SOA {
 	soa := &dns.SOA{Hdr: header,
 		Mbox:    dnsutil.Join(e.hostmaster, e.apex, state.Zone),
 		Ns:      dnsutil.Join("ns1", e.apex, state.Zone),
-		Serial:  12345, // Also dynamic?
+		Serial:  e.externalSerialFunc(state.Zone),
 		Refresh: 7200,
 		Retry:   1800,
 		Expire:  86400,

--- a/plugin/k8s_external/apex_test.go
+++ b/plugin/k8s_external/apex_test.go
@@ -20,7 +20,8 @@ func TestApex(t *testing.T) {
 	e.Zones = []string{"example.com."}
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External
-	e.externalAddrFunc = externalAddress // internal test function
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
 
 	ctx := context.TODO()
 	for i, tc := range testsApex {
@@ -43,6 +44,16 @@ func TestApex(t *testing.T) {
 		if err := test.SortAndCheck(resp, tc); err != nil {
 			t.Error(err)
 		}
+		for i, rr := range tc.Ns {
+			expectsoa := rr.(*dns.SOA)
+			gotsoa, ok := resp.Ns[i].(*dns.SOA)
+			if !ok {
+				t.Fatalf("Unexpected record type in Authority section")
+			}
+			if expectsoa.Serial != gotsoa.Serial {
+				t.Fatalf("Expected soa serial %d, got %d", expectsoa.Serial, gotsoa.Serial)
+			}
+		}
 	}
 }
 
@@ -50,7 +61,7 @@ var testsApex = []test.Case{
 	{
 		Qname: "example.com.", Qtype: dns.TypeSOA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
@@ -65,37 +76,37 @@ var testsApex = []test.Case{
 	{
 		Qname: "example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "dns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "dns.example.com.", Qtype: dns.TypeNS, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeSRV, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeNS, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{
 		Qname: "ns1.dns.example.com.", Qtype: dns.TypeAAAA, Rcode: dns.RcodeSuccess,
 		Ns: []dns.RR{
-			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
+			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
 	{

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -28,9 +28,13 @@ type Externaler interface {
 	External(request.Request) ([]msg.Service, int)
 	// ExternalAddress should return a string slice of addresses for the nameserving endpoint.
 	ExternalAddress(state request.Request) []dns.RR
+	// ExternalServices returns all services in a slice of msg.Service.
+	ExternalServices(string) []msg.Service
+	// ExternalSerial gets the current serial.
+	ExternalSerial(string) uint32
 }
 
-// External resolves Ingress and Loadbalance IPs from kubernetes clusters.
+// External resolves External IPs and Loadbalance IPs from kubernetes clusters.
 type External struct {
 	Next  plugin.Handler
 	Zones []string
@@ -39,8 +43,10 @@ type External struct {
 	apex       string
 	ttl        uint32
 
-	externalFunc     func(request.Request) ([]msg.Service, int)
-	externalAddrFunc func(request.Request) []dns.RR
+	externalFunc         func(request.Request) ([]msg.Service, int)
+	externalAddrFunc     func(request.Request) []dns.RR
+	externalSerialFunc   func(string) uint32
+	externalServicesFunc func(string) []msg.Service
 }
 
 // New returns a new and initialized *External.

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -24,7 +24,8 @@ func TestExternal(t *testing.T) {
 	e.Zones = []string{"example.com."}
 	e.Next = test.NextHandler(dns.RcodeSuccess, nil)
 	e.externalFunc = k.External
-	e.externalAddrFunc = externalAddress // internal test function
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
 
 	ctx := context.TODO()
 	for i, tc := range tests {
@@ -157,6 +158,7 @@ func (external) Stop() error                                  { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints    { return nil }
 func (external) SvcIndexReverse(string) []*object.Service     { return nil }
 func (external) Modified() int64                              { return 0 }
+func (external) ExtModified() int64                           { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints         { return nil }
 func (external) EndpointsList() []*object.Endpoints           { return nil }
 func (external) GetNodeByName(name string) (*api.Node, error) { return nil, nil }
@@ -205,4 +207,8 @@ func (external) ServiceList() []*object.Service {
 func externalAddress(state request.Request) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
+}
+
+func externalSerial(string) uint32 {
+	return 1499347823
 }

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -26,6 +26,8 @@ func setup(c *caddy.Controller) error {
 		if x, ok := m.(Externaler); ok {
 			e.externalFunc = x.External
 			e.externalAddrFunc = x.ExternalAddress
+			e.externalServicesFunc = x.ExternalServices
+			e.externalSerialFunc = x.ExternalSerial
 		}
 		return nil
 	})

--- a/plugin/k8s_external/transfer.go
+++ b/plugin/k8s_external/transfer.go
@@ -1,0 +1,78 @@
+package external
+
+import (
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/transfer"
+	"github.com/coredns/coredns/request"
+	"github.com/miekg/dns"
+)
+
+// Transfer implements transfer.Transferer
+func (e *External) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	z := plugin.Zones(e.Zones).Matches(zone)
+	if z != zone {
+		return nil, transfer.ErrNotAuthoritative
+	}
+
+	ch := make(chan []dns.RR, 2)
+	if zone == "." {
+		zone = ""
+	}
+	state := request.Request{Zone: zone}
+
+	// SOA
+	soa := e.soa(state)
+	ch <- []dns.RR{soa}
+	if serial != 0 && serial >= soa.Serial {
+		close(ch)
+		return ch, nil
+	}
+
+	go func() {
+		// Add NS
+		nsName := "ns1." + e.apex + "." + zone
+		nsHdr := dns.RR_Header{Name: zone, Rrtype: dns.TypeNS, Ttl: e.ttl, Class: dns.ClassINET}
+		ch <- []dns.RR{&dns.NS{Hdr: nsHdr, Ns: nsName}}
+
+		// Add Nameserver A/AAAA records
+		nsRecords := e.externalAddrFunc(state)
+		for i := range nsRecords {
+			// externalAddrFunc returns incomplete header names, correct here
+			nsRecords[i].Header().Name = nsName
+			nsRecords[i].Header().Ttl = e.ttl
+			ch <- []dns.RR{nsRecords[i]}
+		}
+
+		// Add Service A/AAAA records
+		svcs := e.externalServicesFunc(zone)
+		for i := range svcs {
+			name := msg.Domain(svcs[i].Key)
+			if svcs[i].TargetStrip == 0 {
+				s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
+				as := e.a([]msg.Service{svcs[i]}, s)
+				if len(as) > 0 {
+					ch <- as
+				}
+				aaaas := e.aaaa([]msg.Service{svcs[i]}, s)
+				if len(aaaas) > 0 {
+					ch <- aaaas
+				}
+				recs, _ := e.srv([]msg.Service{svcs[i]}, s)
+				if len(recs) > 0 {
+					ch <- recs
+				}
+				continue
+			}
+			s := request.Request{Req: &dns.Msg{Question: []dns.Question{{Name: name}}}}
+			recs, _ := e.srv([]msg.Service{svcs[i]}, s)
+			if len(recs) > 0 {
+				ch <- recs
+			}
+		}
+
+		close(ch)
+	}()
+
+	return ch, nil
+}

--- a/plugin/k8s_external/transfer_test.go
+++ b/plugin/k8s_external/transfer_test.go
@@ -1,0 +1,142 @@
+package external
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes"
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/coredns/coredns/plugin/transfer"
+
+	"github.com/miekg/dns"
+)
+
+func TestImplementsTransferer(t *testing.T) {
+	var e plugin.Handler
+	e = &External{}
+	_, ok := e.(transfer.Transferer)
+	if !ok {
+		t.Error("Transferer not implemented")
+	}
+}
+
+func TestTransferAXFR(t *testing.T) {
+	k := kubernetes.New([]string{"cluster.local."})
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	k.APIConn = &external{}
+
+	e := New()
+	e.Zones = []string{"example.com."}
+	e.externalFunc = k.External
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
+	e.externalServicesFunc = k.ExternalServices
+
+	ch, err := e.Transfer("example.com.", 0)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var records []dns.RR
+	for rrs := range ch {
+		records = append(records, rrs...)
+	}
+
+	expect := []dns.RR{}
+	for _, tc := range append(tests, testsApex...) {
+		if tc.Rcode != dns.RcodeSuccess {
+			continue
+		}
+
+		for _, ans := range tc.Answer {
+			// Exclude wildcard searches
+			if strings.Contains(ans.Header().Name, "*") {
+				continue
+			}
+
+			// Exclude TXT records
+			if ans.Header().Rrtype == dns.TypeTXT {
+				continue
+			}
+			expect = append(expect, ans)
+		}
+	}
+
+	diff := difference(expect, records)
+	if len(diff) != 0 {
+		t.Errorf("Got back %d records that do not exist in test cases, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+	diff = difference(records, expect)
+	if len(diff) != 0 {
+		t.Errorf("Result is missing %d records, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+}
+
+func TestTransferIXFR(t *testing.T) {
+	k := kubernetes.New([]string{"cluster.local."})
+	k.Namespaces = map[string]struct{}{"testns": {}}
+	k.APIConn = &external{}
+
+	e := New()
+	e.Zones = []string{"example.com."}
+	e.externalFunc = k.External
+	e.externalAddrFunc = externalAddress  // internal test function
+	e.externalSerialFunc = externalSerial // internal test function
+	e.externalServicesFunc = k.ExternalServices
+
+	ch, err := e.Transfer("example.com.", externalSerial("example.com."))
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	var records []dns.RR
+	for rrs := range ch {
+		records = append(records, rrs...)
+	}
+
+	expect := []dns.RR{
+		test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.dns.example.com. 1499347823 7200 1800 86400 5"),
+	}
+
+	diff := difference(expect, records)
+	if len(diff) != 0 {
+		t.Errorf("Got back %d records that do not exist in test cases, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+	diff = difference(records, expect)
+	if len(diff) != 0 {
+		t.Errorf("Result is missing %d records, should be 0:", len(diff))
+		for _, rec := range diff {
+			t.Errorf("%+v", rec)
+		}
+	}
+
+}
+
+// difference shows what we're missing when comparing two RR slices
+func difference(testRRs []dns.RR, gotRRs []dns.RR) []dns.RR {
+	expectedRRs := map[string]struct{}{}
+	for _, rr := range testRRs {
+		expectedRRs[rr.String()] = struct{}{}
+	}
+
+	foundRRs := []dns.RR{}
+	for _, rr := range gotRRs {
+		if _, ok := expectedRRs[rr.String()]; !ok {
+			foundRRs = append(foundRRs, rr)
+		}
+	}
+	return foundRRs
+}

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/test"
 
 	"github.com/miekg/dns"
@@ -165,4 +166,69 @@ func createExternalSvc(suffix int, client kubernetes.Interface, ip net.IP) {
 			Type: api.ServiceTypeExternalName,
 		},
 	})
+}
+
+func TestServiceModified(t *testing.T) {
+	var tests = []struct {
+		oldSvc   interface{}
+		newSvc   interface{}
+		ichanged bool
+		echanged bool
+	}{
+		{
+			oldSvc:   nil,
+			newSvc:   &object.Service{},
+			ichanged: true,
+			echanged: false,
+		},
+		{
+			oldSvc:   &object.Service{},
+			newSvc:   nil,
+			ichanged: true,
+			echanged: false,
+		},
+		{
+			oldSvc:   nil,
+			newSvc:   &object.Service{ExternalIPs: []string{"10.0.0.1"}},
+			ichanged: true,
+			echanged: true,
+		},
+		{
+			oldSvc:   &object.Service{ExternalIPs: []string{"10.0.0.1"}},
+			newSvc:   nil,
+			ichanged: true,
+			echanged: true,
+		},
+		{
+			oldSvc:   &object.Service{ExternalIPs: []string{"10.0.0.1"}},
+			newSvc:   &object.Service{ExternalIPs: []string{"10.0.0.2"}},
+			ichanged: false,
+			echanged: true,
+		},
+		{
+			oldSvc:   &object.Service{ExternalName: "10.0.0.1"},
+			newSvc:   &object.Service{ExternalName: "10.0.0.2"},
+			ichanged: true,
+			echanged: false,
+		},
+		{
+			oldSvc:   &object.Service{Ports: []api.ServicePort{{Name: "test1"}}},
+			newSvc:   &object.Service{Ports: []api.ServicePort{{Name: "test2"}}},
+			ichanged: true,
+			echanged: true,
+		},
+		{
+			oldSvc:   &object.Service{Ports: []api.ServicePort{{Name: "test1"}}},
+			newSvc:   &object.Service{Ports: []api.ServicePort{{Name: "test2"}, {Name: "test3"}}},
+			ichanged: true,
+			echanged: true,
+		},
+	}
+
+	for i, test := range tests {
+		ichanged, echanged := serviceModified(test.oldSvc, test.newSvc)
+		if test.ichanged != ichanged || test.echanged != echanged {
+			t.Errorf("Expected %v, %v for test %v. Got %v, %v", test.ichanged, test.echanged, i, ichanged, echanged)
+		}
+	}
 }

--- a/plugin/kubernetes/external_test.go
+++ b/plugin/kubernetes/external_test.go
@@ -84,6 +84,7 @@ func (external) Stop() error                                  { return nil }
 func (external) EpIndexReverse(string) []*object.Endpoints    { return nil }
 func (external) SvcIndexReverse(string) []*object.Service     { return nil }
 func (external) Modified() int64                              { return 0 }
+func (external) ExtModified() int64                           { return 0 }
 func (external) EpIndex(s string) []*object.Endpoints         { return nil }
 func (external) EndpointsList() []*object.Endpoints           { return nil }
 func (external) GetNodeByName(name string) (*api.Node, error) { return nil, nil }

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -525,7 +524,8 @@ func (APIConnServeTest) Run()                                      {}
 func (APIConnServeTest) Stop() error                               { return nil }
 func (APIConnServeTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServeTest) SvcIndexReverse(string) []*object.Service  { return nil }
-func (APIConnServeTest) Modified() int64                           { return time.Now().Unix() }
+func (APIConnServeTest) Modified() int64                           { return 2 }
+func (APIConnServeTest) ExtModified() int64                        { return 2 }
 
 func (APIConnServeTest) PodIndex(ip string) []*object.Pod {
 	if ip != "10.240.0.1" {

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -67,6 +67,7 @@ func (APIConnServiceTest) PodIndex(string) []*object.Pod             { return ni
 func (APIConnServiceTest) SvcIndexReverse(string) []*object.Service  { return nil }
 func (APIConnServiceTest) EpIndexReverse(string) []*object.Endpoints { return nil }
 func (APIConnServiceTest) Modified() int64                           { return 0 }
+func (APIConnServiceTest) ExtModified() int64                        { return 0 }
 
 func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 	svcs := []*object.Service{

--- a/plugin/kubernetes/ns_test.go
+++ b/plugin/kubernetes/ns_test.go
@@ -20,6 +20,7 @@ func (APIConnTest) SvcIndexReverse(string) []*object.Service { return nil }
 func (APIConnTest) EpIndex(string) []*object.Endpoints       { return nil }
 func (APIConnTest) EndpointsList() []*object.Endpoints       { return nil }
 func (APIConnTest) Modified() int64                          { return 0 }
+func (APIConnTest) ExtModified() int64                       { return 0 }
 
 func (a APIConnTest) SvcIndex(s string) []*object.Service {
 	switch s {

--- a/plugin/kubernetes/reverse_test.go
+++ b/plugin/kubernetes/reverse_test.go
@@ -23,6 +23,7 @@ func (APIConnReverseTest) EpIndex(string) []*object.Endpoints { return nil }
 func (APIConnReverseTest) EndpointsList() []*object.Endpoints { return nil }
 func (APIConnReverseTest) ServiceList() []*object.Service     { return nil }
 func (APIConnReverseTest) Modified() int64                    { return 0 }
+func (APIConnReverseTest) ExtModified() int64                 { return 0 }
 
 func (APIConnReverseTest) SvcIndex(svc string) []*object.Service {
 	if svc != "svc1.testns" {

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -22,7 +22,7 @@ func (k *Kubernetes) Serial(state request.Request) uint32 { return uint32(k.APIC
 // MinTTL implements the Transferer interface.
 func (k *Kubernetes) MinTTL(state request.Request) uint32 { return k.ttl }
 
-// Transfer implements the Transferer interface.
+// Transfer handles zone transfer requests
 func (k *Kubernetes) Transfer(ctx context.Context, state request.Request) (int, error) {
 
 	if !k.transferAllowed(state) {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Implements `transfer.Transferer` interface to enable zone transfers.
Add zone serial to for external k8s zones.
Separately track zone serial for internal and external ip services in _kubernetes_ plugin.

### 2. Which issues (if any) are related?
none

### 3. Which documentation changes (if any) need to be made?
Included

### 4. Does this introduce a backward incompatible change or deprecation?
no