### PR TITLE
Add support TLSv1.3 ciphers

### DIFF
--- a/plugin/tls/tls.go
+++ b/plugin/tls/tls.go
@@ -33,6 +33,7 @@ func setTLSDefaults(tls *ctls.Config) {
 		ctls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		ctls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		ctls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		ctls.TLS_AES_256_GCM_SHA384,
 	}
 	tls.PreferServerCipherSuites = true
 }


### PR DESCRIPTION
Add  TLSv1.3 ciphers (TLS_AES_256_GCM_SHA384)
https://github.com/ZcashFoundation/coredns-zcash (dnsseeder)
add for support HorizenOfficial  (https://github.com/HorizenOfficial/zen) and Safecoin (https://github.com/Fair-Exchange/safecoin) 
TLS encryption to the p2p protocol
