### PR TITLE
plugin/metrics: add metric for "plugin that served the response"

### DIFF
--- a/plugin/metrics/metrics.go
+++ b/plugin/metrics/metrics.go
@@ -153,3 +153,10 @@ var buildInfo = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name:      "build_info",
 	Help:      "A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",
 }, []string{"version", "revision", "goversion"})
+
+var PluginResponseCount = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: plugin.Namespace,
+	Subsystem: "plugin",
+	Name:      "responses_total",
+	Help:      "Counter of responses served by plugins",
+}, []string{"plugin"})


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

This adds a response metric per the plugin that "served" the response. 
It's based on the assumption that the deepest plugin reached in the chain is the plugin that "originated" the response. In most/all cases, this _is_ the plugin that essentially "served" the data. Perhaps a more truthful/literal name for the metric would be "coredns_deepest_plugin_reached" or something.  But IMO that is too cryptic.

Plugins like rewrite make this a little fuzzy. E.g. if a plugin like re-wrtite modifies a response, the original creator of the response is logged as the plugin, not rewrite.

In theory, one could write plugins that break this assumption.  e.g. a plugin that looks at a response from a next plugin, and replaces the response with something else entirely - like a response based policy.

This kind of metric has been requested for the host plugin a couple of times.

### 2. Which issues (if any) are related?

#3758
#4221

### 3. Which documentation changes (if any) need to be made?

document the metric

### 4. Does this introduce a backward incompatible change or deprecation?
