### PR TITLE
plugin/hosts: Modifies NODATA handling

### DIFF
--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -52,15 +52,15 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		answers = aaaa(qname, h.options.ttl, ips)
 	}
 
-	if len(answers) == 0 {
+	// This condition hooks only NXDOMAIN.
+	if len(answers) == 0 && !h.otherRecordsExist(qname) {
 		if h.Fall.Through(qname) {
 			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 		}
+
 		// We want to send an NXDOMAIN, but because of /etc/hosts' setup we don't have a SOA, so we make it REFUSED
 		// to at least give an answer back to signals we're having problems resolving this.
-		if !h.otherRecordsExist(qname) {
-			return dns.RcodeServerFailure, nil
-		}
+		return dns.RcodeServerFailure, nil
 	}
 
 	m := new(dns.Msg)

--- a/plugin/hosts/hosts.go
+++ b/plugin/hosts/hosts.go
@@ -52,13 +52,13 @@ func (h Hosts) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		answers = aaaa(qname, h.options.ttl, ips)
 	}
 
-	// This condition hooks only NXDOMAIN.
+	// Only on NXDOMAIN we will fallthrough.
 	if len(answers) == 0 && !h.otherRecordsExist(qname) {
 		if h.Fall.Through(qname) {
 			return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 		}
 
-		// We want to send an NXDOMAIN, but because of /etc/hosts' setup we don't have a SOA, so we make it REFUSED
+		// We want to send an NXDOMAIN, but because of /etc/hosts' setup we don't have a SOA, so we make it SERVFAIL
 		// to at least give an answer back to signals we're having problems resolving this.
 		return dns.RcodeServerFailure, nil
 	}

--- a/plugin/hosts/hosts_test.go
+++ b/plugin/hosts/hosts_test.go
@@ -49,9 +49,10 @@ func TestLookupA(t *testing.T) {
 			return
 		}
 
-		resp := rec.Msg
-		if err := test.SortAndCheck(resp, tc); err != nil {
-			t.Error(err)
+		if resp := rec.Msg; rec.Msg != nil {
+			if err := test.SortAndCheck(resp, tc); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Bug fixing for the issue https://github.com/coredns/coredns/issues/2564.
If hosts file has only A record and this plugin receives a query for AAAA, NODATA should be returned.
Now, this plugin fallthrough the query and a client going to get NXDOMAIN.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/2564

### 3. Which documentation changes (if any) need to be made?
I don't think so.

### 4. Does this introduce a backward incompatible change or deprecation?
No.