### PR TITLE
Enable debug globally if enabled in any server config

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -66,10 +66,6 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 		if site.Debug {
 			s.debug = true
 			log.D.Set()
-		} else {
-			// When reloading we need to explicitly disable debug logging if it is now disabled.
-			s.debug = false
-			log.D.Clear()
 		}
 		// set the config per zone
 		s.zones[site.Zone] = site
@@ -95,6 +91,11 @@ func NewServer(addr string, group []*Config) (*Server, error) {
 			}
 		}
 		site.pluginChain = stack
+	}
+
+	if !s.debug {
+		// When reloading we need to explicitly disable debug logging if it is now disabled.
+		log.D.Clear()
 	}
 
 	return s, nil

--- a/core/dnsserver/server_test.go
+++ b/core/dnsserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/test"
 
 	"github.com/miekg/dns"
@@ -45,6 +46,33 @@ func TestNewServer(t *testing.T) {
 	_, err = NewServerTLS("127.0.0.1:53", []*Config{testConfig("tls", testPlugin{})})
 	if err != nil {
 		t.Errorf("Expected no error for NewServerTLS, got %s", err)
+	}
+}
+
+func TestDebug(t *testing.T) {
+	configNoDebug, configDebug := testConfig("dns", testPlugin{}), testConfig("dns", testPlugin{})
+	configDebug.Debug = true
+
+	s1, err := NewServer("127.0.0.1:53", []*Config{configDebug, configNoDebug})
+	if err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	if !s1.debug {
+		t.Errorf("Expected debug mode enabled for server s1")
+	}
+	if !log.D.Value() {
+		t.Errorf("Expected debug logging enabled")
+	}
+
+	s2, err := NewServer("127.0.0.1:53", []*Config{configNoDebug})
+	if err != nil {
+		t.Errorf("Expected no error for NewServer, got %s", err)
+	}
+	if s2.debug {
+		t.Errorf("Expected debug mode disabled for server s2")
+	}
+	if log.D.Value() {
+		t.Errorf("Expected debug logging disabled")
 	}
 }
 

--- a/plugin/debug/README.md
+++ b/plugin/debug/README.md
@@ -12,6 +12,9 @@ will be printed to standard output.
 
 Note that the *errors* plugin (if loaded) will also set a `recover`, negating this setting.
 
+Enabling this plugin is process-wide: enabling *debug* in at least one server block enables
+debug mode globally.
+
 ## Syntax
 
 ~~~ txt


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Enable debug globally if enabled in any server config. It was currently enabled only if the plugin debug was enabled in the last server config of the Corefile.

This will still disable debug on reload, if debug is no more present.

Example with Corefile:

```
example.net {
    hosts
    debug
}

. {
    whoami
}
```

Logs (with debug message):

```
[DEBUG] plugin/hosts: Parsed hosts file into 0 entries
example.net.:1053
.:1053
CoreDNS-1.7.0
linux/amd64, go1.14.3, 5b4b3569
```

Remove `debug` in the Corefile and reload with SIGHUP1:

Logs (with no more debug message):

```
[INFO] SIGUSR1: Reloading
[INFO] Reloading
[INFO] Reloading complete
```




### 2. Which issues (if any) are related?

Fixes #4006

### 3. Which documentation changes (if any) need to be made?

N/A

### 4. Does this introduce a backward incompatible change or deprecation?

No
