### PR TITLE
redirect handler for pprof index

### DIFF
--- a/plugin/pprof/pprof.go
+++ b/plugin/pprof/pprof.go
@@ -31,6 +31,9 @@ func (h *handler) Startup() error {
 	h.ln = ln
 
 	h.mux = http.NewServeMux()
+	h.mux.HandleFunc(path, func(rw http.ResponseWriter, req *http.Request) {
+		http.Redirect(rw, req, path+"/", http.StatusFound)
+	})
 	h.mux.HandleFunc(path+"/", pp.Index)
 	h.mux.HandleFunc(path+"/cmdline", pp.Cmdline)
 	h.mux.HandleFunc(path+"/profile", pp.Profile)


### PR DESCRIPTION
Signed-off-by: zouyee <zounengren@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
handler `/debug/pprof` redirect to `/debug/pprof/`

### 2. Which issues (if any) are related?
fix https://github.com/coredns/coredns/issues/3504

### 3. Which documentation changes (if any) need to be made?
NONE

### 4. Does this introduce a backward incompatible change or deprecation?
NONE