### PR TITLE
presubmit: test README.md sections

### DIFF
--- a/plugin.md
+++ b/plugin.md
@@ -75,7 +75,7 @@ Each plugin should have a README.md explaining what the plugin does and how it i
 file should have the following layout:
 
 * Title: use the plugin's name
-* Subsection titled: "Named"
+* Subsection titled: "Name"
     with *PLUGIN* - one line description.
 * Subsection titled: "Description" has a longer description.
 * Subsection titled: "Syntax", syntax and supported directives.

--- a/plugin/cancel/README.md
+++ b/plugin/cancel/README.md
@@ -16,6 +16,8 @@ A plugin interested in the cancellation status should call `plugin.Done()` on th
 context was canceled due to a timeout the plugin should not write anything back to the client and
 return a value indicating CoreDNS should not either; a zero return value should suffice for that.
 
+## Syntax
+
 ~~~ txt
 cancel [TIMEOUT]
 ~~~

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -57,7 +57,7 @@ k8s_external [ZONE...] {
 * **APEX** is the name (DNS label) to use for the apex records; it defaults to `dns`.
 * `ttl` allows you to set a custom **TTL** for responses. The default is 5 (seconds).
 
-# Examples
+## Examples
 
 Enable names under `example.org` to be resolved to in-cluster DNS addresses.
 

--- a/plugin/rewrite/README.md
+++ b/plugin/rewrite/README.md
@@ -37,6 +37,8 @@ will behave as follows:
    * `continue` will continue applying the next rule in the rule list.
    * `stop` will consider the current rule the last rule and will not continue.  The default behaviour is `stop`
 
+## Examples
+
 ### Name Field Rewrites
 
 The `rewrite` plugin offers the ability to match the name in the question section of

--- a/plugin/secondary/README.md
+++ b/plugin/secondary/README.md
@@ -10,6 +10,8 @@ With *secondary* you can transfer (via AXFR) a zone from another server. The ret
 *not committed* to disk (a violation of the RFC). This means restarting CoreDNS will cause it to
 retrieve all secondary zones.
 
+## Syntax
+
 ~~~
 secondary [ZONES...]
 ~~~

--- a/plugin/transfer/README.md
+++ b/plugin/transfer/README.md
@@ -29,3 +29,7 @@ transfer [ZONE...] {
 
 * `to ` **HOST...** The hosts *transfer* will transfer to. Use `*` to permit
   transfers to all hosts.
+
+## Examples
+
+TODO


### PR DESCRIPTION
Again one of those things that's super manual. Enforce the standard we
have and fix the few READMEs that didn't adhere to it.

For *transfer* I left a TODO in the (new) Examples section.

plugin.md has been saying this should be done for ages - but without
checks things slip through - as apparent in this PR.