### PR TITLE
plugin/dnssec: fail if key configured twice

### DIFF
--- a/plugin/dnssec/setup.go
+++ b/plugin/dnssec/setup.go
@@ -115,6 +115,19 @@ func dnssecParse(c *caddy.Controller) ([]string, []*DNSKEY, int, bool, error) {
 		}
 	}
 
+	// check if a key is configured multiple times
+	seen := make(map[string]bool)
+	for _, k := range keys {
+		// compare based on DNSKEY resource record that already includes key type, using same key for both KSK and ZSK
+		// is not an issue on CoreDNS side
+		record := k.K.String()
+		_, found := seen[record]
+		if found {
+			return zones, keys, capacity, splitkeys, fmt.Errorf("key %s (keyid: %d) loaded twice", k.K.Header().Name, k.tag)
+		}
+		seen[record] = true
+	}
+
 	return zones, keys, capacity, splitkeys, nil
 }
 

--- a/plugin/dnssec/setup_test.go
+++ b/plugin/dnssec/setup_test.go
@@ -78,6 +78,18 @@ func TestSetupDnssec(t *testing.T) {
 				key file ksk_Kcluster.local
 			}`, false, []string{"cluster.local."}, nil, true, defaultCap, "",
 		},
+		{
+			`dnssec cluster.local {
+				key file Kcluster.local
+                key file Kcluster.local
+			}`, true, []string{"example.org."}, nil, false, defaultCap, "loaded twice",
+		},
+		{
+			`dnssec cluster.local {
+				key file Kcluster.local.private
+                key file Kcluster.local.key
+			}`, true, []string{"example.org."}, nil, false, defaultCap, "loaded twice",
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

If a key is configured twice, the plugin will actually sign records twice. This commit adds two test cases (in especially the one I stumbled into, where I registered both public and private keys  separately) and a check returning an error if a key is registered twice.

The very flexible key configuration invites of putting both public and private keys in there. Alternatively, we might consider simply merging duplicate keys when loading them.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

Please advise whether this might be a breaking change or requires changelog entries.

### 4. Does this introduce a backward incompatible change or deprecation?

In case of existing but undetected misconfiguration, CoreDNS will fail.