### PR TITLE
plugin/template: Add client IP data

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -48,6 +48,7 @@ Each resource record is a full-featured [Go template](https://golang.org/pkg/tex
 * `.Group` a map of the named capture groups.
 * `.Message` the complete incoming DNS message.
 * `.Question` the matched question section.
+* `.Remote` client’s IP address
 * `.Meta` a function that takes a metadata name and returns the value, if the
   metadata plugin is enabled. For example, `.Meta "kubernetes/client-namespace"`
 

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -48,6 +48,7 @@ type templateData struct {
 	Type     string
 	Message  *dns.Msg
 	Question *dns.Question
+	Remote   string
 	md       map[string]metadata.Func
 }
 
@@ -145,7 +146,7 @@ func executeRRTemplate(server, section string, template *gotmpl.Template, data *
 
 func (t template) match(ctx context.Context, state request.Request) (*templateData, bool, bool) {
 	q := state.Req.Question[0]
-	data := &templateData{md: metadata.ValueFuncs(ctx)}
+	data := &templateData{md: metadata.ValueFuncs(ctx), Remote: state.IP()}
 
 	zone := plugin.Zones(t.zones).Matches(state.Name())
 	if zone == "" {


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
This PR adds a `{{ .Remote }}` data in the template module.

I have tested it with the following minimal `Corefile` (kind of emulating the whoami plugin):
```
. {
    template IN A {
      answer "{{ .Name }} 60 {{ .Class }} {{ .Type }} {{ .Remote }}"
    }
}
```

```console
$ dig @127.0.0.1 A example.com +short
127.0.0.1
```

In terms of use case, the client IP can be useful to make decisions.

### 2. Which issues (if any) are related?
None
### 3. Which documentation changes (if any) need to be made?
`plugin/template/README.md` included in the PR
### 4. Does this introduce a backward incompatible change or deprecation?
Adding a field should be backwards compatible. 