### PR TITLE
Azure Plugin: Iterate over all RecordSetListResultPage Pages

### DIFF
--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -133,7 +133,7 @@ func (h *Azure) updateZones(ctx context.Context) error {
 
 }
 
-func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage, newZ *file.Zone) *file.Zone {
+func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage, newZ *file.Zone) {
 	for _, result := range *(recordSet.Response().Value) {
 		resultFqdn := *(result.RecordSetProperties.Fqdn)
 		resultTTL := uint32(*(result.RecordSetProperties.TTL))
@@ -217,7 +217,6 @@ func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage
 			newZ.Insert(cname)
 		}
 	}
-	return newZ
 }
 
 func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPage, newZ *file.Zone) {

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -103,16 +103,18 @@ func (h *Azure) updateZones(ctx context.Context) error {
 	var err error
 	var publicSet publicdns.RecordSetListResultPage
 	var privateSet privatedns.RecordSetListResultPage
-	var newZ *file.Zone
 	errs := make([]string, 0)
 	for zName, z := range h.zones {
 		for i, hostedZone := range z {
+			var newZ = file.NewZone(zName, "")
 			if hostedZone.private {
-				privateSet, err = h.privateClient.List(ctx, hostedZone.id, hostedZone.zone, nil, "")
-				newZ = updateZoneFromPrivateResourceSet(privateSet, zName)
+				for privateSet, err = h.privateClient.List(ctx, hostedZone.id, hostedZone.zone, nil, ""); privateSet.NotDone(); err = privateSet.NextWithContext(ctx) {
+					updateZoneFromPrivateResourceSet(privateSet, newZ)
+				}
 			} else {
-				publicSet, err = h.publicClient.ListByDNSZone(ctx, hostedZone.id, hostedZone.zone, nil, "")
-				newZ = updateZoneFromPublicResourceSet(publicSet, zName)
+				for publicSet, err = h.publicClient.ListByDNSZone(ctx, hostedZone.id, hostedZone.zone, nil, ""); publicSet.NotDone(); err = publicSet.NextWithContext(ctx) {
+					updateZoneFromPublicResourceSet(publicSet, newZ)
+				}
 			}
 			if err != nil {
 				errs = append(errs, fmt.Sprintf("failed to list resource records for %v from azure: %v", hostedZone.zone, err))
@@ -131,9 +133,7 @@ func (h *Azure) updateZones(ctx context.Context) error {
 
 }
 
-func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage, zName string) *file.Zone {
-	newZ := file.NewZone(zName, "")
-
+func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage, newZ *file.Zone) *file.Zone {
 	for _, result := range *(recordSet.Response().Value) {
 		resultFqdn := *(result.RecordSetProperties.Fqdn)
 		resultTTL := uint32(*(result.RecordSetProperties.TTL))
@@ -220,9 +220,7 @@ func updateZoneFromPublicResourceSet(recordSet publicdns.RecordSetListResultPage
 	return newZ
 }
 
-func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPage, zName string) *file.Zone {
-	newZ := file.NewZone(zName, "")
-
+func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPage, newZ *file.Zone) {
 	for _, result := range *(recordSet.Response().Value) {
 		resultFqdn := *(result.RecordSetProperties.Fqdn)
 		resultTTL := uint32(*(result.RecordSetProperties.TTL))
@@ -298,7 +296,6 @@ func updateZoneFromPrivateResourceSet(recordSet privatedns.RecordSetListResultPa
 		}
 
 	}
-	return newZ
 }
 
 // ServeDNS implements the plugin.Handler interface.

--- a/plugin/azure/azure.go
+++ b/plugin/azure/azure.go
@@ -106,7 +106,7 @@ func (h *Azure) updateZones(ctx context.Context) error {
 	errs := make([]string, 0)
 	for zName, z := range h.zones {
 		for i, hostedZone := range z {
-			var newZ = file.NewZone(zName, "")
+			newZ := file.NewZone(zName, "")
 			if hostedZone.private {
 				for privateSet, err = h.privateClient.List(ctx, hostedZone.id, hostedZone.zone, nil, ""); privateSet.NotDone(); err = privateSet.NextWithContext(ctx) {
 					updateZoneFromPrivateResourceSet(privateSet, newZ)


### PR DESCRIPTION
<!--
Thank you for contributing to CoreDNS!
Please provide the following information to help us make the most of your pull request:
-->

### 1. Why is this pull request needed and what does it do?
From the Azure Go [Doc](https://godoc.org/github.com/Azure/azure-sdk-for-go/services/privatedns/mgmt/2018-09-01/privatedns#PrivateZoneListResultIterator.NextWithContext), RecordSetListResultPage are paged. This pull request iterates over all pages to create the zone. Without iteration over all pages, for zones with #records > 100 not all records will be resolved correctly.

### 2. Which issues (if any) are related?
This pull request addresses Issue #4350 .

### 3. Which documentation changes (if any) need to be made?
None

### 4. Does this introduce a backward incompatible change or deprecation?
Not as far as I know.
