### PR TITLE
Do cache NXDOMAIN responses that don't have SOA set

### DIFF
--- a/plugin/cache/cache.go
+++ b/plugin/cache/cache.go
@@ -163,7 +163,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 
 	msgTTL := dnsutil.MinimalTTL(res, mt)
 	var duration time.Duration
-	if mt == response.NameError || mt == response.NoData {
+	if mt == response.NameError || mt == response.NonAuthNameError || mt == response.NoData {
 		duration = computeTTL(msgTTL, w.minnttl, w.nttl)
 	} else if mt == response.ServerError {
 		// use default ttl which is 5s
@@ -211,7 +211,7 @@ func (w *ResponseWriter) set(m *dns.Msg, key uint64, mt response.Type, duration 
 		i := newItem(m, w.now(), duration)
 		w.pcache.Add(key, i)
 
-	case response.NameError, response.NoData, response.ServerError:
+	case response.NameError, response.NonAuthNameError, response.NoData, response.ServerError:
 		i := newItem(m, w.now(), duration)
 		w.ncache.Add(key, i)
 

--- a/plugin/dnssec/dnssec.go
+++ b/plugin/dnssec/dnssec.go
@@ -47,7 +47,7 @@ func (d Dnssec) Sign(state request.Request, now time.Time, server string) *dns.M
 	incep, expir := incepExpir(now)
 
 	mt, _ := response.Typify(req, time.Now().UTC()) // TODO(miek): need opt record here?
-	if mt == response.Delegation {
+	if mt == response.Delegation || mt == response.NonAuthNameError {
 		return req
 	}
 

--- a/plugin/pkg/response/classify.go
+++ b/plugin/pkg/response/classify.go
@@ -51,7 +51,7 @@ func Classify(t Type) Class {
 	switch t {
 	case NoError, Delegation:
 		return Success
-	case NameError, NoData:
+	case NameError, NonAuthNameError, NoData:
 		return Denial
 	case OtherError:
 		fallthrough

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -48,6 +48,31 @@ func TestTypifyRRSIG(t *testing.T) {
 	}
 }
 
+func TestTypifyNonAuthNameError(t *testing.T) {
+	// create an NXDOMAIN message that does not have SOA, and does not have any answer
+	m := new(dns.Msg)
+	m.SetQuestion("bar.www.example.org.", dns.TypeAAAA)
+	m.Rcode = dns.RcodeNameError
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != NonAuthNameError {
+		t.Errorf("Impossible message not typified as NonAuthNameError, got %s", mt)
+	}
+}
+
+func TestTypifyNameError(t *testing.T) {
+	// create an NXDOMAIN message has an SOA header
+	m := new(dns.Msg)
+	m.SetQuestion("bar.www.example.org.", dns.TypeAAAA)
+	m.Rcode = dns.RcodeNameError
+	m.Ns = []dns.RR{
+		test.SOA("example.org. 3600 IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082540 7200 3600 1209600 3600"),
+	}
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != NameError {
+		t.Errorf("Impossible message not typified as NameError, got %s", mt)
+	}
+}
+
 func TestTypifyImpossible(t *testing.T) {
 	// create impossible message that denies its own existence
 	m := new(dns.Msg)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I have observed on EKS (AWS hosted Kubernetes) that the AWS DNS returns NXDOMAIN responses that do not include an SOA. Without this change, it is impossible to cache those responses even for DefaultMinTTL, as seen as `Type`=`OtherError`.

This PR does:
* Add a new Type: NonAuthNameError for recognizing NXDOMAIN responses
  that don't have SOA set
* Treat NonAuthNameError as a Denial for logging
* Do apply the default minTTL to NonAuthNameError responses, i.e. the
  denial MINTTL or the DefaultMinTTL.

NXDOMAIN responses that include some Answer are still `Typify`-ed as `OtherError` in order to respect existing tests.

### 2. Which issues (if any) are related?
See slack thread: https://cloud-native.slack.com/archives/C4DF7FP71/p1584282386084400

### 3. Which documentation changes (if any) need to be made?
I don't think any is needed.

### 4. Does this introduce a backward incompatible change or deprecation?
Some DNS responses that were not being cached are now cached, up to DefaultMinTTL or the denial MINTTL. Personally I don't see it as a backward incompatible change but maybe it is a notable change in behavior.