### PR TITLE
Fix HostPortOrFile to support IPv6 addresses with zone

### DIFF
--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -4,11 +4,22 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/coredns/coredns/plugin/pkg/transport"
 
 	"github.com/miekg/dns"
 )
+
+// Strips the zone, but preserves any port that comes after the zone
+func stripZone(host string) string {
+	if strings.Contains(host, "%") {
+		lastPercent := strings.LastIndex(host, "%")
+		newHost := host[:lastPercent]
+		return newHost
+	}
+	return host
+}
 
 // HostPortOrFile parses the strings in s, each string can either be a
 // address, [scheme://]address:port or a filename. The address part is checked
@@ -21,10 +32,11 @@ func HostPortOrFile(s ...string) ([]string, error) {
 		trans, host := Transport(h)
 
 		addr, _, err := net.SplitHostPort(host)
+
 		if err != nil {
 			// Parse didn't work, it is not a addr:port combo
-			if net.ParseIP(host) == nil {
-				// Not an IP address.
+			hostNoZone := stripZone(host)
+			if net.ParseIP(hostNoZone) == nil {
 				ss, err := tryFile(host)
 				if err == nil {
 					servers = append(servers, ss...)
@@ -47,8 +59,7 @@ func HostPortOrFile(s ...string) ([]string, error) {
 			continue
 		}
 
-		if net.ParseIP(addr) == nil {
-			// Not an IP address.
+		if net.ParseIP(stripZone(addr)) == nil {
 			ss, err := tryFile(host)
 			if err == nil {
 				servers = append(servers, ss...)

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -34,6 +34,26 @@ func TestHostPortOrFile(t *testing.T) {
 			"127.0.0.1:53",
 			false,
 		},
+		{
+			"fe80::1",
+			"[fe80::1]:53",
+			false,
+		},
+		{
+			"fe80::1%ens3",
+			"[fe80::1%ens3]:53",
+			false,
+		},
+		{
+			"[fd01::1]:153",
+			"[fd01::1]:153",
+			false,
+		},
+		{
+			"[fd01::1%ens3]:153",
+			"[fd01::1%ens3]:153",
+			false,
+		},
 	}
 
 	err := ioutil.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)


### PR DESCRIPTION
1. The HostPortOrFile tests don't have any IPv6 tests. This adds some.
2. The HostPortOrFile breaks if any of the addresses have IPv6 zone
defined. ParseIP does not handle %zone anymore.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This was discovered using the forward plugin, but perhaps would affect others. The HostPortOrFile function does not properly support an IPv6 address of the form address%zone. 

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None
### 4. Does this introduce a backward incompatible change or deprecation?
No