### PR TITLE
Add configuration flag to set if RecursionDesired should be set on health checkers in Forward-plugin

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -52,6 +52,7 @@ forward FROM TO... {
     tls_servername NAME
     policy random|round_robin|sequential
     health_check DURATION
+    health_check_non_recursive
     max_concurrent MAX
 }
 ~~~
@@ -86,6 +87,7 @@ forward FROM TO... {
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
 * `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
+* `health_check_non_recursive`, sets the RecursionDesired-flag of the dns-query used in health checking to `false`. The flag is default `true`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a SERVFAIL response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -51,8 +51,7 @@ forward FROM TO... {
     tls CERT KEY CA
     tls_servername NAME
     policy random|round_robin|sequential
-    health_check DURATION
-    health_check_non_recursive
+    health_check DURATION [no_rec]
     max_concurrent MAX
 }
 ~~~
@@ -86,8 +85,10 @@ forward FROM TO... {
   * `random` is a policy that implements random upstream selection.
   * `round_robin` is a policy that selects hosts based on round robin ordering.
   * `sequential` is a policy that selects hosts based on sequential ordering.
-* `health_check`, use a different **DURATION** for health checking, the default duration is 0.5s.
-* `health_check_non_recursive`, sets the RecursionDesired-flag of the dns-query used in health checking to `false`. The flag is default `true`.
+* `health_check` configure the behaviour of health checking of the upstream servers
+  * `<duration>` - use a different duration for health checking, the default duration is 0.5s.
+  * `no_rec` - optional argument that sets the RecursionDesired-flag of the dns-query used in health checking to `false`.
+    The flag is default `true`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
   raise the number of concurrent queries above the **MAX** will result in a SERVFAIL response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -52,7 +52,7 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval, opts: options{false, false, true}}
 	return f
 }
 
@@ -224,8 +224,9 @@ var (
 
 // options holds various options that can be set.
 type options struct {
-	forceTCP  bool
-	preferUDP bool
+	forceTCP           bool
+	preferUDP          bool
+	hcRecursionDesired bool
 }
 
 const defaultTimeout = 5 * time.Second

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -52,7 +52,7 @@ type Forward struct {
 
 // New returns a new Forward.
 func New() *Forward {
-	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval, opts: options{false, false, true}}
+	f := &Forward{maxfails: 2, tlsConfig: new(tls.Config), expire: defaultExpire, p: new(policy.Random), from: ".", hcInterval: hcInterval, opts: options{forceTCP: false, preferUDP: false, hcRecursionDesired: true}}
 	return f
 }
 

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -14,10 +14,14 @@ import (
 type HealthChecker interface {
 	Check(*Proxy) error
 	SetTLSConfig(*tls.Config)
+	SetRecursionDesired(bool)
 }
 
 // dnsHc is a health checker for a DNS endpoint (DNS, and DoT).
-type dnsHc struct{ c *dns.Client }
+type dnsHc struct {
+	c                *dns.Client
+	recursionDesired bool
+}
 
 // NewHealthChecker returns a new HealthChecker based on transport.
 func NewHealthChecker(trans string) HealthChecker {
@@ -28,7 +32,7 @@ func NewHealthChecker(trans string) HealthChecker {
 		c.ReadTimeout = 1 * time.Second
 		c.WriteTimeout = 1 * time.Second
 
-		return &dnsHc{c: c}
+		return &dnsHc{c: c, recursionDesired: true}
 	}
 
 	log.Warningf("No healthchecker for transport %q", trans)
@@ -40,7 +44,11 @@ func (h *dnsHc) SetTLSConfig(cfg *tls.Config) {
 	h.c.TLSConfig = cfg
 }
 
-// For HC we send to . IN NS +norec message to the upstream. Dial timeouts and empty
+func (h *dnsHc) SetRecursionDesired(recursionDesired bool) {
+	h.recursionDesired = recursionDesired
+}
+
+// For HC we send to . IN NS +[no]rec message to the upstream. Dial timeouts and empty
 // replies are considered fails, basically anything else constitutes a healthy upstream.
 
 // Check is used as the up.Func in the up.Probe.
@@ -59,6 +67,7 @@ func (h *dnsHc) Check(p *Proxy) error {
 func (h *dnsHc) send(addr string) error {
 	ping := new(dns.Msg)
 	ping.SetQuestion(".", dns.TypeNS)
+	ping.MsgHdr.RecursionDesired = h.recursionDesired
 
 	m, _, err := h.c.Exchange(ping, addr)
 	// If we got a header, we're alright, basically only care about I/O errors 'n stuff.

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -24,7 +24,7 @@ type dnsHc struct {
 }
 
 // NewHealthChecker returns a new HealthChecker based on transport.
-func NewHealthChecker(trans string) HealthChecker {
+func NewHealthChecker(trans string, recursionDesired bool) HealthChecker {
 	switch trans {
 	case transport.DNS, transport.TLS:
 		c := new(dns.Client)
@@ -32,7 +32,7 @@ func NewHealthChecker(trans string) HealthChecker {
 		c.ReadTimeout = 1 * time.Second
 		c.WriteTimeout = 1 * time.Second
 
-		return &dnsHc{c: c, recursionDesired: true}
+		return &dnsHc{c: c, recursionDesired: recursionDesired}
 	}
 
 	log.Warningf("No healthchecker for transport %q", trans)

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -15,6 +15,7 @@ type HealthChecker interface {
 	Check(*Proxy) error
 	SetTLSConfig(*tls.Config)
 	SetRecursionDesired(bool)
+	GetRecursionDesired() bool
 }
 
 // dnsHc is a health checker for a DNS endpoint (DNS, and DoT).
@@ -46,6 +47,9 @@ func (h *dnsHc) SetTLSConfig(cfg *tls.Config) {
 
 func (h *dnsHc) SetRecursionDesired(recursionDesired bool) {
 	h.recursionDesired = recursionDesired
+}
+func (h *dnsHc) GetRecursionDesired() bool {
+	return h.recursionDesired
 }
 
 // For HC we send to . IN NS +[no]rec message to the upstream. Dial timeouts and empty

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -43,6 +43,37 @@ func TestHealth(t *testing.T) {
 	}
 }
 
+func TestHealthNoRecursion(t *testing.T) {
+	const expected = 0
+	i := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		if r.Question[0].Name == "." {
+			atomic.AddUint32(&i, 1)
+		}
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	p := NewProxy(s.Addr, transport.DNS)
+	p.SetRecursionDesired(false)
+	f := New()
+	f.SetProxy(p)
+	defer f.OnShutdown()
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+
+	time.Sleep(1 * time.Second)
+	i1 := atomic.LoadUint32(&i)
+	if i1 != expected {
+		t.Errorf("Expected number of health checks to be %d, got %d", expected, i1)
+	}
+}
+
 func TestHealthTimeout(t *testing.T) {
 	const expected = 1
 	i := uint32(0)
@@ -67,6 +98,47 @@ func TestHealthTimeout(t *testing.T) {
 	defer s.Close()
 
 	p := NewProxy(s.Addr, transport.DNS)
+	f := New()
+	f.SetProxy(p)
+	defer f.OnShutdown()
+
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	f.ServeDNS(context.TODO(), &test.ResponseWriter{}, req)
+
+	time.Sleep(1 * time.Second)
+	i1 := atomic.LoadUint32(&i)
+	if i1 != expected {
+		t.Errorf("Expected number of health checks to be %d, got %d", expected, i1)
+	}
+}
+
+func TestHealthTimeoutNoRecursion(t *testing.T) {
+	const expected = 1
+	i := uint32(0)
+	q := uint32(0)
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		if r.Question[0].Name == "." {
+			// health check, answer
+			atomic.AddUint32(&i, 1)
+			ret := new(dns.Msg)
+			ret.SetReply(r)
+			w.WriteMsg(ret)
+			return
+		}
+		if atomic.LoadUint32(&q) == 0 { //drop only first query
+			atomic.AddUint32(&q, 1)
+			return
+		}
+		ret := new(dns.Msg)
+		ret.SetReply(r)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	p := NewProxy(s.Addr, transport.DNS)
+	p.SetRecursionDesired(false)
 	f := New()
 	f.SetProxy(p)
 	defer f.OnShutdown()

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -43,6 +43,11 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
 
+// SetRecursionDesired sets recuresion desired flag on the lower proxy health checker
+func (p *Proxy) SetRecursionDesired(recursionDesired bool) {
+	p.health.SetRecursionDesired(recursionDesired)
+}
+
 // Healthcheck kicks of a round of health checks for this proxy.
 func (p *Proxy) Healthcheck() {
 	if p.health == nil {

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -29,7 +29,7 @@ func NewProxy(addr, trans string) *Proxy {
 		probe:     up.New(),
 		transport: newTransport(addr),
 	}
-	p.health = NewHealthChecker(trans)
+	p.health = NewHealthChecker(trans, true)
 	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
 }
@@ -42,11 +42,6 @@ func (p *Proxy) SetTLSConfig(cfg *tls.Config) {
 
 // SetExpire sets the expire duration in the lower p.transport.
 func (p *Proxy) SetExpire(expire time.Duration) { p.transport.SetExpire(expire) }
-
-// SetRecursionDesired sets recuresion desired flag on the lower proxy health checker
-func (p *Proxy) SetRecursionDesired(recursionDesired bool) {
-	p.health.SetRecursionDesired(recursionDesired)
-}
 
 // Healthcheck kicks of a round of health checks for this proxy.
 func (p *Proxy) Healthcheck() {

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -121,7 +121,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 			f.proxies[i].SetTLSConfig(f.tlsConfig)
 		}
 		f.proxies[i].SetExpire(f.expire)
-		f.proxies[i].SetRecursionDesired(f.opts.hcRecursionDesired)
+		f.proxies[i].health.SetRecursionDesired(f.opts.hcRecursionDesired)
 	}
 
 	return f, nil
@@ -162,11 +162,16 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return fmt.Errorf("health_check can't be negative: %d", dur)
 		}
 		f.hcInterval = dur
-	case "health_check_non_recursive":
-		if c.NextArg() {
-			return c.ArgErr()
+
+		for c.NextArg() {
+			switch hcOpts := c.Val(); hcOpts {
+			case "no_rec":
+				f.opts.hcRecursionDesired = false
+			default:
+				return fmt.Errorf("health_check: unknown option %s", hcOpts)
+			}
 		}
-		f.opts.hcRecursionDesired = false
+
 	case "force_tcp":
 		if c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -121,6 +121,7 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 			f.proxies[i].SetTLSConfig(f.tlsConfig)
 		}
 		f.proxies[i].SetExpire(f.expire)
+		f.proxies[i].SetRecursionDesired(f.opts.hcRecursionDesired)
 	}
 
 	return f, nil
@@ -161,6 +162,11 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 			return fmt.Errorf("health_check can't be negative: %d", dur)
 		}
 		f.hcInterval = dur
+	case "health_check_non_recursive":
+		if c.NextArg() {
+			return c.ArgErr()
+		}
+		f.opts.hcRecursionDesired = false
 	case "force_tcp":
 		if c.NextArg() {
 			return c.ArgErr()

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -31,14 +31,15 @@ func TestSetup(t *testing.T) {
 		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . [::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . [2003::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
-		{"forward . 127.0.0.1 {\nhealth_check_non_recursive\n}\n", false, ".", nil, 2, options{hcRecursionDesired: false}, ""},
+		{"forward . 127.0.0.1 {\nhealth_check 5s\n}\n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nhealth_check 5s no_rec\n}\n", false, ".", nil, 2, options{hcRecursionDesired: false}, ""},
 		{"forward . 127.0.0.1 \n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		// negative
 		{"forward . a27.0.0.1", true, "", nil, 0, options{hcRecursionDesired: true}, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true}, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
-		{"forward . 127.0.0.1 {\nhealth_check_non_recursive false\n}\n", true, ".", nil, 2, options{hcRecursionDesired: true}, "Wrong argument count or unexpected line ending"},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s rec\n}\n", true, ".", nil, 2, options{hcRecursionDesired: true}, "health_check: unknown option rec"},
 	}
 
 	for i, test := range tests {

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -31,15 +31,12 @@ func TestSetup(t *testing.T) {
 		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . [::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		{"forward . [2003::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
-		{"forward . 127.0.0.1 {\nhealth_check 5s\n}\n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
-		{"forward . 127.0.0.1 {\nhealth_check 5s no_rec\n}\n", false, ".", nil, 2, options{hcRecursionDesired: false}, ""},
 		{"forward . 127.0.0.1 \n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		// negative
 		{"forward . a27.0.0.1", true, "", nil, 0, options{hcRecursionDesired: true}, "not an IP"},
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true}, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
-		{"forward . 127.0.0.1 {\nhealth_check 0.5s rec\n}\n", true, ".", nil, 2, options{hcRecursionDesired: true}, "health_check: unknown option rec"},
 	}
 
 	for i, test := range tests {
@@ -211,6 +208,45 @@ func TestSetupMaxConcurrent(t *testing.T) {
 
 		if !test.shouldErr && f.maxConcurrent != test.expectedVal {
 			t.Errorf("Test %d: expected: %d, got: %d", i, test.expectedVal, f.maxConcurrent)
+		}
+	}
+}
+
+func TestSetupHealthCheck(t *testing.T) {
+	tests := []struct {
+		input       string
+		shouldErr   bool
+		expectedVal bool
+		expectedErr string
+	}{
+		// positive
+		{"forward . 127.0.0.1\n", false, true, ""},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s\n}\n", false, true, ""},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s no_rec\n}\n", false, false, ""},
+		// negative
+		{"forward . 127.0.0.1 {\nhealth_check no_rec\n}\n", true, true, "time: invalid duration"},
+		{"forward . 127.0.0.1 {\nhealth_check 0.5s rec\n}\n", true, true, "health_check: unknown option rec"},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		f, err := parseForward(c)
+
+		if test.shouldErr && err == nil {
+			t.Errorf("Test %d: expected error but found %s for input %s", i, err, test.input)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
+			}
+
+			if !strings.Contains(err.Error(), test.expectedErr) {
+				t.Errorf("Test %d: expected error to contain: %v, found error: %v, input: %s", i, test.expectedErr, err, test.input)
+			}
+		}
+		if !test.shouldErr && (f.opts.hcRecursionDesired != test.expectedVal || f.proxies[0].health.GetRecursionDesired() != test.expectedVal) {
+			t.Errorf("Test %d: expected: %t, got: %d", i, test.expectedVal, f.maxConcurrent)
 		}
 	}
 }

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -21,21 +21,24 @@ func TestSetup(t *testing.T) {
 		expectedErr     string
 	}{
 		// positive
-		{"forward . 127.0.0.1", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, options{}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true}, ""},
-		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true}, ""},
-		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, forceTCP: true}, ""},
-		{"forward . 127.0.0.1:53", false, ".", nil, 2, options{}, ""},
-		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{}, ""},
-		{"forward . [::1]:53", false, ".", nil, 2, options{}, ""},
-		{"forward . [2003::1]:53", false, ".", nil, 2, options{}, ""},
+		{"forward . 127.0.0.1", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nexcept miek.nl\n}\n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nmax_fails 3\n}\n", false, ".", nil, 3, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\n}\n", false, ".", nil, 2, options{forceTCP: true, hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nforce_tcp\nprefer_udp\n}\n", false, ".", nil, 2, options{preferUDP: true, forceTCP: true, hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1:8080", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . [::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . [2003::1]:53", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
+		{"forward . 127.0.0.1 {\nhealth_check_non_recursive\n}\n", false, ".", nil, 2, options{hcRecursionDesired: false}, ""},
+		{"forward . 127.0.0.1 \n", false, ".", nil, 2, options{hcRecursionDesired: true}, ""},
 		// negative
-		{"forward . a27.0.0.1", true, "", nil, 0, options{}, "not an IP"},
-		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{}, "unknown property"},
+		{"forward . a27.0.0.1", true, "", nil, 0, options{hcRecursionDesired: true}, "not an IP"},
+		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true}, "unknown property"},
 		{`forward . ::1
-		forward com ::2`, true, "", nil, 0, options{}, "plugin"},
+		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
+		{"forward . 127.0.0.1 {\nhealth_check_non_recursive false\n}\n", true, ".", nil, 2, options{hcRecursionDesired: true}, "Wrong argument count or unexpected line ending"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
We would like to configure the health checker for the proxies whether they should do recursive queries (default) or turn it off by setting health_check_non_recursive in the configuration.

### 2. Which issues (if any) are related?
Issues in our environment involve upstream queries to time out before the answer gets back because of how the dns servers (upstream) are configured. They are out of our control and we only care if they are alive.

### 3. Which documentation changes (if any) need to be made?
Configuration file for the forward plugin should reflect the new optional flag to turn off recursion on the health checker.

### 4. Does this introduce a backward incompatible change or deprecation?
No. The default is to keep recursion requests on by default as is coded in previous versions of forward plugin.
