### PR TITLE
plugin/forward: respond with REFUSED when max_concurrent is exceeded

### DIFF
--- a/plugin/forward/README.md
+++ b/plugin/forward/README.md
@@ -88,7 +88,7 @@ forward FROM TO... {
   * `no_rec` - optional argument that sets the RecursionDesired-flag of the dns-query used in health checking to `false`.
     The flag is default `true`.
 * `max_concurrent` **MAX** will limit the number of concurrent queries to **MAX**.  Any new query that would
-  raise the number of concurrent queries above the **MAX** will result in a SERVFAIL response. This
+  raise the number of concurrent queries above the **MAX** will result in a REFUSED response. This
   response does not count as a health failure. When choosing a value for **MAX**, pick a number
   at least greater than the expected *upstream query rate* * *latency* of the upstream servers.
   As an upper bound for **MAX**, consider that each concurrent query will use about 2kb of memory.

--- a/plugin/forward/forward.go
+++ b/plugin/forward/forward.go
@@ -83,7 +83,7 @@ func (f *Forward) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg
 		defer atomic.AddInt64(&(f.concurrent), -1)
 		if count > f.maxConcurrent {
 			MaxConcurrentRejectCount.Add(1)
-			return dns.RcodeServerFailure, f.ErrLimitExceeded
+			return dns.RcodeRefused, f.ErrLimitExceeded
 		}
 	}
 

--- a/plugin/pkg/response/typify_test.go
+++ b/plugin/pkg/response/typify_test.go
@@ -60,6 +60,16 @@ func TestTypifyImpossible(t *testing.T) {
 	}
 }
 
+func TestTypifyRefused(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetQuestion("foo.example.org.", dns.TypeA)
+	m.Rcode = dns.RcodeRefused
+	mt, _ := Typify(m, time.Now().UTC())
+	if mt != OtherError {
+		t.Errorf("Refused message not typified as OtherError, got %s", mt)
+	}
+}
+
 func delegationMsg() *dns.Msg {
 	return &dns.Msg{
 		Ns: []dns.RR{


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?

Respond with `REFUSED` when `max_concurrent` is exceeded to avoid caching the repsonse.  `REFUSED` responses are typified as `OTHERERROR`, which are not cached by the _cache_ plugin.  Currently, the response code used is `SERVFAIL`, which is cached. If `max_concurrent` exceeded responses are cached, those answer are potentially cached beyond the time the load has dropped, barring those clients from getting a valid answers for some time after the limit has dropped below the threshold.  So, yes, [`REFUSED` works better that `SERVFAIL`](https://github.com/coredns/coredns/pull/3640#discussion_r372902512).

### 2. Which issues (if any) are related?

This issue was raised tangentially in #4324

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
