### PR TITLE
plugin/kubernetes: handle tombstones in default processor

### DIFF
--- a/plugin/kubernetes/object/object.go
+++ b/plugin/kubernetes/object/object.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ToFunc converts one empty interface to another.
-type ToFunc func(interface{}) interface{}
+type ToFunc func(interface{}) (interface{}, error)
 
 // ProcessorBuilder returns function to process cache events.
 type ProcessorBuilder func(cache.Indexer, cache.ResourceEventHandler) cache.ProcessFunc

--- a/plugin/kubernetes/object/pod.go
+++ b/plugin/kubernetes/object/pod.go
@@ -19,16 +19,11 @@ type Pod struct {
 // ToPod returns a function that converts an api.Pod to a *Pod.
 func ToPod(skipCleanup bool) ToFunc {
 	return func(obj interface{}) interface{} {
-		return toPod(skipCleanup, obj)
+		return toPod(skipCleanup, obj.(*api.Pod))
 	}
 }
 
-func toPod(skipCleanup bool, obj interface{}) interface{} {
-	pod, ok := obj.(*api.Pod)
-	if !ok {
-		return nil
-	}
-
+func toPod(skipCleanup bool, pod *api.Pod) *Pod {
 	p := &Pod{
 		Version:   pod.GetResourceVersion(),
 		PodIP:     pod.Status.PodIP,

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -1,6 +1,8 @@
 package object
 
 import (
+	"fmt"
+
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -28,8 +30,12 @@ func ServiceKey(name, namespace string) string { return name + "." + namespace }
 
 // ToService returns a function that converts an api.Service to a *Service.
 func ToService(skipCleanup bool) ToFunc {
-	return func(obj interface{}) interface{} {
-		return toService(skipCleanup, obj.(*api.Service))
+	return func(obj interface{}) (interface{}, error) {
+		svc, ok := obj.(*api.Service)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object %v", obj)
+		}
+		return toService(skipCleanup, svc), nil
 	}
 }
 

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -29,16 +29,11 @@ func ServiceKey(name, namespace string) string { return name + "." + namespace }
 // ToService returns a function that converts an api.Service to a *Service.
 func ToService(skipCleanup bool) ToFunc {
 	return func(obj interface{}) interface{} {
-		return toService(skipCleanup, obj)
+		return toService(skipCleanup, obj.(*api.Service))
 	}
 }
 
-func toService(skipCleanup bool, obj interface{}) interface{} {
-	svc, ok := obj.(*api.Service)
-	if !ok {
-		return nil
-	}
-
+func toService(skipCleanup bool, svc *api.Service) *Service {
 	s := &Service{
 		Version:      svc.GetResourceVersion(),
 		Name:         svc.GetName(),


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Like #3887, this applies tombstone handling to the DefaultProcessor (which handles Pods and Services) so we don't panic when encountering tombstones.

It also fixes terminating Pod exclusion, which in the current implementation causes a panic every time a Pod is deleted when `pods verified` is enabled.

### 2. Which issues (if any) are related?

#3887

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No
