### PR TITLE
Fix: Call wg.Add in main goroutine to avoid race conditons.

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -109,8 +109,8 @@ func (t Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	ch := make(chan *dns.Envelope)
 	tr := new(dns.Transfer)
 	wg := new(sync.WaitGroup)
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		tr.Out(w, r, ch)
 		wg.Done()
 	}()


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
If the goroutine call wg.Add by itself, what if the main goroutine run to the end before goroutine start runing? May there are chances.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
No