### PR TITLE
Fix wrong Datadog port in trace plugin example

### DIFF
--- a/plugin/trace/README.md
+++ b/plugin/trace/README.md
@@ -80,7 +80,7 @@ trace http://tracinghost:9411/zipkin/api/v1/spans
 Using DataDog:
 
 ~~~
-trace datadog localhost:8125
+trace datadog localhost:8126
 ~~~
 
 Trace one query every 10000 queries, rename the service, and enable same span:


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
It fixes the Datadog trace port in the example. 8125 is the StatsD port while 8126 is the trace (APM) port.

### 2. Which issues (if any) are related?
N/A

### 3. Which documentation changes (if any) need to be made?
It seems only this document needs to be updated. The default port seems to be correctly set to 8126 in the code.

### 4. Does this introduce a backward incompatible change or deprecation?
No
