### PR TITLE
reduce sleeps

### DIFF
--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -21,7 +21,7 @@ func TestAuto(t *testing.T) {
 	corefile := `org:0 {
 		auto {
 			directory ` + tmpdir + ` db\.(.*) {1}
-			reload 1s
+			reload 0.1s
 		}
 	}`
 
@@ -46,7 +46,7 @@ func TestAuto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(1500 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(150 * time.Millisecond) // wait for it to be picked up
 
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestAuto(t *testing.T) {
 	// Remove db.example.org again.
 	os.Remove(filepath.Join(tmpdir, "db.example.org"))
 
-	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(150 * time.Millisecond) // wait for it to be picked up
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")
@@ -119,7 +119,7 @@ func TestAutoAXFR(t *testing.T) {
 	corefile := `org:0 {
 		auto {
 			directory ` + tmpdir + ` db\.(.*) {1}
-			reload 1s
+			reload 0.1s
 		}
 		transfer {
 			to *
@@ -142,7 +142,7 @@ func TestAutoAXFR(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(150 * time.Millisecond) // wait for it to be picked up
 
 	tr := new(dns.Transfer)
 	m := new(dns.Msg)

--- a/test/file_reload_test.go
+++ b/test/file_reload_test.go
@@ -21,7 +21,7 @@ func TestZoneReload(t *testing.T) {
 	corefile := `
 	example.org:0 {
 		file ` + name + ` {
-			reload 1s
+			reload 0.1s
 		}
 	}
 	example.net:0 {
@@ -47,7 +47,7 @@ func TestZoneReload(t *testing.T) {
 	// Remove RR from the Apex
 	ioutil.WriteFile(name, []byte(exampleOrgUpdated), 0644)
 
-	time.Sleep(2 * time.Second) // reload time
+	time.Sleep(150 * time.Millisecond) // reload time
 
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {

--- a/test/metrics_test.go
+++ b/test/metrics_test.go
@@ -78,7 +78,7 @@ func TestMetricsAuto(t *testing.T) {
 	corefile := `org:0 {
 		auto {
 			directory ` + tmpdir + ` db\.(.*) {1}
-			reload 1s
+			reload 0.1s
 		}
 		prometheus localhost:0
 	}`
@@ -98,8 +98,7 @@ func TestMetricsAuto(t *testing.T) {
 	if err = ioutil.WriteFile(filepath.Join(tmpdir, "db.example.org"), []byte(zoneContent), 0644); err != nil {
 		t.Fatal(err)
 	}
-	// TODO(miek): make the auto sleep even less.
-	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(110 * time.Millisecond) // wait for it to be picked up
 
 	m := new(dns.Msg)
 	m.SetQuestion("www.example.org.", dns.TypeA)
@@ -120,7 +119,7 @@ func TestMetricsAuto(t *testing.T) {
 
 	// Remove db.example.org again. And see if the metric stops increasing.
 	os.Remove(filepath.Join(tmpdir, "db.example.org"))
-	time.Sleep(1100 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(110 * time.Millisecond) // wait for it to be picked up
 	if _, err := dns.Exchange(m, udp); err != nil {
 		t.Fatalf("Could not send message: %s", err)
 	}

--- a/test/reload_test.go
+++ b/test/reload_test.go
@@ -101,7 +101,7 @@ func TestReloadMetricsHealth(t *testing.T) {
 	}
 	defer c1.Stop()
 
-	time.Sleep(1 * time.Second)
+	time.Sleep(100 * time.Millisecond)
 
 	// Health
 	resp, err := http.Get("http://localhost:53184/health")


### PR DESCRIPTION
This reduces the amount of sleep time to speed up testing.

master:
PASS
ok  	github.com/coredns/coredns/test	42.088s
12,33s user 1,30s system 44,29s elapsed 30%CPU ()

this branch:
PASS
ok  	github.com/coredns/coredns/test	33.527s