### PR TITLE
Bump kubernetes plugin DNS schema version to 1.1.0

### DIFF
--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -264,7 +264,7 @@ var dnsTestCases = []test.Case{
 		Qname: "dns-version.cluster.local.", Qtype: dns.TypeTXT,
 		Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.TXT("dns-version.cluster.local 28800 IN TXT 1.0.1"),
+			test.TXT("dns-version.cluster.local 28800 IN TXT 1.1.0"),
 		},
 	},
 	// A Service (Headless) does not exist

--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -69,7 +69,7 @@ const (
 	// podModeInsecure is where pod requests are answered without verifying they exist
 	podModeInsecure = "insecure"
 	// DNSSchemaVersion is the schema version: https://github.com/kubernetes/dns/blob/master/docs/specification.md
-	DNSSchemaVersion = "1.0.1"
+	DNSSchemaVersion = "1.1.0"
 	// Svc is the DNS schema for kubernetes services
 	Svc = "svc"
 	// Pod is the DNS schema for kubernetes pods


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The Kubernetes DNS specification schema version was
updated to 1.1.0 in order to support IPv6

### 2. Which issues (if any) are related?

xref: https://github.com/kubernetes/dns/pull/335

### 3. Which documentation changes (if any) need to be made?

`CoreDNS implements the new Kubernetes DNS 1.1.0 schema with IPv6 support`

### 4. Does this introduce a backward incompatible change or deprecation?

The new schema removes the already deprecated records with format

> - `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. <ttl> IN A <a>.<b>.<c>.<d>`

https://github.com/kubernetes/dns/pull/335#discussion_r359491872