### PR TITLE
Use cancelable contexts for cloud provider plugin refreshes

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -87,11 +87,11 @@ func (h *Azure) Run(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Infof("Breaking out of Azure update loop: %v", ctx.Err())
+				log.Debugf("Breaking out of Azure update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
 			case <-time.After(1 * time.Minute):
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil {
-					log.Errorf("Failed to update zones: %v", err)
+					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}
 			}
 		}

--- a/plugin/azure/setup.go
+++ b/plugin/azure/setup.go
@@ -25,7 +25,7 @@ func setup(c *caddy.Controller) error {
 	if err != nil {
 		return plugin.Error("azure", err)
 	}
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	publicDNSClient := publicAzureDNS.NewRecordSetsClient(env.Values[auth.SubscriptionID])
 	if publicDNSClient.Authorizer, err = env.GetAuthorizer(); err != nil {
@@ -50,6 +50,7 @@ func setup(c *caddy.Controller) error {
 		h.Next = next
 		return h
 	})
+	c.OnShutdown(func() error { cancel(); return nil })
 	return nil
 }
 

--- a/plugin/clouddns/clouddns.go
+++ b/plugin/clouddns/clouddns.go
@@ -85,11 +85,11 @@ func (h *CloudDNS) Run(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Infof("Breaking out of CloudDNS update loop: %v", ctx.Err())
+				log.Debugf("Breaking out of CloudDNS update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
 			case <-time.After(1 * time.Minute):
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil /* Don't log error if ctx expired. */ {
-					log.Errorf("Failed to update zones: %v", err)
+					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}
 			}
 		}

--- a/plugin/clouddns/setup.go
+++ b/plugin/clouddns/setup.go
@@ -78,7 +78,7 @@ func setup(c *caddy.Controller) error {
 			}
 		}
 
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
 		client, err := f(ctx, opt)
 		if err != nil {
 			return err
@@ -98,7 +98,7 @@ func setup(c *caddy.Controller) error {
 			h.Next = next
 			return h
 		})
-		c.OnShutdown(func() error { ctx.Done(); return nil })
+		c.OnShutdown(func() error { cancel(); return nil })
 	}
 
 	return nil

--- a/plugin/route53/route53.go
+++ b/plugin/route53/route53.go
@@ -87,11 +87,11 @@ func (h *Route53) Run(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():
-				log.Infof("Breaking out of Route53 update loop: %v", ctx.Err())
+				log.Debugf("Breaking out of Route53 update loop for %v: %v", h.zoneNames, ctx.Err())
 				return
 			case <-time.After(h.refresh):
 				if err := h.updateZones(ctx); err != nil && ctx.Err() == nil /* Don't log error if ctx expired. */ {
-					log.Errorf("Failed to update zones: %v", err)
+					log.Errorf("Failed to update zones %v: %v", h.zoneNames, err)
 				}
 			}
 		}

--- a/plugin/route53/setup.go
+++ b/plugin/route53/setup.go
@@ -124,7 +124,7 @@ func setup(c *caddy.Controller) error {
 			Client: ec2metadata.New(session),
 		})
 		client := f(credentials.NewChainCredentials(providers))
-		ctx := context.Background()
+		ctx, cancel := context.WithCancel(context.Background())
 		h, err := New(ctx, client, keys, refresh)
 		if err != nil {
 			return plugin.Error("route53", c.Errf("failed to create route53 plugin: %v", err))
@@ -137,7 +137,7 @@ func setup(c *caddy.Controller) error {
 			h.Next = next
 			return h
 		})
-		c.OnShutdown(func() error { ctx.Done(); return nil })
+		c.OnShutdown(func() error { cancel(); return nil })
 	}
 	return nil
 }


### PR DESCRIPTION
### 1. Why is this pull request needed and what does it do?

