### PR TITLE
plugin/trace: fix struct allignment

### DIFF
--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -13,15 +13,13 @@ import (
 
 // Erratic is a plugin that returns erratic responses to each client.
 type Erratic struct {
-	drop uint64
-
+	q        uint64 // counter of queries
+	drop     uint64
 	delay    uint64
-	duration time.Duration
-
 	truncate uint64
-	large    bool // undocumented feature; return large responses for A request (>512B, to test compression).
 
-	q uint64 // counter of queries
+	duration time.Duration
+	large    bool // undocumented feature; return large responses for A request (>512B, to test compression).
 }
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -29,6 +29,8 @@ const (
 )
 
 type trace struct {
+	count uint64 // as per Go spec, needs to be first element in a struct
+
 	Next            plugin.Handler
 	Endpoint        string
 	EndpointType    string
@@ -37,7 +39,6 @@ type trace struct {
 	serviceName     string
 	clientServer    bool
 	every           uint64
-	count           uint64
 	Once            sync.Once
 }
 


### PR DESCRIPTION
A 64 bit entity needs to be the first in a struct to make it work on 32
bit systems.

Fixes: #4111