### PR TITLE
sign: add expiration jitter

### DIFF
--- a/plugin/sign/README.md
+++ b/plugin/sign/README.md
@@ -32,7 +32,7 @@ it do key or algorithm rollovers - it just signs.
     Both these dates are only checked on the SOA's signature(s).
 
  *  Create RRSIGs that have an inception of -3 hours (minus a jitter between 0 and 18 hours)
-    and a expiration of +32 days for every given DNSKEY.
+    and a expiration of +32 (plus a jitter between 0 and 5 days) days for every given DNSKEY.
 
  *  Add NSEC records for all names in the zone. The TTL for these is the negative cache TTL from the
     SOA record.

--- a/plugin/sign/setup.go
+++ b/plugin/sign/setup.go
@@ -23,7 +23,7 @@ func setup(c *caddy.Controller) error {
 	c.OnStartup(sign.OnStartup)
 	c.OnStartup(func() error {
 		for _, signer := range sign.signers {
-			go signer.refresh(DurationRefreshHours)
+			go signer.refresh(durationRefreshHours)
 		}
 		return nil
 	})
@@ -66,8 +66,8 @@ func parse(c *caddy.Controller) (*Sign, error) {
 			signers[i] = &Signer{
 				dbfile:      dbfile,
 				origin:      plugin.Host(origins[i]).Normalize(),
-				jitterIncep: time.Duration(float32(DurationInceptionJitter) * rand.Float32()),
-				jitterExpir: time.Duration(float32(DurationExpirationDayJitter) * rand.Float32()),
+				jitterIncep: time.Duration(float32(durationInceptionJitter) * rand.Float32()),
+				jitterExpir: time.Duration(float32(durationExpirationDayJitter) * rand.Float32()),
 				directory:   "/var/lib/coredns",
 				stop:        make(chan struct{}),
 				signedfile:  fmt.Sprintf("db.%ssigned", origins[i]), // origins[i] is a fqdn, so it ends with a dot, hence %ssigned.

--- a/plugin/sign/setup.go
+++ b/plugin/sign/setup.go
@@ -64,12 +64,13 @@ func parse(c *caddy.Controller) (*Sign, error) {
 		signers := make([]*Signer, len(origins))
 		for i := range origins {
 			signers[i] = &Signer{
-				dbfile:     dbfile,
-				origin:     plugin.Host(origins[i]).Normalize(),
-				jitter:     time.Duration(float32(DurationJitter) * rand.Float32()),
-				directory:  "/var/lib/coredns",
-				stop:       make(chan struct{}),
-				signedfile: fmt.Sprintf("db.%ssigned", origins[i]), // origins[i] is a fqdn, so it ends with a dot, hence %ssigned.
+				dbfile:      dbfile,
+				origin:      plugin.Host(origins[i]).Normalize(),
+				jitterIncep: time.Duration(float32(DurationInceptionJitter) * rand.Float32()),
+				jitterExpir: time.Duration(float32(DurationExpirationDayJitter) * rand.Float32()),
+				directory:   "/var/lib/coredns",
+				stop:        make(chan struct{}),
+				signedfile:  fmt.Sprintf("db.%ssigned", origins[i]), // origins[i] is a fqdn, so it ends with a dot, hence %ssigned.
 			}
 		}
 

--- a/plugin/sign/sign.go
+++ b/plugin/sign/sign.go
@@ -26,13 +26,13 @@ func (s *Sign) OnStartup() error {
 
 // Various duration constants for signing of the zones.
 const (
-	DurationExpireDays              = 7 * 24 * time.Hour  // max time allowed before expiration
-	DurationResignDays              = 6 * 24 * time.Hour  // if the last sign happenend this long ago, sign again
-	DurationSignatureExpireDays     = 32 * 24 * time.Hour // sign for 32 days
-	DurationRefreshHours            = 5 * time.Hour       // check zones every 5 hours
-	DurationInceptionJitter         = -18 * time.Hour     // default max jitter for the inception
-	DurationExpirationDayJitter     = 5 * 24 * time.Hour  // default max jitter for the expiration
-	DurationSignatureInceptionHours = -3 * time.Hour      // -(2+1) hours, be sure to catch daylight saving time and such, jitter is subtracted
+	durationExpireDays              = 7 * 24 * time.Hour  // max time allowed before expiration
+	durationResignDays              = 6 * 24 * time.Hour  // if the last sign happenend this long ago, sign again
+	durationSignatureExpireDays     = 32 * 24 * time.Hour // sign for 32 days
+	durationRefreshHours            = 5 * time.Hour       // check zones every 5 hours
+	durationInceptionJitter         = -18 * time.Hour     // default max jitter for the inception
+	durationExpirationDayJitter     = 5 * 24 * time.Hour  // default max jitter for the expiration
+	durationSignatureInceptionHours = -3 * time.Hour      // -(2+1) hours, be sure to catch daylight saving time and such, jitter is subtracted
 )
 
 const timeFmt = "2006-01-02T15:04:05.000Z07:00"

--- a/plugin/sign/sign.go
+++ b/plugin/sign/sign.go
@@ -30,7 +30,8 @@ const (
 	DurationResignDays              = 6 * 24 * time.Hour  // if the last sign happenend this long ago, sign again
 	DurationSignatureExpireDays     = 32 * 24 * time.Hour // sign for 32 days
 	DurationRefreshHours            = 5 * time.Hour       // check zones every 5 hours
-	DurationJitter                  = -18 * time.Hour     // default max jitter
+	DurationInceptionJitter         = -18 * time.Hour     // default max jitter for the inception
+	DurationExpirationDayJitter     = 5 * 24 * time.Hour  // default max jitter for the expiration
 	DurationSignatureInceptionHours = -3 * time.Hour      // -(2+1) hours, be sure to catch daylight saving time and such, jitter is subtracted
 )
 

--- a/plugin/sign/signer.go
+++ b/plugin/sign/signer.go
@@ -144,8 +144,8 @@ func resign(rd io.Reader, now time.Time) (why error) {
 			}
 			incep, _ := time.Parse("20060102150405", dns.TimeToString(x.Inception))
 			// If too long ago, resign.
-			if now.Sub(incep) >= 0 && now.Sub(incep) > DurationResignDays {
-				return fmt.Errorf("inception %q was more than: %s ago from %s: %s", incep.Format(timeFmt), DurationResignDays, now.Format(timeFmt), now.Sub(incep))
+			if now.Sub(incep) >= 0 && now.Sub(incep) > durationResignDays {
+				return fmt.Errorf("inception %q was more than: %s ago from %s: %s", incep.Format(timeFmt), durationResignDays, now.Format(timeFmt), now.Sub(incep))
 			}
 			// Inception hasn't even start yet.
 			if now.Sub(incep) < 0 {
@@ -153,8 +153,8 @@ func resign(rd io.Reader, now time.Time) (why error) {
 			}
 
 			expire, _ := time.Parse("20060102150405", dns.TimeToString(x.Expiration))
-			if expire.Sub(now) < DurationExpireDays {
-				return fmt.Errorf("expiration %q is less than: %s away from %s: %s", expire.Format(timeFmt), DurationExpireDays, now.Format(timeFmt), expire.Sub(now))
+			if expire.Sub(now) < durationExpireDays {
+				return fmt.Errorf("expiration %q is less than: %s away from %s: %s", expire.Format(timeFmt), durationExpireDays, now.Format(timeFmt), expire.Sub(now))
 			}
 		}
 		i++
@@ -174,7 +174,7 @@ func signAndLog(s *Signer, why error) {
 	z, err := s.Sign(now)
 	log.Infof("Signing %q because %s", s.origin, why)
 	if err != nil {
-		log.Warningf("Error signing %q with key tags %q in %s: %s, next: %s", s.origin, keyTag(s.keys), time.Since(now), err, now.Add(DurationRefreshHours).Format(timeFmt))
+		log.Warningf("Error signing %q with key tags %q in %s: %s, next: %s", s.origin, keyTag(s.keys), time.Since(now), err, now.Add(durationRefreshHours).Format(timeFmt))
 		return
 	}
 
@@ -182,7 +182,7 @@ func signAndLog(s *Signer, why error) {
 		log.Warningf("Error signing %q: failed to move zone file into place: %s", s.origin, err)
 		return
 	}
-	log.Infof("Successfully signed zone %q in %q with key tags %q and %d SOA serial, elapsed %f, next: %s", s.origin, filepath.Join(s.directory, s.signedfile), keyTag(s.keys), z.Apex.SOA.Serial, time.Since(now).Seconds(), now.Add(DurationRefreshHours).Format(timeFmt))
+	log.Infof("Successfully signed zone %q in %q with key tags %q and %d SOA serial, elapsed %f, next: %s", s.origin, filepath.Join(s.directory, s.signedfile), keyTag(s.keys), z.Apex.SOA.Serial, time.Since(now).Seconds(), now.Add(durationRefreshHours).Format(timeFmt))
 }
 
 // refresh checks every val if some zones need to be resigned.
@@ -204,7 +204,7 @@ func (s *Signer) refresh(val time.Duration) {
 }
 
 func lifetime(now time.Time, jitterInception, jitterExpiration time.Duration) (uint32, uint32) {
-	incep := uint32(now.Add(DurationSignatureInceptionHours).Add(jitterInception).Unix())
-	expir := uint32(now.Add(DurationSignatureExpireDays).Add(jitterExpiration).Unix())
+	incep := uint32(now.Add(durationSignatureInceptionHours).Add(jitterInception).Unix())
+	expir := uint32(now.Add(durationSignatureExpireDays).Add(jitterExpiration).Unix())
 	return incep, expir
 }

--- a/plugin/sign/signer.go
+++ b/plugin/sign/signer.go
@@ -18,11 +18,12 @@ var log = clog.NewWithPlugin("sign")
 
 // Signer holds the data needed to sign a zone file.
 type Signer struct {
-	keys      []Pair
-	origin    string
-	dbfile    string
-	directory string
-	jitter    time.Duration
+	keys        []Pair
+	origin      string
+	dbfile      string
+	directory   string
+	jitterIncep time.Duration
+	jitterExpir time.Duration
 
 	signedfile string
 	stop       chan struct{}
@@ -42,7 +43,7 @@ func (s *Signer) Sign(now time.Time) (*file.Zone, error) {
 
 	mttl := z.Apex.SOA.Minttl
 	ttl := z.Apex.SOA.Header().Ttl
-	inception, expiration := lifetime(now, s.jitter)
+	inception, expiration := lifetime(now, s.jitterIncep, s.jitterExpir)
 	z.Apex.SOA.Serial = uint32(now.Unix())
 
 	for _, pair := range s.keys {
@@ -202,8 +203,8 @@ func (s *Signer) refresh(val time.Duration) {
 	}
 }
 
-func lifetime(now time.Time, jitter time.Duration) (uint32, uint32) {
-	incep := uint32(now.Add(DurationSignatureInceptionHours).Add(jitter).Unix())
-	expir := uint32(now.Add(DurationSignatureExpireDays).Unix())
+func lifetime(now time.Time, jitterInception, jitterExpiration time.Duration) (uint32, uint32) {
+	incep := uint32(now.Add(DurationSignatureInceptionHours).Add(jitterInception).Unix())
+	expir := uint32(now.Add(DurationSignatureExpireDays).Add(jitterExpiration).Unix())
 	return incep, expir
 }


### PR DESCRIPTION
This PR adds a expiration jitter to spread out zone re-signing even more.
The max is 5 extra days added when creating the signer for a specific zone.

Also make the duration* constants private to clean up the godoc for this
plugin.

Signed-off-by: Miek Gieben <miek@miek.nl>