### PR TITLE
Oss-fuzz ideal integration

### DIFF
--- a/.github/workflows/buildfuzz.yml
+++ b/.github/workflows/buildfuzz.yml
@@ -1,0 +1,25 @@
+name: Build Fuzz Targets
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Build Fuzz Targets
+      run: |
+        go get github.com/dvyukov/go-fuzz/go-fuzz
+        go get github.com/dvyukov/go-fuzz/go-fuzz-build
+        export PATH=$PATH:$GOBIN:$HOME/go/bin:$GOROOT/bin
+        echo $PATH
+        make -f Makefile.fuzz all

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'go-coredns'
+       dry-run: false
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'go-coredns'
+       fuzz-seconds: 600
+       dry-run: false
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure()
+     with:
+       name: artifacts
+       path: ./out/artifacts

--- a/Makefile.fuzz
+++ b/Makefile.fuzz
@@ -37,7 +37,6 @@ ifeq ($(LIBFUZZER), YES)
 	clang -fsanitize=fuzzer $(@).a -o $(@)
 else
 	go-fuzz-build $(REPO)/plugin/$(@)
-	go-fuzz -bin=./$(@)-fuzz.zip -workdir=fuzz/$(@)
 endif
 
 .PHONY: corefile
@@ -47,7 +46,6 @@ ifeq ($(LIBFUZZER), YES)
 	clang -fsanitize=fuzzer $(@).a -o $(@)
 else
 	go-fuzz-build $(REPO)/test
-	go-fuzz -bin=./test-fuzz.zip -workdir=fuzz/$(@)
 endif
 
 fuzzit:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
This is needed for oss-fuzz _ideal_ integration cf https://google.github.io/oss-fuzz/advanced-topics/ideal-integration/

It adds 2 GitHub workflows 
- CIFuzz cf https://google.github.io/oss-fuzz/getting-started/continuous-integration/
- One workflow to check that we do not break the fuzz targets build

### 2. Which issues (if any) are related?
None

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
No

This was inspired by https://github.com/miekg/dns/pull/1091
The build fuzz targets workflow is not yet tested