### PR TITLE
plugin/transfer: Mention that the transfer plugin is not implemented by any plugins

### DIFF
--- a/plugin/transfer/README.md
+++ b/plugin/transfer/README.md
@@ -7,7 +7,7 @@
 ## Description
 
 This plugin answers zone transfers for authoritative plugins that implement
-`transfer.Transferer`.
+`transfer.Transferer`.  Currently, no internal plugins implement this interface.
 
 Transfer answers full zone transfer (AXFR) requests and incremental zone transfer (IXFR) requests
 with AXFR fallback if the zone has changed.


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Clarifies that no internal plugins currently implement the transfer plugin interface.

### 2. Which issues (if any) are related?

#3849

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
