### PR TITLE
Fix up warnings from govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,11 +16,20 @@ linters-settings:
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
+  govet:
+    enable-all: true
 
 linters:
+  disable-all: true
   enable:
     - gofmt
     - goimports
     - govet
-  disable-all: true
   fast: false
+
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 10m
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  format: line-number
+
+# all available settings of specific linters
+linters-settings:
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+
+linters:
+  enable:
+    - gofmt
+    - goimports
+    - govet
+  disable-all: true
+  fast: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ before_install:
   - sudo bash -c 'if [ `cat /proc/net/if_inet6 | wc -l` = "0" ]; then echo "Enabling IPv6" ; sysctl net.ipv6.conf.all.disable_ipv6=0 ; sysctl net.ipv6.conf.default.disable_ipv6=0 ; sysctl net.ipv6.conf.lo.disable_ipv6=0 ; fi'
   - cat /proc/net/if_inet6
   - env
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
+
+before_script:
+  - make lint
 
 script:
   - make TEST_TYPE=$TEST_TYPE travis

--- a/Makefile
+++ b/Makefile
@@ -72,3 +72,6 @@ pb:
 clean:
 	go clean
 	rm -f coredns
+
+lint:
+	golangci-lint run

--- a/plugin/acl/acl.go
+++ b/plugin/acl/acl.go
@@ -59,8 +59,8 @@ RulesCheckLoop:
 			continue
 		}
 
