### PR TITLE
Add 1.7.0 notes already

### DIFF
--- a/notes/coredns-1.7.0.md
+++ b/notes/coredns-1.7.0.md
@@ -10,7 +10,9 @@ author = "coredns"
 The CoreDNS team has released
 [CoreDNS-1.7.0](https://github.com/coredns/coredns/releases/tag/v1.7.0).
 
-This is a **backwards incompatible release**. Major changes include: better metrics names, and newly
+This is a **backwards incompatible release**. Major changes include:
+* Better metrics names (PR #3776)
+* New `transfer` plugin that removes the need for plugins to perform their own zone transfers.
 added `transfer` plugin that removes the need for plugins to perform their own zone transfers.
 
 As this was already backwards incompatible release, we took the liberty to stuff is much of it in

--- a/notes/coredns-1.7.0.md
+++ b/notes/coredns-1.7.0.md
@@ -1,0 +1,20 @@
++++
+title = "CoreDNS-1.7.0 Release"
+description = "CoreDNS-1.7.0 Release Notes."
+tags = ["Release", "1.7.0", "Notes"]
+release = "1.7.0"
+date = 2020-03-24T10:00:00+00:00
+author = "coredns"
++++
+
+The CoreDNS team has released
+[CoreDNS-1.7.0](https://github.com/coredns/coredns/releases/tag/v1.7.0).
+
+This is a **backwards incompatible release**. Major changes include: better metrics names, and newly
+added `transfer` plugin that removes the need for plugins to perform their own zone transfers.
+
+As this was already backwards incompatible release, we took the liberty to stuff is much of it in
+one release as possible to minimize the disruption going forward.
+
+## Brought to You By
+## Noteworthy Changes


### PR DESCRIPTION
This is the work-in-progress release notes for 1.7.0, adding it now so
we can craft it will we work towards 1.7.0.

Notes currently yell that 1.7.0 is backwards incompatible.