### PR TITLE
plugins/forward: Add max_concurrent option

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -50,6 +50,7 @@ forward FROM TO... {
     tls_servername NAME
     policy random|round_robin|sequential
     health_check DURATION
+    max_queries MAX
 }
 ~~~
 
@@ -83,6 +84,8 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
+* `max_queries`, limit the number of concurrent queries to **MAX**.  Any new query that would
+  this raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -85,7 +85,9 @@ forward FROM TO... {
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
-  raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
+  raise the number of concurrent queries above the **MAX** will result in a REFUSED response. A refusal of
+  this kind does not in itself count as a health failure. When choosing a value for **MAX**, pick a number
+  at least greater than the expected forwarded query rate * the normal latency of the upstream servers.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -105,7 +105,8 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_forward_healthcheck_failure_count_total{to}` - number of failed health checks per upstream.
 * `coredns_forward_healthcheck_broken_count_total{}` - counter of when all upstreams are unhealthy,
   and we are randomly (this always uses the `random` policy) spraying to an upstream.
-
+* `max_concurrent_reject_count_total{}` - counter of the number of queries rejected because the
+  number of concurrent queries were at maximum.
 Where `to` is one of the upstream servers (**TO** from the config), `rcode` is the returned RCODE
 from the upstream.
 

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -84,7 +84,7 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
-* `max_queries` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
+* `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -84,8 +84,8 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
-* `max_queries`, limit the number of concurrent queries to **MAX**.  Any new query that would
-  this raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
+* `max_queries` will limit the number of concurrent queries to **MAX**.  Any new query that would
+  raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -85,9 +85,10 @@ forward FROM TO... {
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
-  raise the number of concurrent queries above the **MAX** will result in a REFUSED response. A refusal of
-  this kind does not in itself count as a health failure. When choosing a value for **MAX**, pick a number
-  at least greater than the expected forwarded query rate * the normal latency of the upstream servers.
+  raise the number of concurrent queries above the **MAX** will result in a SERVFAIL response. This
+  response does not count as a health failure. When choosing a value for **MAX**, pick a number
+  at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
+  As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -84,7 +84,7 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
-* `max_queries` will limit the number of concurrent queries to **MAX**.  Any new query that would
+* `max_queries` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a SERVFAIL.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -48,7 +48,7 @@ type Forward struct {
 
 // ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
 // the maximum allowed (maxConcurrent)
-var ErrLimitExceeded = errors.New("concurrent queries exceeded maximum")
+var ErrLimitExceeded error
 
 // New returns a new Forward.
 func New() *Forward {
@@ -81,7 +81,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		defer atomic.AddInt64(&(f.concurrent), -1)
 		if count > f.maxConcurrent {
 			MaxConcurrentRejectCount.Add(1)
-			return dns.RcodeServerFailure, ErrLimitExceeded
+			return dns.RcodeRefused, ErrLimitExceeded
 		}
 	}
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -80,6 +80,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		count := atomic.AddInt64(&(f.concurrent), 1)
 		defer atomic.AddInt64(&(f.concurrent), -1)
 		if count > f.maxConcurrent {
+			MaxConcurrentRejectCount.Add(1)
 			return dns.RcodeServerFailure, ErrLimitExceeded
 		}
 	}

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -43,12 +43,12 @@ type Forward struct {
 
 	opts options // also here for testing
 
+	// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
+	// the maximum allowed (maxConcurrent)
+	ErrLimitExceeded error
+
 	Next plugin.Handler
 }
-
-// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
-// the maximum allowed (maxConcurrent)
-var ErrLimitExceeded error
 
 // New returns a new Forward.
 func New() *Forward {
@@ -81,7 +81,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		defer atomic.AddInt64(&(f.concurrent), -1)
 		if count > f.maxConcurrent {
 			MaxConcurrentRejectCount.Add(1)
-			return dns.RcodeRefused, ErrLimitExceeded
+			return dns.RcodeRefused, f.ErrLimitExceeded
 		}
 	}
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -26,11 +26,11 @@ var log = clog.NewWithPlugin("forward")
 // Forward represents a plugin instance that can proxy requests to another (DNS) server. It has a list
 // of proxies each representing one upstream proxy.
 type Forward struct {
-	maxConcurrent int64
-	concurrent    int64
-	proxies       []*Proxy
-	p             policy.Policy
-	hcInterval    time.Duration
+	concurrent int64 // atomic counters need to be first in struct for proper alignment
+
+	proxies    []*Proxy
+	p          policy.Policy
+	hcInterval time.Duration
 
 	from    string
 	ignored []string
@@ -39,6 +39,7 @@ type Forward struct {
 	tlsServerName string
 	maxfails      uint32
 	expire        time.Duration
+	maxConcurrent int64
 
 	opts options // also here for testing
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -46,6 +46,8 @@ type Forward struct {
 	Next plugin.Handler
 }
 
+// ErrLimitExceeded indicates that a query was rejected because the number of concurrent queries has exceeded
+// the maximum allowed (maxConcurrent)
 var ErrLimitExceeded = errors.New("concurrent queries exceeded maximum")
 
 // New returns a new Forward.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -76,7 +76,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		count := atomic.AddInt64(&(f.queryCount), 1)
 		defer atomic.AddInt64(&(f.queryCount), -1)
 		if count > f.maxQueryCount {
-			return dns.RcodeRefused, errors.New("inflight forward queries exceeded maximum")
+			return dns.RcodeServerFailure, errors.New("inflight forward queries exceeded maximum")
 		}
 	}
 

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -81,7 +81,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		defer atomic.AddInt64(&(f.concurrent), -1)
 		if count > f.maxConcurrent {
 			MaxConcurrentRejectCount.Add(1)
-			return dns.RcodeRefused, f.ErrLimitExceeded
+			return dns.RcodeServerFailure, f.ErrLimitExceeded
 		}
 	}
 

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -45,4 +45,10 @@ var (
 		Name:      "sockets_open",
 		Help:      "Gauge of open sockets per upstream.",
 	}, []string{"to"})
+	MaxConcurrentRejectCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: plugin.Namespace,
+		Subsystem: "forward",
+		Name:      "max_concurrent_reject_count_total",
+		Help:      "Counter of the number of queries rejected because the concurrent queries were at maximum.",
+	})
 )

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -223,6 +224,7 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		if n < 0 {
 			return fmt.Errorf("max_concurrent can't be negative: %d", n)
 		}
