### PR TITLE
plugin/kubernetes: fix metadata

### DIFF
--- a/plugin/kubernetes/kubernetes.go
+++ b/plugin/kubernetes/kubernetes.go
@@ -252,7 +252,7 @@ func (k *Kubernetes) InitKubeCache() (err error) {
 
 // Records looks up services in kubernetes.
 func (k *Kubernetes) Records(ctx context.Context, state request.Request, exact bool) ([]msg.Service, error) {
-	r, e := parseRequest(state)
+	r, e := parseRequest(state.Name(), state.Zone)
 	if e != nil {
 		return nil, e
 	}

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -10,11 +10,9 @@ import (
 
 // Metadata implements the metadata.Provider interface.
 func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) context.Context {
-	origZone := state.Zone
-	state.Zone = plugin.Zones(k.Zones).Matches(state.Name())
+	zone := plugin.Zones(k.Zones).Matches(state.Name())
 	// possible optimization: cache r so it doesn't need to be calculated again in ServeDNS
-	r, err := parseRequest(state)
-	state.Zone = origZone
+	r, err := parseRequest(state.Name(), zone)
 	if err != nil {
 		metadata.SetValueFunc(ctx, "kubernetes/parse-error", func() string {
 			return err.Error()

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -10,9 +10,11 @@ import (
 
 // Metadata implements the metadata.Provider interface.
 func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) context.Context {
+	origZone := state.Zone
 	state.Zone = plugin.Zones(k.Zones).Matches(state.Name())
 	// possible optimization: cache r so it doesn't need to be calculated again in ServeDNS
 	r, err := parseRequest(state)
+	state.Zone = origZone
 	if err != nil {
 		metadata.SetValueFunc(ctx, "kubernetes/parse-error", func() string {
 			return err.Error()

--- a/plugin/kubernetes/metadata.go
+++ b/plugin/kubernetes/metadata.go
@@ -3,12 +3,14 @@ package kubernetes
 import (
 	"context"
 
+	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metadata"
 	"github.com/coredns/coredns/request"
 )
 
 // Metadata implements the metadata.Provider interface.
 func (k *Kubernetes) Metadata(ctx context.Context, state request.Request) context.Context {
+	state.Zone = plugin.Zones(k.Zones).Matches(state.Name())
 	// possible optimization: cache r so it doesn't need to be calculated again in ServeDNS
 	r, err := parseRequest(state)
 	if err != nil {

--- a/plugin/kubernetes/metadata_test.go
+++ b/plugin/kubernetes/metadata_test.go
@@ -109,7 +109,7 @@ func TestMetadata(t *testing.T) {
 		ctx := metadata.ContextWithMetadata(context.Background())
 		state := request.Request{
 			Req:  &dns.Msg{Question: []dns.Question{{Name: tc.Qname, Qtype: tc.Qtype}}},
-			Zone: "cluster.local.",
+			Zone: ".",
 			W:    &test.ResponseWriter{RemoteIP: tc.RemoteIP},
 		}
 

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -2,8 +2,6 @@ package kubernetes
 
 import (
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
-	"github.com/coredns/coredns/request"
-
 	"github.com/miekg/dns"
 )
 
@@ -26,7 +24,7 @@ type recordRequest struct {
 // parseRequest parses the qname to find all the elements we need for querying k8s. Anything
 // that is not parsed will have the wildcard "*" value (except r.endpoint).
 // Potential underscores are stripped from _port and _protocol.
-func parseRequest(state request.Request) (r recordRequest, err error) {
+func parseRequest(name, zone string) (r recordRequest, err error) {
 	// 3 Possible cases:
 	// 1. _port._protocol.service.namespace.pod|svc.zone
 	// 2. (endpoint): endpoint.service.namespace.pod|svc.zone
@@ -34,7 +32,7 @@ func parseRequest(state request.Request) (r recordRequest, err error) {
 	//
 	// Federations are handled in the federation plugin. And aren't parsed here.
 
-	base, _ := dnsutil.TrimZone(state.Name(), state.Zone)
+	base, _ := dnsutil.TrimZone(name, zone)
 	// return NODATA for apex queries
 	if base == "" || base == Svc || base == Pod {
 		return r, nil

--- a/plugin/kubernetes/parse_test.go
+++ b/plugin/kubernetes/parse_test.go
@@ -31,7 +31,7 @@ func TestParseRequest(t *testing.T) {
 		m.SetQuestion(tc.query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		r, e := parseRequest(state)
+		r, e := parseRequest(state.Name(), state.Zone)
 		if e != nil {
 			t.Errorf("Test %d, expected no error, got '%v'.", i, e)
 		}
@@ -53,7 +53,7 @@ func TestParseInvalidRequest(t *testing.T) {
 		m.SetQuestion(query, dns.TypeA)
 		state := request.Request{Zone: zone, Req: m}
 
-		if _, e := parseRequest(state); e == nil {
+		if _, e := parseRequest(state.Name(), state.Zone); e == nil {
 			t.Errorf("Test %d: expected error from %s, got none", i, query)
 		}
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Kubernetes metadata is empty when the matched serverblock zone is not an exact match for the plugin's handled zone ... e.g. if the serverbock's zone is ".", and the kubernetes plugin zone is "cluster.local".

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
