### PR TITLE
plugin/bufsize: add usecase description

### DIFF
--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -16,6 +16,7 @@ The default value is 512, and the value must be within 512 - 4096.
 Only one argument is acceptable, and it covers both IPv4 and IPv6.
 
 ## Examples
+### As a forwarder
 ```corefile
 . {
     bufsize 512
@@ -25,6 +26,18 @@ Only one argument is acceptable, and it covers both IPv4 and IPv6.
 ```
 
 If you run a resolver on 172.31.0.10, the buffer size of incoming query on the resolver will be set to 512 bytes.
+
+### As an authoritative nameserver
+```corefile
+. {
+    bufsize 512
+    file db.example.org
+    log
+}
+```
+
+Also you can limit the buffer size as an authoritative nameserver.  
+If the answer from *file* plugin exceeds 512 bytes, the response will be truncated.
 
 ## Considerations
 For now, if a client does not use EDNS, this plugin adds OPT RR.

--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -16,7 +16,7 @@ The default value is 512, and the value must be within 512 - 4096.
 Only one argument is acceptable, and it covers both IPv4 and IPv6.
 
 ## Examples
-### As a forwarder
+Enable limiting the buffer size of outgoing query to the resolver (172.31.0.10):
 ```corefile
 . {
     bufsize 512
@@ -25,9 +25,7 @@ Only one argument is acceptable, and it covers both IPv4 and IPv6.
 }
 ```
 
-If you run a resolver on 172.31.0.10, the buffer size of incoming query on the resolver will be set to 512 bytes.
-
-### As an authoritative nameserver
+Enable limiting the buffer size as an authoritative nameserver:
 ```corefile
 . {
     bufsize 512
@@ -36,8 +34,6 @@ If you run a resolver on 172.31.0.10, the buffer size of incoming query on the r
 }
 ```
 
-Also you can limit the buffer size as an authoritative nameserver.  
-If the answer from *file* plugin exceeds 512 bytes, the response will be truncated.
-
 ## Considerations
-For now, if a client does not use EDNS, this plugin adds OPT RR.
+- Setting 1232 bytes to bufsize may avoid fragmentation on the majority of networks in use today, but it depends on the MTU of the physical network links.
+- For now, if a client does not use EDNS, this plugin adds OPT RR.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
the *bufsize* plugin was just added to coredns repo though, I realised the documentation could be better.
I added a usecase on examples section when coredns behaves as an authoritative nameserver.
It would be useful to explain the concept of this plugin precisely.

### 2. Which issues (if any) are related?
None.

### 3. Which documentation changes (if any) need to be made?
None.

### 4. Does this introduce a backward incompatible change or deprecation?
None.