### PR TITLE
Fix readme test by removing extra `~`

### DIFF
--- a/plugin/dns64/README.md
+++ b/plugin/dns64/README.md
@@ -49,7 +49,7 @@ Use a custom prefix.
 . {
     dns64 64:1337::/96
 }
-~~~~
+~~~
 
 Or
 ~~~ corefile


### PR DESCRIPTION
This PR removing extra `~` as it was causing test failure:
```
--- FAIL: TestReadme (0.05s)
476    readme_test.go:81: Failed to start server with ../plugin/dns64/README.md, for input "Corefile:6 - Error during parsing: Unknown directive 'Or'":
477        . {
478            dns64 64:1337::/96
479        }
480        ~~~~
481
482        Or
483        . {
484            dns64 {
485                prefix 64:1337::/96
486            }
487        }
488FAIL
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
