### PR TITLE
plugin/forward: crash if using https

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -99,8 +99,13 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	}
 
 	transports := make([]string, len(toHosts))
+	allowedTrans := map[string]bool{"dns": true, "tls": true}
 	for i, host := range toHosts {
 		trans, h := parse.Transport(host)
+
+		if !allowedTrans[trans] {
+			return f, fmt.Errorf("'%s' is not supported as a destination protocol in forward: %s", trans, host)
+		}
 		p := NewProxy(h, trans)
 		f.proxies = append(f.proxies, p)
 		transports[i] = trans

--- a/plugin/forward/setup_test.go
+++ b/plugin/forward/setup_test.go
@@ -37,6 +37,7 @@ func TestSetup(t *testing.T) {
 		{"forward . 127.0.0.1 {\nblaatl\n}\n", true, "", nil, 0, options{hcRecursionDesired: true}, "unknown property"},
 		{`forward . ::1
 		forward com ::2`, true, "", nil, 0, options{hcRecursionDesired: true}, "plugin"},
+		{"forward . https://127.0.0.1 \n", true, ".", nil, 2, options{hcRecursionDesired: true}, "'https' is not supported as a destination protocol in forward: https://127.0.0.1"},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Signed-off-by: kadern0 <kerno@gmail.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Verifies 'https' is not being used as destination protocol within the forward plugin.

### 2. Which issues (if any) are related?

Fixes #3816 

### 3. Which documentation changes (if any) need to be made?
N/A
### 4. Does this introduce a backward incompatible change or deprecation?
N/A