### PR TITLE
docs: move Also See to See Also

### DIFF
--- a/plugin/any/README.md
+++ b/plugin/any/README.md
@@ -31,6 +31,6 @@ A `dig +nocmd ANY example.org +noall +answer` now returns:
 example.org.  8482	IN	HINFO	"ANY obsoleted" "See RFC 8482"
 ~~~
 
-## Also See
+## See Also
 
 [RFC 8482](https://tools.ietf.org/html/rfc8482).

--- a/plugin/azure/README.md
+++ b/plugin/azure/README.md
@@ -55,6 +55,6 @@ example.org {
 }
 ~~~
 
-## Also See
+## See Also
 
 The [Azure DNS Overview](https://docs.microsoft.com/en-us/azure/dns/dns-overview).

--- a/plugin/cancel/README.md
+++ b/plugin/cancel/README.md
@@ -42,6 +42,6 @@ example.org {
 }
 ~~~
 
-## Also See
+## See Also
 
 The Go documentation for the context package.

--- a/plugin/debug/README.md
+++ b/plugin/debug/README.md
@@ -46,6 +46,6 @@ Disable the ability to recover from crashes and show debug logging:
 }
 ~~~
 
-## Also See
+## See Also
 
 <https://www.wireshark.org/docs/man-pages/text2pcap.html>.

--- a/plugin/dns64/README.md
+++ b/plugin/dns64/README.md
@@ -86,6 +86,6 @@ Not all features required by DNS64 are implemented, only basic AAAA synthesis.
 * Resolve PTR records
 * Make resolver DNSSEC aware. See: [RFC 6147 Section 3](https://tools.ietf.org/html/rfc6147#section-3)
 
-## Also See
+## See Also
 
 See [RFC 6147](https://tools.ietf.org/html/rfc6147) for more information on the DNS64 mechanism.

--- a/plugin/erratic/README.md
+++ b/plugin/erratic/README.md
@@ -84,6 +84,6 @@ example.org {
 }
 ~~~
 
-## Also See
+## See Also
 
 [RFC 3849](https://tools.ietf.org/html/rfc3849) and [RFC 5737](https://tools.ietf.org/html/rfc5737).

--- a/plugin/etcd/README.md
+++ b/plugin/etcd/README.md
@@ -229,6 +229,6 @@ If you query the zone name for `TXT` now, you will get the following response:
 "this is a random text message."
 ~~~
 
-## Also See
+## See Also
 
 If you want to `round robin` A and AAAA responses look at the *loadbalance* plugin.

--- a/plugin/file/README.md
+++ b/plugin/file/README.md
@@ -89,7 +89,7 @@ example.org {
 }
 ~~~
 
-## Also See
+## See Also
 
 See the *loadbalance* plugin if you need simple record shuffling. And the *transfer* plugin for zone
 transfers. Lastly the *root* plugin can help you specificy the location of the zone files.

--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -189,6 +189,6 @@ Or with multiple upstreams from the same provider
 The TLS config is global for the whole forwarding proxy if you need a different `tls_servername` for
 different upstreams you're out of luck.
 
-## Also See
+## See Also
 
 [RFC 7858](https://tools.ietf.org/html/rfc7858) for DNS over TLS.

--- a/plugin/import/README.md
+++ b/plugin/import/README.md
@@ -68,6 +68,6 @@ This imports files found in the zones directory:
 import ../zones/*
 ~~~
 
-## Also See
+## See Also
 
 See corefile(5).

--- a/plugin/k8s_external/README.md
+++ b/plugin/k8s_external/README.md
@@ -84,7 +84,7 @@ spec:
 ~~~
 
 
-# Also See
+# See Also
 
 For some background see [resolve external IP address](https://github.com/kubernetes/dns/issues/242).
 And [A records for services with Load Balancer IP](https://github.com/coredns/coredns/issues/1851).

--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -235,7 +235,7 @@ If monitoring is enabled (via the *prometheus* plugin) then the following metric
 
 The duration metric only supports the "headless\_with\_selector" service currently.
 
-## Also See
+## See Also
 
 See the *autopath* plugin to enable search path optimizations. And use the *transfer* plugin to
 enable outgoing zone transfers.

--- a/plugin/metadata/README.md
+++ b/plugin/metadata/README.md
@@ -43,7 +43,7 @@ Note: this method should work quickly, because it is called for every request.
 
 The *rewrite* plugin uses meta data to rewrite requests.
 
-## Also See
+## See Also
 
 The [Provider interface](https://godoc.org/github.com/coredns/coredns/plugin/metadata#Provider) and
 the [package level](https://godoc.org/github.com/coredns/coredns/plugin/metadata) documentation.

--- a/plugin/nsid/README.md
+++ b/plugin/nsid/README.md
@@ -52,6 +52,6 @@ And now a client with NSID support will see an OPT record with the NSID option:
 ;whoami.example.org.		IN	A
 ~~~
 
-## Also See
+## See Also
 
 [RFC 5001](https://tools.ietf.org/html/rfc5001)

--- a/plugin/pprof/README.md
+++ b/plugin/pprof/README.md
@@ -65,7 +65,7 @@ Listen on an all addresses on port 6060, and enable block profiling
 }
 ~~~
 
-## Also See
+## See Also
 
 See [Go's pprof documentation](https://golang.org/pkg/net/http/pprof/) and [Profiling Go
 Programs](https://blog.golang.org/profiling-go-programs).

--- a/plugin/reload/README.md
+++ b/plugin/reload/README.md
@@ -103,6 +103,6 @@ CoreDNS v1.7.0 and later does parse the Corefile and supports detecting changes 
 
 Currently the type of `hash` is "md5", the `value` is the returned hash value.
 
-## Also See
+## See Also
 
 See coredns-import(7) and corefile(5).

--- a/plugin/secondary/README.md
+++ b/plugin/secondary/README.md
@@ -64,6 +64,6 @@ example.net {
 
 Only AXFR is supported and the retrieved zone is not committed to disk.
 
-## Also See
+## See Also
 
 See the *transfer* plugin to enable zone transfers _to_ other servers.

--- a/plugin/sign/README.md
+++ b/plugin/sign/README.md
@@ -151,7 +151,7 @@ Forcibly resigning a zone can be accomplished by removing the signed zone file (
 on serving it from memory), and sending SIGUSR1 to the process to make it reload and resign the zone
 file.
 
-## Also See
+## See Also
 
 The DNSSEC RFCs: RFC 4033, RFC 4034 and RFC 4035. And the BCP on DNSSEC, RFC 6781. Further more the
 manual pages coredns-keygen(1) and dnssec-keygen(8). And the *file* plugin's documentation.

--- a/plugin/tls/README.md
+++ b/plugin/tls/README.md
@@ -60,6 +60,6 @@ grpc://. {
 Only Knot DNS' `kdig` supports DNS-over-TLS queries, no command line client supports gRPC making
 debugging these transports harder than it should be.
 
-## Also See
+## See Also
 
 RFC 7858 and https://grpc.io.

--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -95,6 +95,6 @@ trace tracinghost:9411 {
 }
 ~~~
 
-## Also See
+## See Also
 
 See the *debug* plugin for more information about debug logging.


### PR DESCRIPTION
sed -i 's/Also See/See Also/' plugin/**/README.md

Some plugins did already use 'See Also', so it's all consistent now.

Fixes: #4196