### PR TITLE
Update auto go mod tidy workflow to remove user association of auto-commit

### DIFF
--- a/.github/workflows/go.tidy.yml
+++ b/.github/workflows/go.tidy.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - 'master'
     paths:
+      - '.github/workflows/go.tidy.yml'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/go.tidy.yml'
 
 jobs:
   fix:
@@ -30,14 +30,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "coredns-auto-go-mod-tidy[bot]"
+          git config user.email "coredns-auto-go-mod-tidy[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes
         run: |
           git add .
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -m 'auto go tidy'
+            git commit -m 'auto go mod tidy'
             git push
           fi


### PR DESCRIPTION
This PR updates go.tidy.yml, and use pseudo name `coredns-auto-go-mod-tidy[bot]`, so that the commit is not associated with real user. Otherwise the commit history could be confusing.

This is similar to what `dependabot[bot]` is doing for commits generated by bots.


Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
