### PR TITLE
remove ignored options from kubernetes plugin

### DIFF
--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -202,8 +202,6 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				continue
 			}
 			return nil, c.ArgErr()
-		case "resyncperiod":
-			continue
 		case "labels":
 			args := c.RemainingArgs()
 			if len(args) > 0 {
@@ -230,9 +228,6 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			return nil, c.ArgErr()
 		case "fallthrough":
 			k8s.Fall.SetZonesFromArgs(c.RemainingArgs())
-		case "upstream":
-			// remove soon
-			c.RemainingArgs() // eat remaining args
 		case "ttl":
 			args := c.RemainingArgs()
 			if len(args) == 0 {


### PR DESCRIPTION
Signed-off-by: zouyee <zounengren@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
code pruning which remove ignored options from kubernetes plugin.
### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3731
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?

Yes. will cause CoreDNS to exit if `resyncperiod` of `upstream` options are present