### PR TITLE
Remove newlines between braces

### DIFF
--- a/plugin/auto/watcher_test.go
+++ b/plugin/auto/watcher_test.go
@@ -51,7 +51,6 @@ func TestWatcher(t *testing.T) {
 	if _, ok := a.Zones.Z["example.org."]; !ok {
 		t.Errorf("Expected %q to still be there.", "example.org.")
 	}
-
 }
 
 func TestSymlinks(t *testing.T) {

--- a/plugin/etcd/msg/type_test.go
+++ b/plugin/etcd/msg/type_test.go
@@ -27,5 +27,4 @@ func TestType(t *testing.T) {
 			t.Errorf("Test %d: Expected what %v, but got %v", i, tc.expectedType, what)
 		}
 	}
-
 }

--- a/plugin/file/reload_test.go
+++ b/plugin/file/reload_test.go
@@ -76,7 +76,6 @@ func TestZoneReloadSOAChange(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Zone should not have been re-parsed")
 	}
-
 }
 
 const reloadZoneTest = `miek.nl.		1627	IN	SOA	linode.atoom.net. miek.miek.nl. 1460175181 14400 3600 604800 14400

--- a/plugin/hosts/setup_test.go
+++ b/plugin/hosts/setup_test.go
@@ -166,5 +166,4 @@ func TestHostsInlineParse(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/plugin/log/setup_test.go
+++ b/plugin/log/setup_test.go
@@ -162,5 +162,4 @@ func TestLogParse(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/plugin/pkg/doh/doh.go
+++ b/plugin/pkg/doh/doh.go
@@ -50,7 +50,6 @@ func NewRequest(method, url string, m *dns.Msg) (*http.Request, error) {
 	default:
 		return nil, fmt.Errorf("method not allowed: %s", method)
 	}
-
 }
 
 // ResponseToMsg converts a http.Response to a dns message.
@@ -72,7 +71,6 @@ func RequestToMsg(req *http.Request) (*dns.Msg, error) {
 	default:
 		return nil, fmt.Errorf("method not allowed: %s", req.Method)
 	}
-
 }
 
 // requestToMsgPost extracts the dns message from the request body.

--- a/plugin/pkg/parse/parse_test.go
+++ b/plugin/pkg/parse/parse_test.go
@@ -55,7 +55,5 @@ func TestTransferIn(t *testing.T) {
 				}
 			}
 		}
-
 	}
-
 }

--- a/test/metric_naming_test.go
+++ b/test/metric_naming_test.go
@@ -37,7 +37,6 @@ func TestMetricNaming(t *testing.T) {
 			t.Fatalf("A slice of Problems indicating any issues found in the metrics stream: %s", problems)
 		}
 	}
-
 }
 
 type validMetricWalker struct {

--- a/test/wildcard_test.go
+++ b/test/wildcard_test.go
@@ -86,5 +86,4 @@ func TestLookupWildcard(t *testing.T) {
 			continue
 		}
 	}
-
 }


### PR DESCRIPTION
These are found with: `pcregrep -M "}\n\n}" **/*.go`
Sometimes a unneeded newline is inserted, remove those.