### PR TITLE
Fix golint warnings

### DIFF
--- a/plugin/forward/persistent_test.go
+++ b/plugin/forward/persistent_test.go
@@ -96,14 +96,14 @@ func TestCleanupAll(t *testing.T) {
 	c2, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
 	c3, _ := dns.DialTimeout("udp", tr.addr, maxDialTimeout)
 
-	tr.conns[typeUdp] = []*persistConn{{c1, time.Now()}, {c2, time.Now()}, {c3, time.Now()}}
+	tr.conns[typeUDP] = []*persistConn{{c1, time.Now()}, {c2, time.Now()}, {c3, time.Now()}}
 
-	if len(tr.conns[typeUdp]) != 3 {
+	if len(tr.conns[typeUDP]) != 3 {
 		t.Error("Expected 3 connections")
 	}
 	tr.cleanup(true)
 
-	if len(tr.conns[typeUdp]) > 0 {
+	if len(tr.conns[typeUDP]) > 0 {
 		t.Error("Expected no cached connections")
 	}
 }

--- a/plugin/forward/type.go
+++ b/plugin/forward/type.go
@@ -5,33 +5,33 @@ import "net"
 type transportType int
 
 const (
-	typeUdp transportType = iota
-	typeTcp
-	typeTls
+	typeUDP transportType = iota
+	typeTCP
+	typeTLS
 	typeTotalCount // keep this last
 )
 
 func stringToTransportType(s string) transportType {
 	switch s {
 	case "udp":
-		return typeUdp
+		return typeUDP
 	case "tcp":
-		return typeTcp
+		return typeTCP
 	case "tcp-tls":
-		return typeTls
+		return typeTLS
 	}
 
-	return typeUdp
+	return typeUDP
 }
 
 func (t *Transport) transportTypeFromConn(pc *persistConn) transportType {
 	if _, ok := pc.c.Conn.(*net.UDPConn); ok {
-		return typeUdp
+		return typeUDP
 	}
 
 	if t.tlsConfig == nil {
-		return typeTcp
+		return typeTCP
 	}
 
-	return typeTls
+	return typeTLS
 }

--- a/plugin/kubernetes/metrics.go
+++ b/plugin/kubernetes/metrics.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	// DnsProgrammingLatency is defined as the time it took to program a DNS instance - from the time
+	// DNSProgrammingLatency is defined as the time it took to program a DNS instance - from the time
 	// a service or pod has changed to the time the change was propagated and was available to be
 	// served by a DNS server.
 	// The definition of this SLI can be found at https://github.com/kubernetes/community/blob/master/sig-scalability/slos/dns_programming_latency.md
@@ -23,7 +23,7 @@ var (
 	//   * cluster_ip
 	//   * headless_with_selector
 	//   * headless_without_selector
-	DnsProgrammingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	DNSProgrammingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: plugin.Namespace,
 		Subsystem: pluginName,
 		Name:      "dns_programming_duration_seconds",
@@ -68,6 +68,6 @@ func recordDNSProgrammingLatency(svcs []*object.Service, endpoints *api.Endpoint
 	// the Endpoints object was created by the endpoints-controller (because the
 	// LastChangeTriggerTime annotation is set). It means that the corresponding service is a
 	// "headless service with selector".
-	DnsProgrammingLatency.WithLabelValues("headless_with_selector").
+	DNSProgrammingLatency.WithLabelValues("headless_with_selector").
 		Observe(durationSinceFunc(lastChangeTriggerTime).Seconds())
 }

--- a/plugin/kubernetes/metrics_test.go
+++ b/plugin/kubernetes/metrics_test.go
@@ -20,7 +20,7 @@ const (
 	namespace = "testns"
 )
 
-func TestDnsProgrammingLatency(t *testing.T) {
+func TestDNSProgrammingLatency(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	now := time.Now()
 	ctx := context.TODO()
@@ -32,7 +32,7 @@ func TestDnsProgrammingLatency(t *testing.T) {
 	durationSinceFunc = func(t time.Time) time.Duration {
 		return now.Sub(t)
 	}
-	DnsProgrammingLatency.Reset()
+	DNSProgrammingLatency.Reset()
 	go controller.Run()
 
 	subset1 := []api.EndpointSubset{{
@@ -86,7 +86,7 @@ func TestDnsProgrammingLatency(t *testing.T) {
         coredns_kubernetes_dns_programming_duration_seconds_sum{service_kind="headless_with_selector"} 3
         coredns_kubernetes_dns_programming_duration_seconds_count{service_kind="headless_with_selector"} 2
 	`
-	if err := testutil.CollectAndCompare(DnsProgrammingLatency, strings.NewReader(expected)); err != nil {
+	if err := testutil.CollectAndCompare(DNSProgrammingLatency, strings.NewReader(expected)); err != nil {
 		t.Error(err)
 	}
 }
@@ -121,11 +121,11 @@ func updateEndpoints(t *testing.T, client kubernetes.Interface, name string, tri
 	}
 }
 
-func createService(t *testing.T, client kubernetes.Interface, controller dnsController, name string, clusterIp string) {
+func createService(t *testing.T, client kubernetes.Interface, controller dnsController, name string, clusterIP string) {
 	ctx := context.TODO()
 	if _, err := client.CoreV1().Services(namespace).Create(ctx, &api.Service{
 		ObjectMeta: meta.ObjectMeta{Namespace: namespace, Name: name},
-		Spec:       api.ServiceSpec{ClusterIP: clusterIp},
+		Spec:       api.ServiceSpec{ClusterIP: clusterIP},
 	}, meta.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Include:
1. plugin/forward/type.go:8:2: const typeUdp should be typeUDP
2. plugin/forward/type.go:9:2: const typeTcp should be typeTCP
3. plugin/forward/type.go:10:2: const typeTls should be typeTLS
4. plugin/kubernetes/metrics.go:24:2: var DnsProgrammingLatency should be DNSProgrammingLatency
5. plugin/kubernetes/metrics_test.go:124:102: func parameter clusterIp should be clusterIP

Signed-off-by: zouyu <zouy.fnst@cn.fujitsu.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Fix golint warning

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
