### PR TITLE
Fix to bug 3810

### DIFF
--- a/plugin/etcd/lookup_test.go
+++ b/plugin/etcd/lookup_test.go
@@ -131,9 +131,9 @@ var dnsTestCases = []test.Case{
 	},
 	// TXT Test
 	{
-		Qname: "server1.prod.region1.skydns.test.", Qtype: dns.TypeTXT,
+		Qname: "txt.server1.prod.region1.skydns.test.", Qtype: dns.TypeTXT,
 		Answer: []dns.RR{
-			test.TXT("server1.prod.region1.skydns.test. 303 IN TXT sometext"),
+			test.TXT("txt.server1.prod.region1.skydns.test. 303 IN TXT sometext"),
 		},
 	},
 	// Wildcard Test


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Hopefully it's a fix to:
https://github.com/coredns/coredns/issues/3810

I added a comment to the issue in which I provided more details.

In short:
The error was introduced in e3266d2 with the change in the line number 330, to be more specific:
value of "exact" parameter was changed from "false" to "true".

As a result of that change, when we make TXT record lookup in etcd, there needs to be an exact match between the value we look up for and the key in etcd.

in lookup_test.go we have the following record definition:
```
// TXT record in server1.
	{Host: "", Port: 8080, Text: "sometext", Key: "txt.server1.prod.region1.skydns.test."},
```

This record is stored in etcd. Later on, in our test case we  look up for that record:
```
	// TXT Test
	{
		Qname: "server1.prod.region1.skydns.test.", Qtype: dns.TypeTXT,
		Answer: []dns.RR{
			test.TXT("server1.prod.region1.skydns.test. 303 IN TXT sometext"),
		},
	},
```

As you can see:
QName!=Key -> that's why the record will not be found in etcd using exact match. 

After my proposed change the test runs successfully.

### 2. Which issues (if any) are related?
https://github.com/coredns/coredns/issues/3810


### 3. Which documentation changes (if any) need to be made?
No changes

### 4. Does this introduce a backward incompatible change or deprecation?
No.