### PR TITLE
forward: retry failed

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -53,6 +53,7 @@ forward FROM TO... {
     policy random|round_robin|sequential
     health_check DURATION [no_rec]
     max_concurrent MAX
+    retry_failed MAX
 }
 ~~~
 
@@ -94,6 +95,9 @@ forward FROM TO... {
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.
+* `retry_failed` **MAX** will limit the number of failed retry queries to **MAX**.
+  When some resolves might return ServerFailure or Refused, retry a different upstream.
+  The default value is 0. The max value is the number of upstreams.
 
 Also note the TLS config is "global" for the whole forwarding proxy if you need a different
 `tls-name` for different upstreams you're out of luck.

--- a/plugin/forward/proxy_test.go
+++ b/plugin/forward/proxy_test.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
@@ -119,5 +120,58 @@ func TestProtocolSelection(t *testing.T) {
 		if proto != exp {
 			t.Errorf("Unexpected protocol in case %d, expected %q, actual %q", i, exp, proto)
 		}
+	}
+}
+
+func TestProxyRetryFailed(t *testing.T) {
+	test := []struct{ setRcode, getRcode int }{
+		{
+			setRcode: dns.RcodeFormatError,
+			getRcode: dns.RcodeFormatError,
+		},
+		{
+			setRcode: dns.RcodeServerFailure,
+			getRcode: dns.RcodeSuccess,
+		},
+		{
+			setRcode: dns.RcodeSuccess,
+			getRcode: dns.RcodeSuccess,
+		},
+	}
+	for _, tc := range test {
+		testProxyRetryFailed(t, tc.setRcode, tc.getRcode)
+	}
+}
+
+func testProxyRetryFailed(t *testing.T, setRcode, getRcode int) {
+	s := dnstest.NewServer(func(w dns.ResponseWriter, r *dns.Msg) {
+		ret := new(dns.Msg)
+		ret.SetRcode(r, setRcode)
+		w.WriteMsg(ret)
+	})
+	defer s.Close()
+
+	c := caddy.NewTestController("dns", fmt.Sprintf(
+		`forward . %s %s {
+					policy sequential
+					retry_failed 2
+				}
+`, s.Addr, "8.8.8.8"))
+	f, err := parseForward(c)
+	if err != nil {
+		t.Errorf("Failed to create forwarder: %s", err)
+	}
+	f.OnStartup()
+	defer f.OnShutdown()
+
+	m := new(dns.Msg)
+	m.SetQuestion("example.org.", dns.TypeA)
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	if _, err := f.ServeDNS(context.TODO(), rec, m); err != nil {
+		t.Fatal("Expected to receive reply, but didn't")
+	}
+	if rec.Msg.Rcode != getRcode {
+		t.Errorf("Expected %d, got %d", getRcode, rec.Msg.Rcode)
 	}
 }

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -241,7 +241,21 @@ func parseBlock(c *caddy.Controller, f *Forward) error {
 		}
 		f.ErrLimitExceeded = errors.New("concurrent queries exceeded maximum " + c.Val())
 		f.maxConcurrent = int64(n)
-
+	case "retry_failed":
+		if !c.NextArg() {
+			return c.ArgErr()
+		}
+		n, err := strconv.Atoi(c.Val())
+		if err != nil {
+			return err
+		}
+		if n < 0 {
+			return fmt.Errorf("retry_failed can't be negative: %d", n)
+		}
+		if n > len(f.proxies) {
+			return fmt.Errorf("retry_failed can't be larger than number of proxies(%d)", len(f.proxies))
+		}
+		f.maxFailedTries = n
 	default:
 		return c.Errf("unknown property '%s'", c.Val())
 	}


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

When some resolves might return ServerFailure or Refused, retry a different upstream. 
 
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

```
forward FROM TO... {
    ...
    retry_failed MAX
}
```

### 4. Does this introduce a backward incompatible change or deprecation?
