### PR TITLE
plugin/file: Use NXDOMAIN response if CNAME target is NXDOMAIN

### DIFF
--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -307,8 +307,9 @@ func (z *Zone) externalLookup(ctx context.Context, state request.Request, elem *
 	targetName := rrs[0].(*dns.CNAME).Target
 	elem, _ = z.Tree.Search(targetName)
 	if elem == nil {
-		rrs = append(rrs, z.doLookup(ctx, state, targetName, qtype)...)
-		return rrs, z.Apex.ns(do), nil, Success
+		lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
+		rrs = append(rrs, lookupRRs...)
+		return rrs, z.Apex.ns(do), nil, result
 	}
 
 	i := 0
@@ -326,8 +327,9 @@ Redo:
 		targetName := cname[0].(*dns.CNAME).Target
 		elem, _ = z.Tree.Search(targetName)
 		if elem == nil {
-			rrs = append(rrs, z.doLookup(ctx, state, targetName, qtype)...)
-			return rrs, z.Apex.ns(do), nil, Success
+			lookupRRs, result := z.doLookup(ctx, state, targetName, qtype)
+			rrs = append(rrs, lookupRRs...)
+			return rrs, z.Apex.ns(do), nil, result
 		}
 
 		i++
@@ -352,15 +354,19 @@ Redo:
 	return rrs, z.Apex.ns(do), nil, Success
 }
 
-func (z *Zone) doLookup(ctx context.Context, state request.Request, target string, qtype uint16) []dns.RR {
+func (z *Zone) doLookup(ctx context.Context, state request.Request, target string, qtype uint16) ([]dns.RR, Result) {
 	m, e := z.Upstream.Lookup(ctx, state, target, qtype)
 	if e != nil {
-		return nil
+		return nil, Success
 	}
 	if m == nil {
-		return nil
+		return nil, Success
 	}
-	return m.Answer
+	if m.Rcode == dns.RcodeNameError {
+		return m.Answer, NameError
+
+	}
+	return m.Answer, Success
 }
 
 // additionalProcessing checks the current answer section and retrieves A or AAAA records

--- a/plugin/file/lookup.go
+++ b/plugin/file/lookup.go
@@ -364,7 +364,12 @@ func (z *Zone) doLookup(ctx context.Context, state request.Request, target strin
 	}
 	if m.Rcode == dns.RcodeNameError {
 		return m.Answer, NameError
-
+	}
+	if m.Rcode == dns.RcodeServerFailure {
+		return m.Answer, ServerFailure
+	}
+	if m.Rcode == dns.RcodeSuccess && len(m.Answer) == 0 {
+		return m.Answer, NoData
 	}
 	return m.Answer, Success
 }

--- a/test/file_upstream_test.go
+++ b/test/file_upstream_test.go
@@ -58,7 +58,47 @@ www 3600 IN CNAME www.example.net.
 	}
 }
 
