### PR TITLE
Add pkg/dnsutil.RRsets function

### DIFF
--- a/plugin/dnssec/rrsig.go
+++ b/plugin/dnssec/rrsig.go
@@ -19,35 +19,4 @@ func (k *DNSKEY) newRRSIG(signerName string, ttl, incep, expir uint32) *dns.RRSI
 	return sig
 }
 
-type rrset struct {
-	qname string
-	qtype uint16
-}
-
-// rrSets returns rrs as a map of RRsets. It skips RRSIG and OPT records as those don't need to be signed.
-func rrSets(rrs []dns.RR) map[rrset][]dns.RR {
-	m := make(map[rrset][]dns.RR)
-
-	for _, r := range rrs {
-		if r.Header().Rrtype == dns.TypeRRSIG || r.Header().Rrtype == dns.TypeOPT {
-			continue
-		}
-
-		if s, ok := m[rrset{r.Header().Name, r.Header().Rrtype}]; ok {
-			s = append(s, r)
-			m[rrset{r.Header().Name, r.Header().Rrtype}] = s
-			continue
-		}
-
-		s := make([]dns.RR, 1, 3)
-		s[0] = r
-		m[rrset{r.Header().Name, r.Header().Rrtype}] = s
-	}
-
-	if len(m) > 0 {
-		return m
-	}
-	return nil
-}
-
 const origTTL = 3600

--- a/plugin/pkg/dnsutil/rrset.go
+++ b/plugin/pkg/dnsutil/rrset.go
@@ -1,32 +1,31 @@
 package dnsutil
 
-import "github.com/miekg/dns"
+import (
+	"strings"
+
+	"github.com/miekg/dns"
+)
 
 type rrset struct {
 	qname string
 	qtype uint16
 }
 
-// RRSets returns the RRSets from rrs as slice of []dns.RR. OPT records are ignored. The ordering of the returned
-// slice is not specified.
+// RRSets returns the RRSets from rrs as slice of []dns.RR. OPT records are ignored.
+// The ordering of the returned slice is not specified.
 func RRSets(rrs []dns.RR) [][]dns.RR {
-	// TODO: include other meta RRs in the ignore list?
 	m := make(map[rrset][]dns.RR)
 
 	for _, r := range rrs {
+		// TODO: include other meta RRs in the ignore list?
 		if r.Header().Rrtype == dns.TypeOPT {
 			continue
 		}
 
-		if s, ok := m[rrset{r.Header().Name, r.Header().Rrtype}]; ok {
-			s = append(s, r)
-			m[rrset{r.Header().Name, r.Header().Rrtype}] = s
-			continue
-		}
+		n := strings.ToLower(r.Header().Name)
+		t := r.Header().Rrtype
 
-		s := make([]dns.RR, 1, 2)
-		s[0] = r
-		m[rrset{r.Header().Name, r.Header().Rrtype}] = s
+		m[rrset{n, t}] = append(m[rrset{n, t}], r)
 	}
 	if len(m) == 0 {
 		return nil

--- a/plugin/pkg/dnsutil/rrset.go
+++ b/plugin/pkg/dnsutil/rrset.go
@@ -1,0 +1,43 @@
+package dnsutil
+
+import "github.com/miekg/dns"
+
+type rrset struct {
+	qname string
+	qtype uint16
+}
+
+// RRSets returns the RRSets from rrs as slice of []dns.RR. OPT records are ignored. The ordering of the returned
+// slice is not specified.
+func RRSets(rrs []dns.RR) [][]dns.RR {
+	// TODO: include other meta RRs in the ignore list?
+	m := make(map[rrset][]dns.RR)
+
+	for _, r := range rrs {
+		if r.Header().Rrtype == dns.TypeOPT {
+			continue
+		}
+
+		if s, ok := m[rrset{r.Header().Name, r.Header().Rrtype}]; ok {
+			s = append(s, r)
+			m[rrset{r.Header().Name, r.Header().Rrtype}] = s
+			continue
+		}
+
+		s := make([]dns.RR, 1, 2)
+		s[0] = r
+		m[rrset{r.Header().Name, r.Header().Rrtype}] = s
+	}
+	if len(m) == 0 {
+		return nil
+	}
+
+	sets := make([][]dns.RR, len(m))
+	i := 0
+	for _, v := range m {
+		sets[i] = v
+		i++
+	}
+
+	return sets
+}

--- a/plugin/pkg/dnsutil/rrset_test.go
+++ b/plugin/pkg/dnsutil/rrset_test.go
@@ -1,0 +1,56 @@
+package dnsutil
+
+import (
+	"testing"
+
+	"github.com/coredns/coredns/plugin/test"
+	"github.com/miekg/dns"
+)
+
+func TestRRSets(t *testing.T) {
+	// define 3 RRsets
+	rrs := []dns.RR{
+		test.A("example.org. IN A 127.0.0.1"),
+		test.A("example.org. IN A 127.0.0.2"),
+		test.AAAA("example.org. IN AAAA ::1"),
+	}
+
+	sets := RRSets(rrs)
+	for i := range sets {
+		if sets[i][0].Header().Rrtype == dns.TypeA {
+			if len(sets[i]) != 2 {
+				t.Errorf("Expected 2 RRs in the %q RRSet", "A")
+			}
+		}
+		if sets[i][0].Header().Rrtype == dns.TypeAAAA {
+			if len(sets[i]) != 1 {
+				t.Errorf("Expected 1 RRs in the %q RRSet", "AAAA")
+			}
+		}
+
+	}
+}
+
+func TestRRSetsOwners(t *testing.T) {
+	// define 3 RRsets
+	rrs := []dns.RR{
+		test.A("example.org. IN A 127.0.0.1"),
+		test.A("example.com. IN A 127.0.0.2"),
+		test.AAAA("example.org. IN AAAA ::1"),
+	}
+
+	sets := RRSets(rrs)
+	for i := range sets {
+		if sets[i][0].Header().Rrtype == dns.TypeA {
+			if len(sets[i]) != 1 {
+				t.Errorf("Expected 1 RRs in the %q RRSet", "A")
+			}
+		}
+		if sets[i][0].Header().Rrtype == dns.TypeAAAA {
+			if len(sets[i]) != 1 {
+				t.Errorf("Expected 1 RRs in the %q RRSet", "AAAA")
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
This function returns the rrset from a slice of rrs. Lifted from the
dnssec plugin (which is now the only user).

This is *also* needed if we're doing per RRset caching which prompted
this PR.

Pros for merging: this function is now tested
Cons: might be less useful than I think