### PR TITLE
1.6.8 release notes: set date to today

### DIFF
--- a/notes/coredns-1.6.8.md
+++ b/notes/coredns-1.6.8.md
@@ -3,15 +3,15 @@ title = "CoreDNS-1.6.8 Release"
 description = "CoreDNS-1.6.8 Release Notes."
 tags = ["Release", "1.6.8", "Notes"]
 release = "1.6.8"
-date = 2020-03-06T10:00:00+00:00
+date = 2020-03-24T10:00:00+00:00
 author = "coredns"
 +++
 
 The CoreDNS team has released
 [CoreDNS-1.6.8](https://github.com/coredns/coredns/releases/tag/v1.6.8).
 
-Again a small release with some nice improvements in the *forward* plugin, and overall polish.
-See "Noteworthy Changes" for more detail.
+Again a small release with some nice improvements in the *forward* plugin, and overall polish. See
+"Noteworthy Changes" for more detail.
 
 Note that 1.7.0 will contain a bunch of backward incompatible changes: the *federation* plugin will
 be full removed and the metrics name will be changed to inline with the naming recommendation from


### PR DESCRIPTION
We should really release. I'm setting the date to today, and kick off a
release after this is merged.