### PR TITLE
enable log.Debugf messages when debug plugin is loaded

### DIFF
--- a/plugin/debug/debug.go
+++ b/plugin/debug/debug.go
@@ -5,6 +5,8 @@ import (
 	"github.com/coredns/coredns/plugin"
 
 	"github.com/caddyserver/caddy"
+
+	"github.com/coredns/coredns/plugin/pkg/log"
 )
 
 func init() { plugin.Register("debug", setup) }
@@ -17,6 +19,7 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("debug", c.ArgErr())
 		}
 		config.Debug = true
+		log.D.Set()
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Causes behavior of `debug` plugin to match [documentation](https://github.com/coredns/coredns/tree/master/plugin/debug/README.md): "A side effect of using *debug* is that `log.Debug` and `log.Debugf` messages will be printed to standard output."

### 2. Which issues (if any) are related?

[4036](https://github.com/coredns/coredns/issues/4036)

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No