### PR TITLE
Use nonroot distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
-FROM debian:stable-slim
+FROM gcr.io/distroless/static:nonroot
 
-RUN apt-get update && apt-get -uy upgrade
-RUN apt-get -y install ca-certificates && update-ca-certificates
-
-FROM scratch
-
-COPY --from=0 /etc/ssl/certs /etc/ssl/certs
 ADD coredns /coredns
 
+USER nonroot:nonroot
 EXPOSE 53 53/udp
 ENTRYPOINT ["/coredns"]


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Uses non root distroless minimal base image that already has ca-certificates included

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
