### PR TITLE
Fix mixed indentation within tests

### DIFF
--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -22,8 +22,7 @@ func TestAuto(t *testing.T) {
 			directory ` + tmpdir + ` db\.(.*) {1}
 			reload 1s
 		}
-	}
-`
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
@@ -82,8 +81,7 @@ func TestAutoNonExistentZone(t *testing.T) {
 			reload 1s
 		}
 		errors stdout
-	}
-`
+	}`
 
 	i, err := CoreDNSServer(corefile)
 	if err != nil {
@@ -121,8 +119,7 @@ func TestAutoAXFR(t *testing.T) {
 			reload 1s
 			transfer to *
 		}
-	}
-`
+	}`
 
 	i, err := CoreDNSServer(corefile)
 	if err != nil {
@@ -160,9 +157,9 @@ func TestAutoAXFR(t *testing.T) {
 }
 
 const zoneContent = `; testzone
-@	IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2016082534 7200 3600 1209600 3600
-		NS	a.iana-servers.net.
-		NS	b.iana-servers.net.
+@   IN SOA sns.dns.icann.org. noc.dns.icann.org. 2016082534 7200 3600 1209600 3600
+    IN NS  a.iana-servers.net.
+    IN NS  b.iana-servers.net.
 
-www IN A 127.0.0.1
+www IN A   127.0.0.1
 `

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -17,9 +17,9 @@ func TestLookupCache(t *testing.T) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -28,10 +28,10 @@ func TestLookupCache(t *testing.T) {
 
 	// Start caching forward CoreDNS that we want to test.
 	corefile = `example.org:0 {
-	forward . ` + udp + `
-	cache 10
-}
-`
+		forward . ` + udp + `
+		cache 10
+	}`
+
 	i, udp, _, err = CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/chaos_test.go
