### PR TITLE
Update README.md

### DIFF
--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -9,7 +9,7 @@
 The *auto* plugin is used for an "old-style" DNS server. It serves from a preloaded file that exists
 on disk. If the zone file contains signatures (i.e. is signed, i.e. using DNSSEC) correct DNSSEC answers
 are returned. Only NSEC is supported! If you use this setup *you* are responsible for re-signing the
-zonefile. New or changed zones are automatically picked up from disk.
+zonefile. New or changed zones are automatically picked up from disk only when serial changes. If the zones are not updated via a zone transfer, serial must be manually changed.
 
 ## Syntax
 

--- a/plugin/auto/README.md
+++ b/plugin/auto/README.md
@@ -9,7 +9,7 @@
 The *auto* plugin is used for an "old-style" DNS server. It serves from a preloaded file that exists
 on disk. If the zone file contains signatures (i.e. is signed, i.e. using DNSSEC) correct DNSSEC answers
 are returned. Only NSEC is supported! If you use this setup *you* are responsible for re-signing the
-zonefile. New or changed zones are automatically picked up from disk only when serial changes. If the zones are not updated via a zone transfer, serial must be manually changed.
+zonefile. New or changed zones are automatically picked up from disk only when SOA's serial changes. If the zones are not updated via a zone transfer, the serial must be manually changed.
 
 ## Syntax
 


### PR DESCRIPTION
Specify that serial must change for the zone file to be reloaded.

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
The caveat that `auto` only automatically reloads the zone file when serial changes was not very clear. This is just a small documentation change to make this clearer. This way, the behavior is mentioned within the scope of the whole plugin and not just within the description of the `reload` parameter.

### 2. Which issues (if any) are related?
This is related to the closed issue 4059.

### 3. Which documentation changes (if any) need to be made?
This is a documentation change.

### 4. Does this introduce a backward incompatible change or deprecation?
No, unless the behavior of `auto` regarding when it reloads the zone file has changed.