### PR TITLE
remove federation related things

### DIFF
--- a/core/dnsserver/zdirectives.go
+++ b/core/dnsserver/zdirectives.go
@@ -42,7 +42,6 @@ var Directives = []string{
 	"route53",
 	"azure",
 	"clouddns",
-	"federation",
 	"k8s_external",
 	"kubernetes",
 	"file",

--- a/core/plugin/zplugin.go
+++ b/core/plugin/zplugin.go
@@ -49,5 +49,4 @@ import (
 	_ "github.com/coredns/coredns/plugin/trace"
 	_ "github.com/coredns/coredns/plugin/transfer"
 	_ "github.com/coredns/coredns/plugin/whoami"
-	_ "github.com/coredns/federation"
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/aws/aws-sdk-go v1.29.29
 	github.com/caddyserver/caddy v1.0.5
 	github.com/cenkalti/backoff/v4 v4.0.0
-	github.com/coredns/federation v0.0.0-20190818181423-e032b096babe
 	github.com/dnstap/golang-dnstap v0.0.0-20170829151710-2cf77a2b5e11
 	github.com/farsightsec/golang-framestream v0.0.0-20181102145529-8a0cb8ba8710
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,6 @@ github.com/cloudflare/cloudflare-go v0.10.2/go.mod h1:qhVI5MKwBGhdNU89ZRz2plgYut
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/coredns/federation v0.0.0-20190818181423-e032b096babe h1:ND08lR/TclI9W4dScCwdRESOacCCdF3FkuB5pBIOv1U=
-github.com/coredns/federation v0.0.0-20190818181423-e032b096babe/go.mod h1:MoqTEFX8GlnKkyq8eBCF94VzkNAOgjdlCJ+Pz/oCLPk=
 github.com/coreos/go-semver v0.2.0 h1:3Jm3tLmsgAYcjC+4Up7hJrFBPr+n7rAqYeSw/SZazuY=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=

--- a/man/coredns-kubernetes.7
+++ b/man/coredns-kubernetes.7
@@ -257,26 +257,6 @@ cluster.local {
 .fi
 .RE
 
-.SH "FEDERATION"
-.PP
-The \fIkubernetes\fP plugin can be used in conjunction with the \fIfederation\fP plugin.  Using this
-feature enables serving federated domains from the Kubernetes clusters.
-
-.PP
-.RS
-
-.nf
-cluster.local {
-    federation {
-        prod prod.example.org
-        staging staging.example.org
-    }
-    kubernetes
-}
-
-.fi
-.RE
-
 .SH "WILDCARDS"
 .PP
 Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (*,

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -51,7 +51,6 @@ hosts:hosts
 route53:route53
 azure:azure
 clouddns:clouddns
-federation:github.com/coredns/federation
 k8s_external:k8s_external
 kubernetes:kubernetes
 file:file

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -182,20 +182,6 @@ be set to `verified` for this to function properly.
         }
     }
 
-## Federation
-
-The *kubernetes* plugin can be used in conjunction with the *federation* plugin.  Using this
-feature enables serving federated domains from the Kubernetes clusters.
-
-    cluster.local {
-        federation {
-            prod prod.example.org
-            staging staging.example.org
-        }
-        kubernetes
-    }
-
-
 ## Wildcards
 
 Some query labels accept a wildcard value to match any value.  If a label is a valid wildcard (\*,

--- a/plugin/kubernetes/local.go
+++ b/plugin/kubernetes/local.go
@@ -35,24 +35,3 @@ func boundIPs(c *caddy.Controller) (ips []net.IP) {
 	}
 	return ips
 }
-
-// LocalNodeName is exclusively used in federation plugin, will be deprecated later.
-func (k *Kubernetes) LocalNodeName() string {
-	if len(k.localIPs) == 0 {
-		return ""
-	}
-
-	// Find fist endpoint matching any localIP
-	for _, localIP := range k.localIPs {
-		for _, ep := range k.APIConn.EpIndexReverse(localIP.String()) {
-			for _, eps := range ep.Subsets {
-				for _, addr := range eps.Addresses {
-					if localIP.Equal(net.ParseIP(addr.IP)) {
-						return addr.NodeName
-					}
-				}
-			}
-		}
-	}
-	return ""
-}

--- a/plugin/kubernetes/parse.go
+++ b/plugin/kubernetes/parse.go
@@ -29,8 +29,6 @@ func parseRequest(name, zone string) (r recordRequest, err error) {
 	// 1. _port._protocol.service.namespace.pod|svc.zone
 	// 2. (endpoint): endpoint.service.namespace.pod|svc.zone
 	// 3. (service): service.namespace.pod|svc.zone
-	//
-	// Federations are handled in the federation plugin. And aren't parsed here.
 
 	base, _ := dnsutil.TrimZone(name, zone)
 	// return NODATA for apex queries


### PR DESCRIPTION
Signed-off-by: Zou Nengren <zouyee1989@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
`fedaration` plugin has been deprecated.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3726

### 3. Which documentation changes (if any) need to be made?
kubernetes readme

### 4. Does this introduce a backward incompatible change or deprecation?
