### PR TITLE
Update more metrics names

### DIFF
--- a/plugin.md
+++ b/plugin.md
@@ -56,7 +56,7 @@ server.
 ## Metrics
 
 When exporting metrics the *Namespace* should be `plugin.Namespace` (="coredns"), and the
-*Subsystem* should be the name of the plugin. The README.md for the plugin should then also contain
+*Subsystem* must be the name of the plugin. The README.md for the plugin should then also contain
 a *Metrics* section detailing the metrics.
 
 ## Readiness

--- a/plugin/acl/README.md
+++ b/plugin/acl/README.md
@@ -73,8 +73,8 @@ example.org {
 
 If monitoring is enabled (via the _prometheus_ plugin) then the following metrics are exported:
 
-- `coredns_dns_blocked_requests_total{server, zone}` - counter of DNS requests being blocked.
+- `coredns_acl_blocked_requests_total{server, zone}` - counter of DNS requests being blocked.
 
-- `coredns_dns_allowed_requests_total{server}` - counter of DNS requests being allowed.
+- `coredns_acl_allowed_requests_total{server}` - counter of DNS requests being allowed.
 
 The `server` and `zone` labels are explained in the _metrics_ plugin documentation.

--- a/plugin/acl/metrics.go
+++ b/plugin/acl/metrics.go
@@ -10,15 +10,15 @@ var (
 	// RequestBlockCount is the number of DNS requests being blocked.
 	RequestBlockCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "dns",
-		Name:      "acl_blocked_requests_total",
+		Subsystem: pluginName,
+		Name:      "blocked_requests_total",
 		Help:      "Counter of DNS requests being blocked.",
 	}, []string{"server", "zone"})
 	// RequestAllowCount is the number of DNS requests being Allowed.
 	RequestAllowCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "dns",
-		Name:      "acl_allowed_requests_total",
+		Subsystem: pluginName,
+		Name:      "allowed_requests_total",
 		Help:      "Counter of DNS requests being allowed.",
 	}, []string{"server"})
 )

--- a/plugin/acl/setup.go
+++ b/plugin/acl/setup.go
@@ -13,7 +13,9 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() { plugin.Register("acl", setup) }
+const pluginName = "acl"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func newDefaultFilter() *iptree.Tree {
 	defaultFilter := iptree.NewTree()
@@ -27,7 +29,7 @@ func newDefaultFilter() *iptree.Tree {
 func setup(c *caddy.Controller) error {
 	a, err := parse(c)
 	if err != nil {
-		return plugin.Error("acl", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/dns64/README.md
+++ b/plugin/dns64/README.md
@@ -6,8 +6,6 @@
 
 ## Description
 
-From Wikipedia:
-
 > DNS64 describes a DNS server that when asked for a domain's AAAA records, but only finds
 > A records, synthesizes the AAAA records from the A records.
 
@@ -55,6 +53,15 @@ dns64 {
 ~~~
 
 * `prefix` specifies any local IPv6 prefix to use, instead of the well known prefix (64:ff9b::/96)
+
+
+## Metrics
+
+If monitoring is enabled (via the _prometheus_ plugin) then the following metrics are exported:
+
+- `coredns_dns64_requests_translated_total{server}` - counter of DNS requests translated
+
+The `server` label is explained in the _prometheus_ plugin documentation.
 
 ## Bugs
 

--- a/plugin/dns64/metrics.go
+++ b/plugin/dns64/metrics.go
@@ -10,8 +10,8 @@ var (
 	// RequestsTranslatedCount is the number of DNS requests translated by dns64.
 	RequestsTranslatedCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "dns",
-		Name:      "requests_dns64_translated_total",
+		Subsystem: pluginName,
+		Name:      "requests_translated_total",
 		Help:      "Counter of DNS requests translated by dns64.",
 	}, []string{"server"})
 )

--- a/plugin/dns64/setup.go
+++ b/plugin/dns64/setup.go
@@ -12,14 +12,16 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-var log = clog.NewWithPlugin("dns64")
+const pluginName = "dns64"
 
-func init() { plugin.Register("dns64", setup) }
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	dns64, err := dns64Parse(c)
 	if err != nil {
-		return plugin.Error("dns64", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/kubernetes/metrics.go
+++ b/plugin/kubernetes/metrics.go
@@ -9,10 +9,6 @@ import (
 	api "k8s.io/api/core/v1"
 )
 
-const (
-	subsystem = "kubernetes"
-)
-
 var (
 	// DnsProgrammingLatency is defined as the time it took to program a DNS instance - from the time
 	// a service or pod has changed to the time the change was propagated and was available to be
@@ -27,7 +23,7 @@ var (
 	//   * headless_without_selector
 	DnsProgrammingLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: subsystem,
+		Subsystem: pluginName,
 		Name:      "dns_programming_duration_seconds",
 		// From 1 millisecond to ~17 minutes.
 		Buckets: prometheus.ExponentialBuckets(0.001, 2, 20),

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -27,21 +27,23 @@ import (
 	"k8s.io/klog"
 )
 
-var log = clog.NewWithPlugin("kubernetes")
+const pluginName = "kubernetes"
 
-func init() { plugin.Register("kubernetes", setup) }
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	klog.SetOutput(os.Stdout)
 
 	k, err := kubernetesParse(c)
 	if err != nil {
-		return plugin.Error("kubernetes", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	err = k.InitKubeCache(context.Background())
 	if err != nil {
-		return plugin.Error("kubernetes", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	k.RegisterKubeCache(c)


### PR DESCRIPTION
The subsystem of a metric must be it's plugin name. "dns" is reserved
for the core. Use a const convention to avoid copy-paste mistakes in
naming.

Fix dns64 and acl plugin.

Signed-off-by: Ben Kochie <superq@gmail.com>