### PR TITLE
auto test: increase sleep

### DIFF
--- a/test/auto_test.go
+++ b/test/auto_test.go
@@ -46,7 +46,7 @@ func TestAuto(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(10 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(50 * time.Millisecond) // wait for it to be picked up
 
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestAuto(t *testing.T) {
 	// Remove db.example.org again.
 	os.Remove(filepath.Join(tmpdir, "db.example.org"))
 
-	time.Sleep(10 * time.Millisecond) // wait for it to be picked up
+	time.Sleep(50 * time.Millisecond) // wait for it to be picked up
 	resp, err = dns.Exchange(m, udp)
 	if err != nil {
 		t.Fatal("Expected to receive reply, but didn't")


### PR DESCRIPTION
Doing a reload every 10ms and sleeping 10ms makes this too racy,
increase all those sleeps to 50ms. A better method would be to get
notified of the reload/change, this would require some polling to get
the RR we expect, with a much longer timeout to stop the test
eventually.

Signed-off-by: Miek Gieben <miek@miek.nl>
