### PR TITLE
plugin/file: return downward referral to SOA query matching delegation

### DIFF
--- a/plugin/file/delegation_test.go
+++ b/plugin/file/delegation_test.go
@@ -14,47 +14,23 @@ import (
 var delegationTestCases = []test.Case{
 	{
 		Qname: "a.delegated.miek.nl.", Qtype: dns.TypeTXT,
-		Ns: []dns.RR{
-			test.NS("delegated.miek.nl.	1800	IN	NS	a.delegated.miek.nl."),
-			test.NS("delegated.miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
-		},
-		Extra: []dns.RR{
-			test.A("a.delegated.miek.nl. 1800 IN A 139.162.196.78"),
-			test.AAAA("a.delegated.miek.nl. 1800 IN AAAA 2a01:7e00::f03c:91ff:fef1:6735"),
-		},
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
 	},
 	{
 		Qname: "delegated.miek.nl.", Qtype: dns.TypeNS,
-		Ns: []dns.RR{
-			test.NS("delegated.miek.nl.	1800	IN	NS	a.delegated.miek.nl."),
-			test.NS("delegated.miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
-		},
-		Extra: []dns.RR{
-			test.A("a.delegated.miek.nl. 1800 IN A 139.162.196.78"),
-			test.AAAA("a.delegated.miek.nl. 1800 IN AAAA 2a01:7e00::f03c:91ff:fef1:6735"),
-		},
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
 	},
 	{
 		Qname: "foo.delegated.miek.nl.", Qtype: dns.TypeA,
-		Ns: []dns.RR{
-			test.NS("delegated.miek.nl.	1800	IN	NS	a.delegated.miek.nl."),
-			test.NS("delegated.miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
-		},
-		Extra: []dns.RR{
-			test.A("a.delegated.miek.nl. 1800 IN A 139.162.196.78"),
-			test.AAAA("a.delegated.miek.nl. 1800 IN AAAA 2a01:7e00::f03c:91ff:fef1:6735"),
-		},
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
 	},
 	{
 		Qname: "foo.delegated.miek.nl.", Qtype: dns.TypeTXT,
-		Ns: []dns.RR{
-			test.NS("delegated.miek.nl.	1800	IN	NS	a.delegated.miek.nl."),
-			test.NS("delegated.miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
-		},
-		Extra: []dns.RR{
-			test.A("a.delegated.miek.nl. 1800 IN A 139.162.196.78"),
-			test.AAAA("a.delegated.miek.nl. 1800 IN AAAA 2a01:7e00::f03c:91ff:fef1:6735"),
-		},
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
 	},
 	{
 		Qname: "miek.nl.", Qtype: dns.TypeSOA,
@@ -68,6 +44,16 @@ var delegationTestCases = []test.Case{
 		Ns: []dns.RR{
 			test.SOA("miek.nl.	1800	IN	SOA	linode.atoom.net. miek.miek.nl. 1282630057 14400 3600 604800 14400"),
 		},
+	},
+	{
+		Qname: "delegated.miek.nl.", Qtype: dns.TypeSOA,
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
+	},
+	{
+		Qname: "foo.delegated.miek.nl.", Qtype: dns.TypeSOA,
+		Ns:    delegatedMiekAuth,
+		Extra: delegatedMiekExtra,
 	},
 }
 
@@ -148,6 +134,16 @@ var miekAuth = []dns.RR{
 	test.NS("miek.nl.	1800	IN	NS	linode.atoom.net."),
 	test.NS("miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
 	test.NS("miek.nl.	1800	IN	NS	omval.tednet.nl."),
+}
+
+var delegatedMiekAuth = []dns.RR{
+	test.NS("delegated.miek.nl.	1800	IN	NS	a.delegated.miek.nl."),
+	test.NS("delegated.miek.nl.	1800	IN	NS	ns-ext.nlnetlabs.nl."),
+}
+
+var delegatedMiekExtra = []dns.RR{
+	test.A("a.delegated.miek.nl.	1800	IN	A	139.162.196.78"),
+	test.AAAA("a.delegated.miek.nl.	1800	IN	AAAA	2a01:7e00::f03c:91ff:fef1:6735"),
 }
 
 func TestLookupDelegation(t *testing.T) {

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -44,7 +44,7 @@ func (z *Zone) Lookup(ctx context.Context, state request.Request, qname string) 
 		return nil, nil, nil, ServerFailure
 	}
 
-	if qtype == dns.TypeSOA {
+	if qtype == dns.TypeSOA && qname == z.origin {
 		return ap.soa(do), ap.ns(do), nil, Success
 	}
 	if qtype == dns.TypeNS && qname == z.origin {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Addresses a bug in the file plugin where SOA queries to zone delegations are inappropriately returned the SOA for the delegating zone, and not a downward referral to the delegated zone.

Here is an example of what I believe the expected downward referral in response to a SOA query for a delegated zone should be (note that no SOA record is returned):
```
; <<>> DiG 9.11.3-1ubuntu1.5-Ubuntu <<>> @k.root-servers.net. miek.nl. SOA
; (2 servers found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58381
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 3, ADDITIONAL: 7
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;miek.nl.                       IN      SOA

;; AUTHORITY SECTION:
nl.                     172800  IN      NS      ns1.dns.nl.
nl.                     172800  IN      NS      ns2.dns.nl.
nl.                     172800  IN      NS      ns3.dns.nl.

;; ADDITIONAL SECTION:
ns1.dns.nl.             172800  IN      A       194.0.28.53
ns2.dns.nl.             172800  IN      A       194.146.106.42
ns3.dns.nl.             172800  IN      A       194.0.25.24
ns1.dns.nl.             172800  IN      AAAA    2001:678:2c:0:194:0:28:53
ns2.dns.nl.             172800  IN      AAAA    2001:67c:1010:10::53
ns3.dns.nl.             172800  IN      AAAA    2001:678:20::24
```

### 2. Which issues (if any) are related?
Nil.

### 3. Which documentation changes (if any) need to be made?
Nil.

### 4. Does this introduce a backward incompatible change or deprecation?
No. It's a bug-fix for a relatively obscure query.