I tested 1.7.1 and 1.8.0 and noticed my previously reported issues were still not fixed. So I decided to take a stab at it, even with my meager Go abilities. While adding debug logging and using the route53 plugin, I noticed that [this line](https://github.com/coredns/coredns/blob/f23171af5f3f6432c249e26265ec6540f6c1b46b/plugin/route53/route53.go#L90) is never logged. I continue to mess around with calling `ctx.Done()` in various places and noticed that it had no effect whatsoever on operation. I looked at the `context` package documentation and saw there is a `WithCancel` function that provides a function for stopping goroutines.

I used the context from that instead of the empty `context.Background` and then provide that cancel function to the `OnShutdown` for Caddy. The old goroutines then printed the log line referenced above when sending the process a USR1 signal after the new goroutines have been successfully been created. I confirmed with additional debug statements that there are in fact the correct number of refresh goroutines running after receiving a USR1. This looks to finally fix the issue of compounding refresh loops when using graceful USR1 restart signals.

I'm not really sure whether or not `ctx.Done()` is supposed to cancel the goroutine or not as I'm inexperienced, but in my testing, it definitely does not in the current code.

Output of bad behavior where old goroutines still run after USR1 (refresh set to 2 minutes):
```
2020-10-22 16:45:00.5952 +0000 UTC m=+0.967324101 running refresh loop:  map[example.:[0xc000639560 0xc000653170]]
2020-10-22 16:45:03.9752894 +0000 UTC m=+4.347408901 running refresh loop:  map[16.172.in-addr.arpa.:[0xc00168dd10]]
2020-10-22 16:45:05.5724594 +0000 UTC m=+5.944585101 running refresh loop:  map[30.172.in-addr.arpa.:[0xc000ff8b70]]
.:53
example.com.:53
30.172.in-addr.arpa.:53
16.172.in-addr.arpa.:53
CoreDNS-1.8.0
linux/amd64, go1.14.1, 
^Z
[1]+  Stopped                 ./coredns -conf Corefile
root@53baf326ce0f:/coredns# kill -USR1 %1

[1]+  Stopped                 ./coredns -conf Corefile
root@53baf326ce0f:/coredns# fg
./coredns -conf Corefile
[INFO] SIGUSR1: Reloading
[INFO] Reloading
2020-10-22 16:45:13.2952233 +0000 UTC m=+13.701160201 running refresh loop:  map[example.com.:[0xc0011536b0 0xc0010e4de0]]
2020-10-22 16:45:15.6731658 +0000 UTC m=+16.079105001 running refresh loop:  map[16.172.in-addr.arpa.:[0xc002042bd0]]
2020-10-22 16:45:17.1218467 +0000 UTC m=+17.527781801 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0013383c0]]
[INFO] Reloading complete
2020-10-22 16:47:03.5949101 +0000 UTC m=+124.102371101 running refresh loop:  map[example.com.:[0xc000639560 0xc000653170]]
2020-10-22 16:47:05.1790668 +0000 UTC m=+125.686425001 running refresh loop:  map[16.172.in-addr.arpa.:[0xc00168dd10]]
2020-10-22 16:47:05.8392299 +0000 UTC m=+126.346584501 running refresh loop:  map[30.172.in-addr.arpa.:[0xc000ff8b70]]
2020-10-22 16:47:15.2888004 +0000 UTC m=+135.829932201 running refresh loop:  map[example.com.:[0xc0011536b0 0xc0010e4de0]]
2020-10-22 16:47:16.7109932 +0000 UTC m=+137.252124001 running refresh loop:  map[16.172.in-addr.arpa.:[0xc002042bd0]]
2020-10-22 16:47:17.2592662 +0000 UTC m=+137.800404701 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0013383c0]]
```

Output of now correct behavior (refresh set to 2 minutes):
```
2020-10-22 17:53:13.0051423 +0000 UTC m=+0.896964301 running refresh loop:  map[example.com.:[0xc000bf4ae0 0xc0003dd7a0]]
2020-10-22 17:53:15.6325376 +0000 UTC m=+3.524359601 running refresh loop:  map[16.172.in-addr.arpa.:[0xc000b00240]]
2020-10-22 17:53:17.0463304 +0000 UTC m=+4.938150201 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0010d64b0]]
.:53
example.com.:53
30.172.in-addr.arpa.:53
16.172.in-addr.arpa.:53
CoreDNS-1.8.0
linux/amd64, go1.14.1, 
^Z
[1]+  Stopped                 ./coredns -conf Corefile
root@53baf326ce0f:/coredns# kill -USR1 %1

[1]+  Stopped                 ./coredns -conf Corefile
root@53baf326ce0f:/coredns# fg
./coredns -conf Corefile
[INFO] SIGUSR1: Reloading
[INFO] Reloading
2020-10-22 17:53:25.8993604 +0000 UTC m=+13.791182501 running refresh loop:  map[example.com.:[0xc000cc9290 0xc000cfd7a0]]
2020-10-22 17:53:28.5020093 +0000 UTC m=+16.393831001 running refresh loop:  map[16.172.in-addr.arpa.:[0xc001dff1a0]]
2020-10-22 17:53:30.0031697 +0000 UTC m=+17.894989701 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0012bfc20]]
[INFO] Reloading complete
[INFO] plugin/route53: Breaking out of Route53 update loop: context canceled
[INFO] plugin/route53: Breaking out of Route53 update loop: context canceled
[INFO] plugin/route53: Breaking out of Route53 update loop: context canceled
2020-10-22 17:55:28.1569171 +0000 UTC m=+136.183934801 running refresh loop:  map[example.com.:[0xc000cc9290 0xc000cfd7a0]]
2020-10-22 17:55:29.5855328 +0000 UTC m=+137.612550201 running refresh loop:  map[16.172.in-addr.arpa.:[0xc001dff1a0]]
2020-10-22 17:55:30.2387855 +0000 UTC m=+138.265802301 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0012bfc20]]
2020-10-22 17:57:30.3442261 +0000 UTC m=+258.506435501 running refresh loop:  map[example.com.:[0xc000cc9290 0xc000cfd7a0]]
2020-10-22 17:57:30.6165745 +0000 UTC m=+258.778781801 running refresh loop:  map[16.172.in-addr.arpa.:[0xc001dff1a0]]
2020-10-22 17:57:30.6646359 +0000 UTC m=+258.826841401 running refresh loop:  map[30.172.in-addr.arpa.:[0xc0012bfc20]]
```

This changes the "Breaking out" log statement level to debug since this really is a debug statement and isn't very informative outside of ensuring the goroutine terminates.

### 2. Which issues (if any) are related?

#2396 , #3815 

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No