### PR TITLE
plugin/forward: register missing metric

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -34,7 +34,7 @@ func setup(c *caddy.Controller) error {
 	})
 
 	c.OnStartup(func() error {
-		metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge)
+		metrics.MustRegister(c, RequestCount, RcodeCount, RequestDuration, HealthcheckFailureCount, SocketGauge, MaxConcurrentRejectCount)
 		return f.OnStartup()
 	})
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds recently added `MaxConcurrentRejectCount` metric missing from `MustRegister()`

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
