### PR TITLE
goreport card fixes

### DIFF
--- a/plugin/kubernetes/informer_test.go
+++ b/plugin/kubernetes/informer_test.go
@@ -83,7 +83,7 @@ func testProcessor(t *testing.T, processor cache.ProcessFunc, idx cache.Indexer)
 	if err != nil {
 		t.Fatalf("delete test failed: %v", err)
 	}
-	got, exists, err = idx.Get(obj2)
+	_, exists, err = idx.Get(obj2)
 	if err != nil {
 		t.Fatalf("get deleted object failed: %v", err)
 	}
@@ -101,7 +101,7 @@ func testProcessor(t *testing.T, processor cache.ProcessFunc, idx cache.Indexer)
 	if err != nil {
 		t.Fatalf("tombstone delete test failed: %v", err)
 	}
-	got, exists, err = idx.Get(svc)
+	_, exists, err = idx.Get(svc)
 	if err != nil {
 		t.Fatalf("get tombstone deleted object failed: %v", err)
 	}

--- a/plugin/test/helpers.go
+++ b/plugin/test/helpers.go
@@ -248,7 +248,7 @@ func Section(tc Case, sec sect, rr []dns.RR) error {
 	return nil
 }
 
-// CNAMEOrder makes sure that CNAMES do not appear after their target records
+// CNAMEOrder makes sure that CNAMES do not appear after their target records.
 func CNAMEOrder(res *dns.Msg) error {
 	for i, c := range res.Answer {
 		if c.Header().Rrtype != dns.TypeCNAME {

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -140,7 +140,6 @@ receive:
 	if len(rrs) > 0 {
 		ch <- &dns.Envelope{RR: rrs}
 		l += len(rrs)
-		rrs = []dns.RR{}
 	}
 
 	if soa != nil {


### PR DESCRIPTION
This fixes some inefassign as report by Go report card:
https://goreportcard.com/report/github.com/coredns/coredns