### PR TITLE
Fix wildcard records issue in rout53 plugin

### DIFF
--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -148,7 +148,7 @@ func (h *Route53) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 	return dns.RcodeSuccess, nil
 }
 
-const escapeSeq = `\\`
+const escapeSeq = "\\"
 
 // maybeUnescape parses s and converts escaped ASCII codepoints (in octal) back
 // to its ASCII representation.

--- a/plugin/route53/route53_test.go
+++ b/plugin/route53/route53_test.go
@@ -37,7 +37,7 @@ func (fakeRoute53) ListResourceRecordSetsPagesWithContext(_ aws.Context, in *rou
 	}{
 		{"A", "example.org.", "1.2.3.4", "1234567890"},
 		{"A", "www.example.org", "1.2.3.4", "1234567890"},
-		{"CNAME", `\\052.www.example.org`, "www.example.org", "1234567890"},
+		{"CNAME", `\052.www.example.org`, "www.example.org", "1234567890"},
 		{"AAAA", "example.org.", "2001:db8:85a3::8a2e:370:7334", "1234567890"},
 		{"CNAME", "sample.example.org.", "example.org", "1234567890"},
 		{"PTR", "example.org.", "ptr.example.org.", "1234567890"},
@@ -275,17 +275,17 @@ func TestMaybeUnescape(t *testing.T) {
 		// 1. non-escaped sequence.
 		{escaped: "example.com.", want: "example.com."},
 		// 2. escaped `*` as first label - OK.
-		{escaped: `\\052.example.com`, want: "*.example.com"},
+		{escaped: `\052.example.com`, want: "*.example.com"},
 		// 3. Escaped dot, 'a' and a hyphen. No idea why but we'll allow it.
-		{escaped: `weird\\055ex\\141mple\\056com\\056\\056`, want: "weird-example.com.."},
+		{escaped: `weird\055ex\141mple\056com\056\056`, want: "weird-example.com.."},
 		// 4. escaped `*` in the middle - NOT OK.
-		{escaped: `e\\052ample.com`, wantErr: errors.New("`*' only supported as wildcard (leftmost label)")},
+		{escaped: `e\052ample.com`, wantErr: errors.New("`*' only supported as wildcard (leftmost label)")},
 		// 5. Invalid character.
-		{escaped: `\\000.example.com`, wantErr: errors.New(`invalid character: \\000`)},
+		{escaped: `\000.example.com`, wantErr: errors.New(`invalid character: \000`)},
 		// 6. Invalid escape sequence in the middle.
-		{escaped: `example\\0com`, wantErr: errors.New(`invalid escape sequence: '\\0co'`)},
+		{escaped: `example\0com`, wantErr: errors.New(`invalid escape sequence: '\0co'`)},
 		// 7. Invalid escape sequence at the end.
-		{escaped: `example.com\\0`, wantErr: errors.New(`invalid escape sequence: '\\0'`)},
+		{escaped: `example.com\0`, wantErr: errors.New(`invalid escape sequence: '\0'`)},
 	} {
 		got, gotErr := maybeUnescape(tc.escaped)
 		if tc.wantErr != gotErr && !reflect.DeepEqual(tc.wantErr, gotErr) {


### PR DESCRIPTION

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR tries to address #4035 where wild card records does not return
correctly in route53 plugin. The issue was that `strings.Index(s, substr string)`
expect substr to be a string but the code defines as char.

### 2. Which issues (if any) are related?


This PR fixes #4035.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
