### PR TITLE
plugin/template: EDNS local option

### DIFF
--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -12,7 +12,7 @@ The *template* plugin allows you to dynamically respond to queries by just writi
 
 ~~~
 template CLASS TYPE [ZONE...] {
-    match [REGEX...]
+    match REGEX...
     answer RR
     additional RR
     authority RR
@@ -25,7 +25,7 @@ template CLASS TYPE [ZONE...] {
 * **CLASS** the query class (usually IN or ANY).
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
 * **ZONE** the zone scope(s) for this template. Defaults to the server zones.
-* `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no **REGEX** matches everything (default: `.*`). First matching regex wins.
+* `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Omitting `match` will match everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
 * `edns local` add an EDNS0 local OPT pseudo-RR to the response. Each **CODE**=**DATA** pair adds an EDNS0 local value.

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -12,10 +12,11 @@ The *template* plugin allows you to dynamically respond to queries by just writi
 
 ~~~
 template CLASS TYPE [ZONE...] {
-    match REGEX...
+    match [REGEX...]
     answer RR
     additional RR
     authority RR
+    ednslocal CODE=DATA...
     rcode CODE
     fallthrough [ZONE...]
 }
@@ -24,9 +25,10 @@ template CLASS TYPE [ZONE...] {
 * **CLASS** the query class (usually IN or ANY).
 * **TYPE** the query type (A, PTR, ... can be ANY to match all types).
 * **ZONE** the zone scope(s) for this template. Defaults to the server zones.
-* **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no regex matches everything (default: `.*`). First matching regex wins.
+* `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no **REGEX** matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
+* `ednslocal` add an EDNS0 local OPT pseudo-RR to the response. Each **CODE**=**DATA** adds an EDNS0 local value.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
   If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for

--- a/plugin/template/README.md
+++ b/plugin/template/README.md
@@ -16,7 +16,7 @@ template CLASS TYPE [ZONE...] {
     answer RR
     additional RR
     authority RR
-    ednslocal CODE=DATA...
+    edns local CODE=DATA...
     rcode CODE
     fallthrough [ZONE...]
 }
@@ -28,7 +28,7 @@ template CLASS TYPE [ZONE...] {
 * `match` **REGEX** [Go regexp](https://golang.org/pkg/regexp/) that are matched against the incoming question name. Specifying no **REGEX** matches everything (default: `.*`). First matching regex wins.
 * `answer|additional|authority` **RR** A [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5) style resource record fragment
   built by a [Go template](https://golang.org/pkg/text/template/) that contains the reply.
-* `ednslocal` add an EDNS0 local OPT pseudo-RR to the response. Each **CODE**=**DATA** adds an EDNS0 local value.
+* `edns local` add an EDNS0 local OPT pseudo-RR to the response. Each **CODE**=**DATA** pair adds an EDNS0 local value.
 * `rcode` **CODE** A response code (`NXDOMAIN, SERVFAIL, ...`). The default is `SUCCESS`.
 * `fallthrough` Continue with the next plugin if the zone matched but no regex matched.
   If specific zones are listed (for example `in-addr.arpa` and `ip6.arpa`), then only queries for

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -109,6 +109,19 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 					t.additional = append(t.additional, tmpl)
 				}
 
+			case "ednslocal":
+				args := c.RemainingArgs()
+				if len(args) == 0 {
+					return handler, c.ArgErr()
+				}
+				for _, ednslocal := range args {
+					tmpl, err := gotmpl.New("ednslocal").Parse(ednslocal)
+					if err != nil {
+						return handler, c.Errf("could not compile template: %s, %v\n", c.Val(), err)
+					}
+					t.ednsLocal = append(t.ednsLocal, tmpl)
+				}
+
 			case "authority":
 				args := c.RemainingArgs()
 				if len(args) == 0 {

--- a/plugin/template/setup.go
+++ b/plugin/template/setup.go
@@ -109,12 +109,15 @@ func templateParse(c *caddy.Controller) (handler Handler, err error) {
 					t.additional = append(t.additional, tmpl)
 				}
 
-			case "ednslocal":
+			case "edns":
 				args := c.RemainingArgs()
-				if len(args) == 0 {
+				if len(args) < 2 {
 					return handler, c.ArgErr()
 				}
-				for _, ednslocal := range args {
+				if args[0] != "local" {
+					return handler, c.Errf("Unsupported edns type '%v'", args[1])
+				}
+				for _, ednslocal := range args[1:] {
 					tmpl, err := gotmpl.New("ednslocal").Parse(ednslocal)
 					if err != nil {
 						return handler, c.Errf("could not compile template: %s, %v\n", c.Val(), err)

--- a/plugin/template/setup_test.go
+++ b/plugin/template/setup_test.go
@@ -84,6 +84,12 @@ func TestSetupParse(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			`template ANY A example.com {
+					edns unspportedOptionType "12345=test123"
+                }`,
+			true,
+		},
 		// examples
 		{`template ANY ANY (?P<x>`, false},
 		{
@@ -139,6 +145,12 @@ func TestSetupParse(t *testing.T) {
 					additional "ns0.example. 60 IN A 203.0.113.8"
 					additional "ns1.example. 60 IN A 198.51.100.8"
 				}`,
+			false,
+		},
+		{
+			`template ANY A example.com {
+					edns local "12345=test123"
+                }`,
 			false,
 		},
 	}

--- a/plugin/template/template.go
+++ b/plugin/template/template.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"regexp"
 	"strconv"
+	"strings"
 	gotmpl "text/template"
 
 	"github.com/coredns/coredns/plugin"
@@ -32,6 +33,7 @@ type template struct {
 	answer     []*gotmpl.Template
 	additional []*gotmpl.Template
 	authority  []*gotmpl.Template
+	ednsLocal  []*gotmpl.Template
 	qclass     uint16
 	qtype      uint16
 	fall       fall.F
@@ -116,6 +118,28 @@ func (h Handler) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 				return dns.RcodeServerFailure, err
 			}
 			msg.Ns = append(msg.Ns, rr)
+		}
+		if len(template.ednsLocal) > 0 {
+			o := new(dns.OPT)
+			o.Hdr.Name = "."
+			o.Hdr.Rrtype = dns.TypeOPT
+			for _, e := range template.ednsLocal {
+				buffer := &bytes.Buffer{}
+				err := e.Execute(buffer, data)
+				if err != nil {
+					return dns.RcodeServerFailure, err
+				}
+				pos := strings.Index(buffer.String(), "=")
+				i, err := strconv.Atoi(buffer.String()[0:pos])
+				code := uint16(i)
+				var edata []byte
+				if buffer.Len() > pos {
+					edata = buffer.Bytes()[pos+1:]
+				}
+				e := &dns.EDNS0_LOCAL{Code: code, Data: edata}
+				o.Option = append(o.Option, e)
+			}
+			msg.Extra = append(msg.Extra, o)
 		}
 
 		w.WriteMsg(msg)


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Adds the option to respond with an OPT pseudo-record with EDNS local options.
I used this to test an external plugin that depends on an upstream response including edns local options.

I could not puzzle out a way of adding edns options using the existing additional section RR string parsing. Looks like it has to do with the way RR string parser treats OPT records as RFC-3597 (unknown type).

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
