### PR TITLE
Pass the simple communication test result as a pre-condition for ready check

### DIFF
--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -319,12 +319,11 @@ func (dns *dnsControl) HasSynced() bool {
 	// If that's the case wait and resend watch request.
 	v, err := dns.client.Discovery().ServerVersion()
 	if err != nil {
-		log.Warningf("While trying to communicate with apiserver found err: %v", err)
+		log.Warningf("While trying to communicate with apiserver found error: %v", err)
 		return false
 	}
 	log.Infof("Running with Kubernetes cluster version: v%s.%s. git version: %s. git tree state: %s. commit: %s. platform: %s",
 		v.Major, v.Minor, v.GitVersion, v.GitTreeState, v.GitCommit, v.Platform)
-	log.Infof("Communication with server successful")
 	a := dns.svcController.HasSynced()
 	b := true
 	if dns.epController != nil {


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
 Although the connection between coredns and apiserver is broken, but the HasSynced () method  of reflector will not report the error.

If this is "connection refused" error, it means that most likely apiserver is not responsive.
It doesn't make sense to re-list all objects because most likely we will be able to restart watch where we ended.
If that's the case wait and resend watch request.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3587
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
none