### PR TITLE
plugin/health: fix lameduck docs

### DIFF
--- a/plugin/health/README.md
+++ b/plugin/health/README.md
@@ -26,8 +26,8 @@ health [ADDRESS] {
 }
 ~~~
 
-* Where `lameduck` will make the process unhealthy then *wait* for **DURATION** before the process
-  shuts down.
+* Where `lameduck` will delay shutdown for **DURATION**. /health will still answer 200 OK.
+  Note: The *ready* plugin will not answer OK while CoreDNS is in lameduck mode prior to shutdown.
 
 If you have multiple Server Blocks, *health* can only be enabled in one of them (as it is process
 wide). If you really need multiple endpoints, you must run health endpoints on different ports:


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fixes lameduck docs.  Also mention _ready_ plugin behavior during lameduck.

### 2. Which issues (if any) are related?

fixes #4084

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
