### PR TITLE
plugins/auto: allow fallthrough if no zone match

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -50,6 +50,9 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	// Now the real zone.
 	zone = plugin.Zones(a.Zones.Names()).Matches(qname)
+	if zone == "" {
+		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)
+	}
 
 	a.Zones.RLock()
 	z, ok := a.Zones.Z[zone]

--- a/plugin/erratic/erratic.go
+++ b/plugin/erratic/erratic.go
@@ -13,15 +13,13 @@ import (
 
 // Erratic is a plugin that returns erratic responses to each client.
 type Erratic struct {
-	drop uint64
-
+	q        uint64 // counter of queries
+	drop     uint64
 	delay    uint64
-	duration time.Duration
-
 	truncate uint64
-	large    bool // undocumented feature; return large responses for A request (>512B, to test compression).
 
-	q uint64 // counter of queries
+	duration time.Duration
+	large    bool // undocumented feature; return large responses for A request (>512B, to test compression).
 }
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -29,6 +29,8 @@ const (
 )
 
 type trace struct {
+	count uint64 // as per Go spec, needs to be first element in a struct
+
 	Next            plugin.Handler
 	Endpoint        string
 	EndpointType    string
@@ -37,7 +39,6 @@ type trace struct {
 	serviceName     string
 	clientServer    bool
 	every           uint64
-	count           uint64
 	Once            sync.Once
 }
 


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
auto plugin currently responds to client with a failure if non of the zonefiles match the query zone. right now the only way for it to fallthrough to the next plugin is by explicitly naming the authoritative zones for this plugin, e.g. `auto example.com example.org`. This is not ideal if there are a lot of zones, or the zonefiles directory changes dynamically. This PR makes the auto plugin pass the query to the next plugin if the query zone doesn't match any of the loaded zonefiles.

### 2. Which issues (if any) are related?
this is a solution to #3033

### 3. Which documentation changes (if any) need to be made?
current doc is silent on the issue. 

### 4. Does this introduce a backward incompatible change or deprecation?
no.