### PR TITLE
plugin/transfer: remove duplicate code

### DIFF
--- a/plugin/transfer/transfer.go
+++ b/plugin/transfer/transfer.go
@@ -141,22 +141,6 @@ func (t *Transfer) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 		m.Answer = []dns.RR{soa}
 		w.WriteMsg(m)
 
-		log.Infof("Outgoing incremental transfer for up to date zone %q to %s for %d SOA serial", state.QName(), state.IP(), serial)
-		return 0, nil
-	}
-
-	// if we are here and we only hold 1 soa (len(rrs) == 1) and soa != nil, and IXFR fallback should
-	// be performed. We haven't send anything on ch yet, so that can be closed (and waited for), and we only
-	// need to return the SOA back to the client and return.
-	if len(rrs) == 1 && soa != nil { // soa should never be nil...
-		close(ch)
-		wg.Wait()
-
-		m := new(dns.Msg)
-		m.SetReply(r)
-		m.Answer = []dns.RR{soa}
-		w.WriteMsg(m)
-
 		log.Infof("Outgoing noop, incremental transfer for up to date zone %q to %s for %d SOA serial", state.QName(), state.IP(), soa.Serial)
 		return 0, nil
 	}


### PR DESCRIPTION
Was running coredns-master on my servers and kept seeing:

~~~
okt 14 10:38:06.473281 deb coredns[30303]: [INFO] plugin/transfer: Outgoing incremental transfer for up to date zone "miek.nl." to 37.97.149.87 for 1602370680 SOA serial
okt 14 10:40:06.498512 deb coredns[30303]: [INFO] plugin/transfer: Outgoing incremental transfer for up to date zone "miek.nl." to 37.97.149.87 for 1602370680 SOA serial
okt 14 10:42:06.553747 deb coredns[30303]: [INFO] plugin/transfer: Outgoing incremental transfer for up to date zone "miek.nl." to 37.97.149.87 for 1602370680 SOA serial
~~~

and I'm like shouldn't that be noop transfer? And sure enough, a
duplicated code block in the transfer code that logs this, so the `noop`
line is never reached.