### PR TITLE
plugin/cache: fix negative cache masking cases

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -174,7 +174,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 
 	if hasKey && duration > 0 {
 		if w.state.Match(res) {
-			w.set(res, key, mt, duration, w.prefetch)
+			w.set(res, key, mt, duration)
 			cacheSize.WithLabelValues(w.server, Success).Set(float64(w.pcache.Len()))
 			cacheSize.WithLabelValues(w.server, Denial).Set(float64(w.ncache.Len()))
 		} else {
@@ -203,7 +203,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	return w.ResponseWriter.WriteMsg(res)
 }
 
-func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration time.Duration, prefetch bool) {
+func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration time.Duration) {
 	// duration is expected > 0
 	// and key is valid
 	switch mt {
@@ -211,7 +211,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 		i := newItem(m, w.now(), duration)
 		w.pcache.Add(key, i)
 		// when pre-fetching, remove the negative cache entry if it exists
-		if prefetch {
+		if w.prefetch {
 			w.ncache.Remove(key)
 		}
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -199,7 +199,7 @@ func TestCache(t *testing.T) {
 		valid, k := key(state.Name(), m, mt, state.Do())
 
 		if valid {
-			crr.set(m, k, mt, c.pttl)
+			crr.set(m, k, mt, c.pttl, false)
 		}
 
 		i, _ := c.get(time.Now().UTC(), state, "dns://:53")
@@ -296,6 +296,92 @@ func TestServeFromStaleCache(t *testing.T) {
 	}
 }
 
+func TestNegativeStaleMaskingPositiveCache(t *testing.T) {
+	c := New()
+	c.staleUpTo = time.Minute * 10
+	c.Next = nxDomainBackend(60)
+
+	req := new(dns.Msg)
+	qname := "cached.org."
+	req.SetQuestion(qname, dns.TypeA)
+	ctx := context.TODO()
+
+	// Add an entry to Negative Cache": cached.org. = NXDOMAIN
+	expectedResult := dns.RcodeNameError
+	if ret, _ := c.ServeDNS(ctx, &test.ResponseWriter{}, req); ret != expectedResult {
+		t.Errorf("Test 0 Negative Cache Population: expecting %v; got %v", expectedResult, ret)
+	}
+
+	// Confirm item was added to negative cache and not to positive cache
+	if c.ncache.Len() == 0 {
+		t.Errorf("Test 0 Negative Cache Population: item not added to negative cache")
+	}
+	if c.pcache.Len() != 0 {
+		t.Errorf("Test 0 Negative Cache Population: item added to positive cache")
+	}
+
+	// Set the Backend to return non-cachable errors only
+	c.Next = plugin.HandlerFunc(func(context.Context, dns.ResponseWriter, *dns.Msg) (int, error) {
+		return 255, nil // Below, a 255 means we tried querying upstream.
+	})
+
+	// Confirm we get the NXDOMAIN from the negative cache, not the error form the backend
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+	req = new(dns.Msg)
+	req.SetQuestion(qname, dns.TypeA)
+	expectedResult = dns.RcodeNameError
+	if c.ServeDNS(ctx, rec, req); rec.Rcode != expectedResult {
+		t.Errorf("Test 1 NXDOMAIN from Negative Cache: expecting %v; got %v", expectedResult, rec.Rcode)
+	}
+
+	// Jump into the future beyond when the negative cache item would go stale
+	// but before the item goes rotten (exceeds serve stale time)
+	c.now = func() time.Time { return time.Now().Add(time.Duration(5) * time.Minute) }
+
+	// Set Backend to return a positive NOERROR + A record response
+	c.Next = BackendHandler()
+
+	// Make a query for the stale cache item
+	rec = dnstest.NewRecorder(&test.ResponseWriter{})
+	req = new(dns.Msg)
+	req.SetQuestion(qname, dns.TypeA)
+	expectedResult = dns.RcodeNameError
+	if c.ServeDNS(ctx, rec, req); rec.Rcode != expectedResult {
+		t.Errorf("Test 2 NOERROR from Backend: expecting %v; got %v", expectedResult, rec.Rcode)
+	}
+
+	// Confirm that prefetch removes the negative cache item.
+	waitFor := 3
+	for i := 1; i <= waitFor; i++ {
+		if c.ncache.Len() != 0 {
+			if i == waitFor {
+				t.Errorf("Test 2 NOERROR from Backend: item still exists in negative cache")
+			}
+			time.Sleep(time.Second)
+			continue
+		}
+	}
+
+	// Confirm that positive cache has the item
+	if c.pcache.Len() != 1 {
+		t.Errorf("Test 2 NOERROR from Backend: item missing from positive cache")
+	}
+
+	// Backend - Give error only
+	c.Next = plugin.HandlerFunc(func(context.Context, dns.ResponseWriter, *dns.Msg) (int, error) {
+		return 255, nil // Below, a 255 means we tried querying upstream.
+	})
+
+	// Query again, expect that positive cache entry is not masked by a negative cache entry
+	rec = dnstest.NewRecorder(&test.ResponseWriter{})
+	req = new(dns.Msg)
+	req.SetQuestion(qname, dns.TypeA)
+	expectedResult = dns.RcodeSuccess
+	if ret, _ := c.ServeDNS(ctx, rec, req); ret != expectedResult {
+		t.Errorf("Test 3 NOERROR from Cache: expecting %v; got %v", expectedResult, ret)
+	}
+}
+
 func BenchmarkCacheResponse(b *testing.B) {
 	c := New()
 	c.prefetch = 1
@@ -331,6 +417,20 @@ func BackendHandler() plugin.Handler {
 
 		w.WriteMsg(m)
 		return dns.RcodeSuccess, nil
+	})
+}
+
+func nxDomainBackend(ttl int) plugin.Handler {
+	return plugin.HandlerFunc(func(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Response, m.RecursionAvailable = true, true
+
+		m.Ns = []dns.RR{test.SOA(fmt.Sprintf("example.org. %d IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600", ttl))}
+
+		m.MsgHdr.Rcode = dns.RcodeNameError
+		w.WriteMsg(m)
+		return dns.RcodeNameError, nil
 	})
 }
 

--- a/plugin/cache/cache_test.go
+++ b/plugin/cache/cache_test.go
@@ -199,7 +199,7 @@ func TestCache(t *testing.T) {
 		valid, k := key(state.Name(), m, mt, state.Do())
 
 		if valid {
-			crr.set(m, k, mt, c.pttl, false)
+			crr.set(m, k, mt, c.pttl)
 		}
 
 		i, _ := c.get(time.Now().UTC(), state, "dns://:53")


### PR DESCRIPTION
**Note:** This PR fixes a bug that affects the default usage of cache, not just those who enable stale cache retrieval.

### 1. Why is this pull request needed and what does it do?

This fixes some bugs introduced when the stale cache retrieval feature was added (#3468):
1. An expired (beyond stale) negative cache would mask positive cache, sending a query upstream thus missing the cache. This affects the default usage of cache. (#3701 ) Cache misses would also not be counted in this case. 
2. A stale negative cache entry could be returned to a client despite a fresh positive cache being available. (#3586)

The first issue is fixed by tweaking the logic in getIgnoreTTL.
The other issue is fixed by having prefetch remove cache entries from the negative cache when writing to the positive cache.

The test added in this PR is based on the test in PR #3702 (thanks @huntharo !)
I also successfully tested this change with tests in PR #3702, which could therefore merge if this PR merges.

This PR should supersede #3736 

### 2. Which issues (if any) are related?

Issues:
#3701 
#3586 

PRs:
#3702
#3736 

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
no