### PR TITLE
Setup GitHub Workflow for auto `go tidy`

### DIFF
--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -1,0 +1,43 @@
+name: go tidy
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/go.tidy.yml'
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        # https://github.com/actions/checkout/issues/6
+        name: Fix detached HEAD
+        run: git checkout ${GITHUB_REF#refs/heads/}
+      -
+        name: Tidy
+        run: |
+          rm -f go.sum
+          go mod tidy
+      -
+        name: Set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+      -
+        name: Commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'auto go tidy'
+            git push
+          fi


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Setup GitHub Workflow for auto `go tidy`, when
- 'go.mod'
- 'go.sum'
- '.github/workflows/go.tidy.yml'
has been touched.

Note it covers both `dependabot[bot]` and non `dependabot` (manual touching those two files) case.

### 2. Which issues (if any) are related?

#3509

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>