### PR TITLE
plugins/auto: allow fallthrough if no zone match

### DIFF
--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -50,7 +50,10 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 
 	// Now the real zone.
 	zone = plugin.Zones(a.Zones.Names()).Matches(qname)
-
+	if zone == "" {
+		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)
+	}
+	
 	a.Zones.RLock()
 	z, ok := a.Zones.Z[zone]
 	a.Zones.RUnlock()

--- a/plugin/auto/auto.go
+++ b/plugin/auto/auto.go
@@ -53,7 +53,7 @@ func (a Auto) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (i
 	if zone == "" {
 		return plugin.NextOrFailure(a.Name(), a.Next, ctx, w, r)
 	}
-	
+
 	a.Zones.RLock()
 	z, ok := a.Zones.Z[zone]
 	a.Zones.RUnlock()


### PR DESCRIPTION
this is a solution to #3033

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
auto plugin currently responds to client with a failure if non of the zonefiles match the query zone. right now the only way for it to fallthrough to the next plugin is by explicitly naming the authoritative zones for this plugin, e.g. auto example.com example.org. This is not ideal if there are a lot of zones, or the zonefiles directory changes dynamically. This PR makes the auto plugin pass the query to the next plugin if the query zone doesn't match any of the loaded zonefiles.

### 2. Which issues (if any) are related?
this is a solution to #3033

### 3. Which documentation changes (if any) need to be made?
current doc is silent on the issue.

### 4. Does this introduce a backward incompatible change or deprecation?
no.
