### PR TITLE
k8s_external can now resolve CNAME returned by AWS ELB/NLB

### DIFF
--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
@@ -38,6 +39,8 @@ type External struct {
 	hostmaster string
 	apex       string
 	ttl        uint32
+
+	upstream *upstream.Upstream
 
 	externalFunc     func(request.Request) ([]msg.Service, int)
 	externalAddrFunc func(request.Request) []dns.RR
@@ -90,9 +93,9 @@ func (e *External) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 	switch state.QType() {
 	case dns.TypeA:
-		m.Answer = e.a(svc, state)
+		m.Answer = e.a(ctx, svc, state)
 	case dns.TypeAAAA:
-		m.Answer = e.aaaa(svc, state)
+		m.Answer = e.aaaa(ctx, svc, state)
 	case dns.TypeSRV:
 		m.Answer, m.Extra = e.srv(svc, state)
 	default:

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -16,11 +16,15 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
-	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
+
+// UpstreamInt wraps the Upstream API for dependency injection during testing
+type UpstreamInt interface {
+	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
+}
 
 // Externaler defines the interface that a plugin should implement in order to be used by External.
 type Externaler interface {
@@ -40,7 +44,7 @@ type External struct {
 	apex       string
 	ttl        uint32
 
-	upstream *upstream.Upstream
+	upstream UpstreamInt
 
 	externalFunc     func(request.Request) ([]msg.Service, int)
 	externalAddrFunc func(request.Request) []dns.RR

--- a/plugin/k8s_external/external.go
+++ b/plugin/k8s_external/external.go
@@ -16,15 +16,11 @@ import (
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 	"github.com/coredns/coredns/request"
 
 	"github.com/miekg/dns"
 )
-
-// UpstreamInt wraps the Upstream API for dependency injection during testing
-type UpstreamInt interface {
-	Lookup(ctx context.Context, state request.Request, name string, typ uint16) (*dns.Msg, error)
-}
 
 // Externaler defines the interface that a plugin should implement in order to be used by External.
 type Externaler interface {
@@ -44,7 +40,7 @@ type External struct {
 	apex       string
 	ttl        uint32
 
-	upstream UpstreamInt
+	upstream *upstream.Upstream
 
 	externalFunc     func(request.Request) ([]msg.Service, int)
 	externalAddrFunc func(request.Request) []dns.RR

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -147,21 +147,33 @@ var tests = []test.Case{
 			test.SOA("example.com.	5	IN	SOA	ns1.dns.example.com. hostmaster.example.com. 1499347823 7200 1800 86400 5"),
 		},
 	},
+	{
+		Qname: "svc11.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("svc11.testns.example.com.	5	IN	A	1.2.3.4"),
+		},
+	},
+	{
+		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
+		},
+	},
 }
 
 type external struct{}
 
-func (external) HasSynced() bool                              { return true }
-func (external) Run()                                         {}
-func (external) Stop() error                                  { return nil }
-func (external) EpIndexReverse(string) []*object.Endpoints    { return nil }
-func (external) SvcIndexReverse(string) []*object.Service     { return nil }
-func (external) Modified() int64                              { return 0 }
-func (external) EpIndex(s string) []*object.Endpoints         { return nil }
-func (external) EndpointsList() []*object.Endpoints           { return nil }
+func (external) HasSynced() bool                                                   { return true }
+func (external) Run()                                                              {}
+func (external) Stop() error                                                       { return nil }
+func (external) EpIndexReverse(string) []*object.Endpoints                         { return nil }
+func (external) SvcIndexReverse(string) []*object.Service                          { return nil }
+func (external) Modified() int64                                                   { return 0 }
+func (external) EpIndex(s string) []*object.Endpoints                              { return nil }
+func (external) EndpointsList() []*object.Endpoints                                { return nil }
 func (external) GetNodeByName(ctx context.Context, name string) (*api.Node, error) { return nil, nil }
-func (external) SvcIndex(s string) []*object.Service          { return svcIndexExternal[s] }
-func (external) PodIndex(string) []*object.Pod                { return nil }
+func (external) SvcIndex(s string) []*object.Service                               { return svcIndexExternal[s] }
+func (external) PodIndex(string) []*object.Pod                                     { return nil }
 
 func (external) GetNamespaceByName(name string) (*api.Namespace, error) {
 	return &api.Namespace{
@@ -189,6 +201,24 @@ var svcIndexExternal = map[string][]*object.Service{
 			Type:        api.ServiceTypeClusterIP,
 			ClusterIP:   "10.0.0.3",
 			ExternalIPs: []string{"1:2::5"},
+			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+	"svc11.testns": {
+		{
+			Name:        "svc11",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeLoadBalancer,
+			ExternalIPs: []string{"1.2.3.4"},
+			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
+		},
+	},
+	"svc12.testns": {
+		{
+			Name:        "svc12",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeLoadBalancer,
+			ExternalIPs: []string{"dummy.hostname"},
 			Ports:       []api.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}},
 		},
 	},

--- a/plugin/k8s_external/external_test.go
+++ b/plugin/k8s_external/external_test.go
@@ -31,8 +31,6 @@ func TestExternal(t *testing.T) {
 		r := tc.Msg()
 		w := dnstest.NewRecorder(&test.ResponseWriter{})
 
-		e.upstream = &fakeUpstream{t, tc.Qname, fakeResponse}
-
 		_, err := e.ServeDNS(ctx, w, r)
 		if err != tc.Error {
 			t.Errorf("Test %d expected no error, got %v", i, err)
@@ -159,8 +157,6 @@ var tests = []test.Case{
 	{
 		Qname: "svc12.testns.example.com.", Qtype: dns.TypeA, Rcode: dns.RcodeSuccess,
 		Answer: []dns.RR{
-			test.A("dummy.hostname.	60 IN A 192.0.2.42"),
-			test.A("dummy.hostname.	60 IN A 192.0.2.43"),
 			test.CNAME("svc12.testns.example.com.	5	IN	CNAME	dummy.hostname"),
 		},
 	},
@@ -240,30 +236,4 @@ func (external) ServiceList() []*object.Service {
 func externalAddress(state request.Request) []dns.RR {
 	a := test.A("example.org. IN A 127.0.0.1")
 	return []dns.RR{a}
-}
-
-var fakeResponse = &dns.Msg{
-	MsgHdr: dns.MsgHdr{
-		Id:               43,
-		Opcode:           dns.OpcodeQuery,
-		RecursionDesired: true,
-		Rcode:            dns.RcodeSuccess,
-		Response:         true,
-	},
-	Question: []dns.Question{dns.Question{"dummy.hostname.", dns.TypeA, dns.ClassINET}},
-	Answer: []dns.RR{
-		test.A("dummy.hostname. 60 IN A 192.0.2.42"),
-		test.A("dummy.hostname. 60 IN A 192.0.2.43"),
-	},
-}
-
-type fakeUpstream struct {
-	t     *testing.T
-	qname string
-	resp  *dns.Msg
-}
-
-func (fu *fakeUpstream) Lookup(_ context.Context, _ request.Request, name string, typ uint16) (*dns.Msg, error) {
-
-	return fu.resp, nil
 }

--- a/plugin/k8s_external/setup.go
+++ b/plugin/k8s_external/setup.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/upstream"
 
 	"github.com/caddyserver/caddy"
 )
@@ -29,6 +30,8 @@ func setup(c *caddy.Controller) error {
 		}
 		return nil
 	})
+
+	e.upstream = upstream.New()
 
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		e.Next = next

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -62,11 +62,11 @@ func toService(skipCleanup bool, svc *api.Service) *Service {
 
 	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
-		if &lb.IP != nil {
+		if lb.IP == "" {
 			s.ExternalIPs[li+i] = lb.IP
-		} else if &lb.Hostname != nil {
-			s.ExternalIPs[li+i] = lb.Hostname
+			continue
 		}
+		s.ExternalIPs[li+i] = lb.Hostname
 
 	}
 

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -63,6 +63,7 @@ func toService(skipCleanup bool, svc *api.Service) *Service {
 	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
 		s.ExternalIPs[li+i] = lb.IP
+		s.ExternalIPs[li+i] = lb.Hostname
 	}
 
 	if !skipCleanup {

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -62,8 +62,12 @@ func toService(skipCleanup bool, svc *api.Service) *Service {
 
 	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
-		s.ExternalIPs[li+i] = lb.IP
-		s.ExternalIPs[li+i] = lb.Hostname
+		if &lb.IP != nil {
+			s.ExternalIPs[li+i] = lb.IP
+		} else if &lb.Hostname != nil {
+			s.ExternalIPs[li+i] = lb.Hostname
+		}
+
 	}
 
 	if !skipCleanup {

--- a/plugin/kubernetes/object/service.go
+++ b/plugin/kubernetes/object/service.go
@@ -62,7 +62,7 @@ func toService(skipCleanup bool, svc *api.Service) *Service {
 
 	li := copy(s.ExternalIPs, svc.Spec.ExternalIPs)
 	for i, lb := range svc.Status.LoadBalancer.Ingress {
-		if lb.IP == "" {
+		if lb.IP != "" {
 			s.ExternalIPs[li+i] = lb.IP
 			continue
 		}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

This PR allows `k8s_external` plugin to resolve CNAME returned by NLB/ELB when creating a service of type LoadBalancer on AWS-based clusters.

### 2. Which issues (if any) are related?

issue #3878 

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No