### PR TITLE
Remove grobie from maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # @miekg, miek@miek.nl, project lead: 11/11/2020
 
-*                       @bradbeam @chrisohaver @dilyevsky @fastest963 @greenpau @grobie @isolus @johnbelamaric @miekg @pmoroney @rajansandeep @stp-ip @superq @yongtang
+*                       @bradbeam @chrisohaver @dilyevsky @fastest963 @greenpau @isolus @johnbelamaric @miekg @pmoroney @rajansandeep @stp-ip @superq @yongtang
 
 /plugin/pkg/            @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /coremain/              @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
@@ -17,7 +17,7 @@ go.mod                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /plugin/azure/          @miekg @yongtang @darshanime
 /plugin/bind/           @miekg
 /plugin/bufsize/        @ykhr53
-/plugin/cache/          @grobie @miekg
+/plugin/cache/          @miekg
 /plugin/cancel/         @miekg
 /plugin/chaos/          @miekg
 /plugin/clouddns/       @miekg @yongtang
@@ -27,7 +27,7 @@ go.mod                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /plugin/errors/         @miekg
 /plugin/etcd/           @miekg @nitisht
 /plugin/file/           @miekg @yongtang @stp-ip
-/plugin/forward/        @grobie @johnbelamaric @miekg @rdrozhdzh
+/plugin/forward/        @johnbelamaric @miekg @rdrozhdzh
 /plugin/grpc/           @inigohu @miekg
 /plugin/health/         @fastest963 @miekg
 /plugin/hosts/          @johnbelamaric @pmoroney

--- a/plugin/chaos/zowners.go
+++ b/plugin/chaos/zowners.go
@@ -1,4 +1,4 @@
 package chaos
 
 // Owners are all GitHub handlers of all maintainers.
-var Owners = []string{"bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "fastest963", "greenpau", "grobie", "ihac", "inigohu", "isolus", "johnbelamaric", "miekg", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang"}
+var Owners = []string{"bradbeam", "chrisohaver", "darshanime", "dilyevsky", "ekleiner", "fastest963", "greenpau", "ihac", "inigohu", "isolus", "johnbelamaric", "miekg", "nchrisdk", "nitisht", "pmoroney", "rajansandeep", "rdrozhdzh", "rtreffer", "stp-ip", "superq", "varyoo", "ykhr53", "yongtang"}


### PR DESCRIPTION
I haven't been maintaining production DNS setups in quite a while and
don't have the time to review CoreDNS pull requests. Hereby I resign
from all positions in the CoreDNS project.

CoreDNS is a great project and SoundCloud still processes hundreds of
thousands of requests per second with the help of CoreDNS. Thanks a lot
for your hard work and all the best for the future.