### PR TITLE
use map to accelerate ignore name lookup

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -131,9 +131,8 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return c.ArgErr()
 		}
 		for i := 0; i < len(ignore); i++ {
-			ignore[i] = plugin.Host(ignore[i]).Normalize()
+			f.ignored[plugin.Host(ignore[i]).Normalize()] = struct{}{}
 		}
-		f.ignored = ignore
 	case "max_fails":
 		if !c.NextArg() {
 			return c.ArgErr()


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I have a very large except list (> 73660 items) for `forward` plugin, linear lookup is not efficient enough. I use std map to accelerate this operation.

### 2. Which issues (if any) are related?

N/A

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

N/A