### PR TITLE
Add support for five TLSv1.3 ciphersuites

### DIFF
--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -33,6 +33,11 @@ func setTLSDefaults(tls *ctls.Config) {
 		ctls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		ctls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		ctls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		ctls.TLS_AES_256_GCM_SHA384,
+		ctls.TLS_CHACHA20_POLY1305_SHA256,
+		ctls.TLS_AES_128_GCM_SHA256,
+		ctls.TLS_AES_128_CCM_8_SHA256,
+		ctls.TLS_AES_128_CCM_SHA256,
 	}
 	tls.PreferServerCipherSuites = true
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add support for five TLSv1.3 ciphersuites
### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
