### PR TITLE
add default reviewers for circleci config

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 *                       @bradbeam @chrisohaver @dilyevsky @fastest963 @greenpau @isolus @johnbelamaric @miekg @pmoroney @rajansandeep @stp-ip @superq @yongtang
 
+/.circleci/             @miekg @chrisohaver @rajansandeep
 /plugin/pkg/            @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /coremain/              @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip
 /core/                  @miekg @chrisohaver @johnbelamaric @yongtang @stp-ip


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

Prevent all maintainers from getting spammed for review of circleci config changes.
Please let me know if anyone else should be added.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
