### PR TITLE
fix alpn for http/2 upgrade when using DoH

### DIFF
--- a/core/dnsserver/server_https.go
+++ b/core/dnsserver/server_https.go
@@ -41,6 +41,9 @@ func NewServerHTTPS(addr string, group []*Config) (*ServerHTTPS, error) {
 	if tlsConfig == nil {
 		return nil, fmt.Errorf("DoH requires TLS to be configured, see the tls plugin")
 	}
+	// http/2 is recommended when using DoH. We need to specify it in next protos
+	// or the upgrade won't happen.
+	tlsConfig.NextProtos = []string{"h2", "http/1.1"}
 
 	srv := &http.Server{
 		ReadTimeout:  5 * time.Second,


### PR DESCRIPTION
### What

Provide "h2" in NextProtos for the TLS config that are set on the https server.

### Why

This is used for ALPN which is required to be able to upgrade the connection to http/2 which is recommended for DoH.
Without this we will be left with http/1.1 only.

Fixes #2566

