### PR TITLE
Change the recommened version to 1.14 (as we use 1.14 by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ CoreDNS requires Go to compile. However, if you already have docker installed an
 setup a Go environment, you could build CoreDNS easily:
 
 ```
-$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.12 make
+$ docker run --rm -i -t -v $PWD:/v -w /v golang:1.14 make
 ```
 
 The above command alone will have `coredns` binary generated.


### PR DESCRIPTION
Change the recommened version to 1.14 (as we use 1.14 by default now)

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
