### PR TITLE
plugin/azure return FQDN as MNAME in SOA record

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -286,7 +286,7 @@ func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPa
 				Refresh: uint32(*(SOA.RefreshTime)),
 				Serial:  uint32(*(SOA.SerialNumber)),
 				Mbox:    dns.Fqdn(*(SOA.Email)),
-				Ns:      *(SOA.Host)}
+				Ns:      dns.Fqdn(*(SOA.Host))}
 			newZ.Insert(soa)
 		}
 


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

See #4285 - adds error handling for failure to send DNS response and ensures SOA host is an FQDN, as Azure private zones return a DNS name here currently.

### 2. Which issues (if any) are related?

#4285 

### 3. Which documentation changes (if any) need to be made?

None

### 4. Does this introduce a backward incompatible change or deprecation?

No