### PR TITLE
docs: update README and log plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,25 +77,20 @@ The above command alone will have `coredns` binary generated.
 ## Examples
 
 When starting CoreDNS without any configuration, it loads the
-[*whoami*](https://coredns.io/plugins/whoami) plugin and starts listening on port 53 (override with
-`-dns.port`), it should show the following:
+[*whoami*](https://coredns.io/plugins/whoami) and [*log*](https://coredns.io/plugins/log) plugins
+and starts listening on port 53 (override with `-dns.port`), it should show the following:
 
 ~~~ txt
 .:53
-   ______                ____  _   _______
-  / ____/___  ________  / __ \/ | / / ___/	~ CoreDNS-1.6.3
- / /   / __ \/ ___/ _ \/ / / /  |/ /\__ \ 	~ linux/amd64, go1.13,
-/ /___/ /_/ / /  /  __/ /_/ / /|  /___/ /
-\____/\____/_/   \___/_____/_/ |_//____/
+CoreDNS-1.6.6
+linux/amd64, go1.13.5, aa8c32
 ~~~
 
 Any query sent to port 53 should return some information; your sending address, port and protocol
-used.
+used. The query should also be logged to standard output.
 
 If you have a Corefile without a port number specified it will, by default, use port 53, but you can
-override the port with the `-dns.port` flag:
-
-`./coredns -dns.port 1053`, runs the server on port 1053.
+override the port with the `-dns.port` flag: `coredns -dns.port 1053`, runs the server on port 1053.
 
 Start a simple proxy. You'll need to be root to start listening on port 53.
 
@@ -108,11 +103,11 @@ Start a simple proxy. You'll need to be root to start listening on port 53.
 }
 ~~~
 
-Just start CoreDNS: `./coredns`. Then just query on that port (53). The query should be forwarded
-to 8.8.8.8 and the response will be returned. Each query should also show up in the log which is
-printed on standard output.
+Start CoreDNS and then query on that port (53). The query should be forwarded to 8.8.8.8 and the
+response will be returned. Each query should also show up in the log which is printed on standard
+output.
 
-Serve the (NSEC) DNSSEC-signed `example.org` on port 1053, with errors and logging sent to standard
+To serve the (NSEC) DNSSEC-signed `example.org` on port 1053, with errors and logging sent to standard
 output. Allow zone transfers to everybody, but specifically mention 1 IP address so that CoreDNS can
 send notifies to it.
 
@@ -139,6 +134,7 @@ example.org:1053 {
     errors
     log
 }
+
 . {
     any
     forward . 8.8.8.8:53

--- a/plugin/log/README.md
+++ b/plugin/log/README.md
@@ -7,10 +7,10 @@
 ## Description
 
 By just using *log* you dump all queries (and parts for the reply) on standard output. Options exist
-to tweak the output a little. The date/time prefix on log lines is RFC3339 formatted with
-milliseconds.
+to tweak the output a little. Note that for busy servers logging will incur a performance hit.
 
-Note that for busy servers logging will incur a performance hit.
+Enabling or disabling the *log* plugin only affects the query logging, any other logging from
+CoreDNS will show up regardless.
 
 ## Syntax
 
@@ -18,8 +18,7 @@ Note that for busy servers logging will incur a performance hit.
 log
 ~~~
 
-* With no arguments, a query log entry is written to *stdout* in the common log format for all requests
-
+With no arguments, a query log entry is written to *stdout* in the common log format for all requests.
 Or if you want/need slightly more control:
 
 ~~~ txt
@@ -47,11 +46,11 @@ The classes of responses have the following meaning:
 * `denial`: either NXDOMAIN or nodata responses (Name exists, type does not). A nodata response
    sets the return code to NOERROR.
 * `error`: SERVFAIL, NOTIMP, REFUSED, etc. Anything that indicates the remote server is not willing to
-    resolve the request.
+  resolve the request.
 * `all`: the default - nothing is specified. Using of this class means that all messages will be
   logged whatever we mix together with "all".
 
-If no class is specified, it defaults to *all*.
+If no class is specified, it defaults to `all`.
 
 ## Log Format
 


### PR DESCRIPTION
README: remove the logo thing as we stopped doing that
log: remote the lines about the clock output as that's gone as well and
     discuss the query log vs other logging a bit.