### PR TITLE
Fix reloading in health and ready

### DIFF
--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
 )
 
 var log = clog.NewWithPlugin("health")
@@ -29,8 +30,7 @@ func (h *health) OnStartup() error {
 		h.Addr = ":8080"
 	}
 	h.stop = make(chan bool)
-
-	ln, err := net.Listen("tcp", h.Addr)
+	ln, err := reuseport.Listen("tcp", h.Addr)
 	if err != nil {
 		return err
 	}

--- a/plugin/ready/ready.go
+++ b/plugin/ready/ready.go
@@ -12,6 +12,7 @@ import (
 
 	clog "github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/uniq"
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
 )
 
 var (
@@ -30,7 +31,7 @@ type ready struct {
 }
 
 func (rd *ready) onStartup() error {
-	ln, err := net.Listen("tcp", rd.Addr)
+	ln, err := reuseport.Listen("tcp", rd.Addr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Zou Nengren <zouyee1989@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Reloading the server without changing the listen address results in an
error because Startup is called for newly set up plugins before Shutdown
is called for the old ones.
### 2. Which issues (if any) are related?
a part of https://github.com/coredns/coredns/issues/3464
xref https://github.com/coredns/coredns/pull/3454
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
None