### PR TITLE
Remove trailing whitespace as otherwise `make check` fails

### DIFF
--- a/plugin/dnstap/dnstapio/io_test.go
+++ b/plugin/dnstap/dnstapio/io_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
-	
+
 	tap "github.com/dnstap/golang-dnstap"
 	fs "github.com/farsightsec/golang-framestream"
 )


### PR DESCRIPTION
This PR removes trailing whitespace as otherwise `make check` fails

This PR fixes #3513

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
