### PR TITLE
use pkg/reuseport in rest plugins

### DIFF
--- a/plugin/dnstap/dnstapio/io_test.go
+++ b/plugin/dnstap/dnstapio/io_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
+	
 	tap "github.com/dnstap/golang-dnstap"
 	fs "github.com/farsightsec/golang-framestream"
 )
@@ -55,7 +57,7 @@ func TestTransport(t *testing.T) {
 
 	for _, param := range transport {
 		// Start TCP listener
-		l, err := net.Listen(param[0], param[1])
+		l, err := reuseport.Listen(param[0], param[1])
 		if err != nil {
 			t.Fatalf("Cannot start listener: %s", err)
 		}
@@ -82,7 +84,7 @@ func TestRace(t *testing.T) {
 	count := 10
 
 	// Start TCP listener
-	l, err := net.Listen("tcp", endpointTCP)
+	l, err := reuseport.Listen("tcp", endpointTCP)
 	if err != nil {
 		t.Fatalf("Cannot start listener: %s", err)
 	}
@@ -115,7 +117,7 @@ func TestReconnect(t *testing.T) {
 	count := 5
 
 	// Start TCP listener
-	l, err := net.Listen("tcp", endpointTCP)
+	l, err := reuseport.Listen("tcp", endpointTCP)
 	if err != nil {
 		t.Fatalf("Cannot start listener: %s", err)
 	}
@@ -141,7 +143,7 @@ func TestReconnect(t *testing.T) {
 	l.Close()
 
 	// And start TCP listener again on the same port
-	l, err = net.Listen("tcp", addr)
+	l, err = reuseport.Listen("tcp", addr)
 	if err != nil {
 		t.Fatalf("Cannot start listener: %s", err)
 	}

--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics/vars"
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -95,7 +96,7 @@ func (m *Metrics) ZoneNames() []string {
 
 // OnStartup sets up the metrics on startup.
 func (m *Metrics) OnStartup() error {
-	ln, err := net.Listen("tcp", m.Addr)
+	ln, err := reuseport.Listen("tcp", m.Addr)
 	if err != nil {
 		log.Errorf("Failed to start metrics handler: %s", err)
 		return err

--- a/plugin/pkg/dnstest/server.go
+++ b/plugin/pkg/dnstest/server.go
@@ -3,6 +3,8 @@ package dnstest
 import (
 	"net"
 
+	"github.com/coredns/coredns/plugin/pkg/reuseport"
+
 	"github.com/miekg/dns"
 )
 
@@ -27,7 +29,7 @@ func NewServer(f dns.HandlerFunc) *Server {
 	s2 := &dns.Server{} // tcp
 
 	for i := 0; i < 5; i++ { // 5 attempts
-		s2.Listener, _ = net.Listen("tcp", ":0")
+		s2.Listener, _ = reuseport.Listen("tcp", ":0")
 		if s2.Listener == nil {
 			continue
 		}


### PR DESCRIPTION
Signed-off-by: Zou Nengren <zouyee1989@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Reloading the server without changing the listen address results in an
error because Startup is called for newly set up plugins before Shutdown
is called for the old ones.
### 2. Which issues (if any) are related?
fix https://github.com/coredns/coredns/issues/3464
xref https://github.com/coredns/coredns/pull/3454
### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
None