### PR TITLE
plugin/forward: remove exp backoff stuff

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -9,14 +9,12 @@
 The *forward* plugin re-uses already opened sockets to the upstreams. It supports UDP, TCP and
 DNS-over-TLS and uses in band health checking.
 
-When it detects an error a health check is performed. This checks runs in a loop, starting with
-a *0.5s* interval and exponentially backing off with randomized intervals up to *15s* for as long
-as the upstream reports unhealthy. The exponential backoff will reset to *0.5s* after 2 minutes.
-Once healthy we stop health checking (until the next error). The health checks use a recursive
-DNS query (`. IN NS`) to get upstream health. Any response that is not a network error (REFUSED,
-NOTIMPL, SERVFAIL, etc) is taken as a healthy upstream. The health check uses the same protocol as
-specified in **TO**. If `max_fails` is set to 0, no checking is performed and upstreams will always
-be considered healthy.
+When it detects an error a health check is performed. This checks runs in a loop, performing each
+check at a *0.5s* interval for as long as the upstream reports unhealthy. Once healthy we stop
+health checking (until the next error). The health checks use a recursive DNS query (`. IN NS`)
+to get upstream health. Any response that is not a network error (REFUSED, NOTIMPL, SERVFAIL, etc)
+is taken as a healthy upstream. The health check uses the same protocol as specified in **TO**. If
+`max_fails` is set to 0, no checking is performed and upstreams will always be considered healthy.
 
 When *all* upstreams are down it assumes health checking as a mechanism has failed and will try to
 connect to a random upstream (which may or may not work).


### PR DESCRIPTION
we hc every 0.5s, doing exp backoff will create a large gap in the
ability to re-use an upstream. Doing a exp. backoff up to (say) 3s,
isn't really exp backoff either.

Remove the wording from the documentation.