### PR TITLE
plugin/trace: Fix zipkin json_v2 and #4160

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -56,6 +56,8 @@ You can run Zipkin on a Docker host like this:
 docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
+:warning: The zipkin provider does not support the v1 API since coredns 1.7.1
+
 ## Examples
 
 Use an alternative Zipkin address:

--- a/plugin/trace/setup.go
+++ b/plugin/trace/setup.go
@@ -35,7 +35,9 @@ func traceParse(c *caddy.Controller) (*trace, error) {
 	)
 
 	cfg := dnsserver.GetConfig(c)
-	tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
+	if cfg.ListenHosts[0] != "" {
+		tr.serviceEndpoint = cfg.ListenHosts[0] + ":" + cfg.Port
+	}
 
 	for c.Next() { // trace
 		var err error
@@ -115,7 +117,7 @@ func normalizeEndpoint(epType, ep string) (string, string, error) {
 
 	if epType == "zipkin" {
 		if !strings.Contains(ep, "http") {
-			ep = "http://" + ep + "/api/v1/spans"
+			ep = "http://" + ep + "/api/v2/spans"
 		}
 	}
 

--- a/plugin/trace/setup_test.go
+++ b/plugin/trace/setup_test.go
@@ -16,17 +16,17 @@ func TestTraceParse(t *testing.T) {
 		clientServer bool
 	}{
 		// oks
-		{`trace`, false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
-		{`trace localhost:1234`, false, "http://localhost:1234/api/v1/spans", 1, `coredns`, false},
+		{`trace`, false, "http://localhost:9411/api/v2/spans", 1, `coredns`, false},
+		{`trace localhost:1234`, false, "http://localhost:1234/api/v2/spans", 1, `coredns`, false},
 		{`trace http://localhost:1234/somewhere/else`, false, "http://localhost:1234/somewhere/else", 1, `coredns`, false},
-		{`trace zipkin localhost:1234`, false, "http://localhost:1234/api/v1/spans", 1, `coredns`, false},
+		{`trace zipkin localhost:1234`, false, "http://localhost:1234/api/v2/spans", 1, `coredns`, false},
 		{`trace datadog localhost`, false, "localhost", 1, `coredns`, false},
 		{`trace datadog http://localhost:8127`, false, "http://localhost:8127", 1, `coredns`, false},
 		{"trace datadog localhost {\n datadog_analytics_rate 0.1\n}", false, "localhost", 1, `coredns`, false},
-		{"trace {\n every 100\n}", false, "http://localhost:9411/api/v1/spans", 100, `coredns`, false},
-		{"trace {\n every 100\n service foobar\nclient_server\n}", false, "http://localhost:9411/api/v1/spans", 100, `foobar`, true},
-		{"trace {\n every 2\n client_server true\n}", false, "http://localhost:9411/api/v1/spans", 2, `coredns`, true},
-		{"trace {\n client_server false\n}", false, "http://localhost:9411/api/v1/spans", 1, `coredns`, false},
+		{"trace {\n every 100\n}", false, "http://localhost:9411/api/v2/spans", 100, `coredns`, false},
+		{"trace {\n every 100\n service foobar\nclient_server\n}", false, "http://localhost:9411/api/v2/spans", 100, `foobar`, true},
+		{"trace {\n every 2\n client_server true\n}", false, "http://localhost:9411/api/v2/spans", 2, `coredns`, true},
+		{"trace {\n client_server false\n}", false, "http://localhost:9411/api/v2/spans", 1, `coredns`, false},
 		// fails
 		{`trace footype localhost:4321`, true, "", 1, "", false},
 		{"trace {\n every 2\n client_server junk\n}", true, "", 1, "", false},
@@ -47,6 +47,9 @@ func TestTraceParse(t *testing.T) {
 			continue
 		}
 
+		if "" != m.serviceEndpoint {
+			t.Errorf("Test %v: Expected serviceEndpoint to be '' but found: %s", i, m.serviceEndpoint)
+		}
 		if test.endpoint != m.Endpoint {
 			t.Errorf("Test %v: Expected endpoint %s but found: %s", i, test.endpoint, m.Endpoint)
 		}

--- a/plugin/trace/trace.go
+++ b/plugin/trace/trace.go
@@ -84,6 +84,7 @@ func (t *trace) setupZipkin() error {
 	tracer, err := zipkin.NewTracer(
 		reporter,
 		zipkin.WithLocalEndpoint(recorder),
+		zipkin.WithSharedSpans(t.clientServer),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?
In #4171 i noticed that the client_server was not being used anymore.
It appears that it should still be there.

While testing that change i noticed that the zipkin provider was borked and couldn't push traces anymore
Tcpdump showed that the zipkin server was responding with

```
Expected a JSON_V1 encoded list, but received: JSON_V2
```

There was also an issue (#4160)  with
```

	recorder, err := zipkin.NewEndpoint(t.serviceName, t.serviceEndpoint)
```
As `t.serviceEndpoint` is `:53` in most cases
Zipkin can't parse the ip:port tuple and send a warning with
```
[WARNING] build Zipkin endpoint found err: lookup : no such host
```
cf: [openzipkin/endpoint.go](https://github.com/openzipkin/zipkin-go/blob/master/endpoint.go#L27-L80)

To actively set a correct values in serviceEndpoint you need to use the bind plugin
```
.:53 {
    bind 127.0.0.1
    trace
}
```

### 2. Which issues (if any) are related?
#4160 
#4109 
#4171 

### 3. Which documentation changes (if any) need to be made?
Indicate that the zipkin api v1 is not working as of `1.7.1`

### 4. Does this introduce a backward incompatible change or deprecation?
Yes the api version of zipkin is now using `v2`
Though that fix a bug introduced with #4109 

