### PR TITLE
plugin/dnssec: Change hash key input

### DIFF
--- a/plugin/dnssec/cache.go
+++ b/plugin/dnssec/cache.go
@@ -2,6 +2,9 @@ package dnssec
 
 import (
 	"hash/fnv"
+	"io"
+	"strconv"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -9,14 +12,16 @@ import (
 // hash serializes the RRset and returns a signature cache key.
 func hash(rrs []dns.RR) uint64 {
 	h := fnv.New64()
-	buf := make([]byte, 256)
-	for _, r := range rrs {
-		off, err := dns.PackRR(r, buf, 0, nil, false)
-		if err == nil {
-			h.Write(buf[:off])
-		}
+	// Only need this to be unique for ownername + qtype (+class), but we
+	// only care about IN. Its already an RRSet, so the ownername is the
+	// same as is the qtype. Take the first one and construct the hash
+	// string that creates the key
+	io.WriteString(h, strings.ToLower(rrs[0].Header().Name))
+	typ, ok := dns.TypeToString[rrs[0].Header().Rrtype]
+	if !ok {
+		typ = "TYPE" + strconv.FormatUint(uint64(rrs[0].Header().Rrtype), 10)
 	}
-
+	io.WriteString(h, typ)
 	i := h.Sum64()
 	return i
 }


### PR DESCRIPTION
Make this vastly simpler and more efficient. Adding all the bytes and
then letting loose fnv doesn't add anything and may actually do the
wrong thing.

See: #3953
Fixes: #3953

Signed-off-by: Miek Gieben <miek@miek.nl>