### PR TITLE
plugin/trace: cleanup README.md

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -6,8 +6,8 @@
 
 ## Description
 
-With *trace* you enable OpenTracing of how a request flows through CoreDNS.
-Enable *debug* plugin to get logs from the trace plugin.
+With *trace* you enable OpenTracing of how a request flows through CoreDNS. Enable the *debug*
+plugin to get logs from the trace plugin.
 
 ## Syntax
 
@@ -20,7 +20,7 @@ trace [ENDPOINT-TYPE] [ENDPOINT]
 * **ENDPOINT-TYPE** is the type of tracing destination. Currently only `zipkin` and `datadog` are supported.
   Defaults to `zipkin`.
 * **ENDPOINT** is the tracing destination, and defaults to `localhost:9411`. For Zipkin, if
-  ENDPOINT does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v1/spans`.
+  **ENDPOINT** does not begin with `http`, then it will be transformed to `http://ENDPOINT/api/v1/spans`.
 
 With this form, all queries will be traced.
 
@@ -31,12 +31,6 @@ trace [ENDPOINT-TYPE] [ENDPOINT] {
     every AMOUNT
     service NAME
     client_server
-}
-~~~
-~~~
-trace datadog {
-    every AMOUNT
-    service NAME
     datadog_analytics_rate RATE
 }
 ~~~
@@ -47,16 +41,18 @@ trace datadog {
   Default is `coredns`.
 * `client_server` will enable the `ClientServerSameSpan` OpenTracing feature.
 * `datadog_analytics_rate` **RATE** will enable [trace analytics](https://docs.datadoghq.com/tracing/app_analytics) on the traces sent
-  from *0* to *1*, *1* being every trace sent will be analyzed. This is a datadog only feature.
+  from *0* to *1*, *1* being every trace sent will be analyzed. This is a datadog only feature
+  (**ENDPOINT-TYPE** needs to be `datadog`)
 
 ## Zipkin
+
 You can run Zipkin on a Docker host like this:
 
 ```
 docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
-:warning: The zipkin provider does not support the v1 API since coredns 1.7.1
+Note the zipkin provider does not support the v1 API since coredns 1.7.1.
 
 ## Examples
 


### PR DESCRIPTION
Various improvements to the documentation. Started because `:warning:`
isn't a markdown feature (replace with Note:).

Signed-off-by: Miek Gieben <miek@miek.nl>
