### PR TITLE
plugin/ready: Don't return 200 OK during shutdown

### DIFF
--- a/plugin/ready/ready.go
+++ b/plugin/ready/ready.go
@@ -43,6 +43,13 @@ func (rd *ready) onStartup() error {
 	rd.Unlock()
 
 	rd.mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		rd.Lock()
+		defer rd.Unlock()
+		if !rd.done {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			io.WriteString(w, "Shutting down")
+			return
+		}
 		ok, todo := plugins.Ready()
 		if ok {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Don't reply that we are ready during shutdown.  We already stop listening for new connections when we shutdown, but for clients that re-use connections, ready still answered OK during shutdown (extended by health's lameduck mode). This change makes ready report "not ready" during the shutdown period.

### 2. Which issues (if any) are related?

#4099

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
