### PR TITLE
plugin/kubernetes: Don't panic with metadata enabled and pods mode not verified

### DIFF
--- a/plugin/kubernetes/autopath.go
+++ b/plugin/kubernetes/autopath.go
@@ -51,6 +51,9 @@ func (k *Kubernetes) AutoPath(state request.Request) []string {
 
 // podWithIP return the api.Pod for source IP. It returns nil if nothing can be found.
 func (k *Kubernetes) podWithIP(ip string) *object.Pod {
+	if k.podMode != podModeVerified {
+		return nil
+	}
 	ps := k.APIConn.PodIndex(ip)
 	if len(ps) == 0 {
 		return nil

--- a/plugin/kubernetes/metadata_test.go
+++ b/plugin/kubernetes/metadata_test.go
@@ -32,8 +32,6 @@ var metadataCases = []struct {
 			"kubernetes/port-name":        "*",
 			"kubernetes/protocol":         "*",
 			"kubernetes/service":          "10-240-0-1",
-			"kubernetes/client-namespace": "podns",
-			"kubernetes/client-pod-name":  "foo",
 		},
 	},
 	{
@@ -45,8 +43,6 @@ var metadataCases = []struct {
 			"kubernetes/port-name":        "*",
 			"kubernetes/protocol":         "*",
 			"kubernetes/service":          "s",
-			"kubernetes/client-namespace": "podns",
-			"kubernetes/client-pod-name":  "foo",
 		},
 	},
 	{
@@ -101,10 +97,9 @@ func mapsDiffer(a, b map[string]string) bool {
 	return false
 }
 
-func TestMetadataPodsVerified(t *testing.T) {
+func TestMetadata(t *testing.T) {
 	k := New([]string{"cluster.local."})
 	k.APIConn = &APIConnServeTest{}
-	k.podMode = podModeVerified
 
 	for i, tc := range metadataCases {
 		ctx := metadata.ContextWithMetadata(context.Background())
@@ -126,8 +121,9 @@ func TestMetadataPodsVerified(t *testing.T) {
 	}
 }
 
-func TestMetadataPodsUnverified(t *testing.T) {
+func TestMetadataPodsVerified(t *testing.T) {
 	k := New([]string{"cluster.local."})
+	k.podMode = podModeVerified
 	k.APIConn = &APIConnServeTest{}
 
 	ctx := metadata.ContextWithMetadata(context.Background())
@@ -146,6 +142,8 @@ func TestMetadataPodsUnverified(t *testing.T) {
 		"kubernetes/port-name": "*",
 		"kubernetes/protocol":  "*",
 		"kubernetes/service":   "s",
+		"kubernetes/client-namespace": "podns",
+		"kubernetes/client-pod-name":  "foo",
 	}
 
 	md := make(map[string]string)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enabling _metadata_ without enabling `pods verified` in _kubernetes_ would cause a panic when building metadata. Users should be able to use kubernetes metadata without enabling `pods verified`. This PR prevents the panic by making sure `pods verified` is enabled before looking up the IP address in the Pod index.

This may also be fixing a panic if _autopath_ is enabled without enabling `pods verified` in _kubernetes_ (though that would be a misconfiguration anyways).

### 2. Which issues (if any) are related?

None.

### 3. Which documentation changes (if any) need to be made?

None.

### 4. Does this introduce a backward incompatible change or deprecation?

No.