### PR TITLE
Disable debug mode for tracing - removes extra logging

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -7,6 +7,7 @@
 ## Description
 
 With *trace* you enable OpenTracing of how a request flows through CoreDNS.
+Enable *debug* plugin to get logs from the trace plugin.
 
 ## Syntax
 
@@ -84,3 +85,7 @@ trace tracinghost:9411 {
 	client_server
 }
 ~~~
+
+## Also See
+
+See the *debug* plugin for more information about debug logging.

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
 	"github.com/coredns/coredns/plugin/pkg/dnstest"
+	"github.com/coredns/coredns/plugin/pkg/log"
 	"github.com/coredns/coredns/plugin/pkg/rcode"
 	_ "github.com/coredns/coredns/plugin/pkg/trace" // Plugin the trace package.
 	"github.com/coredns/coredns/request"
@@ -52,7 +53,7 @@ func (t *trace) OnStartup() error {
 		case "zipkin":
 			err = t.setupZipkin()
 		case "datadog":
-			tracer := opentracer.New(tracer.WithAgentAddr(t.Endpoint), tracer.WithServiceName(t.serviceName), tracer.WithDebugMode(true))
+			tracer := opentracer.New(tracer.WithAgentAddr(t.Endpoint), tracer.WithServiceName(t.serviceName), tracer.WithDebugMode(log.D.Value()))
 			t.tracer = tracer
 		default:
 			err = fmt.Errorf("unknown endpoint type: %s", t.EndpointType)


### PR DESCRIPTION
With debug mode tracer generates too many logs and they are written even without `log` plugin enabled.

This is an easiest option.
Other are: respect `log` plugin (might be difficult) or add configuration to a plugin.  