### PR TITLE
plugin/kubernetes: Return all records with matching IP for PTR requests

### DIFF
--- a/plugin/kubernetes/reverse.go
+++ b/plugin/kubernetes/reverse.go
@@ -38,6 +38,7 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 		return []msg.Service{{Host: domain, TTL: k.ttl}}
 	}
 	// If no cluster ips match, search endpoints
+	var svcs []msg.Service
 	for _, ep := range k.APIConn.EpIndexReverse(ip) {
 		if len(k.Namespaces) > 0 && !k.namespaceExposed(ep.Namespace) {
 			continue
@@ -46,10 +47,10 @@ func (k *Kubernetes) serviceRecordForIP(ip, name string) []msg.Service {
 			for _, addr := range eps.Addresses {
 				if addr.IP == ip {
 					domain := strings.Join([]string{endpointHostname(addr, k.endpointNameMode), ep.Name, ep.Namespace, Svc, k.primaryZone()}, ".")
-					return []msg.Service{{Host: domain, TTL: k.ttl}}
+					svcs = append(svcs, msg.Service{Host: domain, TTL: k.ttl})
 				}
 			}
 		}
 	}
-	return nil
+	return svcs
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

For PTR requests of an Endpoint that has two or more Services pointed to it, provide an answer for each Service. Previously, we were arbitrarily selecting the first one encountered (based on ordering in the index).

### 2. Which issues (if any) are related?

#3686

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no