### PR TITLE
correct metrics name of cache size

### DIFF
--- a/man/coredns-cache.7
+++ b/man/coredns-cache.7
@@ -94,7 +94,7 @@ Entries with 0 TTL will remain in the cache until randomly evicted when the shar
 If monitoring is enabled (via the \fIprometheus\fP plugin) then the following metrics are exported:
 
 .IP \(bu 4
-\fB\fCcoredns_cache_size{server, type}\fR - Total elements in the cache by cache type.
+\fB\fCcoredns_cache_entries{server, type}\fR - Total elements in the cache by cache type.
 .IP \(bu 4
 \fB\fCcoredns_cache_hits_total{server, type}\fR - Counter of cache hits by cache type.
 .IP \(bu 4

--- a/notes/coredns-1.7.0.md
+++ b/notes/coredns-1.7.0.md
@@ -51,6 +51,8 @@ It's mostly dropping `count` from `_total` metrics names:
 
 * `coredns_reload_failed_count_total` -\> `coredns_reload_failed_total`
 
+* `coredns_cache_size` -\> `coredns_cache_entries`
+
 And note that
 `coredns_dns_request_type_count_total` is now part of `coredns_dns_requests_total` .
 

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -70,7 +70,7 @@ Entries with 0 TTL will remain in the cache until randomly evicted when the shar
 
 If monitoring is enabled (via the *prometheus* plugin) then the following metrics are exported:
 
-* `coredns_cache_size{server, type}` - Total elements in the cache by cache type.
+* `coredns_cache_entries{server, type}` - Total elements in the cache by cache type.
 * `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
 * `coredns_cache_misses_total{server}` - Counter of cache misses.
 * `coredns_cache_drops_total{server}` - Counter of responses excluded from the cache due to request/response question name mismatch.

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -11,7 +11,7 @@ var (
 	cacheSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: "cache",
-		Name:      "size",
+		Name:      "entries",
 		Help:      "The number of elements in the cache.",
 	}, []string{"server", "type"})
 	// cacheHits is counter of cache hits by cache type.

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -138,7 +138,7 @@ func TestMetricsAuto(t *testing.T) {
 // Show that when 2 blocs share the same metric listener (they have a prometheus plugin on the same listening address),
 // ALL the metrics of the second bloc in order are declared in prometheus, especially the plugins that are used ONLY in the second bloc
 func TestMetricsSeveralBlocs(t *testing.T) {
-	cacheSizeMetricName := "coredns_cache_size"
+	cacheSizeMetricName := "coredns_cache_entries"
 	addrMetrics := "localhost:9155"
 
 	corefile := fmt.Sprintf(`
@@ -227,7 +227,7 @@ example.com:0 {
 
 func TestMetricsAvailable(t *testing.T) {
 	procMetric := "coredns_build_info"
-	procCache := "coredns_cache_size"
+	procCache := "coredns_cache_entries"
 	procCacheMiss := "coredns_cache_misses_total"
 	procForward := "coredns_dns_request_duration_seconds"
 	corefileWithMetrics := `

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -209,7 +209,7 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 	// that is not used in another test
 	promAddress := "127.0.0.1:53186"
 	procMetric := "coredns_build_info"
-	procCache := "coredns_cache_size"
+	procCache := "coredns_cache_entries"
 	procForward := "coredns_dns_request_duration_seconds"
 	corefileWithMetrics := `
 	.:0 {
@@ -263,7 +263,7 @@ func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 	// that is not used in another test
 	promAddress := "127.0.0.1:53187"
 	procMetric := "coredns_build_info"
-	procCache := "coredns_cache_size"
+	procCache := "coredns_cache_entries"
 	procForward := "coredns_dns_request_duration_seconds"
 	corefileWithMetrics := `
 	.:0 {


### PR DESCRIPTION
Signed-off-by: zounengren <zounengren@cmss.chinamobile.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
As mentioned https://github.com/coredns/coredns/pull/3789#discussion_r399803733

"size" is ambiguous,  "entries" to match the similar metric in dnssec.

### 2. Which issues (if any) are related?
xref https://github.com/coredns/coredns/issues/3778

### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
incompatible change : metric `coredns_cache_size ` renamed
These changes may need to be included in  https://github.com/coredns/coredns/pull/3798
