### PR TITLE
add hairpin option to kubernetes plugin

### DIFF
--- a/plugin/kubernetes/README.md
+++ b/plugin/kubernetes/README.md
@@ -98,6 +98,12 @@ kubernetes [ZONES...] {
 * `ignore empty_service` returns NXDOMAIN for services without any ready endpoint addresses (e.g., ready pods).
   This allows the querying pod to continue searching for the service in the search path.
   The search path could, for example, include another Kubernetes cluster.
+* `hairpin` **HAIRPIN-TYPE** **EXPRESSION** exposes ExternalIP instead of ClusterIP for Kubernetes services
+   that match this selector. Valid values for **HAIRPIN-TYPE**:
+
+   * `labels`: the labels of Services match this selector.
+   * `annotations`: the annotations of Services match this selector.
+
 
 Enabling zone transfer is done by using the *transfer* plugin.
 

--- a/plugin/kubernetes/controller.go
+++ b/plugin/kubernetes/controller.go
@@ -95,6 +95,11 @@ type dnsControlOpts struct {
 	zones                 []string
 	endpointNameMode      bool
 	skipAPIObjectsCleanup bool
+
+	hairpinLabelSelector        *meta.LabelSelector
+	hairpinLabelAsSelector      labels.Selector
+	hairpinAnnotationSelector   *meta.LabelSelector
+	hairpinAnnotationAsSelector labels.Selector
 }
 
 // newDNSController creates a controller for CoreDNS.
@@ -116,7 +121,7 @@ func newdnsController(ctx context.Context, kubeClient kubernetes.Interface, opts
 		&api.Service{},
 		cache.ResourceEventHandlerFuncs{AddFunc: dns.Add, UpdateFunc: dns.Update, DeleteFunc: dns.Delete},
 		cache.Indexers{svcNameNamespaceIndex: svcNameNamespaceIndexFunc, svcIPIndex: svcIPIndexFunc},
-		object.DefaultProcessor(object.ToService(opts.skipAPIObjectsCleanup), nil),
+		object.DefaultProcessor(object.ToService(opts.skipAPIObjectsCleanup, opts.hairpinLabelAsSelector, opts.hairpinAnnotationAsSelector), nil),
 	)
 
 	if opts.initPodCache {

--- a/plugin/kubernetes/handler_test.go
+++ b/plugin/kubernetes/handler_test.go
@@ -30,6 +30,14 @@ var dnsTestCases = []test.Case{
 			test.A("svcempty.testns.svc.cluster.local.	5	IN	A	10.0.0.1"),
 		},
 	},
+	// A Service (hairpin)
+	{
+		Qname: "hairpinsvc.testns.svc.cluster.local.", Qtype: dns.TypeA,
+		Rcode: dns.RcodeSuccess,
+		Answer: []dns.RR{
+			test.A("hairpinsvc.testns.svc.cluster.local.	5	IN	A	8.8.8.8"),
+		},
+	},
 	// A Service (wildcard)
 	{
 		Qname: "svc1.*.svc.cluster.local.", Qtype: dns.TypeA,
@@ -614,6 +622,18 @@ var svcIndex = map[string][]*object.Service{
 			Namespace: "unexposedns",
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: "10.0.0.2",
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+	},
+	"hairpinsvc.testns": {
+		{
+			Name:        "hairpinsvc",
+			Namespace:   "testns",
+			Type:        api.ServiceTypeClusterIP,
+			ClusterIP:   "Skip",
+			ExternalIPs: []string{"8.8.8.8"},
 			Ports: []api.ServicePort{
 				{Name: "http", Protocol: "tcp", Port: 80},
 			},

--- a/plugin/kubernetes/kubernetes_test.go
+++ b/plugin/kubernetes/kubernetes_test.go
@@ -92,6 +92,15 @@ func (APIConnServiceTest) SvcIndex(string) []*object.Service {
 				{Name: "http", Protocol: "tcp", Port: 80},
 			},
 		},
+		{
+			Name:        "hairpinsvc",
+			Namespace:   "testns",
+			ClusterIP:   "Skip",
+			ExternalIPs: []string{"8.8.8.8"},
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
 	}
 	return svcs
 }
@@ -116,6 +125,15 @@ func (APIConnServiceTest) ServiceList() []*object.Service {
 			Namespace:    "testns",
 			ExternalName: "coredns.io",
 			Type:         api.ServiceTypeExternalName,
+			Ports: []api.ServicePort{
+				{Name: "http", Protocol: "tcp", Port: 80},
+			},
+		},
+		{
+			Name:        "hairpinsvc",
+			Namespace:   "testns",
+			ClusterIP:   "Skip",
+			ExternalIPs: []string{"8.8.8.8"},
 			Ports: []api.ServicePort{
 				{Name: "http", Protocol: "tcp", Port: 80},
 			},
@@ -269,6 +287,9 @@ func TestServices(t *testing.T) {
 
 		// Headless Services
 		{qname: "hdls1.testns.svc.interwebs.test.", qtype: dns.TypeA, answer: svcAns{host: "172.0.0.2", key: "/" + coredns + "/test/interwebs/svc/testns/hdls1/172-0-0-2"}},
+
+		// Hairpin Services
+		{qname: "hairpinsvc.testns.svc.interwebs.tests.", qtype: dns.TypeA, answer: svcAns{host: "8.8.8.8", key: "/" + coredns + "/test/interwebs/svc/testns/hairpinsvc"}},
 	}
 
 	for i, test := range tests {

--- a/plugin/kubernetes/setup.go
+++ b/plugin/kubernetes/setup.go
@@ -262,6 +262,31 @@ func ParseStanza(c *caddy.Controller) (*Kubernetes, error) {
 				continue
 			}
 			return nil, c.ArgErr()
+		case "hairpin":
+			args := c.RemainingArgs()
+			if len(args) > 0 {
+				selectorType := args[0]
+				if selectorType == "labels" {
+					labelSelectorString := strings.Join(args[1:], " ")
+					ls, err := meta.ParseToLabelSelector(labelSelectorString)
+					if err != nil {
+						return nil, fmt.Errorf("unable to parse label selector value: '%v': %v", labelSelectorString, err)
+					}
+					k8s.opts.hairpinLabelSelector = ls
+					continue
+				} else if selectorType == "annotations" {
+					annotationSelectorString := strings.Join(args[1:], " ")
+					as, err := meta.ParseToLabelSelector(annotationSelectorString)
+					if err != nil {
+						return nil, fmt.Errorf("unable to parse annotation selector value: '%v': %v", annotationSelectorString, err)
+					}
+					k8s.opts.hairpinAnnotationSelector = as
+					continue
+				} else {
+					return nil, fmt.Errorf("unsupported selector type for hairpin: '%v'", selectorType)
+				}
+			}
+			return nil, c.ArgErr()
 		default:
 			return nil, c.Errf("unknown property '%s'", c.Val())
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

In practice, we can use SLB or HLB as the lb provider of servicecontroller. For SLB, TLS terminating can be done in the pod sidecar. But for HLB, TLS certs are bound to LB devices, then if the end user wants to access this kind of HLB-TLS services from the cluster inside, the requests must be transferred to ExternalIP instead of ClusterIP.

This PR introduces a new option for kubernetes plugin, named 'hairpin'. This option is used to resolve specific labeled service fqdn to ExternalIP instead of clusterIP.

For example:
```
kubernetes cluster.local in-addr.arpa ip6.arpa {
    hairpin labels hlb-tls=true
}

kubernetes cluster.local in-addr.arpa ip6.arpa {
    hairpin annotations hlb-tls=true
}
```

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?
The kubernetes plugin README.md documentation has been updated.

### 4. Does this introduce a backward incompatible change or deprecation?
No.