-		action := matchWithPolicies(rule.policies, w, r)
-		switch action {
+		policyAction := matchWithPolicies(rule.policies, w, r)
+		switch policyAction {
 		case actionBlock:
 			{
 				m := new(dns.Msg)

--- a/plugin/auto/walk_test.go
+++ b/plugin/auto/walk_test.go
@@ -73,7 +73,7 @@ func createFiles() (string, error) {
 	}
 
 	for _, name := range dbFiles {
-		if err := ioutil.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
+		if err = ioutil.WriteFile(filepath.Join(dir, name), []byte(zoneContent), 0644); err != nil {
 			return dir, err
 		}
 	}

--- a/plugin/auto/watcher_test.go
+++ b/plugin/auto/watcher_test.go
@@ -78,7 +78,7 @@ func TestSymlinks(t *testing.T) {
 	a.Walk()
 
 	// Now create a duplicate file in a subdirectory and repoint the symlink
-	if err := os.Remove(filepath.Join(tempdir, "db.example.com")); err != nil {
+	if err = os.Remove(filepath.Join(tempdir, "db.example.com")); err != nil {
 		t.Fatal(err)
 	}
 	dataDir := filepath.Join(tempdir, "..data")

--- a/plugin/cache/handler.go
+++ b/plugin/cache/handler.go
@@ -40,9 +40,9 @@ func (c *Cache) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 		// Adjust the time to get a 0 TTL in the reply built from a stale item.
 		now = now.Add(time.Duration(ttl) * time.Second)
 		go func() {
-			r := r.Copy()
+			rc := r.Copy()
 			crr := &ResponseWriter{Cache: c, state: state, server: server, prefetch: true, remoteAddr: w.LocalAddr()}
-			plugin.NextOrFailure(c.Name(), c.Next, ctx, crr, r)
+			plugin.NextOrFailure(c.Name(), c.Next, ctx, crr, rc)
 		}()
 	}
 	resp := i.toMsg(r, now)

--- a/plugin/clouddns/clouddns_test.go
+++ b/plugin/clouddns/clouddns_test.go
@@ -144,9 +144,9 @@ func TestCloudDNS(t *testing.T) {
 		rcode := dns.RcodeServerFailure
 		if qname == "example.gov." {
 			m.SetReply(r)
-			rr, err := dns.NewRR("example.gov.  300 IN  A   2.4.6.8")
-			if err != nil {
-				t.Fatalf("Failed to create Resource Record: %v", err)
+			rr, rerr := dns.NewRR("example.gov.  300 IN  A   2.4.6.8")
+			if rerr != nil {
+				t.Fatalf("Failed to create Resource Record: %v", rerr)
 			}
 			m.Answer = []dns.RR{rr}
 

--- a/plugin/debug/pcap_test.go
+++ b/plugin/debug/pcap_test.go
@@ -32,6 +32,7 @@ func TestNoDebug(t *testing.T) {
 	}
 }
 
+//nolint: govet
 func ExampleLogHexdump() {
 	buf, _ := msg().Pack()
 	h := hexdump(buf)

--- a/plugin/dnstap/msg/msg.go
+++ b/plugin/dnstap/msg/msg.go
@@ -82,7 +82,7 @@ func (b *Builder) HostPort(addr string) *Builder {
 
 	if ip := net.ParseIP(ip); ip != nil {
 		b.Address = []byte(ip)
-		if ip := ip.To4(); ip != nil {
+		if ipf := ip.To4(); ipf != nil {
 			b.SocketFam = tap.SocketFamily_INET
 		} else {
 			b.SocketFam = tap.SocketFamily_INET6

--- a/plugin/dnstap/taprw/writer_test.go
+++ b/plugin/dnstap/taprw/writer_test.go
@@ -34,7 +34,7 @@ func TestClientQueryResponse(t *testing.T) {
 	}
 	d.Packed = bin
 
-	if err := rw.WriteMsg(m); err != nil {
+	if err = rw.WriteMsg(m); err != nil {
 		t.Fatal(err)
 		return
 	}

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -87,7 +87,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 			// wildcard we should expand the wildcard.
 
 			wildcard := replaceWithAsteriskLabel(parts)
-			if wild, found := tr.Search(wildcard); found {
+			if wild, wfound := tr.Search(wildcard); wfound {
 				wildElem = wild
 			}
 

--- a/plugin/file/notify.go
+++ b/plugin/file/notify.go
@@ -60,11 +60,14 @@ func notify(zone string, to []string) error {
 }
 
 func notifyAddr(c *dns.Client, m *dns.Msg, s string) error {
-	var err error
+	var (
+		err error
+		ret *dns.Msg
+	)
 
 	code := dns.RcodeServerFailure
 	for i := 0; i < 3; i++ {
-		ret, _, err := c.Exchange(m, s)
+		ret, _, err = c.Exchange(m, s)
 		if err != nil {
 			continue
 		}

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -55,7 +55,7 @@ func TestZoneReload(t *testing.T) {
 	if len(rrs) != 5 {
 		t.Fatalf("Expected 5 RRs, got %d", len(rrs))
 	}
-	if err := ioutil.WriteFile(fileName, []byte(reloadZone2Test), 0644); err != nil {
+	if err = ioutil.WriteFile(fileName, []byte(reloadZone2Test), 0644); err != nil {
 		t.Fatalf("Failed to write new zone data: %s", err)
 	}
 	// Could still be racy, but we need to wait a bit for the event to be seen

--- a/plugin/file/secondary_test.go
+++ b/plugin/file/secondary_test.go
@@ -70,9 +70,9 @@ func (s *soa) TransferHandler(w dns.ResponseWriter, req *dns.Msg) {
 const testZone = "secondary.miek.nl."
 
 func TestShouldTransfer(t *testing.T) {
-	soa := soa{250}
+	testSoa := soa{250}
 
-	s := dnstest.NewServer(soa.Handler)
+	s := dnstest.NewServer(testSoa.Handler)
 	defer s.Close()
 
 	z := NewZone("testzone", "test")
@@ -85,32 +85,32 @@ func TestShouldTransfer(t *testing.T) {
 		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if !should {
-		t.Fatalf("ShouldTransfer should return true for serial: %d", soa.serial)
+		t.Fatalf("ShouldTransfer should return true for serial: %d", testSoa.serial)
 	}
 	// Serial smaller
-	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, soa.serial-1))
+	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, testSoa.serial-1))
 	should, err = z.shouldTransfer()
 	if err != nil {
 		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if !should {
-		t.Fatalf("ShouldTransfer should return true for serial: %q", soa.serial-1)
+		t.Fatalf("ShouldTransfer should return true for serial: %q", testSoa.serial-1)
 	}
 	// Serial equal
-	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, soa.serial))
+	z.Apex.SOA = test.SOA(fmt.Sprintf("%s IN SOA bla. bla. %d 0 0 0 0 ", testZone, testSoa.serial))
 	should, err = z.shouldTransfer()
 	if err != nil {
 		t.Fatalf("Unable to run shouldTransfer: %v", err)
 	}
 	if should {
-		t.Fatalf("ShouldTransfer should return false for serial: %d", soa.serial)
+		t.Fatalf("ShouldTransfer should return false for serial: %d", testSoa.serial)
 	}
 }
 
 func TestTransferIn(t *testing.T) {
-	soa := soa{250}
+	testSoa := soa{250}
 
-	s := dnstest.NewServer(soa.Handler)
+	s := dnstest.NewServer(testSoa.Handler)
 	defer s.Close()
 
 	z := new(Zone)

--- a/plugin/forward/connect.go
+++ b/plugin/forward/connect.go
@@ -95,7 +95,7 @@ func (p *Proxy) Connect(ctx context.Context, state request.Request, opts options
 	}
 
 	pc.c.SetWriteDeadline(time.Now().Add(maxTimeout))
-	if err := pc.c.WriteMsg(state.Req); err != nil {
+	if err = pc.c.WriteMsg(state.Req); err != nil {
 		pc.c.Close() // not giving it back
 		if err == io.EOF && cached {
 			return nil, ErrCachedClosed

--- a/plugin/kubernetes/controller_test.go
+++ b/plugin/kubernetes/controller_test.go
@@ -70,10 +70,10 @@ func generateEndpoints(cidr string, client kubernetes.Interface) {
 			Namespace: "testns",
 		},
 	}
-	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+	for eip := ip.Mask(ipnet.Mask); ipnet.Contains(eip); inc(eip) {
 		ep.Subsets[0].Addresses = []api.EndpointAddress{
 			{
-				IP:       ip.String(),
+				IP:       eip.String(),
 				Hostname: "foo" + strconv.Itoa(count),
 			},
 		}
@@ -92,28 +92,28 @@ func generateSvcs(cidr string, svcType string, client kubernetes.Interface) {
 	count := 1
 	switch svcType {
 	case "clusterip":
-		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
-			createClusterIPSvc(count, client, ip)
+		for cip := ip.Mask(ipnet.Mask); ipnet.Contains(cip); inc(cip) {
+			createClusterIPSvc(count, client, cip)
 			count++
 		}
 	case "headless":
-		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
-			createHeadlessSvc(count, client, ip)
+		for hip := ip.Mask(ipnet.Mask); ipnet.Contains(hip); inc(hip) {
+			createHeadlessSvc(count, client, hip)
 			count++
 		}
 	case "external":
-		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
-			createExternalSvc(count, client, ip)
+		for eip := ip.Mask(ipnet.Mask); ipnet.Contains(eip); inc(eip) {
+			createExternalSvc(count, client, eip)
 			count++
 		}
 	default:
-		for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
+		for dip := ip.Mask(ipnet.Mask); ipnet.Contains(dip); inc(dip) {
 			if count%3 == 0 {
-				createClusterIPSvc(count, client, ip)
+				createClusterIPSvc(count, client, dip)
 			} else if count%3 == 1 {
-				createHeadlessSvc(count, client, ip)
+				createHeadlessSvc(count, client, dip)
 			} else if count%3 == 2 {
-				createExternalSvc(count, client, ip)
+				createExternalSvc(count, client, dip)
 			}
 			count++
 		}

--- a/plugin/normalize.go
+++ b/plugin/normalize.go
@@ -97,7 +97,8 @@ func SplitHostPort(s string) (host, port string, ipnet *net.IPNet, err error) {
 		return "", "", nil, fmt.Errorf("expecting data after last colon: %q", s)
 	}
 	if colon != -1 {
-		if p, err := strconv.Atoi(s[colon+1:]); err == nil {
+		var p int
+		if p, err = strconv.Atoi(s[colon+1:]); err == nil {
 			port = strconv.Itoa(p)
 			host = s[:colon]
 		}

--- a/plugin/rewrite/name.go
+++ b/plugin/rewrite/name.go
@@ -185,7 +185,7 @@ func newNameRule(nextAction string, args ...string) (Rule, error) {
 			if err != nil {
 				return nil, err
 			}
-			rewriteQuestionTo := plugin.Name(args[2]).Normalize()
+			rewriteQuestionTo = plugin.Name(args[2]).Normalize()
 			return &regexNameRule{
 				nextAction,
 				rewriteQuestionFromPattern,

--- a/plugin/sign/signer.go
+++ b/plugin/sign/signer.go
@@ -58,7 +58,8 @@ func (s *Signer) Sign(now time.Time) (*file.Zone, error) {
 	ln := len(names)
 
 	for _, pair := range s.keys {
-		rrsig, err := pair.signRRs([]dns.RR{z.Apex.SOA}, s.origin, ttl, inception, expiration)
+		var rrsig *dns.RRSIG
+		rrsig, err = pair.signRRs([]dns.RR{z.Apex.SOA}, s.origin, ttl, inception, expiration)
 		if err != nil {
 			return nil, err
 		}
@@ -95,7 +96,8 @@ func (s *Signer) Sign(now time.Time) (*file.Zone, error) {
 				continue
 			}
 			for _, pair := range s.keys {
-				rrsig, err := pair.signRRs(rrs, s.origin, rrs[0].Header().Ttl, inception, expiration)
+				var rrsig *dns.RRSIG
+				rrsig, err = pair.signRRs(rrs, s.origin, rrs[0].Header().Ttl, inception, expiration)
 				if err != nil {
 					return err
 				}

--- a/plugin/test/file.go
+++ b/plugin/test/file.go
@@ -45,7 +45,7 @@ xGbtCkhVk2VQ+BiCWnjYXJ6ZMzabP7wiOFDP9Pvr2ik22PRItsW/TLfHFXM1jDmc
 I1rs/VUGKzcJGVIWbHrgjP68CTStGAvKgbsTqw7aLXTSqtPw88N9XVSyRg==
 -----END CERTIFICATE-----`
 	path := filepath.Join(tempDir, "ca.pem")
-	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
+	if err = ioutil.WriteFile(path, []byte(data), 0644); err != nil {
 		return "", nil, err
 	}
 	data = `-----BEGIN CERTIFICATE-----

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -39,7 +39,6 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
 
 	for c.Next() { // trace
-		var err error
 		args := c.RemainingArgs()
 		switch len(args) {
 		case 0:

--- a/test/file_xfr_test.go
+++ b/test/file_xfr_test.go
@@ -63,8 +63,9 @@ func TestLargeAXFR(t *testing.T) {
 
 	// The AXFR query should be responded first.
 	nrr := 0 // total number of transferred RRs
+	var resp *dns.Msg
 	for {
-		resp, err := co.ReadMsg()
+		resp, err = co.ReadMsg()
 		if err != nil {
 			t.Fatalf("Expected to receive reply, but didn't: %s", err)
 		}
@@ -88,7 +89,7 @@ func TestLargeAXFR(t *testing.T) {
 	}
 
 	// The file plugin shouldn't hijack or (yet) close the connection, so the second query should also be responded.
-	resp, err := co.ReadMsg()
+	resp, err = co.ReadMsg()
 	if err != nil {
 		t.Fatalf("Expected to receive reply, but didn't: %s", err)
 	}

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caddyserver/caddy"
 	"github.com/miekg/dns"
 )
 
@@ -174,18 +175,19 @@ func TestReloadSeveralTimeMetrics(t *testing.T) {
 		t.Errorf("Could not get service instance: %s", err)
 	}
 	// verify prometheus is running
-	if err := collectMetricsInfo(promAddress, proc); err != nil {
+	if err = collectMetricsInfo(promAddress, proc); err != nil {
 		t.Errorf("Prometheus is not listening : %s", err)
 	}
 	reloadCount := 2
+	var serverReload *caddy.Instance
 	for i := 0; i < reloadCount; i++ {
-		serverReload, err := serverWithMetrics.Restart(
+		serverReload, err = serverWithMetrics.Restart(
 			NewInput(corefileWithMetrics),
 		)
 		if err != nil {
 			t.Errorf("Could not restart CoreDNS : %s, at loop %v", err, i)
 		}
-		if err := collectMetricsInfo(promAddress, proc); err != nil {
+		if err = collectMetricsInfo(promAddress, proc); err != nil {
 			t.Errorf("Prometheus is not listening : %s", err)
 		}
 		serverWithMetrics = serverReload
@@ -231,17 +233,18 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("www.example.org.", dns.TypeA)
 
-	if _, _, err := cl.Exchange(m, tcp); err != nil {
+	if _, _, err = cl.Exchange(m, tcp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
 	// we should have metrics from forward, cache, and metrics itself
-	if err := collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
+	if err = collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
 		t.Errorf("Could not scrap one of expected stats : %s", err)
 	}
 
 	// now reload
-	instReload, err := inst.Restart(
+	var instReload *caddy.Instance
+	instReload, err = inst.Restart(
 		NewInput(corefileWithMetrics),
 	)
 	if err != nil {
@@ -294,18 +297,19 @@ func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 	m := new(dns.Msg)
 	m.SetQuestion("www.example.org.", dns.TypeA)
 
-	if _, _, err := cl.Exchange(m, tcp); err != nil {
+	if _, _, err = cl.Exchange(m, tcp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}
 
 	// we should have metrics from forward, cache, and metrics itself
-	if err := collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
+	if err = collectMetricsInfo(promAddress, procMetric, procCache, procForward); err != nil {
 		t.Errorf("Could not scrap one of expected stats : %s", err)
 	}
 
+	var invInst *caddy.Instance
 	for i := 0; i < 2; i++ {
 		// now provide a failed reload
-		invInst, err := inst.Restart(
+		invInst, err = inst.Restart(
 			NewInput(invalidCorefileWithMetrics),
 		)
 		if err == nil {


### PR DESCRIPTION
A continuation of #3638. 
This cleans up the initial run of enabling all tests for govet. A majority of these are shadow declarations [0]

I can rebase once #3638 is merged and squash into a single commit after lgtm. 

[0]
```
# make lint | awk '/govet/ { print $0 }' | sort
make: *** [lint] Error 1
plugin/acl/acl.go:62:3: shadow: declaration of "action" shadows declaration at line 30 (govet)
plugin/auto/walk_test.go:76:6: shadow: declaration of "err" shadows declaration at line 70 (govet)
plugin/auto/watcher_test.go:81:5: shadow: declaration of "err" shadows declaration at line 58 (govet)
plugin/cache/handler.go:43:4: shadow: declaration of "r" shadows declaration at line 17 (govet)
plugin/clouddns/clouddns_test.go:147:8: shadow: declaration of "err" shadows declaration at line 126 (govet)
plugin/dnstap/msg/msg.go:85:6: shadow: declaration of "ip" shadows declaration at line 83 (govet)
plugin/dnstap/taprw/writer_test.go:37:5: shadow: declaration of "err" shadows declaration at line 30 (govet)
plugin/file/lookup.go:90:13: shadow: declaration of "found" shadows declaration at line 57 (govet)
plugin/file/notify.go:67:11: shadow: declaration of "err" shadows declaration at line 63 (govet)
plugin/file/notify.go:76:9: nilness: impossible condition: nil != nil (govet)
plugin/file/reload_test.go:58:5: shadow: declaration of "err" shadows declaration at line 18 (govet)
plugin/file/secondary_test.go:111:2: shadow: declaration of "soa" shadows declaration at line 40 (govet)
plugin/file/secondary_test.go:73:2: shadow: declaration of "soa" shadows declaration at line 40 (govet)
plugin/forward/connect.go:98:5: shadow: declaration of "err" shadows declaration at line 86 (govet)
plugin/kubernetes/controller_test.go:100:7: shadow: declaration of "ip" shadows declaration at line 87 (govet)
plugin/kubernetes/controller_test.go:105:7: shadow: declaration of "ip" shadows declaration at line 87 (govet)
plugin/kubernetes/controller_test.go:110:7: shadow: declaration of "ip" shadows declaration at line 87 (govet)
plugin/kubernetes/controller_test.go:73:6: shadow: declaration of "ip" shadows declaration at line 53 (govet)
plugin/kubernetes/controller_test.go:95:7: shadow: declaration of "ip" shadows declaration at line 87 (govet)
plugin/normalize.go:100:9: shadow: declaration of "err" shadows declaration at line 89 (govet)
plugin/rewrite/name.go:188:4: shadow: declaration of "rewriteQuestionTo" shadows declaration at line 115 (govet)
plugin/sign/signer.go:61:10: shadow: declaration of "err" shadows declaration at line 34 (govet)
plugin/sign/signer.go:98:12: shadow: declaration of "err" shadows declaration at line 34 (govet)
plugin/test/file.go:48:5: shadow: declaration of "err" shadows declaration at line 24 (govet)
plugin/trace/setup.go:42:7: shadow: declaration of "err" shadows declaration at line 35 (govet)
test/file_xfr_test.go:67:9: shadow: declaration of "err" shadows declaration at line 25 (govet)
test/reload_test.go:177:5: shadow: declaration of "err" shadows declaration at line 169 (govet)
test/reload_test.go:182:17: shadow: declaration of "err" shadows declaration at line 169 (govet)
test/reload_test.go:234:11: shadow: declaration of "err" shadows declaration at line 222 (govet)
test/reload_test.go:239:5: shadow: declaration of "err" shadows declaration at line 222 (govet)
test/reload_test.go:297:11: shadow: declaration of "err" shadows declaration at line 285 (govet)
test/reload_test.go:302:5: shadow: declaration of "err" shadows declaration at line 285 (govet)
test/reload_test.go:308:12: shadow: declaration of "err" shadows declaration at line 285 (govet)
```