### PR TITLE
plugin/azure: Fix environment option

### DIFF
--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -112,7 +112,6 @@ func parse(c *caddy.Controller) (auth.EnvironmentSettings, map[string][]string, 
 				if !c.NextArg() {
 					return env, resourceGroupMapping, accessMap, fall, c.ArgErr()
 				}
-				env.Values[auth.ClientSecret] = c.Val()
 				var err error
 				if azureEnv, err = azurerest.EnvironmentFromName(c.Val()); err != nil {
 					return env, resourceGroupMapping, accessMap, fall, c.Errf("cannot set azure environment: %q", err.Error())


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

`environment` option overwrites a client secret.

```
example.org {
    azure resource_group_foo:example.org {
      secret mysecret
      environment AZUREGERMANCLOUD
    }
}
```

then the secret changes to "AZUREGERMANCLOUD".

### 2. Which issues (if any) are related?

No

### 3. Which documentation changes (if any) need to be made?

No

### 4. Does this introduce a backward incompatible change or deprecation?

No
