### PR TITLE
gofmt -w -s **/*.go

### DIFF
--- a/plugin/etcd/etcd.go
+++ b/plugin/etcd/etcd.go
@@ -178,7 +178,7 @@ func (e *Etcd) TTL(kv *mvccpb.KeyValue, serv *msg.Service) uint32 {
 
 // shouldInclude returns true if the service should be included in a list of records, given the qType. For all the
 // currently supported lookup types, the only one to allow for an empty Host field in the service are TXT records
-// which resolve directly.  If a TXT record is being resolved by CNAME, then we expect the Host field to have a 
+// which resolve directly.  If a TXT record is being resolved by CNAME, then we expect the Host field to have a
 // value while the TXT field will be empty.
 func shouldInclude(serv *msg.Service, qType uint16) bool {
 	return (qType == dns.TypeTXT && serv.Text != "") || serv.Host != ""

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/debug"
-	"github.com/coredns/coredns/plugin/pkg/policy"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/coredns/coredns/plugin/pkg/policy"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -8,8 +8,8 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
-	"github.com/coredns/coredns/plugin/pkg/policy"
 	"github.com/coredns/coredns/plugin/pkg/parse"
+	"github.com/coredns/coredns/plugin/pkg/policy"
 	pkgtls "github.com/coredns/coredns/plugin/pkg/tls"
 	"github.com/coredns/coredns/plugin/pkg/transport"
 

--- a/plugin/ready/ready.go
+++ b/plugin/ready/ready.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 
 	clog "github.com/coredns/coredns/plugin/pkg/log"
-	"github.com/coredns/coredns/plugin/pkg/uniq"
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
+	"github.com/coredns/coredns/plugin/pkg/uniq"
 )
 
 var (


### PR DESCRIPTION
format and remove trailing white space; makes 'make presubmit' pass
again.