### PR TITLE
fix goroutine leak when writeMsg failed

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -112,7 +112,7 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	go func() {
 		err := tr.Out(w, r, ch)
 		if err != nil {
-			log.Infof("failed to write message zone %q to %s for %d SOA serial: %s", state.QName(), state.IP(), serial, err.Error())
+			log.Warningf("Failed to write zone transfer of zone %q to %s for %d SOA serial: %s", state.QName(), state.IP(), serial, err)
 		}
 		close(closeCh)
 	}()

--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -3,7 +3,6 @@ package transfer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 
 	"github.com/coredns/coredns/plugin"
@@ -50,6 +49,8 @@ type Transferer interface {
 var (
 	// ErrNotAuthoritative is returned by Transfer() when the plugin is not authoritative for the zone.
 	ErrNotAuthoritative = errors.New("not authoritative for zone")
+	// ErrWriteMessage is returned by ServeDNS() when failed to write message.
+	ErrWriteMessage = errors.New("not authoritative for zone")
 )
 
 // ServeDNS implements the plugin.Handler interface.
@@ -107,26 +108,14 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	// Send response to client
 	ch := make(chan *dns.Envelope)
 	tr := new(dns.Transfer)
-	closeCh := make(chan error)
+	closeCh := make(chan struct{})
 	go func() {
 		err := tr.Out(w, r, ch)
 		if err != nil {
 			log.Warningf("Failed to write zone transfer of zone %q to %s for %d SOA serial: %s", state.QName(), state.IP(), serial, err)
 		}
-		closeCh <- err
+		close(closeCh)
 	}()
-
-	send := func(ev *dns.Envelope) error {
-		select {
-		case ch <- ev:
-		case err = <-closeCh:
-			if err != nil {
-				return fmt.Errorf("failed to write transfer message: %w", err)
-			}
-			return fmt.Errorf("finish transfer before ch close")
-		}
-		return nil
-	}
 
 	rrs := []dns.RR{}
 	l := 0
@@ -137,10 +126,10 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		}
 		rrs = append(rrs, records...)
 		if len(rrs) > 500 {
-			if err := send(&dns.Envelope{RR: rrs}); err != nil {
-				close(ch)
-				close(closeCh)
-				return dns.RcodeServerFailure, err
+			select {
+			case ch <- &dns.Envelope{RR: rrs}:
+			case <-closeCh:
+				return dns.RcodeServerFailure, ErrWriteMessage
 			}
 			l += len(rrs)
 			rrs = []dns.RR{}
@@ -153,7 +142,6 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	if len(rrs) == 1 && soa != nil { // soa should never be nil...
 		close(ch)
 		<-closeCh
-		close(closeCh)
 
 		m := new(dns.Msg)
 		m.SetReply(r)
@@ -170,7 +158,6 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	if len(rrs) == 1 && soa != nil { // soa should never be nil...
 		close(ch)
 		<-closeCh
-		close(closeCh)
 
 		m := new(dns.Msg)
 		m.SetReply(r)
@@ -182,20 +169,16 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 	}
 
 	if len(rrs) > 0 {
-		if err := send(&dns.Envelope{RR: rrs}); err != nil {
-			close(ch)
-			close(closeCh)
-			return dns.RcodeServerFailure, err
+		select {
+		case ch <- &dns.Envelope{RR: rrs}:
+		case <-closeCh:
+			return dns.RcodeServerFailure, ErrWriteMessage
 		}
 		l += len(rrs)
 	}
 
-	close(ch)       // Even though we close the channel here, we still have
-	err = <-closeCh // to wait before we can return and close the connection.
-	if err != nil {
-		return dns.RcodeServerFailure, err
-	}
-	close(closeCh)
+	close(ch) // Even though we close the channel here, we still have
+	<-closeCh // to wait before we can return and close the connection.
 
 	logserial := uint32(0)
 	if soa != nil {

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -296,11 +295,9 @@ func newBadWriter(w dns.ResponseWriter) *badwriter {
 	}
 }
 
-var errBadWriterErr = fmt.Errorf("failed to write msg")
-
 func (w *badwriter) WriteMsg(res *dns.Msg) error {
 	if w.count > 0 {
-		return errBadWriterErr
+		return fmt.Errorf("failed to write msg")
 	}
 	w.count++
 	return nil
@@ -315,7 +312,7 @@ func TestWriteMessageFailed(t *testing.T) {
 	m.SetAxfr("example.org.")
 
 	_, err := transfer.ServeDNS(ctx, w, m)
-	if !errors.Is(err, errBadWriterErr) {
-		t.Error("failed to get write msg error")
+	if err == nil {
+		t.Error("failed to get error")
 	}
 }

--- a/plugin/transfer/transfer_test.go
+++ b/plugin/transfer/transfer_test.go
@@ -2,6 +2,7 @@ package transfer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -295,9 +296,11 @@ func newBadWriter(w dns.ResponseWriter) *badwriter {
 	}
 }
 
+var errBadWriterErr = fmt.Errorf("failed to write msg")
+
 func (w *badwriter) WriteMsg(res *dns.Msg) error {
 	if w.count > 0 {
-		return fmt.Errorf("failed to write msg")
+		return errBadWriterErr
 	}
 	w.count++
 	return nil
@@ -312,7 +315,7 @@ func TestWriteMessageFailed(t *testing.T) {
 	m.SetAxfr("example.org.")
 
 	_, err := transfer.ServeDNS(ctx, w, m)
-	if err == nil {
-		t.Error("failed to get error")
+	if !errors.Is(err, errBadWriterErr) {
+		t.Error("failed to get write msg error")
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
Fix transfer plugin goroutine leak.
When an error occurs during writeMsg, Transfer can't sent dns.Envelope into channel.

### 2. Which issues (if any) are related?
nothing

### 3. Which documentation changes (if any) need to be made?
no need

### 4. Does this introduce a backward incompatible change or deprecation?
no