-func TestFileUpstreamNx(t *testing.T) {
+func TestFileUpstreamError(t *testing.T) {
+	cases := map[string]test.Case{
+		"nxdomain": {
+			Qname: "nxdomain.example.org.", Qtype: dns.TypeA,
+			Answer: []dns.RR{
+				test.CNAME("nxdomain.example.org.	3600	IN	CNAME	nxdomain.example.net"),
+			},
+			Rcode: dns.RcodeNameError,
+		},
+		"nxdomain-chain": {
+			Qname: "chain1.example.org.", Qtype: dns.TypeA,
+			Answer: []dns.RR{
+				test.CNAME("chain1.example.org.	3600	IN	CNAME	nxdomain.example.org"),
+				test.CNAME("nxdomain.example.org.	3600	IN	CNAME	nxdomain.example.net"),
+			},
+			Rcode: dns.RcodeNameError,
+		},
+		"srvfail": {
+			Qname: "srvfail.example.org.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeServerFailure,
+		},
+		"srvfail-chain": {
+			Qname: "chain2.example.org.", Qtype: dns.TypeA,
+			Rcode: dns.RcodeServerFailure,
+		},
+		"nodata": {
+			Qname: "nodata.example.org.", Qtype: dns.TypeA,
+			Answer: []dns.RR{
+				test.CNAME("nodata.example.org.	3600	IN	CNAME	nodata.example.net"),
+			},
+			Rcode: dns.RcodeSuccess,
+		},
+		"nodata-chain": {
+			Qname: "chain3.example.org.", Qtype: dns.TypeA,
+			Answer: []dns.RR{
+				test.CNAME("chain3.example.org.	3600	IN	CNAME	nodata.example.org"),
+				test.CNAME("nodata.example.org.	3600	IN	CNAME	nodata.example.net"),
+			},
+			Rcode: dns.RcodeSuccess,
+		},
+	}
 	name, rm, err := test.TempFile(".", `$ORIGIN example.org.
 @	3600 IN	SOA   sns.dns.icann.org. noc.dns.icann.org. (
         2017042745 ; serial
@@ -71,8 +111,13 @@ func TestFileUpstreamNx(t *testing.T) {
     3600 IN NS    a.iana-servers.net.
     3600 IN NS    b.iana-servers.net.
 
-chain   3600 IN CNAME deadend
-deadend 3600 IN CNAME non-existent.example.net.
+chain1   3600 IN CNAME nxdomain
+nxdomain 3600 IN CNAME nxdomain.example.net.
+chain2   3600 IN CNAME srvfail
+srvfail  3600 IN CNAME srvfail.example.net.
+chain3   3600 IN CNAME nodata
+nodata   3600 IN CNAME nodata.example.net.
+
 `)
 	if err != nil {
 		t.Fatalf("Failed to create zone: %s", err)
@@ -80,8 +125,13 @@ deadend 3600 IN CNAME non-existent.example.net.
 	defer rm()
 
 	corefile := `.:0 {
-	template ANY ANY non-existent.example.net. {
+	template ANY A nxdomain.example.net. {
 		rcode NXDOMAIN
+	}
+	template ANY A srvfail.example.net. {
+		rcode SERVFAIL
+	}
+	template ANY A nodata.example.net. {
 	}
 	file ` + name + ` example.org
 }`
@@ -92,38 +142,27 @@ deadend 3600 IN CNAME non-existent.example.net.
 	}
 	defer i.Stop()
 
-	t.Run("Target", func(t *testing.T) {
-		m := new(dns.Msg)
-		m.SetQuestion("deadend.example.org.", dns.TypeA)
-		m.SetEdns0(4096, true)
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetQuestion(tc.Qname, tc.Qtype)
+			m.SetEdns0(4096, true)
 
-		r, err := dns.Exchange(m, udp)
-		if err != nil {
-			t.Fatalf("Could not exchange msg: %s", err)
-		}
-		if r.Rcode != dns.RcodeNameError {
-			t.Fatal("expected dns.RcodeNameError")
-		}
-		if n := len(r.Answer); n != 1 {
-			t.Errorf("Expected 1 answer, got %v", n)
-		}
-	})
-	t.Run("Chain", func(t *testing.T) {
-		m := new(dns.Msg)
-		m.SetQuestion("chain.example.org.", dns.TypeA)
-		m.SetEdns0(4096, true)
-
-		r, err := dns.Exchange(m, udp)
-		if err != nil {
-			t.Fatalf("Could not exchange msg: %s", err)
-		}
-		if r.Rcode != dns.RcodeNameError {
-			t.Fatal("expected dns.RcodeNameError")
-		}
-		if n := len(r.Answer); n != 2 {
-			t.Errorf("Expected 2 answers, got %v", n)
-		}
-	})
+			r, err := dns.Exchange(m, udp)
+			if err != nil {
+				t.Fatalf("Could not exchange msg: %s", err)
+			}
+			if r.Rcode != tc.Rcode {
+				t.Fatalf("expected rcode %v, got %v", tc.Rcode, r.Rcode)
+			}
+			if n := len(r.Answer); n != len(tc.Answer) {
+				t.Fatalf("Expected %v answers, got %v", len(tc.Answer), n)
+			}
+			if err := test.Section(tc, test.Answer, r.Answer); err != nil {
+				t.Error(err)
+			}
+		})
+	}
 }
 
 // TestFileUpstreamAdditional runs two CoreDNS servers that serve example.org and foo.example.org.

--- a/test/go-test-tmpfile565156097
+++ b/test/go-test-tmpfile565156097
@@ -1,0 +1,19 @@
+$ORIGIN example.org.
+@	3600 IN	SOA   sns.dns.icann.org. noc.dns.icann.org. (
+        2017042745 ; serial
+        7200       ; refresh (2 hours)
+        3600       ; retry (1 hour)
+        1209600    ; expire (2 weeks)
+        3600       ; minimum (1 hour)
+)
+
+    3600 IN NS    a.iana-servers.net.
+    3600 IN NS    b.iana-servers.net.
+
+chain1   3600 IN CNAME nxdomain
+nxdomain 3600 IN CNAME nxdomain.example.net.
+chain2   3600 IN CNAME srvfail
+srvfail  3600 IN CNAME srvfail.example.net.
+chain3   3600 IN CNAME nodata
+nodata   3600 IN CNAME nodata.example.net.
+


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

As cited in  #4288, per https://tools.ietf.org/html/rfc6604#section-3, when following a CNAME chain the response code sent to the client should be the same response code received when resolving the target of the final link in the chain.  Strictly this means we should be passing through the exact Rcode received when looking up the final target. But since _file_ uses an alternate response code datatype `file.Result` which does not map 1:1 to DNS response codes, making that happen might require some larger scope refactoring.  So for now, just addressing response codes that do map.

### 2. Which issues (if any) are related?

fixes #4288

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
