### PR TITLE
plugin/file+auto: implement transfer.Transferer

### DIFF
--- a/plugin/auto/transfer.go
+++ b/plugin/auto/transfer.go
@@ -5,7 +5,7 @@ import (
 	"github.com/coredns/coredns/plugin/transfer"
 	"github.com/miekg/dns"
 )
-
+// Transfer implements Transfer.Transferer
 func (a Auto) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
 	// look for exact zone match
 	var z *file.Zone

--- a/plugin/auto/transfer.go
+++ b/plugin/auto/transfer.go
@@ -1,0 +1,22 @@
+package auto
+
+import (
+	"github.com/coredns/coredns/plugin/file"
+	"github.com/coredns/coredns/plugin/transfer"
+	"github.com/miekg/dns"
+)
+
+func (a Auto) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	// look for exact zone match
+	var z *file.Zone
+	for fz, zo := range a.Z {
+		if zone == fz {
+			z = zo
+			break
+		}
+	}
+	if z == nil {
+		return nil, transfer.ErrNotAuthoritative
+	}
+	return z.Transfer(serial)
+}

--- a/plugin/file/transfer.go
+++ b/plugin/file/transfer.go
@@ -1,0 +1,52 @@
+package file
+
+import (
+	"github.com/coredns/coredns/plugin/file/tree"
+	"github.com/coredns/coredns/plugin/transfer"
+	"github.com/miekg/dns"
+)
+
+func (f File) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
+	// look for exact zone match
+	var z *Zone
+	for fz, zo := range f.Z {
+		if zone == fz {
+			z = zo
+			break
+		}
+	}
+	if z == nil {
+		return nil, transfer.ErrNotAuthoritative
+	}
+	return z.Transfer(serial)
+}
+
+func (z Zone) Transfer(serial uint32) (<-chan []dns.RR, error) {
+	ch := make(chan []dns.RR, 2)
+
+	// get soa and apex
+	apex, err := z.ApexIfDefined()
+	if err != nil {
+		close(ch)
+		return nil, err
+	}
+
+	ch <- apex
+
+	// ApexIfDefined ensures that first record is an SOA
+	if serial >= apex[0].(*dns.SOA).Serial && serial != 0 {
+		// Zone is up to date. Just return the SOA
+		close(ch)
+		return ch, nil
+	}
+
+	go func() {
+		z.Walk(func(e *tree.Elem, _ map[uint16][]dns.RR) error {
+			ch <- e.All()
+			return nil
+		})
+		close(ch)
+	}()
+
+	return ch, nil
+}

--- a/plugin/file/transfer.go
+++ b/plugin/file/transfer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/miekg/dns"
 )
 
+// Transfer implements Transfer.Transferer
 func (f File) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
 	// look for exact zone match
 	var z *Zone
@@ -21,6 +22,7 @@ func (f File) Transfer(zone string, serial uint32) (<-chan []dns.RR, error) {
 	return z.Transfer(serial)
 }
 
+// Transfer returns a channel containing records of a zone transfer response for the zone
 func (z Zone) Transfer(serial uint32) (<-chan []dns.RR, error) {
 	ch := make(chan []dns.RR, 2)
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Implements zone transfer using the _transfer_ plugin.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Could mention it in README, but we should not deprecate existing functionality until Notify PR and  auto/file notify implementations merge.  Without notify, it could be confusing/esoteric to document in this state.

### 4. Does this introduce a backward incompatible change or deprecation?

no