### PR TITLE
parse.HostPortorFile: return error when 0 found

### DIFF
--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -139,6 +139,8 @@ nameserver 10.10.255.253`), 0666); err != nil {
 	}{
 		// pass
 		{`forward . ` + resolv, false, "", []string{"10.10.255.252:53", "10.10.255.253:53"}},
+		// fail
+		{`forward . /dev/null`, true, "no nameservers", nil},
 	}
 
 	for i, test := range tests {
@@ -167,6 +169,9 @@ nameserver 10.10.255.253`), 0666); err != nil {
 					t.Errorf("Test %d, expected %q, got %q", j, n, addr)
 				}
 			}
+		}
+		if test.shouldErr {
+			continue
 		}
 		for _, p := range f.proxies {
 			p.health.Check(p) // this should almost always err, we don't care it shouldn't crash

--- a/plugin/pkg/parse/host.go
+++ b/plugin/pkg/parse/host.go
@@ -69,6 +69,9 @@ func HostPortOrFile(s ...string) ([]string, error) {
 		}
 		servers = append(servers, h)
 	}
+	if len(servers) == 0 {
+		return servers, fmt.Errorf("no nameservers found")
+	}
 	return servers, nil
 }
 

--- a/plugin/pkg/parse/host_test.go
+++ b/plugin/pkg/parse/host_test.go
@@ -54,6 +54,11 @@ func TestHostPortOrFile(t *testing.T) {
 			"[fd01::1%ens3]:153",
 			false,
 		},
+		{
+			"8.9.1043",
+			"",
+			true,
+		},
 	}
 
 	err := ioutil.WriteFile("resolv.conf", []byte("nameserver 127.0.0.1\n"), 0600)


### PR DESCRIPTION
Return an error when we haven't found any nameservers. This is the
alternative considered in #3735. It's also slighly less code to be
changing.

Replaces: #3741
Closes: #3741 #3735