### PR TITLE
Fix trailing whitespace

### DIFF
--- a/core/dnsserver/server.go
+++ b/core/dnsserver/server.go
@@ -194,7 +194,7 @@ func (s *Server) Stop() (err error) {
 // Address together with Stop() implement caddy.GracefulServer.
 func (s *Server) Address() string { return s.Addr }
 
-// ServeDNS is the entry point for every request to the address that 
+// ServeDNS is the entry point for every request to the address that
 // is bound to. It acts as a multiplexer for the requests zonename as
 // defined in the request so that the correct zone
 // (configuration and plugin stack) will handle the request.


### PR DESCRIPTION
The latest commit (e233f59) on master branch introduced a trailing whitespace and is causing Travis CI build to fail:

https://travis-ci.org/github/coredns/coredns/builds/722988413

This PR fixes the failing test.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
