### PR TITLE
plugin/cache: Add a test for denial cache masking the success cache

### DIFF
--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -202,7 +202,7 @@ func TestCache(t *testing.T) {
 			crr.set(m, k, mt, c.pttl)
 		}
 
-		i, _ := c.get(time.Now().UTC(), state, "dns://:53")
+		i := c.getIgnoreTTL(time.Now().UTC(), state, "dns://:53")
 		ok := i != nil
 
 		if ok != tc.shouldCache {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

- New failing test case for a bug as described in #3701 

```
go test
--- FAIL: TestNegativeExpiredMaskingPositiveCache (0.00s)
    cache_test.go:371: Test 3 NOERROR from Cache: expecting 0; got 255
FAIL
exit status 1
FAIL    github.com/coredns/coredns/plugin/cache 0.033s
```

### 2. Which issues (if any) are related?

#3701 

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

None.