### PR TITLE
plugin/reload: Fix "durations" documentation link

### DIFF
--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -40,7 +40,7 @@ reload [INTERVAL] [JITTER]
 
 The plugin will check for changes every **INTERVAL**, subject to +/- the **JITTER** duration.
 
-*  **INTERVAL** and **JITTER** are Golang (durations)[[https://golang.org/pkg/time/#ParseDuration](https://golang.org/pkg/time/#ParseDuration)].
+*  **INTERVAL** and **JITTER** are Golang [durations](https://golang.org/pkg/time/#ParseDuration).
    The default **INTERVAL** is 30s, default **JITTER** is 15s, the minimal value for **INTERVAL**
    is 2s, and for **JITTER** it is 1s. If **JITTER** is more than half of **INTERVAL**, it will be
    set to half of **INTERVAL**


### PR DESCRIPTION
* `plugin/reload/README.md`: Fix the syntax of the link to the Go documentation for duration values.

### 1. Why is this pull request needed and what does it do?

The documentation for the reload plugin has a link with incorrect syntax.  This PR fixes the link's syntax.

### 2. Which issues (if any) are related?

None that I am aware of.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.