### PR TITLE
Add timeouts for http server

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -40,7 +40,12 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 		tlsConfig = conf.TLSConfig
 	}
 
-	sh := &ServerHTTPS{Server: s, tlsConfig: tlsConfig, httpsServer: new(http.Server)}
+	srv := &http.Server{
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+	sh := &ServerHTTPS{Server: s, tlsConfig: tlsConfig, httpsServer: srv}
 	sh.httpsServer.Handler = sh
 
 	return sh, nil


### PR DESCRIPTION

### 1. Why is this pull request needed and what does it do?
Currently the http.Server created for DoH does not have timeouts, it can lead to file descriptors leakage and DoS attacks by malicious clients.
Values from https://blog.cloudflare.com/exposing-go-on-the-internet/
### 2. Which issues (if any) are related?
No
### 3. Which documentation changes (if any) need to be made?
No
### 4. Does this introduce a backward incompatible change or deprecation?
No