### PR TITLE
Fix forward policy

### DIFF
--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -207,10 +207,19 @@ func (f *Forward) PreferUDP() bool { return f.opts.preferUDP }
 
 // List returns a set of proxies to be used for this client depending on the policy in f.
 func (f *Forward) List() []*Proxy {
-	if len(f.p.List(f.proxies)) == 1 {
-		return f.p.List(f.proxies)[0].([]*Proxy)
+	var interfaceSlice []interface{} = make([]interface{}, len(f.proxies))
+	for i, p := range f.proxies {
+		interfaceSlice[i] = p
 	}
-	return nil
+
+	sortedProxies := f.p.List(interfaceSlice...)
+
+	proxies := make([]*Proxy, len(sortedProxies))
+	for i, p := range sortedProxies {
+		proxies[i] = p.(*Proxy)
+	}
+
+	return proxies
 }
 
 var (

--- a/plugin/forward/setup_policy_test.go
+++ b/plugin/forward/setup_policy_test.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -42,6 +43,42 @@ func TestSetupPolicy(t *testing.T) {
 
 		if !test.shouldErr && f.p.String() != test.expectedPolicy {
 			t.Errorf("Test %d: expected: %s, got: %s", i, test.expectedPolicy, f.p.String())
+		}
+	}
+}
+
+func TestSetupPolicySelection(t *testing.T) {
+	tests := []struct {
+		input         string
+		shouldErr     bool
+		expectedOrder []string
+		expectedErr   string
+	}{
+		{"forward . 1.1.1.1 {\npolicy sequential \n}\n", false, []string{"1.1.1.1:53"}, ""},
+		{"forward . 1.1.1.1 {\npolicy random\n}\n", false, []string{"1.1.1.1:53"}, ""},
+		{"forward . 1.1.1.1 {\npolicy round_robin\n}\n", false, []string{"1.1.1.1:53"}, ""},
+		{"forward . 1.1.1.1 2.2.2.2 3.3.3.3 4.4.4.4 {\npolicy sequential\n}\n", false, []string{"1.1.1.1:53", "2.2.2.2:53", "3.3.3.3:53", "4.4.4.4:53"}, ""},
+		{"forward . 1.1.1.1 2.2.2.2 3.3.3.3 4.4.4.4 {\npolicy round_robin\n}\n", false, []string{"2.2.2.2:53", "1.1.1.1:53", "3.3.3.3:53", "4.4.4.4:53"}, ""},
+	}
+
+	for i, test := range tests {
+		c := caddy.NewTestController("dns", test.input)
+		f, err := parseForward(c)
+
+		orderedProxies := f.List()
+		var orderedProxiesString []string
+		for _, p := range orderedProxies {
+			orderedProxiesString = append(orderedProxiesString, p.addr)
+		}
+
+		if err != nil {
+			if !test.shouldErr {
+				t.Errorf("Test %d: expected no error but found one for input %s, got: %v", i, test.input, err)
+			}
+		}
+
+		if !test.shouldErr && !reflect.DeepEqual(orderedProxiesString, test.expectedOrder) {
+			t.Errorf("Test %d: expected: %v, got: %v", i, test.expectedOrder, orderedProxiesString)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

The policy for selecting upstream servers in the forward plugin is not working properly. Only the first upstream server is always selected no matter which policy is set. The issue seems to occur in 1.6.7 and later.

I changed the way the `List` method in `proxy.go` is used. Instead of passing a slice of structs I converted `[]*Proxy` into `[]interface{}` used the proxy selection method and the converted back to  `[]*Proxy`.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/3900

### 3. Which documentation changes (if any) need to be made?

none

### 4. Does this introduce a backward incompatible change or deprecation?

no