### PR TITLE
Bumb travis Go version to 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - "1.13.x"
+  - "1.14.x"
 
 cache:
   directories:


### PR DESCRIPTION
Start using latest Go for travis.