### PR TITLE
Improve gRPC Plugin when backend is not available

### DIFF
--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"time"
 
 	"github.com/coredns/coredns/plugin"
@@ -87,6 +88,9 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		return 0, nil
 	}
 
+	if ret == nil {
+		return dns.RcodeServerFailure, errors.New("no healthy gRPC backend")
+	}
 	return 0, nil
 }
 

--- a/plugin/grpc/grpc.go
+++ b/plugin/grpc/grpc.go
@@ -37,10 +37,10 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 	}
 
 	var (
-		span, child ot.Span
-		ret         *dns.Msg
-		err         error
-		i           int
+		span, child      ot.Span
+		ret              *dns.Msg
+		upstreamErr, err error
+		i                int
 	)
 	span = ot.SpanFromContext(ctx)
 	list := g.list()
@@ -74,6 +74,8 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 			child.Finish()
 		}
 
+		upstreamErr = err
+
 		// Check if the reply is correct; if not return FormErr.
 		if !state.Match(ret) {
 			debug.Hexdumpf(ret, "Wrong reply for id: %d, %s %d", ret.Id, state.QName(), state.QType())
@@ -88,10 +90,11 @@ func (g *GRPC) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (
 		return 0, nil
 	}
 
-	if ret == nil {
-		return dns.RcodeServerFailure, errors.New("no healthy gRPC backend")
+	if upstreamErr != nil {
+		return dns.RcodeServerFailure, upstreamErr
 	}
-	return 0, nil
+
+	return dns.RcodeServerFailure, ErrNoHealthy
 }
 
 // NewGRPC returns a new GRPC.
@@ -133,3 +136,8 @@ func (g *GRPC) isAllowedDomain(name string) bool {
 func (g *GRPC) list() []*Proxy { return g.p.List(g.proxies) }
 
 const defaultTimeout = 5 * time.Second
+
+var (
+	// ErrNoHealthy means no healthy proxies left.
+	ErrNoHealthy = errors.New("no healthy gRPC proxies")
+)


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

1. Why is this pull request needed and what does it do? This PR always adds a return to gRPC plugin, even if the backend is unavailable. This way the client does not wait 5s (DNS Timeout) and got an error if no backend can provide answer

2. Which issues (if any) are related? Fixes #3965

3. Which documentation changes (if any) need to be made? None

4. Does this introduce a backward incompatible change or deprecation? No

