### PR TITLE
Fix plugin name in project README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Currently CoreDNS is able to:
 * Use etcd as a backend (replacing [SkyDNS](https://github.com/skynetservices/skydns)) (*etcd*).
 * Use k8s (kubernetes) as a backend (*kubernetes*).
 * Serve as a proxy to forward queries to some other (recursive) nameserver (*forward*).
-* Provide metrics (by using Prometheus) (*metrics*).
+* Provide metrics (by using Prometheus) (*prometheus*).
 * Provide query (*log*) and error (*errors*) logging.
 * Integrate with cloud providers (*route53*).
 * Support the CH class: `version.bind` and friends (*chaos*).

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -77,7 +77,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.
 
 Cache types are either "denial" or "success". `Server` is the server handling the request, see the
-metrics plugin for documentation.
+prometheus plugin for documentation.
 
 ## Examples
 

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -86,7 +86,7 @@ is already listening on that port. The process reloads and performs the followin
 4. fail loading the new Corefile, abort and keep using the old process
 
 After the aborted attempt to reload we are left with the old processes running, but the listener is
-closed in step 1; so the health endpoint is broken. The same can happen in the prometheus metrics plugin.
+closed in step 1; so the health endpoint is broken. The same can happen in the prometheus plugin.
 
 In general be careful with assigning new port and expecting reload to work fully.
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Just noticed this on the project README.  The outward name of the metrics plugin is "prometheus" not "metrics".

### 2. Which issues (if any) are related?

none

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no