### PR TITLE
Add proto and client-ip tags to trace plugin

### DIFF
--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -26,6 +26,8 @@ const (
 	tagName  = "coredns.io/name"
 	tagType  = "coredns.io/type"
 	tagRcode = "coredns.io/rcode"
+	tagProto = "coredns.io/proto"
+	tagClientIP = "coredns.io/client-ip"
 )
 
 type trace struct {
@@ -103,6 +105,8 @@ func (t *trace) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) 
 
 	span.SetTag(tagName, req.Name())
 	span.SetTag(tagType, req.Type())
+	span.SetTag(tagProto, req.Proto())
+	span.SetTag(tagClientIP, req.IP())
 	span.SetTag(tagRcode, rcode.ToString(rw.Rcode))
 
 	return status, err

--- a/plugin/trace/trace_test.go
+++ b/plugin/trace/trace_test.go
@@ -88,6 +88,12 @@ func TestTrace(t *testing.T) {
 			if rootSpan.Tag(tagType) != req.Type() {
 				t.Errorf("Unexpected span tag: rootSpan.Tag(%v): want %v, got %v", tagType, req.Type(), rootSpan.Tag(tagType))
 			}
+			if rootSpan.Tag(tagProto) != req.Proto() {
+				t.Errorf("Unexpected span tag: rootSpan.Tag(%v): want %v, got %v", tagProto, req.Proto(), rootSpan.Tag(tagProto))
+			}
+			if rootSpan.Tag(tagClientIP) != req.IP() {
+				t.Errorf("Unexpected span tag: rootSpan.Tag(%v): want %v, got %v", tagClientIP, req.IP(), rootSpan.Tag(tagClientIP))
+			}
 			if rootSpan.Tag(tagRcode) != rcode.ToString(tc.rcode) {
 				t.Errorf("Unexpected span tag: rootSpan.Tag(%v): want %v, got %v", tagRcode, rcode.ToString(tc.rcode), rootSpan.Tag(tagRcode))
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Add proto and client-ip tags to traces from the trace plugin. Not sure if there a limit or cost to adding tags, but these ones seem useful to analyse if certain types of requests are slower than others, or to identify which client a particular request comes from.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
I don't see the tag keys documented anywhere, perhaps they should be?

### 4. Does this introduce a backward incompatible change or deprecation?
No.