### PR TITLE
cleanup tempfiles for erratic_autopath_test

### DIFF
--- a/test/erratic_autopath_test.go
+++ b/test/erratic_autopath_test.go
@@ -14,7 +14,7 @@ func setupProxyTargetCoreDNS(t *testing.T, fn func(string)) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpdir)
+	defer os.RemoveAll(tmpdir)
 
 	content := `
 example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 1 3600 3600 3600 3600


### PR DESCRIPTION


<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
cleanup tempfiles

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
Signed-off-by: Zhou Hao <zhouhao@cn.fujitsu.com>
