### PR TITLE
Add SingleSRV used by Kubernetes

### DIFF
--- a/plugin/kubernetes/handler.go
+++ b/plugin/kubernetes/handler.go
@@ -43,7 +43,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	case dns.TypeMX:
 		records, extra, err = plugin.MX(ctx, &k, zone, state, plugin.Options{})
 	case dns.TypeSRV:
-		records, extra, err = plugin.SRV(ctx, &k, zone, state, plugin.Options{})
+		records, extra, err = plugin.SingleSRV(ctx, &k, zone, state, plugin.Options{})
 	case dns.TypeSOA:
 		records, err = plugin.SOA(ctx, &k, zone, state, plugin.Options{})
 	case dns.TypeNS:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Simplifies `SRV` in `backend_lookup.go` for kubernetes plugin
### 2. Which issues (if any) are related?
#3381
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
No