### PR TITLE
Fix 0 weight in SRV records with 100 more records in answer

### DIFF
--- a/plugin/backend_lookup.go
+++ b/plugin/backend_lookup.go
@@ -185,6 +185,10 @@ func SRV(ctx context.Context, b ServiceBackend, zone string, state request.Reque
 			w1 *= float64(serv.Weight)
 		}
 		weight := uint16(math.Floor(w1))
+		// weight should be at least 1
+		if weight == 0 {
+			weight = 1
+		}
 
 		what, ip := serv.HostType()
 

--- a/plugin/k8s_external/msg_to_dns.go
+++ b/plugin/k8s_external/msg_to_dns.go
@@ -103,6 +103,10 @@ func (e *External) srv(services []msg.Service, state request.Request) (records, 
 			w1 *= float64(s.Weight)
 		}
 		weight := uint16(math.Floor(w1))
+		// weight should be at least 1
+		if weight == 0 {
+			weight = 1
+		}
 
 		what, ip := s.HostType()
 

--- a/plugin/kubernetes/xfr.go
+++ b/plugin/kubernetes/xfr.go
@@ -228,6 +228,11 @@ func calcSRVWeight(numservices int) uint16 {
 		}
 		w[serv.Priority] += weight
 	}
+	weight := uint16(math.Floor((100.0 / float64(w[0])) * 100))
+	// weight should be at least 1
+	if weight == 0 {
+		weight = 1
+	}
 
-	return uint16(math.Floor((100.0 / float64(w[0])) * 100))
+	return weight
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
Currently the SRV records' weight is 0 if the number of endpoints
is greater than 100. This will cause the upstream lb(haproxy e.g.)
using SRV records for service-discovery to mark the servers as
unavailable due to 0 weight.

The fix is to use math.Ceil instead of math.Floor for weight
calculation to make sure that the weight is at least 1.

### 2. Which issues (if any) are related?
#3930

### 3. Which documentation changes (if any) need to be made?
none

### 4. Does this introduce a backward incompatible change or deprecation?
none
