### PR TITLE
plugin/autopath: Add k8s Pod namespace known issue

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -148,7 +148,7 @@ docker-build: tar
 
 .PHONY: docker-push
 docker-push:
-	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
+	#@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_LOGIN) --password-stdin
 	@echo Pushing: $(VERSION) to $(DOCKER_IMAGE_NAME)
 	for arch in $(LINUX_ARCH); do \
 	    docker push $(DOCKER_IMAGE_NAME):coredns-$$arch ;\

--- a/plugin/autopath/README.md
+++ b/plugin/autopath/README.md
@@ -12,6 +12,8 @@ failures, the original reply is returned. Because *autopath* returns a reply for
 the original question it will add a CNAME that points from the original name (with the search path
 element in it) to the name of this answer.
 
+**Note**: There are several known issues and caveats.  See section below.
+
 ## Syntax
 
 ~~~
@@ -48,8 +50,18 @@ autopath @kubernetes
 
 Use the search path dynamically retrieved from the *kubernetes* plugin.
 
-## Known Issues
+## Known Issues and Caveats
 
-In Kubernetes, *autopath* is not compatible with pods running from Windows nodes.
+In Kubernetes, *autopath* can derive the wrong namespace of a client Pod (and therefore wrong search path)
+in the following case.  To properly build the search path of a client *autopath* needs to
+know the namespace of the a Pod making a DNS request. To do this, it relies on the
+*kubernetes* plugin's Pod cache to resolve the client's IP address to a Pod.  The Pod cache is maintained by
+an API watch on Pods.  When Pod IP assignments change, the Kubernetes API notifies CoreDNS via the API watch.
+However, that notification is not instantaneous. In the case that a Pod is deleted, and it's IP is
+immediately provisioned to a Pod in another namespace, and that new Pod make a DNS lookup *before* the API watch
+can notify CoreDNS of the change, *autopath* will resolve the IP to the previous Pod's namespace.
 
-If the server side search ultimately results in a negative answer (e.g. `NXDOMAIN`), then the client will fruitlessly search all paths manually, thus negating the *autopath* optimization.
+In Kubernetes, *autopath* is not compatible with Pods running from Windows nodes.
+
+If the server side search ultimately results in a negative answer (e.g. `NXDOMAIN`), then the client will
+fruitlessly search all paths manually, thus negating the *autopath* optimization.

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/kubernetes/object"
 	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/pkg/dnsutil"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
@@ -46,7 +47,7 @@ func setup(c *caddy.Controller) error {
 	k.RegisterKubeCache(c)
 
 	c.OnStartup(func() error {
-		metrics.MustRegister(c, DnsProgrammingLatency)
+		metrics.MustRegister(c, DnsProgrammingLatency, object.APIIndexErrorCount, object.APIIndexSize, object.APIWatchEventCount)
 		return nil
 	})
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Document Pod namespace issue raised in #3765

### 2. Which issues (if any) are related?

#3765

### 3. Which documentation changes (if any) need to be made?

Included here in autopath readme, but possibly should also be in kubernetes readme.

### 4. Does this introduce a backward incompatible change or deprecation?

no