### PR TITLE
Switch from actions/setup-go@v2-beta to actions/setup-go@v2 to fix the GitHub Actions set-env failure

### DIFF
--- a/.github/workflows/make.doc.yml
+++ b/.github/workflows/make.doc.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       -
         name: Setup Go
-        uses: actions/setup-go@v2-beta
+        uses: actions/setup-go@v2
         with:
           go-version: '^1.14.1'
       -


### PR DESCRIPTION
This PR switches from actions/setup-go@v2-beta to actions/setup-go@v2 to fix the
GitHub Actions `set-env` failure. Without this PR the following error shown up
(see https://github.com/coredns/coredns/runs/1423802307):
```
Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.15.5/x64' successfully.
7
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>
