### PR TITLE
plugin/dnstap: add query time to response messages

### DIFF
--- a/plugin/dnstap/taprw/writer.go
+++ b/plugin/dnstap/taprw/writer.go
@@ -67,7 +67,7 @@ func (w *ResponseWriter) WriteMsg(resp *dns.Msg) (writeErr error) {
 			if w.Pack() {
 				b.Msg(resp)
 			}
-			if m, err := b.Time(writeEpoch).ToClientResponse(); err != nil {
+			if m, err := b.QueryTime(w.QueryEpoch).Time(writeEpoch).ToClientResponse(); err != nil {
 				w.dnstapErr = fmt.Errorf("client response: %s", err)
 			} else {
 				w.TapMessage(m)

--- a/plugin/forward/dnstap.go
+++ b/plugin/forward/dnstap.go
@@ -50,7 +50,7 @@ func toDnstap(ctx context.Context, host string, f *Forward, state request.Reques
 		if tapper.Pack() {
 			b.Msg(reply)
 		}
-		m, err := b.Time(time.Now()).ToOutsideResponse(tap.Message_FORWARDER_RESPONSE)
+		m, err := b.QueryTime(start).Time(time.Now()).ToOutsideResponse(tap.Message_FORWARDER_RESPONSE)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Ruslan Drozhdzh <rdrozhdzh@infoblox.com>

### 1. Why is this pull request needed and what does it do?
add query timestamp to the DNSTAP messages on response events. This is a simple alternative to PR #4179. We can consider further dnstap plugin enhancements as a separate issue.
### 2. Which issues (if any) are related?
#4165
### 3. Which documentation changes (if any) need to be made?
none
### 4. Does this introduce a backward incompatible change or deprecation?
no