### PR TITLE
GitHub action: Update Homebrew formula on new release

### DIFF
--- a/.github/actions/update-homebrew/Dockerfile
+++ b/.github/actions/update-homebrew/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+RUN apk add curl git sed
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/update-homebrew/action.yml
+++ b/.github/actions/update-homebrew/action.yml
@@ -1,0 +1,6 @@
+---
+name: 'Update Homebrew'
+description: 'Updates Homebrew formula in coredns/deployment'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/update-homebrew/entrypoint.sh
+++ b/.github/actions/update-homebrew/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Exit when no release tag (GITHUB_REF) is provided
+[[ -z "$GITHUB_REF" ]] && exit
+
+version=${GITHUB_REF:1}
+sha256="$(curl -sLf "https://github.com/coredns/coredns/releases/download/v${version}/coredns_${version}_darwin_amd64.tgz.sha256")"
+
+# Exit when no hash could be retrieved (e.g. release without published assets)
+[[ -z "$sha256" ]] && exit
+
+# The numbers at the beginning indicate the lines in `coredns.rb`,
+# just to make sure to not replace some other occurrence by accident.
+sed -i \
+  -e "4s|url.*|url \"https://github.com/coredns/coredns/releases/download/v${version}/coredns_${version}_darwin_amd64.tgz\"|" \
+  -e "5s|version.*|version \"$version\"|" \
+  -e "6s|sha256.*|sha256 \"${sha256%% *}\"|" \
+  "${CHECKOUT_PATH:-.}/HomebrewFormula/coredns.rb"

--- a/.github/workflows/update.deployment.yml
+++ b/.github/workflows/update.deployment.yml
@@ -1,0 +1,38 @@
+name: update homebrew deployment
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'coredns/deployment'
+          path: deployment
+      -
+        name: Update Homebrew formula
+        uses: ./.github/actions/update-homebrew
+        env:
+          CHECKOUT_PATH: 'deployment'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "coredns-auto-homebrew-deployment[bot]"
+          git config user.email "coredns-auto-go-homebrew-deployment[bot]@users.noreply.github.com"
+      -
+        name: Commit and push changes
+        run: |
+          cd deployment
+          git add HomebrewFormula/coredns.rb
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'auto update homebrew formula to ${GITHUB_REF}'
+            git push
+          fi


### PR DESCRIPTION
This action checks out `coredns/deployment` and replaces values in `HomebrewFormula/coredns.rb` with the one from the new release tag (`GITHUB_REF`): version, download URL and SHA256 hash.

---

I already updated the Homebrew formula a couple of times manually in the past, but this is a bit tedious on every release and is sometimes forgotten. That's why I'm giving GitHub Actions a try.

Of course I couldn't test the Git push workflow itself (I took that from the other actions), also I'm not sure if `on release (published)` is the right trigger (as the assets may not be ready by the time the release is published), this still needs some testing.

However, the core logic in the Bash file works, and the values are replaced successfully. The script also detects if there are no assets for a release (e.g. for v1.6.8).

It would be great if you could have a look at it so macOS users get regular updates for coredns over Homebrew as well.

/cc @chrisohaver @miekg 