### PR TITLE
plugin/cache/forward: Clean up grammar/wording in forward & cache metrics descriptions.

### DIFF
--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -73,7 +73,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_cache_entries{server, type}` - Total elements in the cache by cache type.
 * `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
 * `coredns_cache_misses_total{server}` - Counter of cache misses.
-* `coredns_cache_prefetch_total{server}` - Counter of times the cache has prefetched a cached item..
+* `coredns_cache_prefetch_total{server}` - Counter of times the cache has prefetched a cached item.
 * `coredns_cache_drops_total{server}` - Counter of responses excluded from the cache due to request/response question name mismatch.
 * `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.
 

--- a/plugin/cache/README.md
+++ b/plugin/cache/README.md
@@ -73,7 +73,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 * `coredns_cache_entries{server, type}` - Total elements in the cache by cache type.
 * `coredns_cache_hits_total{server, type}` - Counter of cache hits by cache type.
 * `coredns_cache_misses_total{server}` - Counter of cache misses.
-* `coredns_cache_prefetch_total{server}` - Counter of cache has prefetched a cached item.
+* `coredns_cache_prefetch_total{server}` - Counter of times the cache has prefetched a cached item..
 * `coredns_cache_drops_total{server}` - Counter of responses excluded from the cache due to request/response question name mismatch.
 * `coredns_cache_served_stale_total{server}` - Counter of requests served from stale cache entries.
 

--- a/plugin/cache/metrics.go
+++ b/plugin/cache/metrics.go
@@ -33,7 +33,7 @@ var (
 		Namespace: plugin.Namespace,
 		Subsystem: "cache",
 		Name:      "prefetch_total",
-		Help:      "The number of time the cache has prefetched a cached item.",
+		Help:      "The number of times the cache has prefetched a cached item.",
 	}, []string{"server"})
 	// cacheDrops is the number responses that are not cached, because the reply is malformed.
 	cacheDrops = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -108,7 +108,7 @@ On each endpoint, the timeouts for communication are set as follows:
 If monitoring is enabled (via the *prometheus* plugin) then the following metric are exported:
 
 * `coredns_forward_requests_total{to}` - query count per upstream.
-* `coredns_forward_responses_total{to}` - Counter of responses made per upstream.
+* `coredns_forward_responses_total{to}` - Counter of responses received per upstream.
 * `coredns_forward_request_duration_seconds{to}` - duration per upstream interaction.
 * `coredns_forward_responses_total{to, rcode}` - count of RCODEs per upstream.
 * `coredns_forward_healthcheck_failures_total{to}` - number of failed health checks per upstream.

--- a/plugin/forward/metrics.go
+++ b/plugin/forward/metrics.go
@@ -18,7 +18,7 @@ var (
 		Namespace: plugin.Namespace,
 		Subsystem: "forward",
 		Name:      "responses_total",
-		Help:      "Counter of response made per upstream.",
+		Help:      "Counter of responses received per upstream.",
 	}, []string{"rcode", "to"})
 	RequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Clean up grammar/wording in forward/cache metrics descriptions.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
