### PR TITLE
forward: Allow selection of health check transport

### DIFF
--- a/plugin/forward/fuzz.go
+++ b/plugin/forward/fuzz.go
@@ -16,8 +16,8 @@ var f *Forward
 func init() {
 	f = New()
 	s := dnstest.NewServer(r{}.reflectHandler)
-	f.SetProxy(NewProxy(s.Addr, "tcp"))
-	f.SetProxy(NewProxy(s.Addr, "udp"))
+	f.SetProxy(NewProxy(s.Addr, "tcp", false))
+	f.SetProxy(NewProxy(s.Addr, "udp", false))
 }
 
 // Fuzz fuzzes forward.

--- a/plugin/forward/health.go
+++ b/plugin/forward/health.go
@@ -25,11 +25,15 @@ type dnsHc struct {
 }
 
 // NewHealthChecker returns a new HealthChecker based on transport.
-func NewHealthChecker(trans string, recursionDesired bool) HealthChecker {
+func NewHealthChecker(trans string, healthCheckTCP bool, recursionDesired bool) HealthChecker {
 	switch trans {
 	case transport.DNS, transport.TLS:
 		c := new(dns.Client)
-		c.Net = "udp"
+		if healthCheckTCP {
+			c.Net = "tcp"
+		} else {
+			c.Net = "udp"
+		}
 		c.ReadTimeout = 1 * time.Second
 		c.WriteTimeout = 1 * time.Second
 

--- a/plugin/forward/health_test.go
+++ b/plugin/forward/health_test.go
@@ -31,7 +31,7 @@ func TestHealth(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	f := New()
 	f.SetProxy(p)
 	defer f.OnShutdown()
@@ -66,7 +66,7 @@ func TestHealthNoRecursion(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	p.health.SetRecursionDesired(false)
 	f := New()
 	f.SetProxy(p)
@@ -107,7 +107,7 @@ func TestHealthTimeout(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	f := New()
 	f.SetProxy(p)
 	defer f.OnShutdown()
@@ -151,7 +151,7 @@ func TestHealthFailTwice(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	f := New()
 	f.SetProxy(p)
 	defer f.OnShutdown()
@@ -174,7 +174,7 @@ func TestHealthMaxFails(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	f := New()
 	f.maxfails = 2
 	f.SetProxy(p)
@@ -206,7 +206,7 @@ func TestHealthNoMaxFails(t *testing.T) {
 	})
 	defer s.Close()
 
-	p := NewProxy(s.Addr, transport.DNS)
+	p := NewProxy(s.Addr, transport.DNS, false)
 	f := New()
 	f.maxfails = 0
 	f.SetProxy(p)

--- a/plugin/forward/proxy.go
+++ b/plugin/forward/proxy.go
@@ -22,14 +22,14 @@ type Proxy struct {
 }
 
 // NewProxy returns a new proxy.
-func NewProxy(addr, trans string) *Proxy {
+func NewProxy(addr, trans string, healthCheckTCP bool) *Proxy {
 	p := &Proxy{
 		addr:      addr,
 		fails:     0,
 		probe:     up.New(),
 		transport: newTransport(addr),
 	}
-	p.health = NewHealthChecker(trans, true)
+	p.health = NewHealthChecker(trans, healthCheckTCP, true)
 	runtime.SetFinalizer(p, (*Proxy).finalizer)
 	return p
 }

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -27,7 +27,7 @@ func TestProxyClose(t *testing.T) {
 	ctx := context.TODO()
 
 	for i := 0; i < 100; i++ {
-		p := NewProxy(s.Addr, transport.DNS)
+		p := NewProxy(s.Addr, transport.DNS, false)
 		p.start(hcInterval)
 
 		go func() { p.Connect(ctx, state, options{}) }()
@@ -96,7 +96,7 @@ func TestProxyTLSFail(t *testing.T) {
 }
 
 func TestProtocolSelection(t *testing.T) {
-	p := NewProxy("bad_address", transport.DNS)
+	p := NewProxy("bad_address", transport.DNS, false)
 
 	stateUDP := request.Request{W: &test.ResponseWriter{}, Req: new(dns.Msg)}
 	stateTCP := request.Request{W: &test.ResponseWriter{TCP: true}, Req: new(dns.Msg)}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

And select TCP when `force_tcp` is set.

### 1. Why is this pull request needed and what does it do?

It sets the transport used to query upstream servers in health checks to TCP when `force_tcp` is set true.

### 2. Which issues (if any) are related?

https://github.com/coredns/coredns/issues/3938

### 3. Which documentation changes (if any) need to be made?

The documentation should call the switch out.

### 4. Does this introduce a backward incompatible change or deprecation?

Yes, this will need to be called out in release notes. HOWEVER, it can be assumed that it won't break things since all queries to these upstreams will be over TCP anyway.