### PR TITLE
plugin/kubernetes: Mention remote IP requirement for autopath and metadata in README

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -173,7 +173,8 @@ upstreamNameservers: |
 
 The *kubernetes* plugin can be used in conjunction with the *autopath* plugin.  Using this
 feature enables server-side domain search path completion in Kubernetes clusters.  Note: `pods` must
-be set to `verified` for this to function properly.
+be set to `verified` for this to function properly. Furthermore, the remote IP address in the DNS
+packet received by CoreDNS must be the IP address of the Pod that sent the request.
 
     cluster.local {
         autopath @kubernetes
@@ -206,14 +207,20 @@ or the word "any"), then that label will match all values.  The labels that acce
 The kubernetes plugin will publish the following metadata, if the *metadata*
 plugin is also enabled:
 
- * kubernetes/endpoint: the endpoint name in the query
- * kubernetes/kind: the resource kind (pod or svc) in the query
- * kubernetes/namespace: the namespace in the query
- * kubernetes/port-name: the port name in an SRV query
- * kubernetes/protocol: the protocol in an SRV query
- * kubernetes/service: the service name in the query
- * kubernetes/client-namespace: the client pod's namespace, if `pods verified` mode is enabled
- * kubernetes/client-pod-name: the client pod's name, if `pods verified` mode is enabled
+ * `kubernetes/endpoint`: the endpoint name in the query
+ * `kubernetes/kind`: the resource kind (pod or svc) in the query
+ * `kubernetes/namespace`: the namespace in the query
+ * `kubernetes/port-name`: the port name in an SRV query
+ * `kubernetes/protocol`: the protocol in an SRV query
+ * `kubernetes/service`: the service name in the query
+ * `kubernetes/client-namespace`: the client pod's namespace (see requirements below)
+ * `kubernetes/client-pod-name`: the client pod's name (see requirements below)
+
+The `kubernetes/client-namespace` and `kubernetes/client-pod-name` metadata work by reconciling the
+client IP address in the DNS request packet to a known pod IP address. Therefore the following is required:
+ * `pods verified` mode must be enabled
+ * the remote IP address in the DNS packet received by CoreDNS must be the IP address 
+   of the Pod that sent the request.
 
 ## Metrics
 

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -219,7 +219,7 @@ plugin is also enabled:
 The `kubernetes/client-namespace` and `kubernetes/client-pod-name` metadata work by reconciling the
 client IP address in the DNS request packet to a known pod IP address. Therefore the following is required:
  * `pods verified` mode must be enabled
- * the remote IP address in the DNS packet received by CoreDNS must be the IP address 
+ * the remote IP address in the DNS packet received by CoreDNS must be the IP address
    of the Pod that sent the request.
 
 ## Metrics


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Note the remote IP requirement for autopath and the client based metadata in _kubernetes_.

### 2. Which issues (if any) are related?

#3868

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
