### PR TITLE
Add GitHub Actions to  `gofmt -s -w` all `*.go` files

### DIFF
--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -1,0 +1,36 @@
+name: Go Fmt
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - '*.go'
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Fmt
+        run: |
+          find . -not -path '*/\.git/*' -type f -name '*.go' -exec gofmt -s -w {} \+
+      -
+        name: Set up Git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "coredns-auto-go-mod-fmt[bot]"
+          git config user.email "coredns-auto-go-mod-fmt[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+      -
+        name: Commit and push changes
+        run: |
+          git add .
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            git commit -m 'auto go mod fmt'
+            git push
+          fi

--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -23,14 +23,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "coredns-auto-go-mod-fmt[bot]"
-          git config user.email "coredns-auto-go-mod-fmt[bot]@users.noreply.github.com"
+          git config user.name "coredns-auto-go-fmt[bot]"
+          git config user.email "coredns-auto-go-fmt[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
       -
         name: Commit and push changes
         run: |
           git add .
           if output=$(git status --porcelain) && [ ! -z "$output" ]; then
-            git commit -m 'auto go mod fmt'
+            git commit -m 'auto go fmt'
             git push
           fi


### PR DESCRIPTION
This PR adds GitHub Actions to  `gofmt -s -w` all `*.go` files,
if any `*.go` files are touched on each commit.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
