### PR TITLE
plugin/forward: init ClientSessionCache in tls.Config

### DIFF
--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -118,6 +118,9 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	if f.tlsServerName != "" {
 		f.tlsConfig.ServerName = f.tlsServerName
 	}
+
+	// Initialize ClientSessionCache in tls.Config. This may speed up a TLS handshake
+	// in upcoming connections to the same TLS server.
 	f.tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(len(f.proxies))
 
 	for i := range f.proxies {

--- a/plugin/forward/setup.go
+++ b/plugin/forward/setup.go
@@ -1,6 +1,7 @@
 package forward
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strconv"
@@ -117,6 +118,8 @@ func parseStanza(c *caddy.Controller) (*Forward, error) {
 	if f.tlsServerName != "" {
 		f.tlsConfig.ServerName = f.tlsServerName
 	}
+	f.tlsConfig.ClientSessionCache = tls.NewLRUClientSessionCache(len(f.proxies))
+
 	for i := range f.proxies {
 		// Only set this for proxies that need it.
 		if transports[i] == transport.TLS {


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
initialize ClientSessionCache in tls.Config. This may speed up a TLS handshake in upcoming connections to the same TLS server, i.e. the main reason is increasing performance

### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
none
