### PR TITLE
plugin/template: fix panic when missing next handler

### DIFF
--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -122,7 +122,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		return template.rcode, nil
 	}
 
-	return h.Next.ServeDNS(ctx, w, r)
+	return plugin.NextOrFailure(h.Name(), h.Next, ctx, w, r)
 }
 
 // Name implements the plugin.Handler interface.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This fixes a panic by avoiding a nil pointer dereference.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
N/A

### 4. Does this introduce a backward incompatible change or deprecation?
No.