### PR TITLE
Bump to golang 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: go
 go:
-  - "1.14.x"
+  - "1.15.x"
 
 cache:
   directories:


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

Golang 1.15 is out so give it a try to update.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>