### PR TITLE
Fix goconst warnings

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -87,4 +87,4 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 }
 
 // Name implements the Handler interface.
-func (a Auto) Name() string { return "auto" }
+func (a Auto) Name() string { return pluginName }

--- a/plugin/auto/setup.go
+++ b/plugin/auto/setup.go
@@ -16,14 +16,16 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-var log = clog.NewWithPlugin("auto")
+const pluginName = "auto"
 
-func init() { plugin.Register("auto", setup) }
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	a, err := autoParse(c)
 	if err != nil {
-		return plugin.Error("auto", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	c.OnStartup(func() error {
@@ -157,7 +159,7 @@ func autoParse(c *caddy.Controller) (Auto, error) {
 				}
 
 			default:
-				return Auto{}, c.Errf("unknown property '%s'", c.Val())
+				return Auto{}, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/autopath/autopath.go
+++ b/plugin/autopath/autopath.go
@@ -144,7 +144,7 @@ func (a *AutoPath) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 }
 
 // Name implements the Handler interface.
-func (a *AutoPath) Name() string { return "autopath" }
+func (a *AutoPath) Name() string { return pluginName }
 
 // firstInSearchPath checks if name is equal to are a sibling of the first element in the search path.
 func firstInSearchPath(name string, searchpath []string) bool {

--- a/plugin/autopath/metrics.go
+++ b/plugin/autopath/metrics.go
@@ -10,7 +10,7 @@ var (
 	// autoPathCount is counter of successfully autopath-ed queries.
 	autoPathCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "autopath",
+		Subsystem: pluginName,
 		Name:      "success_total",
 		Help:      "Counter of requests that did autopath.",
 	}, []string{"server"})

--- a/plugin/autopath/setup.go
+++ b/plugin/autopath/setup.go
@@ -11,12 +11,14 @@ import (
 	"github.com/miekg/dns"
 )
 
-func init() { plugin.Register("autopath", setup) }
+const pluginName = "autopath"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	ap, mw, err := autoPathParse(c)
 	if err != nil {
-		return plugin.Error("autopath", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	c.OnStartup(func() error {
@@ -33,7 +35,7 @@ func setup(c *caddy.Controller) error {
 		if x, ok := m.(AutoPather); ok {
 			ap.searchFunc = x.AutoPath
 		} else {
-			return plugin.Error("autopath", fmt.Errorf("%s does not implement the AutoPather interface", mw))
+			return plugin.Error(pluginName, fmt.Errorf("%s does not implement the AutoPather interface", mw))
 		}
 		return nil
 	})

--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -129,7 +129,7 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 				}
 				accessMap[resourceGroup+zoneName] = access
 			default:
-				return env, resourceGroupMapping, accessMap, fall, c.Errf("unknown property: %q", c.Val())
+				return env, resourceGroupMapping, accessMap, fall, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/cache/setup.go
+++ b/plugin/cache/setup.go
@@ -15,14 +15,16 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-var log = clog.NewWithPlugin("cache")
+const pluginName = "cache"
 
-func init() { plugin.Register("cache", setup) }
+var log = clog.NewWithPlugin(pluginName)
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	ca, err := cacheParse(c)
 	if err != nil {
-		return plugin.Error("cache", err)
+		return plugin.Error(pluginName, err)
 	}
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		ca.Next = next

--- a/plugin/chaos/chaos.go
+++ b/plugin/chaos/chaos.go
@@ -55,4 +55,4 @@ func (c Chaos) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 }
 
 // Name implements the Handler interface.
-func (c Chaos) Name() string { return "chaos" }
+func (c Chaos) Name() string { return pluginName }

--- a/plugin/chaos/setup.go
+++ b/plugin/chaos/setup.go
@@ -11,12 +11,14 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() { plugin.Register("chaos", setup) }
+const pluginName = "chaos"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	version, authors, err := parse(c)
 	if err != nil {
-		return plugin.Error("chaos", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -75,7 +75,7 @@ func setup(c *caddy.Controller) error {
 			case "fallthrough":
 				fall.SetZonesFromArgs(c.RemainingArgs())
 			default:
-				return c.Errf("unknown property '%s'", c.Val())
+				return c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 

--- a/plugin/dns64/setup.go
+++ b/plugin/dns64/setup.go
@@ -75,7 +75,7 @@ func dns64Parse(c *caddy.Controller) (*DNS64, error) {
 			case "translate_all":
 				dns64.TranslateAll = true
 			default:
-				return nil, c.Errf("unknown property '%s'", c.Val())
+				return nil, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -80,7 +80,7 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 				}
 				capacity = cacheCap
 			default:
-				return nil, nil, 0, false, c.Errf("unknown property '%s'", x)
+				return nil, nil, 0, false, c.Errf(plugin.UnknownPropertyErrmsg, x)
 			}
 
 		}

--- a/plugin/erratic/setup.go
+++ b/plugin/erratic/setup.go
@@ -102,7 +102,7 @@ func parseErratic(c *caddy.Controller) (*Erratic, error) {
 			case "large":
 				e.large = true
 			default:
-				return nil, c.Errf("unknown property '%s'", c.Val())
+				return nil, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/etcd/handler.go
+++ b/plugin/etcd/handler.go
@@ -77,4 +77,4 @@ func (e *Etcd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 }
 
 // Name implements the Handler interface.
-func (e *Etcd) Name() string { return "etcd" }
+func (e *Etcd) Name() string { return pluginName }

--- a/plugin/etcd/setup.go
+++ b/plugin/etcd/setup.go
@@ -12,12 +12,14 @@ import (
 	etcdcv3 "go.etcd.io/etcd/clientv3"
 )
 
-func init() { plugin.Register("etcd", setup) }
+const pluginName = "etcd"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	e, err := etcdParse(c)
 	if err != nil {
-		return plugin.Error("etcd", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
@@ -89,7 +91,7 @@ func etcdParse(c *caddy.Controller) (*Etcd, error) {
 				username, password = args[0], args[1]
 			default:
 				if c.Val() != "}" {
-					return &Etcd{}, c.Errf("unknown property '%s'", c.Val())
+					return &Etcd{}, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 				}
 			}
 		}

--- a/plugin/file/setup.go
+++ b/plugin/file/setup.go
@@ -116,7 +116,7 @@ func fileParse(c *caddy.Controller) (Zones, error) {
 				c.RemainingArgs()
 
 			default:
-				return Zones{}, c.Errf("unknown property '%s'", c.Val())
+				return Zones{}, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 
 			for _, origin := range origins {

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -239,7 +239,7 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		f.maxConcurrent = int64(n)
 
 	default:
-		return c.Errf("unknown property '%s'", c.Val())
+		return c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 	}
 
 	return nil

--- a/plugin/grpc/setup.go
+++ b/plugin/grpc/setup.go
@@ -143,7 +143,7 @@ func parseBlock(c *caddy.Controller, g *GRPC) error {
 		}
 	default:
 		if c.Val() != "}" {
-			return c.Errf("unknown property '%s'", c.Val())
+			return c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 		}
 	}
 

--- a/plugin/health/health.go
+++ b/plugin/health/health.go
@@ -11,7 +11,7 @@ import (
 	"github.com/coredns/coredns/plugin/pkg/reuseport"
 )
 
-var log = clog.NewWithPlugin("health")
+var log = clog.NewWithPlugin(pluginName)
 
 // Health implements healthchecks by exporting a HTTP endpoint.
 type health struct {

--- a/plugin/health/overloaded.go
+++ b/plugin/health/overloaded.go
@@ -41,7 +41,7 @@ var (
 	// HealthDuration is the metric used for exporting how fast we can retrieve the /health endpoint.
 	HealthDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "health",
+		Subsystem: pluginName,
 		Name:      "request_duration_seconds",
 		Buckets:   plugin.TimeBuckets,
 		Help:      "Histogram of the time (in seconds) each request took.",

--- a/plugin/health/setup.go
+++ b/plugin/health/setup.go
@@ -11,12 +11,14 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() { plugin.Register("health", setup) }
+const pluginName = "health"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	addr, lame, err := parse(c)
 	if err != nil {
-		return plugin.Error("health", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	h := &health{Addr: addr, stop: make(chan bool), lameduck: lame}

--- a/plugin/hosts/setup.go
+++ b/plugin/hosts/setup.go
@@ -163,7 +163,7 @@ func hostsParse(c *caddy.Controller) (Hosts, error) {
 					inline = append(inline, line)
 					continue
 				}
-				return h, c.Errf("unknown property '%s'", c.Val())
+				return h, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -73,7 +73,7 @@ func parse(c *caddy.Controller) (*External, error) {
 				}
 				e.apex = args[0]
 			default:
-				return nil, c.Errf("unknown property '%s'", c.Val())
+				return nil, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 	}

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -283,7 +283,7 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 			}
 			return nil, c.ArgErr()
 		default:
-			return nil, c.Errf("unknown property '%s'", c.Val())
+			return nil, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 		}
 	}
 

--- a/plugin/metrics/handler.go
+++ b/plugin/metrics/handler.go
@@ -32,4 +32,4 @@ func (m *Metrics) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 }
 
 // Name implements the Handler interface.
-func (m *Metrics) Name() string { return "prometheus" }
+func (m *Metrics) Name() string { return pluginName }

--- a/plugin/metrics/register.go
+++ b/plugin/metrics/register.go
@@ -9,7 +9,7 @@ import (
 
 // MustRegister registers the prometheus Collectors when the metrics plugin is used.
 func MustRegister(c *caddy.Controller, cs ...prometheus.Collector) {
-	m := dnsserver.GetConfig(c).Handler("prometheus")
+	m := dnsserver.GetConfig(c).Handler(pluginName)
 	if m == nil {
 		return
 	}

--- a/plugin/metrics/setup.go
+++ b/plugin/metrics/setup.go
@@ -14,18 +14,20 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
+const pluginName = "prometheus"
+
 var (
-	log      = clog.NewWithPlugin("prometheus")
+	log      = clog.NewWithPlugin(pluginName)
 	u        = uniq.New()
 	registry = newReg()
 )
 
-func init() { plugin.Register("prometheus", setup) }
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	m, err := parse(c)
 	if err != nil {
-		return plugin.Error("prometheus", err)
+		return plugin.Error(pluginName, err)
 	}
 	m.Reg = registry.getOrSet(m.Addr, m.Reg)
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -107,3 +107,6 @@ var TimeBuckets = prometheus.ExponentialBuckets(0.00025, 2, 16) // from 0.25ms t
 
 // ErrOnce is returned when a plugin doesn't support multiple setups per server.
 var ErrOnce = errors.New("this plugin can only be used once per Server Block")
+
+// UnknownPropertyErrmsg formats unknown property error string.
+const UnknownPropertyErrmsg = "unknown property '%s'"

--- a/plugin/pprof/setup.go
+++ b/plugin/pprof/setup.go
@@ -10,11 +10,13 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-var log = clog.NewWithPlugin("pprof")
+const pluginName = "pprof"
+
+var log = clog.NewWithPlugin(pluginName)
 
 const defaultAddr = "localhost:6053"
 
-func init() { plugin.Register("pprof", setup) }
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	h := &handler{addr: defaultAddr}
@@ -22,7 +24,7 @@ func setup(c *caddy.Controller) error {
 	i := 0
 	for c.Next() {
 		if i > 0 {
-			return plugin.Error("pprof", plugin.ErrOnce)
+			return plugin.Error(pluginName, plugin.ErrOnce)
 		}
 		i++
 
@@ -31,12 +33,12 @@ func setup(c *caddy.Controller) error {
 			h.addr = args[0]
 			_, _, e := net.SplitHostPort(h.addr)
 			if e != nil {
-				return plugin.Error("pprof", c.Errf("%v", e))
+				return plugin.Error(pluginName, c.Errf("%v", e))
 			}
 		}
 
 		if len(args) > 1 {
-			return plugin.Error("pprof", c.ArgErr())
+			return plugin.Error(pluginName, c.ArgErr())
 		}
 
 		for c.NextBlock() {
@@ -44,18 +46,18 @@ func setup(c *caddy.Controller) error {
 			case "block":
 				args := c.RemainingArgs()
 				if len(args) > 1 {
-					return plugin.Error("pprof", c.ArgErr())
+					return plugin.Error(pluginName, c.ArgErr())
 				}
 				h.rateBloc = 1
 				if len(args) > 0 {
 					t, err := strconv.Atoi(args[0])
 					if err != nil {
-						return plugin.Error("pprof", c.Errf("property '%s' invalid integer value '%v'", "block", args[0]))
+						return plugin.Error(pluginName, c.Errf("property '%s' invalid integer value '%v'", "block", args[0]))
 					}
 					h.rateBloc = t
 				}
 			default:
-				return plugin.Error("pprof", c.Errf("unknown property '%s'", c.Val()))
+				return plugin.Error(pluginName, c.Errf(plugin.UnknownPropertyErrmsg, c.Val()))
 			}
 		}
 

--- a/plugin/rewrite/rewrite.go
+++ b/plugin/rewrite/rewrite.go
@@ -70,7 +70,7 @@ func (rw Rewrite) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 }
 
 // Name implements the Handler interface.
-func (rw Rewrite) Name() string { return "rewrite" }
+func (rw Rewrite) Name() string { return pluginName }
 
 // Rule describes a rewrite rule.
 type Rule interface {

--- a/plugin/rewrite/setup.go
+++ b/plugin/rewrite/setup.go
@@ -7,12 +7,14 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() { plugin.Register("rewrite", setup) }
+const pluginName = "rewrite"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	rewrites, err := rewriteParse(c)
 	if err != nil {
-		return plugin.Error("rewrite", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -289,4 +289,4 @@ func (h *Route53) updateZones(ctx context.Context) error {
 }
 
 // Name implements plugin.Handler.Name.
-func (h *Route53) Name() string { return "route53" }
+func (h *Route53) Name() string { return pluginName }

--- a/plugin/secondary/setup.go
+++ b/plugin/secondary/setup.go
@@ -10,12 +10,14 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
-func init() { plugin.Register("secondary", setup) }
+const pluginName = "secondary"
+
+func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
 	zones, err := secondaryParse(c)
 	if err != nil {
-		return plugin.Error("secondary", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	// Add startup functions to retrieve the zone and keep it up to date.
@@ -47,7 +49,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 	upstr := upstream.New()
 	for c.Next() {
 
-		if c.Val() == "secondary" {
+		if c.Val() == pluginName {
 			// secondary [origin]
 			origins := make([]string, len(c.ServerBlockKeys))
 			copy(origins, c.ServerBlockKeys)
@@ -76,7 +78,7 @@ func secondaryParse(c *caddy.Controller) (file.Zones, error) {
 					// remove soon
 					c.RemainingArgs()
 				default:
-					return file.Zones{}, c.Errf("unknown property '%s'", c.Val())
+					return file.Zones{}, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 				}
 
 				for _, origin := range origins {

--- a/plugin/sign/setup.go
+++ b/plugin/sign/setup.go
@@ -100,7 +100,7 @@ func parse(c *caddy.Controller) (*Sign, error) {
 					signers[i].signedfile = fmt.Sprintf("db.%ssigned", signers[i].origin)
 				}
 			default:
-				return nil, c.Errf("unknown property '%s'", c.Val())
+				return nil, c.Errf(plugin.UnknownPropertyErrmsg, c.Val())
 			}
 		}
 		sign.signers = append(sign.signers, signers...)

--- a/plugin/template/metrics.go
+++ b/plugin/template/metrics.go
@@ -12,21 +12,21 @@ var (
 	// templateMatchesCount is the counter of template regex matches.
 	templateMatchesCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "template",
+		Subsystem: pluginName,
 		Name:      "matches_total",
 		Help:      "Counter of template regex matches.",
 	}, []string{"server", "zone", "class", "type"})
 	// templateFailureCount is the counter of go template failures.
 	templateFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "template",
+		Subsystem: pluginName,
 		Name:      "template_failures_total",
 		Help:      "Counter of go template failures.",
 	}, []string{"server", "zone", "class", "type", "section", "template"})
 	// templateRRFailureCount is the counter of mis-templated RRs.
 	templateRRFailureCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: plugin.Namespace,
-		Subsystem: "template",
+		Subsystem: pluginName,
 		Name:      "rr_failures_total",
 		Help:      "Counter of mis-templated RRs.",
 	}, []string{"server", "zone", "class", "type", "section", "template"})

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -93,7 +93,7 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		msg.Rcode = template.rcode
 
 		for _, answer := range template.answer {
-			rr, err := executeRRTemplate(metrics.WithServer(ctx), "answer", answer, data)
+			rr, err := executeRRTemplate(metrics.WithServer(ctx), templateAnswer, answer, data)
 			if err != nil {
 				return dns.RcodeServerFailure, err
 			}
@@ -104,14 +104,14 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			}
 		}
 		for _, additional := range template.additional {
-			rr, err := executeRRTemplate(metrics.WithServer(ctx), "additional", additional, data)
+			rr, err := executeRRTemplate(metrics.WithServer(ctx), templateAdditional, additional, data)
 			if err != nil {
 				return dns.RcodeServerFailure, err
 			}
 			msg.Extra = append(msg.Extra, rr)
 		}
 		for _, authority := range template.authority {
-			rr, err := executeRRTemplate(metrics.WithServer(ctx), "authority", authority, data)
+			rr, err := executeRRTemplate(metrics.WithServer(ctx), templateAuthority, authority, data)
 			if err != nil {
 				return dns.RcodeServerFailure, err
 			}

--- a/plugin/transfer/setup.go
+++ b/plugin/transfer/setup.go
@@ -9,8 +9,10 @@ import (
 	"github.com/caddyserver/caddy"
 )
 
+const pluginName = "transfer"
+
 func init() {
-	caddy.RegisterPlugin("transfer", caddy.Plugin{
+	caddy.RegisterPlugin(pluginName, caddy.Plugin{
 		ServerType: "dns",
 		Action:     setup,
 	})
@@ -20,7 +22,7 @@ func setup(c *caddy.Controller) error {
 	t, err := parse(c)
 
 	if err != nil {
-		return plugin.Error("transfer", err)
+		return plugin.Error(pluginName, err)
 	}
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
@@ -90,11 +92,11 @@ func parse(c *caddy.Controller) (*Transfer, error) {
 					x.to = append(x.to, normalized)
 				}
 			default:
-				return nil, plugin.Error("transfer", c.Errf("unknown property '%s'", c.Val()))
+				return nil, plugin.Error(pluginName, c.Errf(plugin.UnknownPropertyErrmsg, c.Val()))
 			}
 		}
 		if len(x.to) == 0 {
-			return nil, plugin.Error("transfer", c.Err("'to' is required"))
+			return nil, plugin.Error(pluginName, c.Err("'to' is required"))
 		}
 		t.xfrs = append(t.xfrs, x)
 	}

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-var log = clog.NewWithPlugin("transfer")
+var log = clog.NewWithPlugin(pluginName)
 
 // Transfer is a plugin that handles zone transfers.
 type Transfer struct {
@@ -178,4 +178,4 @@ func (x xfr) allowed(state request.Request) bool {
 }
 
 // Name implements the Handler interface.
-func (Transfer) Name() string { return "transfer" }
+func (Transfer) Name() string { return pluginName }


### PR DESCRIPTION
Replace duplicate string literals with const values.

Signed-off-by: Ben Kochie <superq@gmail.com>