### PR TITLE
metrics: add type to latency as well

### DIFF
--- a/plugin/metrics/README.md
+++ b/plugin/metrics/README.md
@@ -13,7 +13,7 @@ The following metrics are exported:
 * `coredns_build_info{version, revision, goversion}` - info about CoreDNS itself.
 * `coredns_panic_count_total{}` - total number of panics.
 * `coredns_dns_request_count_total{server, zone, proto, family}` - total query count.
-* `coredns_dns_request_duration_seconds{server, zone}` - duration to process each query.
+* `coredns_dns_request_duration_seconds{server, zone, type}` - duration to process each query.
 * `coredns_dns_request_size_bytes{server, zone, proto}` - size of the request in bytes.
 * `coredns_dns_request_do_count_total{server, zone}` -  queries that have the DO bit set
 * `coredns_dns_request_type_count_total{server, zone, type}` - counter of queries per zone and type.

--- a/plugin/metrics/vars/report.go
+++ b/plugin/metrics/vars/report.go
@@ -21,7 +21,6 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 
 	typ := req.QType()
 	RequestCount.WithLabelValues(server, zone, net, fam).Inc()
-	RequestDuration.WithLabelValues(server, zone).Observe(time.Since(start).Seconds())
 
 	if req.Do() {
 		RequestDo.WithLabelValues(server, zone).Inc()
@@ -29,8 +28,10 @@ func Report(server string, req request.Request, zone, rcode string, size int, st
 
 	if _, known := monitorType[typ]; known {
 		RequestType.WithLabelValues(server, zone, dns.Type(typ).String()).Inc()
+		RequestDuration.WithLabelValues(server, zone, dns.Type(typ).String()).Observe(time.Since(start).Seconds())
 	} else {
 		RequestType.WithLabelValues(server, zone, other).Inc()
+		RequestDuration.WithLabelValues(server, zone, other).Observe(time.Since(start).Seconds())
 	}
 
 	ResponseSize.WithLabelValues(server, zone, net).Observe(float64(size))

--- a/plugin/metrics/vars/vars.go
+++ b/plugin/metrics/vars/vars.go
@@ -21,7 +21,7 @@ var (
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time (in seconds) each request took.",
-	}, []string{"server", "zone"})
+	}, []string{"server", "zone", "type"})
 
 	RequestSize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
Add the record type to the latency metric as well.

This effectively removes the need for the _total because the histogram
contains the same information, this should probably be included in #3671

Fixes: #3684