### PR TITLE
plugin/pkg/up: make default intervals shorter

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -9,14 +9,14 @@
 The *forward* plugin re-uses already opened sockets to the upstreams. It supports UDP, TCP and
 DNS-over-TLS and uses in band health checking.
 
-When it detects an error a health check is performed. This checks runs in a loop,
-starting with a *0.5s* interval and exponentially backing off with randomized intervals
-up to *60s* for as long as the upstream reports unhealthy. The exponential backoff
-will reset to *0.5s* after 15 minutes. Once healthy we stop health checking (until the next
-error). The health checks use a recursive DNS query (`. IN NS`) to get upstream health. Any response
-that is not a network error (REFUSED, NOTIMPL, SERVFAIL, etc) is taken as a healthy upstream. The
-health check uses the same protocol as specified in **TO**. If `max_fails` is set to 0, no checking
-is performed and upstreams will always be considered healthy.
+When it detects an error a health check is performed. This checks runs in a loop, starting with
+a *0.5s* interval and exponentially backing off with randomized intervals up to *15s* for as long
+as the upstream reports unhealthy. The exponential backoff will reset to *0.5s* after 2 minutes.
+Once healthy we stop health checking (until the next error). The health checks use a recursive
+DNS query (`. IN NS`) to get upstream health. Any response that is not a network error (REFUSED,
+NOTIMPL, SERVFAIL, etc) is taken as a healthy upstream. The health check uses the same protocol as
+specified in **TO**. If `max_fails` is set to 0, no checking is performed and upstreams will always
+be considered healthy.
 
 When *all* upstreams are down it assumes health checking as a mechanism has failed and will try to
 connect to a random upstream (which may or may not work).

--- a/plugin/pkg/up/up.go
+++ b/plugin/pkg/up/up.go
@@ -79,8 +79,8 @@ func (p *Probe) Start(interval time.Duration) {
 		InitialInterval:     interval,
 		RandomizationFactor: backoff.DefaultRandomizationFactor,
 		Multiplier:          backoff.DefaultMultiplier,
-		MaxInterval:         backoff.DefaultMaxInterval,
-		MaxElapsedTime:      backoff.DefaultMaxElapsedTime,
+		MaxInterval:         15 * time.Second,
+		MaxElapsedTime:      2 * time.Minute,
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}


### PR DESCRIPTION
I think 15 min is too high, make this lower to react faster.