### PR TITLE
plugin/forward: fix health check backoff interval between checks

### DIFF
--- a/plugin/pkg/up/up.go
+++ b/plugin/pkg/up/up.go
@@ -49,7 +49,7 @@ func (p *Probe) Do(f Func) {
 			}
 			interval := p.expBackoff.NextBackOff()
 			// If exponential backoff has reached the maximum elapsed time, reset it
-			if interval == -1 {
+			if interval == backoff.Stop {
 				p.expBackoff.Reset()
 				interval = p.expBackoff.NextBackOff()
 			}

--- a/plugin/pkg/up/up.go
+++ b/plugin/pkg/up/up.go
@@ -48,11 +48,6 @@ func (p *Probe) Do(f Func) {
 				return
 			}
 			interval := p.expBackoff.NextBackOff()
-			// If exponential backoff has reached the maximum elapsed time, reset it
-			if interval == backoff.Stop {
-				p.expBackoff.Reset()
-				interval = p.expBackoff.NextBackOff()
-			}
 			p.Unlock()
 			time.Sleep(interval)
 			i++
@@ -80,7 +75,7 @@ func (p *Probe) Start(interval time.Duration) {
 		RandomizationFactor: backoff.DefaultRandomizationFactor,
 		Multiplier:          backoff.DefaultMultiplier,
 		MaxInterval:         15 * time.Second,
-		MaxElapsedTime:      2 * time.Minute,
+		MaxElapsedTime:      0,
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}

--- a/plugin/pkg/up/up_test.go
+++ b/plugin/pkg/up/up_test.go
@@ -66,7 +66,7 @@ func TestDoBackoff(t *testing.T) {
 	wg.Wait()
 
 	elapsed := time.Now().Sub(start)
-	expected := time.Millisecond * (1 + 2 + 4 + 5 + 6) // plus execution time
+	expected := time.Millisecond * (1 + 2 + 4 + 8 + 16) // plus execution time
 	if elapsed < expected {
 		t.Errorf("backoff was not exponential")
 	}


### PR DESCRIPTION
Signed-off-by: Chris O'Haver <cohaver@infoblox.com>

### 1. Why is this pull request needed and what does it do?

The existing implementation of health check backoff is broken.

Currently during a health probe of an upstream, the same sleep interval is used between each check.  The interval only changes/backs-off after the upstream becomes healthy and then goes unhealthy again and another probe is launched.  Since an upstream isn't considered "down" until 3 failed checks, this could potentially delay detection of a down upstream by up to 30 seconds (2X the maximum interval).

This change makes the interval back off between each retry while probing an unhealthy upstream. It also resets the backoff interval at the start of each probe.

### 2. Which issues (if any) are related?

### 3. Which documentation changes (if any) need to be made?

### 4. Does this introduce a backward incompatible change or deprecation?
