### PR TITLE
validate object implements the corresponding interface

### DIFF
--- a/core/dnsserver/register.go
+++ b/core/dnsserver/register.go
@@ -52,6 +52,9 @@ func (h *dnsContext) saveConfig(key string, cfg *Config) {
 	h.keysToConfigs[key] = cfg
 }
 
+// Compile-time check to ensure dnsContext implements the caddy.Context interface
+var _ caddy.Context = &dnsContext{}
+
 // InspectServerBlocks make sure that everything checks out before
 // executing directives and otherwise prepares the directives to
 // be parsed and executed.

--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/transport"
 	"github.com/coredns/coredns/request"
 
+	"github.com/caddyserver/caddy"
 	"github.com/miekg/dns"
 	ot "github.com/opentracing/opentracing-go"
 )
@@ -98,6 +99,9 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 
 	return s, nil
 }
+
+// Compile-time check to ensure Server implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &Server{}
 
 // Serve starts the server with an existing listener. It blocks until the server stops.
 // This implements caddy.TCPServer interface.

--- a/core/dnsserver/server_grpc.go
+++ b/core/dnsserver/server_grpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 	"github.com/coredns/coredns/plugin/pkg/transport"
 
+	"github.com/caddyserver/caddy"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/miekg/dns"
 	"github.com/opentracing/opentracing-go"
@@ -42,6 +43,9 @@ func NewServergRPC(addr string, group []*Config) (*ServergRPC, error) {
 
 	return &ServergRPC{Server: s, tlsConfig: tlsConfig}, nil
 }
+
+// Compile-time check to ensure Server implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &Server{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServergRPC) Serve(l net.Listener) error {

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -14,6 +14,8 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/response"
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 	"github.com/coredns/coredns/plugin/pkg/transport"
+
+	"github.com/caddyserver/caddy"
 )
 
 // ServerHTTPS represents an instance of a DNS-over-HTTPS server.
@@ -43,6 +45,9 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 
 	return sh, nil
 }
+
+// Compile-time check to ensure Server implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &Server{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerHTTPS) Serve(l net.Listener) error {

--- a/core/dnsserver/server_tls.go
+++ b/core/dnsserver/server_tls.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 	"github.com/coredns/coredns/plugin/pkg/transport"
 
+	"github.com/caddyserver/caddy"
 	"github.com/miekg/dns"
 )
 
@@ -34,6 +35,9 @@ func NewServerTLS(addr string, group []*Config) (*ServerTLS, error) {
 
 	return &ServerTLS{Server: s, tlsConfig: tlsConfig}, nil
 }
+
+// Compile-time check to ensure Server implements the caddy.GracefulServer interface
+var _ caddy.GracefulServer = &Server{}
 
 // Serve implements caddy.TCPServer interface.
 func (s *ServerTLS) Serve(l net.Listener) error {


### PR DESCRIPTION
Signed-off-by: zouyee <zounengren@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
- Compile-time check to ensure object implements the corresponding interface
- Improve code readability
 For example, some people don’t understand the principle of caddy, so they don’t know why to implement these interfaces, such as the MakeServers method.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3723

### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
none