### PR TITLE
Add CI test for man page updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,14 @@ buildCoreDNSImage: &buildCoreDNSImage
         kind load docker-image coredns
 
 jobs:
+  doc-test:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - checkout
+      - run: ./fixup_file_mtime.sh
+      - run: make -f Makefile.doc
+      - run: git diff --exit-code -- man/
   kubernetes-tests:
     <<: *integrationDefaults
     steps:
@@ -62,4 +70,5 @@ workflows:
   version: 2
   integration-tests:
     jobs:
+      - doc-test
       - kubernetes-tests

--- a/Makefile.doc
+++ b/Makefile.doc
@@ -3,20 +3,35 @@
 # updated before doing a release. The Debian package, for instance, looks at these pages
 # and will install them on your system.
 
-MMARK:=mmark -man
+MMARK_VERSION:=2.2.4
 PLUGINS:=$(wildcard plugin/*/README.md)
 READMES:=$(subst plugin/,,$(PLUGINS))
 READMES:=$(subst /README.md,,$(READMES))
 PLUGINS:=$(subst plugin/,coredns-,$(PLUGINS))
 PLUGINS:=$(subst /README.md,(7),$(PLUGINS))
 
-ifeq (, $(shell which mmark))
-    $(warning "No mmark in $$PATH, exiting, see github.com/mmarkdown/mmark")
-all:
-	@echo "noop"
-else
-all: man/coredns.1 man/corefile.5 plugins
-endif
+all: mmark man/coredns.1 man/corefile.5 plugins
+
+GO           ?= go
+GOHOSTOS     ?= $(shell $(GO) env GOHOSTOS)
+GOHOSTARCH   ?= $(shell $(GO) env GOHOSTARCH)
+GO_BUILD_PLATFORM ?= $(GOHOSTOS)_$(GOHOSTARCH)
+
+FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
+MMARK_BIN    := $(FIRST_GOPATH)/bin/mmark
+MMARK        := $(FIRST_GOPATH)/bin/mmark -man
+
+MMARK_URL := https://github.com/mmarkdown/mmark/releases/download/v$(MMARK_VERSION)/mmark_$(MMARK_VERSION)_$(GO_BUILD_PLATFORM).tgz
+
+.PHONY: mmark
+mmark: $(MMARK_BIN)
+
+$(MMARK_BIN):
+	$(eval MMARK_TMP := $(shell mktemp -d))
+	curl -s -L $(MMARK_URL) | tar -xvzf - -C $(MMARK_TMP)
+	mkdir -p $(FIRST_GOPATH)/bin
+	cp $(MMARK_TMP)/mmark $(FIRST_GOPATH)/bin/mmark
+	rm -r $(MMARK_TMP)
 
 man/coredns.1: coredns.1.md
 	@/bin/echo -e '%%%\n title = "coredns 1"\n' \

--- a/fixup_file_mtime.sh
+++ b/fixup_file_mtime.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Description: Fix up the file mtimes based on the git log.
+
+set -u -o pipefail
+
+if [[ ! -f 'coredns.1.md' ]]; then
+  echo 'ERROR: Must be run from the top of the git repo.'
+  exit 1
+fi
+
+for file in coredns.1.md corefile.5.md plugin/*/README.md; do
+  time=$(git log --pretty=format:%cd -n 1 --date='format:%Y%m%d%H%M.%S' "${file}")
+  touch -m -t "${time}" "${file}"
+done


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Run make -f Makefile.doc in CircleCI to test that man pages are updated
in PRs.

### 2. Which issues (if any) are related?

None

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

None

Signed-off-by: Ben Kochie <superq@gmail.com>