### PR TITLE
plugin/bufsize: remove trailing whitespace

### DIFF
--- a/plugin/bufsize/README.md
+++ b/plugin/bufsize/README.md
@@ -3,7 +3,7 @@
 *bufsize* - sizes EDNS0 buffer size to prevent IP fragmentation.
 
 ## Description
-*bufsize* limits a requester's UDP payload size.  
+*bufsize* limits a requester's UDP payload size.
 It prevents IP fragmentation so that to deal with DNS vulnerability.
 
 ## Syntax
@@ -11,8 +11,8 @@ It prevents IP fragmentation so that to deal with DNS vulnerability.
 bufsize [SIZE]
 ```
 
-**[SIZE]** is an int value for setting the buffer size.  
-The default value is 512, and the value must be within 512 - 4096.  
+**[SIZE]** is an int value for setting the buffer size.
+The default value is 512, and the value must be within 512 - 4096.
 Only one argument is acceptable, and it covers both IPv4 and IPv6.
 
 ## Examples


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Remove trailing whitespace to clear warnings in build...
```
** presubmit/trailing-whitespace
plugin/bufsize/README.md:*bufsize* limits a requester's UDP payload size.  
plugin/bufsize/README.md:**[SIZE]** is an int value for setting the buffer size.  
plugin/bufsize/README.md:The default value is 512, and the value must be within 512 - 4096.  
** presubmit/trailing-whitespace: please remove any trailing white space
```

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
