### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/plugin/pkg/fall/fall.go
+++ b/plugin/pkg/fall/fall.go
@@ -7,7 +7,7 @@
 //
 // The take away: be mindful of this and don't blindly assume it's a good feature to have in your plugin.
 //
-// See http://github.com/coredns/coredns/issues/2723 for some discussion on this, which includes this quote:
+// See https://github.com/coredns/coredns/issues/2723 for some discussion on this, which includes this quote:
 //
 // TL;DR: `fallthrough` is indeed risky and hackish, but still a good feature of CoreDNS as it allows to quickly answer boring edge cases.
 //


### PR DESCRIPTION
Currently, when we access github.com with HTTP, it is redirected to HTTPS automatically. So this commit aims to replace http://github.com by https://github.com for security.

Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
