### PR TITLE
De-duplicating plugin chains from multi zone serverblocks

### DIFF
--- a/core/dnsserver/config.go
+++ b/core/dnsserver/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	// on them should register themselves here. The name should be the name as return by the
 	// Handler's Name method.
 	registry map[string]plugin.Handler
+
+	// The server block index
+	blocIndex int
 }
 
 // keyForConfig build a key for identifying the configs during setup time

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -34,6 +34,10 @@ var log = clog.NewWithPlugin(pluginName)
 func init() { plugin.Register(pluginName, setup) }
 
 func setup(c *caddy.Controller) error {
+	if c.ServerBlockKeyIndex > 0 {
+		return nil
+	}
+
 	klog.SetOutput(os.Stdout)
 
 	k, err := kubernetesParse(c)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

In this PR, I'm spitballing a way to resolve the memory bloat issue caused when a server block has multiple zones defined.  When multiple zones are defined in a server block, a separate duplicate of the plugin chain is created and initialized for each zone.

The de-duplication happens in two places.
* First, plugin lists from zones from the same server block are de-duplicated in `register.go` - resulting in the zones pointing to the same plugin list.
* Second, initialization of plugins (example included kubernetes), are only initialized once per server block (only for the first zone in the block).  This feels kludgey, requiring a change at the plugin level, but I don't see another way around it at the moment.  Without this change, a plugin will re-initialize for each zone in the serverblock.  

I'm not terribly familiar with the register.go/server.go code, so I may be breaking things horribly here.  That said, I have tested some simple test cases with kubernetes, and it seems to work.

### 2. Which issues (if any) are related?

Discussed in: https://github.com/coredns/deployment/issues/153, wherein the issue prevents us from deploying _kubernetes_ in a separate stanza from _forward_ and _cache_ (preferred).

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