+++ b/test/chaos_test.go
@@ -13,8 +13,7 @@ import (
 func TestChaos(t *testing.T) {
 	corefile := `.:0 {
 		chaos
-}
-`
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/compression_scrub_test.go
+++ b/test/compression_scrub_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestCompressScrub(t *testing.T) {
 	corefile := `example.org:0 {
-                       erratic {
-			  drop 0
-			  delay 0
-			  large
-		       }
-		     }`
+		erratic {
+			drop 0
+			delay 0
+			large
+		}
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/ds_file_test.go
+++ b/test/ds_file_test.go
@@ -35,9 +35,8 @@ func TestLookupDS(t *testing.T) {
 	defer rm()
 
 	corefile := `miek.nl:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/edns0_test.go
+++ b/test/edns0_test.go
@@ -9,8 +9,7 @@ import (
 func TestEDNS0(t *testing.T) {
 	corefile := `.:0 {
 		whoami
-}
-`
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -17,7 +17,7 @@ func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
 	defer os.Remove(tmpdir)
 
 	content := `
-example.org. IN	SOA sns.dns.icann.org. noc.dns.icann.org. 1 3600 3600 3600 3600
+example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 1 3600 3600 3600 3600
 
 google.com. IN SOA ns1.google.com. dns-admin.google.com. 1 3600 3600 3600 3600
 google.com. IN A 172.217.25.110
@@ -30,9 +30,9 @@ google.com. IN A 172.217.25.110
 	defer os.Remove(path)
 
 	corefile := `.:0 {
-	file ` + path + `
-}
-`
+		file ` + path + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get proxy target CoreDNS serving instance: %s", err)
@@ -45,12 +45,12 @@ google.com. IN A 172.217.25.110
 func TestLookupAutoPathErratic(t *testing.T) {
 	setupProxyTargetCoreDNS(t, func(proxyPath string) {
 		corefile := `.:0 {
-		erratic
-		autopath @erratic
-		forward . ` + proxyPath + `
-		debug
-		}
-`
+			erratic
+			autopath @erratic
+			forward . ` + proxyPath + `
+			debug
+		}`
+
 		i, udp, _, err := CoreDNSServerAndPorts(corefile)
 		if err != nil {
 			t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -91,11 +91,11 @@ func TestLookupAutoPathErratic(t *testing.T) {
 func TestAutoPathErraticNotLoaded(t *testing.T) {
 	setupProxyTargetCoreDNS(t, func(proxyPath string) {
 		corefile := `.:0 {
-	autopath @erratic
-	forward . ` + proxyPath + `
-	debug
-    }
-`
+			autopath @erratic
+			forward . ` + proxyPath + `
+			debug
+		}`
+
 		i, err := CoreDNSServer(corefile)
 		if err != nil {
 			t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/etcd_cache_test.go
+++ b/test/etcd_cache_test.go
@@ -15,11 +15,11 @@ import (
 
 func TestEtcdCache(t *testing.T) {
 	corefile := `.:0 {
-    etcd skydns.test {
-        path /skydns
-    }
-    cache skydns.test
-}`
+		etcd skydns.test {
+			path /skydns
+		}
+		cache skydns.test
+	}`
 
 	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/etcd_credentials_test.go
+++ b/test/etcd_credentials_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestEtcdCredentials(t *testing.T) {
 	corefile := `.:0 {
-    etcd skydns.test {
-        path /skydns
-    }
-}`
+		etcd skydns.test {
+			path /skydns
+		}
+	}`
 
 	ex, _, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/etcd_test.go
+++ b/test/etcd_test.go
@@ -41,15 +41,15 @@ func TestEtcdStubLoop(t *testing.T) {
 
 func TestEtcdStubAndProxyLookup(t *testing.T) {
 	corefile := `.:0 {
-    etcd skydns.local {
-        stubzones
-        path /skydns
-        endpoint http://localhost:2379
-        upstream
-	fallthrough
-    }
-    forward . 8.8.8.8:53
-}`
+		etcd skydns.local {
+			stubzones
+			path /skydns
+			endpoint http://localhost:2379
+			upstream
+			fallthrough
+		}
+		forward . 8.8.8.8:53
+	}`
 
 	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/example_test.go
+++ b/test/example_test.go
@@ -2,15 +2,15 @@ package test
 
 const exampleOrg = `; example.org test file
 $TTL 3600
-@		IN	SOA	sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
-@		IN	NS	b.iana-servers.net.
-@		IN	NS	a.iana-servers.net.
-@		IN	A	127.0.0.1
-@		IN	A	127.0.0.2
-short	1	IN	A	127.0.0.3
+@            IN  SOA    sns.dns.icann.org. noc.dns.icann.org. 2015082541 7200 3600 1209600 3600
+@            IN  NS     b.iana-servers.net.
+@            IN  NS     a.iana-servers.net.
+@            IN  A      127.0.0.1
+@            IN  A      127.0.0.2
+short   1    IN  A      127.0.0.3
 
-*.w        3600 IN      TXT     "Wildcard"
-a.b.c.w    IN      TXT     "Not a wildcard"
-cname      IN      CNAME   www.example.net.
-service    IN      SRV     8080 10 10 @
+*.w     3600 IN  TXT    "Wildcard"
+a.b.c.w      IN  TXT    "Not a wildcard"
+cname        IN  CNAME  www.example.net.
+service      IN  SRV    8080 10 10 @
 `

--- a/test/file_cname_proxy_test.go
+++ b/test/file_cname_proxy_test.go
@@ -19,9 +19,9 @@ func TestZoneExternalCNAMELookupWithoutProxy(t *testing.T) {
 
 	// Corefile with for example without proxy section.
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -51,12 +51,12 @@ func TestZoneExternalCNAMELookupWithProxy(t *testing.T) {
 
 	// Corefile with for example proxy section.
 	corefile := `.:0 {
-       file ` + name + ` example.org {
-	       upstream
-	}
-	forward . 8.8.8.8 8.8.4.4
-}
-`
+		file ` + name + ` example.org {
+			upstream
+		}
+		forward . 8.8.8.8 8.8.4.4
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -18,16 +18,16 @@ func TestZoneReload(t *testing.T) {
 	defer rm()
 
 	// Corefile with two stanzas
-	corefile := `example.org:0 {
-       file ` + name + ` {
-           reload 1s
-       }
-}
+	corefile := `
+	example.org:0 {
+		file ` + name + ` {
+			reload 1s
+		}
+	}
+	example.net:0 {
+		file ` + name + `
+	}`
 
-example.net:0 {
-	file ` + name + `
-}
-`
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/file_serve_test.go
+++ b/test/file_serve_test.go
@@ -12,19 +12,19 @@ func TestZoneEDNS0Lookup(t *testing.T) {
 	t.Parallel()
 
 	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
-@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
-		2017042745 ; serial
-		7200       ; refresh (2 hours)
-		3600       ; retry (1 hour)
-		1209600    ; expire (2 weeks)
-		3600       ; minimum (1 hour)
-	)
+@ 3600 IN SOA  sns.dns.icann.org. noc.dns.icann.org. (
+        2017042745 ; serial
+        7200       ; refresh (2 hours)
+        3600       ; retry (1 hour)
+        1209600    ; expire (2 weeks)
+        3600       ; minimum (1 hour)
+)
 
-        3600 IN NS a.iana-servers.net.
-	3600 IN NS b.iana-servers.net.
+  3600 IN NS   a.iana-servers.net.
+  3600 IN NS   b.iana-servers.net.
 
-www     IN A 127.0.0.1
-www     IN AAAA ::1
+www    IN A    127.0.0.1
+www    IN AAAA ::1
 `)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
@@ -33,9 +33,9 @@ www     IN AAAA ::1
 
 	// Corefile with for example without proxy section.
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -59,7 +59,7 @@ func TestZoneNoNS(t *testing.T) {
 	t.Parallel()
 
 	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
-@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
+@ 3600 IN SOA  sns.dns.icann.org. noc.dns.icann.org. (
 		2017042745 ; serial
 		7200       ; refresh (2 hours)
 		3600       ; retry (1 hour)
@@ -67,8 +67,8 @@ func TestZoneNoNS(t *testing.T) {
 		3600       ; minimum (1 hour)
 	)
 
-www     IN A 127.0.0.1
-www     IN AAAA ::1
+www    IN A    127.0.0.1
+www    IN AAAA ::1
 `)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
@@ -77,9 +77,9 @@ www     IN AAAA ::1
 
 	// Corefile with for example without proxy section.
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/file_srv_additional_test.go
+++ b/test/file_srv_additional_test.go
@@ -19,9 +19,9 @@ func TestZoneSRVAdditional(t *testing.T) {
 
 	// Corefile with for example without proxy section.
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/file_upstream_test.go
+++ b/test/file_upstream_test.go
@@ -10,18 +10,18 @@ import (
 
 func TestFileUpstream(t *testing.T) {
 	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
-@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. (
-		2017042745 ; serial
-		7200       ; refresh (2 hours)
-		3600       ; retry (1 hour)
-		1209600    ; expire (2 weeks)
-		3600       ; minimum (1 hour)
-	)
+@	3600 IN	SOA   sns.dns.icann.org. noc.dns.icann.org. (
+        2017042745 ; serial
+        7200       ; refresh (2 hours)
+        3600       ; retry (1 hour)
+        1209600    ; expire (2 weeks)
+        3600       ; minimum (1 hour)
+)
 
-        3600 IN NS a.iana-servers.net.
-	3600 IN NS b.iana-servers.net.
+    3600 IN NS    a.iana-servers.net.
+    3600 IN NS    b.iana-servers.net.
 
-www 3600 IN CNAME   www.example.net.
+www 3600 IN CNAME www.example.net.
 `)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
@@ -29,15 +29,15 @@ www 3600 IN CNAME   www.example.net.
 	defer rm()
 
 	corefile := `.:0 {
-	file ` + name + ` example.org {
-	       upstream
-	}
-	hosts {
-               10.0.0.1 www.example.net.
-               fallthrough
-       }
-}
-`
+		file ` + name + ` example.org {
+			upstream
+		}
+		hosts {
+			10.0.0.1 www.example.net.
+			fallthrough
+		}
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -64,11 +64,11 @@ www 3600 IN CNAME   www.example.net.
 // example.org contains a cname to foo.example.org; this should be resolved via upstream.Self.
 func TestFileUpstreamAdditional(t *testing.T) {
 	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
-@	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
+@	3600 IN	SOA   sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
 
-	3600 IN NS b.iana-servers.net.
+    3600 IN NS    b.iana-servers.net.
 
-www 3600 IN CNAME   www.foo
+www 3600 IN CNAME www.foo
 `)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
@@ -78,7 +78,7 @@ www 3600 IN CNAME   www.foo
 	name2, rm2, err2 := test.TempFile(".", `$ORIGIN foo.example.org.
 @	3600 IN	SOA sns.dns.icann.org. noc.dns.icann.org. 2017042745 7200 3600 1209600 3600
 
-	3600 IN NS b.iana-servers.net.
+    3600 IN NS  b.iana-servers.net.
 
 www 3600 IN A   127.0.0.53
 `)
@@ -88,14 +88,14 @@ www 3600 IN A   127.0.0.53
 	defer rm2()
 
 	corefile := `.:0 {
-	file ` + name + ` example.org {
-	       upstream
-	}
-	file ` + name2 + ` foo.example.org {
-	       upstream
-	}
-}
-`
+		file ` + name + ` example.org {
+			upstream
+		}
+		file ` + name2 + ` foo.example.org {
+			upstream
+		}
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/file_xfr_test.go
+++ b/test/file_xfr_test.go
@@ -29,11 +29,11 @@ func TestLargeAXFR(t *testing.T) {
 	defer rm()
 
 	corefile := `example.com:0 {
-       file ` + name + ` {
-           transfer to *
-       }
-}
-`
+		file ` + name + ` {
+			transfer to *
+		}
+	}`
+
 	// Start server, and send an AXFR query to the TCP port. We set the deadline to prevent the test from hanging.
 	i, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/grpc_test.go
+++ b/test/grpc_test.go
@@ -14,8 +14,8 @@ import (
 func TestGrpc(t *testing.T) {
 	corefile := `grpc://.:0 {
 		whoami
-}
-`
+	}`
+
 	g, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/hosts_file_test.go
+++ b/test/hosts_file_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestHostsInlineLookup(t *testing.T) {
 	corefile := `example.org:0 {
-                       hosts highly_unlikely_to_exist_hosts_file example.org {
-                         10.0.0.1 example.org
-                         fallthrough
-                      }
-                    }`
+		hosts highly_unlikely_to_exist_hosts_file example.org {
+			10.0.0.1 example.org
+			fallthrough
+		}
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/miek_test.go
+++ b/test/miek_test.go
@@ -4,28 +4,28 @@ const miekNL = `; miek.nl test zone
 $TTL    30M
 $ORIGIN miek.nl.
 @       IN      SOA     linode.atoom.net. miek.miek.nl. (
-			     1282630059 ; Serial
-                             4H         ; Refresh
-                             1H         ; Retry
-                             7D         ; Expire
-                             4H )       ; Negative Cache TTL
-                IN      NS      linode.atoom.net.
-		IN	NS	ns-ext.nlnetlabs.nl.
-		IN	NS	omval.tednet.nl.
-                IN      NS      ext.ns.whyscream.net.
+        1282630059 ; Serial
+        4H         ; Refresh
+        1H         ; Retry
+        7D         ; Expire
+        4H )       ; Negative Cache TTL
+        IN  NS     linode.atoom.net.
+        IN  NS     ns-ext.nlnetlabs.nl.
+        IN  NS     omval.tednet.nl.
+        IN  NS     ext.ns.whyscream.net.
 
-                IN      MX      1  aspmx.l.google.com.
-                IN      MX      5  alt1.aspmx.l.google.com.
-                IN      MX      5  alt2.aspmx.l.google.com.
-                IN      MX      10 aspmx2.googlemail.com.
-                IN      MX      10 aspmx3.googlemail.com.
+        IN  MX     1  aspmx.l.google.com.
+        IN  MX     5  alt1.aspmx.l.google.com.
+        IN  MX     5  alt2.aspmx.l.google.com.
+        IN  MX     10 aspmx2.googlemail.com.
+        IN  MX     10 aspmx3.googlemail.com.
 
-		IN 	A       176.58.119.54
-		IN 	AAAA    2a01:7e00::f03c:91ff:fe79:234c
-                IN      HINFO "Please stop asking for ANY" "See draft-ietf-dnsop-refuse-any"
+        IN  A      176.58.119.54
+        IN  AAAA   2a01:7e00::f03c:91ff:fe79:234c
+        IN  HINFO  "Please stop asking for ANY" "See draft-ietf-dnsop-refuse-any"
 
-a		IN 	A       176.58.119.54
-		IN 	AAAA    2a01:7e00::f03c:91ff:fe79:234c
-www     	IN 	CNAME 	a
-archive         IN      CNAME   a
+a       IN  A      176.58.119.54
+        IN  AAAA   2a01:7e00::f03c:91ff:fe79:234c
+www     IN  CNAME  a
+archive IN  CNAME  a
 `

--- a/test/plugin_dnssec_test.go
+++ b/test/plugin_dnssec_test.go
@@ -21,14 +21,14 @@ func TestLookupBalanceRewriteCacheDnssec(t *testing.T) {
 	defer rm1()
 
 	corefile := `example.org:0 {
-    file ` + name + `
-    rewrite type ANY HINFO
-    dnssec {
-        key file ` + base + `
-    }
-    loadbalance
-}
-`
+		file ` + name + `
+		rewrite type ANY HINFO
+		dnssec {
+			key file ` + base + `
+		}
+		loadbalance
+	}`
+
 	ex, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/proxy_health_test.go
+++ b/test/proxy_health_test.go
@@ -15,8 +15,7 @@ func TestProxyThreeWay(t *testing.T) {
 		erratic {
 			drop 2
 		}
-	}
-`
+	}`
 
 	up1, err := CoreDNSServer(corefileUp1)
 	if err != nil {
@@ -26,8 +25,7 @@ func TestProxyThreeWay(t *testing.T) {
 
 	corefileUp2 := `example.org:0 {
 		whoami
-	}
-`
+	}`
 
 	up2, err := CoreDNSServer(corefileUp2)
 	if err != nil {

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -17,9 +17,8 @@ func TestLookupProxy(t *testing.T) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
@@ -54,9 +53,8 @@ func BenchmarkProxyLookup(b *testing.B) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
 
 	i, err := CoreDNSServer(corefile)
 	if err != nil {

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestReload(t *testing.T) {
 	corefile := `.:0 {
-	whoami
-}
-`
+		whoami
+	}`
+
 	coreInput := NewInput(corefile)
 
 	c, err := CoreDNSServer(corefile)
@@ -60,11 +60,11 @@ func send(t *testing.T, server string) {
 }
 
 func TestReloadHealth(t *testing.T) {
-	corefile := `
-.:0 {
-	health 127.0.0.1:52182
-	whoami
-}`
+	corefile := `.:0 {
+		health 127.0.0.1:52182
+		whoami
+	}`
+
 	c, err := CoreDNSServer(corefile)
 	if err != nil {
 		if strings.Contains(err.Error(), inUse) {
@@ -81,12 +81,12 @@ func TestReloadHealth(t *testing.T) {
 }
 
 func TestReloadMetricsHealth(t *testing.T) {
-	corefile := `
-.:0 {
-	prometheus 127.0.0.1:53183
-	health 127.0.0.1:53184
-	whoami
-}`
+	corefile := `.:0 {
+		prometheus 127.0.0.1:53183
+		health 127.0.0.1:53184
+		whoami
+	}`
+
 	c, err := CoreDNSServer(corefile)
 	if err != nil {
 		if strings.Contains(err.Error(), inUse) {
@@ -154,15 +154,14 @@ func TestReloadSeveralTimeMetrics(t *testing.T) {
 	// that is not used in another test
 	promAddress := "127.0.0.1:53185"
 	proc := "coredns_build_info"
-	corefileWithMetrics := `
-	.:0 {
+	corefileWithMetrics := `.:0 {
 		prometheus ` + promAddress + `
 		whoami
 	}`
-	corefileWithoutMetrics := `
-	.:0 {
+	corefileWithoutMetrics := `.:0 {
 		whoami
 	}`
+
 	if err := collectMetricsInfo(promAddress, proc); err == nil {
 		t.Errorf("Prometheus is listening before the test started")
 	}
@@ -211,14 +210,14 @@ func TestMetricsAvailableAfterReload(t *testing.T) {
 	procMetric := "coredns_build_info"
 	procCache := "coredns_cache_entries"
 	procForward := "coredns_dns_request_duration_seconds"
-	corefileWithMetrics := `
-	.:0 {
+	corefileWithMetrics := `.:0 {
 		prometheus ` + promAddress + `
 		cache
 		forward . 8.8.8.8 {
-           force_tcp
+			force_tcp
 		}
 	}`
+
 	inst, _, tcp, err := CoreDNSServerAndPorts(corefileWithMetrics)
 	if err != nil {
 		if strings.Contains(err.Error(), inUse) {
@@ -265,23 +264,22 @@ func TestMetricsAvailableAfterReloadAndFailedReload(t *testing.T) {
 	procMetric := "coredns_build_info"
 	procCache := "coredns_cache_entries"
 	procForward := "coredns_dns_request_duration_seconds"
-	corefileWithMetrics := `
-	.:0 {
+	corefileWithMetrics := `.:0 {
 		prometheus ` + promAddress + `
 		cache
 		forward . 8.8.8.8 {
-           force_tcp
+			force_tcp
 		}
 	}`
-	invalidCorefileWithMetrics := `
-	.:0 {
+	invalidCorefileWithMetrics := `.:0 {
 		prometheus ` + promAddress + `
 		cache
 		forward . 8.8.8.8 {
-           force_tcp
+			force_tcp
 		}
 		invalid
 	}`
+
 	inst, _, tcp, err := CoreDNSServerAndPorts(corefileWithMetrics)
 	if err != nil {
 		if strings.Contains(err.Error(), inUse) {

--- a/test/rewrite_test.go
+++ b/test/rewrite_test.go
@@ -10,12 +10,12 @@ import (
 func TestRewrite(t *testing.T) {
 	t.Parallel()
 	corefile := `.:0 {
-       rewrite type MX a
-       rewrite edns0 local set 0xffee hello-world
-       erratic . {
-	drop 0
-	}
-}`
+		rewrite type MX a
+		rewrite edns0 local set 0xffee hello-world
+		erratic . {
+			drop 0
+		}
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/secondary_test.go
+++ b/test/secondary_test.go
@@ -15,8 +15,7 @@ func TestEmptySecondaryZone(t *testing.T) {
 		secondary {
 			transfer from 127.0.0.1:1717
 		}
-	}
-`
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
@@ -43,11 +42,10 @@ func TestSecondaryZoneTransfer(t *testing.T) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + ` {
-	       transfer to *
-       }
-}
-`
+		file ` + name + ` {
+			transfer to *
+		}
+	}`
 
 	i, _, tcp, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
@@ -59,8 +57,8 @@ func TestSecondaryZoneTransfer(t *testing.T) {
 		secondary {
 			transfer from ` + tcp + `
 		}
-}
-`
+	}`
+
 	i1, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -93,11 +91,10 @@ func TestIxfrResponse(t *testing.T) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + ` {
-	       transfer to *
-       }
-}
-`
+		file ` + name + ` {
+		transfer to *
+		}
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {

--- a/test/server_reverse_test.go
+++ b/test/server_reverse_test.go
@@ -11,8 +11,8 @@ func TestClasslessReverse(t *testing.T) {
 	// 25 -> so anything above 1.127 won't be answered, below is OK.
 	corefile := `192.168.1.0/25:0 {
 		whoami
-}
-`
+	}`
+
 	s, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -51,8 +51,8 @@ func TestClasslessReverse(t *testing.T) {
 func TestReverse(t *testing.T) {
 	corefile := `192.168.1.0/24:0 {
 		whoami
-}
-`
+	}`
+
 	s, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -97,8 +97,8 @@ func TestReverse(t *testing.T) {
 func TestReverseInAddr(t *testing.T) {
 	corefile := `1.168.192.in-addr.arpa:0 {
 		whoami
-}
-`
+	}`
+
 	s, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -10,9 +10,9 @@ import (
 func TestProxyToChaosServer(t *testing.T) {
 	t.Parallel()
 	corefile := `.:0 {
-	chaos CoreDNS-001 miek@miek.nl
-}
-`
+		chaos CoreDNS-001 miek@miek.nl
+	}`
+
 	chaos, udpChaos, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)
@@ -22,8 +22,8 @@ func TestProxyToChaosServer(t *testing.T) {
 
 	corefileProxy := `.:0 {
 		forward . ` + udpChaos + `
-}
-`
+	}`
+
 	proxy, udp, _, err := CoreDNSServerAndPorts(corefileProxy)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance")

--- a/test/template_upstream_test.go
+++ b/test/template_upstream_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestTemplateUpstream(t *testing.T) {
 	corefile := `.:0 {
- 		# CNAME
+		# CNAME
 		template IN ANY cname.example.net. {
 			match ".*"
 			answer "cname.example.net. 60 IN CNAME target.example.net."
@@ -20,8 +20,8 @@ func TestTemplateUpstream(t *testing.T) {
 			match ".*"
 			answer "target.example.net. 60 IN A 1.2.3.4"
 		}
-}
-`
+	}`
+
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {
 		t.Fatalf("Could not get CoreDNS serving instance: %s", err)

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -17,9 +17,8 @@ func TestLookupWildcard(t *testing.T) {
 	defer rm()
 
 	corefile := `example.org:0 {
-       file ` + name + `
-}
-`
+		file ` + name + `
+	}`
 
 	i, udp, _, err := CoreDNSServerAndPorts(corefile)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

It removes all mixed indentation within tests and improves the formatting a little. I assumed there was no existing preference for the closing backtick. 

Rules used:
1. Corefiles: Tabs, following indentation of surrounding Go code. 
2. Corefiles: If only one zone, no preceding newline. 
3. Corefiles: Backtick follows the last closing brace.
4. Zones: Align fields using spaces

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