+		ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
 
 	default:

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -224,7 +224,7 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		if n < 0 {
 			return fmt.Errorf("max_concurrent can't be negative: %d", n)
 		}
-		ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
+		f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
 
 	default:

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -121,6 +121,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 		}
 		f.proxies[i].SetExpire(f.expire)
 	}
+
 	return f, nil
 }
 
@@ -211,6 +212,18 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}
+	case "max_queries":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.Atoi(c.Val())
+		if err != nil {
+			return err
+		}
+		if n < 0 {
+			return fmt.Errorf("max_queries can't be negative: %d", n)
+		}
+		f.maxQueryCount = int64(n)
 
 	default:
 		return c.Errf("unknown property '%s'", c.Val())

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -212,7 +212,7 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		default:
 			return c.Errf("unknown policy '%s'", x)
 		}
-	case "max_queries":
+	case "max_concurrent":
 		if !c.NextArg() {
 			return c.ArgErr()
 		}
@@ -221,9 +221,9 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return err
 		}
 		if n < 0 {
-			return fmt.Errorf("max_queries can't be negative: %d", n)
+			return fmt.Errorf("max_concurrent can't be negative: %d", n)
 		}
-		f.maxQueryCount = int64(n)
+		f.maxConcurrent = int64(n)
 
 	default:
 		return c.Errf("unknown property '%s'", c.Val())

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -168,7 +168,45 @@ nameserver 10.10.255.253`), 0666); err != nil {
 			}
 		}
 		for _, p := range f.proxies {
-			p.health.Check(p) // this should almost always err, we don't care it shoulnd't crash
+			p.health.Check(p) // this should almost always err, we don't care it shouldn't crash
+		}
+	}
+}
+
+func TestSetupMaxQueryCount(t *testing.T) {
+	tests := []struct {
+		input       string
+		shouldErr   bool
+		expectedVal int64
+		expectedErr string
+	}{
+		// positive
+		{"forward . 127.0.0.1 {\nmax_queries 1000\n}\n", false, 1000, ""},
+		// negative
+		{"forward . 127.0.0.1 {\nmax_queries many\n}\n", true, 0, "invalid"},
+		{"forward . 127.0.0.1 {\nmax_queries -4\n}\n", true, 0, "negative"},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		f, err := parseForward(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
+			}
+		}
+
+		if !test.shouldErr && f.maxQueryCount != test.expectedVal {
+			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedVal, f.maxQueryCount)
 		}
 	}
 }

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -173,7 +173,7 @@ nameserver 10.10.255.253`), 0666); err != nil {
 	}
 }
 
-func TestSetupMaxQueryCount(t *testing.T) {
+func TestSetupMaxConcurrent(t *testing.T) {
 	tests := []struct {
 		input       string
 		shouldErr   bool
@@ -181,10 +181,10 @@ func TestSetupMaxQueryCount(t *testing.T) {
 		expectedErr string
 	}{
 		// positive
-		{"forward . 127.0.0.1 {\nmax_queries 1000\n}\n", false, 1000, ""},
+		{"forward . 127.0.0.1 {\nmax_concurrent 1000\n}\n", false, 1000, ""},
 		// negative
-		{"forward . 127.0.0.1 {\nmax_queries many\n}\n", true, 0, "invalid"},
-		{"forward . 127.0.0.1 {\nmax_queries -4\n}\n", true, 0, "negative"},
+		{"forward . 127.0.0.1 {\nmax_concurrent many\n}\n", true, 0, "invalid"},
+		{"forward . 127.0.0.1 {\nmax_concurrent -4\n}\n", true, 0, "negative"},
 	}
 
 	for i, test := range tests {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -205,8 +205,8 @@ func TestSetupMaxQueryCount(t *testing.T) {
 			}
 		}
 
-		if !test.shouldErr && f.maxQueryCount != test.expectedVal {
-			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedVal, f.maxQueryCount)
+		if !test.shouldErr && f.maxConcurrent != test.expectedVal {
+			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedVal, f.maxConcurrent)
 		}
 	}
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds a concurrent query limit option to the forward plugin, as described in #3635 

### 2. Which issues (if any) are related?

#3635

### 3. Which documentation changes (if any) need to be made?

included

### 4. Does this introduce a backward incompatible change or deprecation?

no