### PR TITLE
plugin/forward: fix panic when `expire` is configured as 0s

### DIFF
--- a/plugin/forward/persistent.go
+++ b/plugin/forward/persistent.go
@@ -44,7 +44,7 @@ func newTransport(addr string) *Transport {
 
 // connManagers manages the persistent connection cache for UDP and TCP.
 func (t *Transport) connManager() {
-	ticker := time.NewTicker(t.expire)
+	ticker := time.NewTicker(defaultExpire)
 Wait:
 	for {
 		select {


### PR DESCRIPTION
Signed-off-by: Ruslan Drozhdzh <rdrozhdzh@infoblox.com>

### 1. Why is this pull request needed and what does it do?
fixed panic when `expire` is configured as 0s. Instead, the ticker will be initialized with default value. This will also prevent calling `cleanup()` func too often.
### 2. Which issues (if any) are related?
none
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
no