### PR TITLE
doh support: make no TLS config fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,16 @@ And for DNS over HTTP/2 (DoH) use:
 ~~~ corefile
 https://example.org {
     whoami
+    tls mycert mykey
 }
 ~~~
+
+Note that you must have the *tls* plugin configured as DoH requires that to be setup.
 
 Specifying ports works in the same way:
 
 ~~~ txt
-grpc://example.org:1443 {
+grpc://example.org:1443 https://example.org:1444 {
     # ...
 }
 ~~~

--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -38,6 +38,9 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 		// Should we error if some configs *don't* have TLS?
 		tlsConfig = conf.TLSConfig
 	}
+	if tlsConfig == nil {
+		return nil, fmt.Errorf("DoH requires TLS to be configured, see the tls plugin")
+	}
 
 	srv := &http.Server{
 		ReadTimeout:  5 * time.Second,


### PR DESCRIPTION
without TLS you can't have a functioning DoH server as no client will be
able to talk to it. Make this a fatal failure.

Add some extra docs on how to start a DoH capable server.
### 1. Why is this pull request needed and what does it do?

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?