### PR TITLE
[WIP] Add minimal plugin

### DIFF
--- a/plugin.cfg
+++ b/plugin.cfg
@@ -64,3 +64,4 @@ erratic:erratic
 whoami:whoami
 on:github.com/coredns/caddy/onevent
 sign:sign
+minimal:minimal

--- a/plugin/minimal/README.md
+++ b/plugin/minimal/README.md
@@ -39,11 +39,20 @@ present in the dns response which is essential to complete the dns query succesf
 
 Pseudo code:
 
-type MinimalResponseWriter struct {
-  dns.ResponseWriter
+type Minimal struct {
+  Next plugin.Handler
 }
 
-func (m *MinimalResponseWriter) minimalMsg(res *dns.Msg) error {
+func (m Minimal) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	mm := &MinimalResponseWriter{w}
+	return plugin.NextOrFailure(rr.Name(), mm.Next, ctx, mm, r)
+}
+
+type MinimalResponseWriter struct {
+  dns.ResponseWriter
+} 
+
+func (m *MinimalResponseWriter) WriteMsg(res *dns.Msg) error {
   type := response.Typify(res)
 
   if type != response.NoError {

--- a/plugin/minimal/README.md
+++ b/plugin/minimal/README.md
@@ -1,0 +1,65 @@
+# minimal
+
+## Name
+
+*minimal* - minimizes the size of the DNS query response 
+
+## Description
+
+The minimal plugin controls the addition of records to the AUTHORITY and ADDITIONAL section of the dns query response.
+
+## Syntax
+
+~~~
+minimal yes | no
+~~~
+
+## Examples
+
+~~~ corefile
+. {
+    minimal yes
+    forward . 8.8.8.8 
+}
+~~~
+
+## Design and Implementation details
+
+If minimal is set as yes, this plugin wraps a response writer around dns.ResponseWriter and passes it on the to the next plugin 
+in the plugin chain. If minimal is explicitly set as no, then this plugin will not be added at all. This should be better than 
+making this plugin a passthrough plugin
+
+This response writer implements the dns.ResponseWriter interface. 
+
+The writer first checks the type of the dns.Msg. If the response type is any type apart from NoError, we just return the response back to the 
+client. We even return back any Delegations because delegations sometimes contain glue records which are essential for dns resolution.
+
+If the response type is NoError, then we strip away the ADDITIONAL and AUTHORITY sections away and ensure that only the answer section is
+present in the dns response which is essential to complete the dns query succesfully.
+
+Pseudo code:
+
+type MinimalResponseWriter struct {
+  dns.ResponseWriter
+}
+
+func (m *MinimalResponseWriter) minimalMsg(res *dns.Msg) error {
+  type := response.Typify(res)
+
+  if type != response.NoError {
+    m.ResponseWriter.WriteMsg(m)
+  }
+
+  // will such a case ever arise?????
+  if len(res.Answer) == 0 {
+    return m.ResponseWriter.WriteMsg(m)
+  }
+
+  // set the AUTHORITY and ADDITIONAL record to nil. Empty the records.
+  res.Ns = nil
+  res.Extra = nil
+
+  return m.ResponseWriter.WriteMsg(m)
+}
+
+Tests: 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

This PR adds the minimal plugin. It minimizes the size of the dns query response returned by coredns.

### 2. Which issues (if any) are related?

This PR was suggest by @miekg in issue https://github.com/coredns/coredns/issues/4220

### 3. Which documentation changes (if any) need to be made?

A README.md file has been added to the plugin directory

### 4. Does this introduce a backward incompatible change or deprecation?

No

I have written up the README.md indicating the implemenation and design of the minimal plugin. I am currently working on tests. Working on getting some good tests to write for this plugin. 

I feel that this plugin should be at the end of the plugin chain. Since it is stripping away the records right before the client receives it.

Looking forward to some running feedback on this plugin.

## Design and Implementation details

If minimal is set as yes, this plugin wraps a response writer around dns.ResponseWriter and passes it on the to the next plugin 
in the plugin chain. If minimal is explicitly set as no, then this plugin will not be added at all. This should be better than 
making this plugin a passthrough plugin

This response writer implements the dns.ResponseWriter interface. 

The writer first checks the type of the dns.Msg. If the response type is any type apart from NoError, we just return the response back to the 
client. We even return back any Delegations because delegations sometimes contain glue records which are essential for dns resolution.

If the response type is NoError, then we strip away the ADDITIONAL and AUTHORITY sections away and ensure that only the answer section is
present in the dns response which is essential to complete the dns query succesfully.

Pseudo code:

```
type Minimal struct {
  Next plugin.Handler
}

func (m Minimal) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
	mm := &MinimalResponseWriter{w}
	return plugin.NextOrFailure(rr.Name(), mm.Next, ctx, mm, r)
}

type MinimalResponseWriter struct {
  dns.ResponseWriter
} 

func (m *MinimalResponseWriter) WriteMsg(res *dns.Msg) error {
  type := response.Typify(res)

  if type != response.NoError {
    m.ResponseWriter.WriteMsg(m)
  }

  // will such a case ever arise?????
  if len(res.Answer) == 0 {
    return m.ResponseWriter.WriteMsg(m)
  }

  // set the AUTHORITY and ADDITIONAL record to nil. Empty the records.
  res.Ns = nil
  res.Extra = nil

  return m.ResponseWriter.WriteMsg(m)
}

```